### PR TITLE
fix: route /json WebSocket upgrades through load balancer

### DIFF
--- a/crates/obscura-cli/src/main.rs
+++ b/crates/obscura-cli/src/main.rs
@@ -218,7 +218,7 @@ async fn run_multi_worker_serve(
             let request_line = String::from_utf8_lossy(&full_peek[..n]);
 
             if request_line.contains("/json") {
-                let worker_addr = format!("127.0.0.1:{}", port + 1);
+                let worker_addr = format!("127.0.0.1:{}", worker_port);
                 if let Ok(mut worker_stream) = tokio::net::TcpStream::connect(&worker_addr).await {
                     tokio::spawn(async move {
                         let _ = tokio::io::copy_bidirectional(&mut tokio::net::TcpStream::from_std(client_stream.into_std().unwrap()).unwrap(), &mut worker_stream).await;


### PR DESCRIPTION
## Summary

Fixed /json endpoint routing in the load balancer. Previously all CDP WebSocket clients were routed to the same fixed worker (port+1), bypassing round-robin distribution entirely. Now uses the same `next_worker % workers` logic as regular HTTP requests.

## Changes

- `/json` WebSocket upgrade requests now go through worker selection: `port + 1 + (next_worker % workers)`
- Previously: hardcoded `port + 1` — all CDP clients hit the same worker

## Testing

- Code review: routing logic now matches other request handling

Fixes h4ckf0r0day/obscura#2