### PR TITLE
feat: support file:// URL scheme for local HTML testing

### DIFF
--- a/crates/obscura-js/src/ops.rs
+++ b/crates/obscura-js/src/ops.rs
@@ -551,11 +551,15 @@ fn glob_match(pattern: &str, url: &str) -> bool {
 
 fn validate_fetch_url(url: &url::Url) -> Result<(), String> {
     let scheme = url.scheme();
-    if scheme != "http" && scheme != "https" {
+    if scheme != "http" && scheme != "https" && scheme != "file" {
         return Err(format!(
-            "Forbidden URL scheme '{}' - only http and https are allowed",
+            "Forbidden URL scheme '{}' - only http, https, and file are allowed",
             scheme
         ));
+    }
+
+    if scheme == "file" {
+        return Ok(());
     }
 
     if let Some(host) = url.host() {

--- a/crates/obscura-net/src/client.rs
+++ b/crates/obscura-net/src/client.rs
@@ -66,11 +66,15 @@ pub type ResponseCallback = Arc<dyn Fn(&RequestInfo, &Response) + Send + Sync>;
 
 fn validate_url(url: &Url) -> Result<(), ObscuraNetError> {
     let scheme = url.scheme();
-    if scheme != "http" && scheme != "https" {
+    if scheme != "http" && scheme != "https" && scheme != "file" {
         return Err(ObscuraNetError::Network(format!(
-            "Forbidden URL scheme '{}' - only http and https are allowed",
+            "Forbidden URL scheme '{}' - only http, https, and file are allowed",
             scheme
         )));
+    }
+
+    if scheme == "file" {
+        return Ok(());
     }
 
     if let Some(host) = url.host() {
@@ -113,6 +117,41 @@ fn validate_url(url: &Url) -> Result<(), ObscuraNetError> {
     }
 
     Ok(())
+}
+
+async fn fetch_file_url(url: &Url) -> Result<Response, ObscuraNetError> {
+    let path = url
+        .to_file_path()
+        .map_err(|_| ObscuraNetError::Network("Invalid file URL".to_string()))?;
+    let body = tokio::fs::read(&path)
+        .await
+        .map_err(|e| ObscuraNetError::Network(format!("Failed to read file: {}", e)))?;
+
+    let mut headers = HashMap::new();
+    if let Some(ext) = path.extension().and_then(|e| e.to_str()) {
+        let ct = match ext.to_lowercase().as_str() {
+            "html" | "htm" => "text/html",
+            "css" => "text/css",
+            "js" | "mjs" => "application/javascript",
+            "json" => "application/json",
+            "png" => "image/png",
+            "jpg" | "jpeg" => "image/jpeg",
+            "gif" => "image/gif",
+            "svg" => "image/svg+xml",
+            "webp" => "image/webp",
+            "ico" => "image/x-icon",
+            _ => "application/octet-stream",
+        };
+        headers.insert("content-type".to_string(), ct.to_string());
+    }
+
+    Ok(Response {
+        url: url.clone(),
+        status: 200,
+        headers,
+        body,
+        redirected_from: Vec::new(),
+    })
 }
 
 pub struct ObscuraHttpClient {
@@ -189,6 +228,10 @@ impl ObscuraHttpClient {
         initial_body: Option<Vec<u8>>,
     ) -> Result<Response, ObscuraNetError> {
         validate_url(url)?;
+
+        if url.scheme() == "file" {
+            return fetch_file_url(url).await;
+        }
 
         let mut method = initial_method;
         let mut body = initial_body;


### PR DESCRIPTION
## Summary

Allow loading local HTML/CSS/JS files via the `file://` protocol, enabling Obscura to be used for testing static sites without running a local HTTP server.

## Changes

- **obscura-net/src/client.rs**
  - Allow `file` scheme in `validate_url()` alongside http/https
  - Add `fetch_file_url()` helper to read local files and return synthetic HTTP responses
  - Handle `file://` URLs in `fetch_with_method()` before the HTTP path
  - Skip private IP / localhost checks for `file://` URLs

- **obscura-js/src/ops.rs**
  - Allow `file` scheme in `validate_fetch_url()`

## How it works

When a `file://` URL is navigated or fetched:
1. The URL path is extracted via `url.to_file_path()`
2. The file is read asynchronously with `tokio::fs::read()`
3. A `Response` is returned with status 200 and a `content-type` header guessed from the file extension

Relative resources (CSS, JS) referenced from a `file://` base URL are resolved automatically by the existing `Url::join()` logic.

## Verification

Tested against a real-world Puppeteer test suite (210 tests) that loads local HTML files via `file://`. All tests pass with this change.

Closes #16
