### PR TITLE
Add container isolation and file URL policy

### DIFF
--- a/.containerignore
+++ b/.containerignore
@@ -1,0 +1,7 @@
+.git
+.codex
+target
+**/target
+
+*.log
+*.tmp

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,7 @@
+.git
+.codex
+target
+**/target
+
+*.log
+*.tmp

--- a/Containerfile
+++ b/Containerfile
@@ -1,0 +1,22 @@
+FROM docker.io/rust:1-bookworm AS builder
+
+WORKDIR /src
+COPY . .
+
+RUN cargo build --release --bin obscura --bin obscura-worker
+
+FROM docker.io/debian:bookworm-slim
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends ca-certificates \
+    && rm -rf /var/lib/apt/lists/* \
+    && useradd --system --uid 10001 --gid nogroup --home-dir /nonexistent --shell /usr/sbin/nologin obscura
+
+COPY --from=builder /src/target/release/obscura /usr/local/bin/obscura
+COPY --from=builder /src/target/release/obscura-worker /usr/local/bin/obscura-worker
+
+USER 10001:65534
+EXPOSE 9222
+
+ENTRYPOINT ["obscura"]
+CMD ["serve", "--host", "0.0.0.0", "--port", "9222"]

--- a/README.md
+++ b/README.md
@@ -62,6 +62,36 @@ cargo build --release --features stealth
 
 Requires Rust 1.75+ ([rustup.rs](https://rustup.rs)). First build takes ~5 min (V8 compiles from source, cached after).
 
+### Run in a container
+
+Obscura denies `file://` URLs by default, and can also run behind Podman or Docker so any explicitly allowed file access is limited to the container filesystem:
+
+```bash
+podman build -t obscura:dev -f Containerfile .
+podman run --rm \
+  --read-only \
+  --tmpfs /tmp:rw,nosuid,nodev,noexec,size=64m \
+  --cap-drop=all \
+  --security-opt=no-new-privileges \
+  -p 127.0.0.1:9222:9222 \
+  obscura:dev
+```
+
+Docker uses the same image definition:
+
+```bash
+docker build -t obscura:dev -f Containerfile .
+docker run --rm \
+  --read-only \
+  --tmpfs /tmp:rw,nosuid,nodev,noexec,size=64m \
+  --cap-drop=ALL \
+  --security-opt=no-new-privileges \
+  -p 127.0.0.1:9222:9222 \
+  obscura:dev
+```
+
+See [docs/container.md](docs/container.md) for why `file://` is restricted, how to allow only specific fixture directories, Artix Linux Rust setup, and Podman/Docker hardening flags.
+
 ## Quick Start
 
 ### Fetch a page
@@ -87,6 +117,12 @@ obscura serve --port 9222
 
 # With stealth mode (anti-detection + tracker blocking)
 obscura serve --port 9222 --stealth
+
+# Bind all interfaces, useful inside a container only
+obscura serve --host 0.0.0.0 --port 9222
+
+# Allow file:// access only under one local directory
+obscura serve --allow-file-access "$PWD/fixtures" --port 9222
 ```
 
 ### Scrape in parallel
@@ -202,13 +238,18 @@ Obscura implements the Chrome DevTools Protocol for Puppeteer/Playwright compati
 | **LP** | getMarkdown (DOM-to-Markdown conversion) |
 ## CLI Reference
 
+`file://` URLs are denied by default. `--allow-file-access <DIR>` and `--allow-all-file-urls` are global flags and can be used with `serve`, `fetch`, or `scrape`.
+
 ### `obscura serve`
 
 Start a CDP WebSocket server.
 
 | Flag | Default | Description |
 |------|---------|-------------|
+| `--host` | `127.0.0.1` | Address to bind the CDP server |
 | `--port` | `9222` | WebSocket port |
+| `--allow-file-access <DIR>` | — | Allow `file://` reads under a canonicalized directory; can be repeated |
+| `--allow-all-file-urls` | off | Allow unrestricted `file://` reads; unsafe legacy mode |
 | `--proxy` | — | HTTP/SOCKS5 proxy URL |
 | `--stealth` | off | Enable anti-detection + tracker blocking |
 | `--workers` | `1` | Number of parallel worker processes |
@@ -221,6 +262,8 @@ Fetch and render a single page.
 | Flag | Default | Description |
 |------|---------|-------------|
 | `--dump` | `html` | Output: `html`, `text`, or `links` |
+| `--allow-file-access <DIR>` | — | Allow `file://` reads under a canonicalized directory; can be repeated |
+| `--allow-all-file-urls` | off | Allow unrestricted `file://` reads; unsafe legacy mode |
 | `--eval` | — | JavaScript expression to evaluate |
 | `--wait-until` | `load` | Wait: `load`, `domcontentloaded`, `networkidle0` |
 | `--selector` | — | Wait for CSS selector |

--- a/crates/obscura-browser/src/context.rs
+++ b/crates/obscura-browser/src/context.rs
@@ -1,6 +1,6 @@
 use std::sync::Arc;
 
-use obscura_net::{CookieJar, ObscuraHttpClient, RobotsCache};
+use obscura_net::{CookieJar, FileUrlPolicy, ObscuraHttpClient, RobotsCache};
 
 pub struct BrowserContext {
     pub id: String,
@@ -15,25 +15,28 @@ pub struct BrowserContext {
 
 impl BrowserContext {
     pub fn new(id: String) -> Self {
-        let cookie_jar = Arc::new(CookieJar::new());
-        let http_client = Arc::new(ObscuraHttpClient::with_cookie_jar(cookie_jar.clone()));
-        BrowserContext {
-            id,
-            cookie_jar,
-            http_client,
-            user_agent: "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/145.0.0.0 Safari/537.36".to_string(),
-            proxy_url: None,
-            robots_cache: Arc::new(RobotsCache::new()),
-            obey_robots: false,
-            stealth: false,
-        }
+        Self::with_options_and_file_url_policy(id, None, false, FileUrlPolicy::Deny)
+    }
+
+    pub fn new_with_file_url_policy(id: String, file_url_policy: FileUrlPolicy) -> Self {
+        Self::with_options_and_file_url_policy(id, None, false, file_url_policy)
     }
 
     pub fn with_options(id: String, proxy_url: Option<String>, stealth: bool) -> Self {
+        Self::with_options_and_file_url_policy(id, proxy_url, stealth, FileUrlPolicy::Deny)
+    }
+
+    pub fn with_options_and_file_url_policy(
+        id: String,
+        proxy_url: Option<String>,
+        stealth: bool,
+        file_url_policy: FileUrlPolicy,
+    ) -> Self {
         let cookie_jar = Arc::new(CookieJar::new());
-        let mut client = ObscuraHttpClient::with_options(
+        let mut client = ObscuraHttpClient::with_options_and_file_url_policy(
             cookie_jar.clone(),
             proxy_url.as_deref(),
+            file_url_policy,
         );
         if stealth {
             client.block_trackers = true;

--- a/crates/obscura-browser/src/page.rs
+++ b/crates/obscura-browser/src/page.rs
@@ -99,6 +99,10 @@ impl Page {
     }
 
     async fn do_fetch(&self, url: &Url) -> Result<Response, ObscuraNetError> {
+        if url.scheme() == "file" {
+            return self.http_client.fetch(url).await;
+        }
+
         #[cfg(feature = "stealth")]
         if let Some(ref stealth) = self.stealth_client {
             return stealth.fetch(url).await;

--- a/crates/obscura-cdp/src/dispatch.rs
+++ b/crates/obscura-cdp/src/dispatch.rs
@@ -3,6 +3,7 @@ use std::sync::Arc;
 
 use obscura_browser::{BrowserContext, Page};
 use obscura_js::ops::{InterceptResolution, InterceptedRequest};
+use obscura_net::FileUrlPolicy;
 use serde_json::json;
 
 use crate::domains;
@@ -35,7 +36,19 @@ impl CdpContext {
     }
 
     pub fn new_with_proxy(proxy: Option<String>) -> Self {
-        let default_context = Arc::new(BrowserContext::with_proxy("default".to_string(), proxy));
+        Self::new_with_proxy_and_file_url_policy(proxy, FileUrlPolicy::Deny)
+    }
+
+    pub fn new_with_proxy_and_file_url_policy(
+        proxy: Option<String>,
+        file_url_policy: FileUrlPolicy,
+    ) -> Self {
+        let default_context = Arc::new(BrowserContext::with_options_and_file_url_policy(
+            "default".to_string(),
+            proxy,
+            false,
+            file_url_policy,
+        ));
         CdpContext {
             pages: Vec::new(),
             sessions: HashMap::new(),

--- a/crates/obscura-cdp/src/lib.rs
+++ b/crates/obscura-cdp/src/lib.rs
@@ -3,4 +3,6 @@ pub mod dispatch;
 pub mod types;
 pub mod domains;
 
-pub use server::{start, start_with_options};
+pub use server::{
+    start, start_with_bind, start_with_bind_and_file_url_policy, start_with_options,
+};

--- a/crates/obscura-cdp/src/server.rs
+++ b/crates/obscura-cdp/src/server.rs
@@ -1,7 +1,8 @@
 use std::collections::HashMap;
-use std::net::SocketAddr;
+use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 
 use futures_util::{SinkExt, StreamExt};
+use obscura_net::FileUrlPolicy;
 use serde_json::json;
 use tokio::net::{TcpListener, TcpStream};
 use tokio::sync::mpsc;
@@ -28,10 +29,27 @@ pub async fn start(port: u16) -> anyhow::Result<()> {
 }
 
 pub async fn start_with_options(port: u16, proxy: Option<String>) -> anyhow::Result<()> {
-    let addr = SocketAddr::from(([127, 0, 0, 1], port));
+    start_with_bind(port, IpAddr::V4(Ipv4Addr::LOCALHOST), proxy).await
+}
+
+pub async fn start_with_bind(
+    port: u16,
+    host: IpAddr,
+    proxy: Option<String>,
+) -> anyhow::Result<()> {
+    start_with_bind_and_file_url_policy(port, host, proxy, FileUrlPolicy::Deny).await
+}
+
+pub async fn start_with_bind_and_file_url_policy(
+    port: u16,
+    host: IpAddr,
+    proxy: Option<String>,
+    file_url_policy: FileUrlPolicy,
+) -> anyhow::Result<()> {
+    let addr = SocketAddr::new(host, port);
     let listener = TcpListener::bind(&addr).await?;
 
-    info!("Obscura CDP server listening on ws://127.0.0.1:{}", port);
+    info!("Obscura CDP server listening on {}:{}", host, port);
     info!(
         "DevTools endpoint: ws://127.0.0.1:{}/devtools/browser",
         port
@@ -42,7 +60,8 @@ pub async fn start_with_options(port: u16, proxy: Option<String>) -> anyhow::Res
         .run_until(async {
             let (msg_tx, msg_rx) = mpsc::unbounded_channel::<ServerMessage>();
 
-            let processor_handle = tokio::task::spawn_local(cdp_processor(msg_rx, proxy));
+            let _processor_handle =
+                tokio::task::spawn_local(cdp_processor(msg_rx, proxy, file_url_policy));
 
             loop {
                 match listener.accept().await {
@@ -67,8 +86,9 @@ pub async fn start_with_options(port: u16, proxy: Option<String>) -> anyhow::Res
 async fn cdp_processor(
     mut rx: mpsc::UnboundedReceiver<ServerMessage>,
     proxy: Option<String>,
+    file_url_policy: FileUrlPolicy,
 ) {
-    let mut ctx = CdpContext::new_with_proxy(proxy);
+    let mut ctx = CdpContext::new_with_proxy_and_file_url_policy(proxy, file_url_policy);
     let (itx, irx) = mpsc::unbounded_channel::<obscura_js::ops::InterceptedRequest>();
     ctx.intercept_tx = Some(itx);
     let mut intercept_rx: Option<mpsc::UnboundedReceiver<obscura_js::ops::InterceptedRequest>> = Some(irx);

--- a/crates/obscura-cli/src/main.rs
+++ b/crates/obscura-cli/src/main.rs
@@ -1,8 +1,11 @@
+use std::net::IpAddr;
+use std::path::PathBuf;
 use std::sync::Arc;
 use std::time::Instant;
 
 use clap::{Parser, Subcommand};
 use obscura_browser::{BrowserContext, Page};
+use obscura_net::FileUrlPolicy;
 use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
 use tokio::process::Command as TokioCommand;
 use tokio::time::{timeout, Duration};
@@ -18,6 +21,15 @@ struct Args {
 
     #[arg(short, long, default_value_t = 9222)]
     port: u16,
+
+    #[arg(long, global = true, default_value = "127.0.0.1")]
+    host: IpAddr,
+
+    #[arg(long, global = true, value_name = "DIR")]
+    allow_file_access: Vec<PathBuf>,
+
+    #[arg(long, global = true)]
+    allow_all_file_urls: bool,
 
     #[arg(long)]
     proxy: Option<String>,
@@ -102,7 +114,7 @@ enum DumpFormat {
     Links,
 }
 
-fn print_banner(port: u16) {
+fn print_banner(host: IpAddr, port: u16) {
     println!(r#"
    ____  _                              
   / __ \| |                             
@@ -112,13 +124,16 @@ fn print_banner(port: u16) {
   \____/|_.__/|___/\___|\__,_|_|  \__,_|
                    
   Headless Browser v0.1.0
-  CDP server: ws://127.0.0.1:{}/devtools/browser
-"#, port);
+  CDP bind address: {}:{}
+"#, host, port);
 }
 
 #[tokio::main(flavor = "current_thread")]
 async fn main() -> anyhow::Result<()> {
     let args = Args::parse();
+    let host = args.host;
+    let file_url_policy =
+        build_file_url_policy(args.allow_all_file_urls, &args.allow_file_access)?;
 
     let filter = if args.verbose { "debug" } else { "warn" };
     tracing_subscriber::fmt()
@@ -131,7 +146,7 @@ async fn main() -> anyhow::Result<()> {
 
     match args.command {
         Some(Command::Serve { port, proxy, user_agent, stealth, workers }) => {
-            print_banner(port);
+            print_banner(host, port);
             if let Some(ref proxy) = proxy {
                 tracing::info!("Using proxy: {}", proxy);
             }
@@ -145,34 +160,117 @@ async fn main() -> anyhow::Result<()> {
 
             if workers > 1 {
                 tracing::info!("{} worker processes", workers);
-                run_multi_worker_serve(port, workers, proxy, stealth).await?;
+                run_multi_worker_serve(host, port, workers, proxy, stealth, file_url_policy).await?;
             } else {
-                obscura_cdp::start_with_options(port, proxy).await?;
+                obscura_cdp::start_with_bind_and_file_url_policy(
+                    port,
+                    host,
+                    proxy,
+                    file_url_policy,
+                )
+                .await?;
             }
         }
         Some(Command::Fetch { url, dump, selector, wait, wait_until, user_agent, stealth, eval, quiet }) => {
-            run_fetch(&url, dump, selector, wait, &wait_until, user_agent, stealth, eval, quiet).await?;
+            run_fetch(
+                &url,
+                dump,
+                selector,
+                wait,
+                &wait_until,
+                user_agent,
+                stealth,
+                eval,
+                quiet,
+                file_url_policy,
+            )
+            .await?;
         }
         Some(Command::Scrape { urls, eval, concurrency, format, timeout }) => {
-            run_parallel_scrape(urls, eval, concurrency, &format, timeout).await?;
+            run_parallel_scrape(urls, eval, concurrency, &format, timeout, file_url_policy).await?;
         }
         None => {
-            print_banner(args.port);
+            print_banner(host, args.port);
             if let Some(ref proxy) = args.proxy {
                 tracing::info!("Using proxy: {}", proxy);
             }
-            obscura_cdp::start_with_options(args.port, args.proxy).await?;
+            obscura_cdp::start_with_bind_and_file_url_policy(
+                args.port,
+                host,
+                args.proxy,
+                file_url_policy,
+            )
+            .await?;
         }
     }
 
     Ok(())
 }
 
+fn build_file_url_policy(
+    allow_all_file_urls: bool,
+    allow_file_access: &[PathBuf],
+) -> anyhow::Result<FileUrlPolicy> {
+    if allow_all_file_urls && !allow_file_access.is_empty() {
+        anyhow::bail!(
+            "--allow-all-file-urls cannot be combined with --allow-file-access <DIR>"
+        );
+    }
+
+    if allow_all_file_urls {
+        Ok(FileUrlPolicy::AllowAll)
+    } else {
+        Ok(FileUrlPolicy::allow_roots(allow_file_access.iter())?)
+    }
+}
+
+fn add_file_policy_args(cmd: &mut std::process::Command, file_url_policy: &FileUrlPolicy) {
+    match file_url_policy {
+        FileUrlPolicy::Deny => {}
+        FileUrlPolicy::AllowAll => {
+            cmd.arg("--allow-all-file-urls");
+        }
+        FileUrlPolicy::AllowRoots(roots) => {
+            for root in roots {
+                cmd.arg("--allow-file-access").arg(root);
+            }
+        }
+    }
+}
+
+fn add_file_policy_env(cmd: &mut TokioCommand, file_url_policy: &FileUrlPolicy) {
+    const ALLOW_ALL_ENV: &str = "OBSCURA_ALLOW_ALL_FILE_URLS";
+    const ROOTS_ENV: &str = "OBSCURA_FILE_ACCESS_ROOTS_JSON";
+
+    match file_url_policy {
+        FileUrlPolicy::Deny => {
+            cmd.env_remove(ALLOW_ALL_ENV);
+            cmd.env_remove(ROOTS_ENV);
+        }
+        FileUrlPolicy::AllowAll => {
+            cmd.env(ALLOW_ALL_ENV, "1");
+            cmd.env_remove(ROOTS_ENV);
+        }
+        FileUrlPolicy::AllowRoots(roots) => {
+            let roots: Vec<String> = roots
+                .iter()
+                .map(|root| root.to_string_lossy().into_owned())
+                .collect();
+            if let Ok(roots_json) = serde_json::to_string(&roots) {
+                cmd.env(ALLOW_ALL_ENV, "0");
+                cmd.env(ROOTS_ENV, roots_json);
+            }
+        }
+    }
+}
+
 async fn run_multi_worker_serve(
+    host: IpAddr,
     port: u16,
     workers: u16,
     proxy: Option<String>,
     stealth: bool,
+    file_url_policy: FileUrlPolicy,
 ) -> anyhow::Result<()> {
     use tokio::net::TcpListener;
     use tokio::io::{AsyncReadExt as _, AsyncWriteExt as _};
@@ -183,6 +281,7 @@ async fn run_multi_worker_serve(
     for i in 0..workers {
         let worker_port = port + 1 + i;
         let mut cmd = std::process::Command::new(&exe);
+        add_file_policy_args(&mut cmd, &file_url_policy);
         cmd.arg("serve").arg("--port").arg(worker_port.to_string());
         if let Some(ref p) = proxy {
             cmd.arg("--proxy").arg(p);
@@ -200,7 +299,7 @@ async fn run_multi_worker_serve(
 
     tokio::time::sleep(tokio::time::Duration::from_millis(500)).await;
 
-    let addr = std::net::SocketAddr::from(([127, 0, 0, 1], port));
+    let addr = std::net::SocketAddr::new(host, port);
     let listener = TcpListener::bind(&addr).await?;
     tracing::info!("Load balancer on port {}, {} workers", port, workers);
 
@@ -252,8 +351,14 @@ async fn run_fetch(
     stealth: bool,
     eval: Option<String>,
     quiet: bool,
+    file_url_policy: FileUrlPolicy,
 ) -> anyhow::Result<()> {
-    let context = Arc::new(BrowserContext::with_options("fetch".to_string(), None, stealth));
+    let context = Arc::new(BrowserContext::with_options_and_file_url_policy(
+        "fetch".to_string(),
+        None,
+        stealth,
+        file_url_policy,
+    ));
     let mut page = Page::new("fetch-page".to_string(), context);
 
     if let Some(ref ua) = user_agent {
@@ -408,6 +513,7 @@ async fn run_parallel_scrape(
     concurrency: usize,
     format: &str,
     timeout_secs: u64,
+    file_url_policy: FileUrlPolicy,
 ) -> anyhow::Result<()> {
     let total = urls.len();
     let start = Instant::now();
@@ -432,6 +538,7 @@ async fn run_parallel_scrape(
     let semaphore = Arc::new(tokio::sync::Semaphore::new(concurrency));
     let eval = Arc::new(eval);
     let worker_path = Arc::new(worker_path);
+    let file_url_policy = Arc::new(file_url_policy);
     let worker_timeout = Duration::from_secs(timeout_secs);
     let read_timeout = Duration::from_secs(timeout_secs.min(30));
     let shutdown_timeout = Duration::from_secs(5);
@@ -442,12 +549,15 @@ async fn run_parallel_scrape(
         let sem = semaphore.clone();
         let eval = eval.clone();
         let worker_path = worker_path.clone();
+        let file_url_policy = file_url_policy.clone();
 
         let handle = tokio::spawn(async move {
             let _permit = sem.acquire().await.unwrap();
             let task_start = Instant::now();
 
-            let mut child = match TokioCommand::new(worker_path.as_ref())
+            let mut worker_cmd = TokioCommand::new(worker_path.as_ref());
+            add_file_policy_env(&mut worker_cmd, &file_url_policy);
+            let mut child = match worker_cmd
                 .stdin(std::process::Stdio::piped())
                 .stdout(std::process::Stdio::piped())
                 .stderr(std::process::Stdio::null())

--- a/crates/obscura-cli/src/worker.rs
+++ b/crates/obscura-cli/src/worker.rs
@@ -2,6 +2,7 @@
 use std::sync::Arc;
 
 use obscura_browser::{BrowserContext, Page};
+use obscura_net::FileUrlPolicy;
 use serde::{Deserialize, Serialize};
 use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
 
@@ -47,7 +48,10 @@ async fn main() {
         .with_writer(std::io::stderr)
         .init();
 
-    let context = Arc::new(BrowserContext::new("worker".to_string()));
+    let context = Arc::new(BrowserContext::new_with_file_url_policy(
+        "worker".to_string(),
+        file_url_policy_from_env(),
+    ));
     let mut page = Page::new("page-1".to_string(), context);
 
     let stdin = tokio::io::stdin();
@@ -134,5 +138,34 @@ async fn main() {
         out.push('\n');
         let _ = stdout.write_all(out.as_bytes()).await;
         let _ = stdout.flush().await;
+    }
+}
+
+fn file_url_policy_from_env() -> FileUrlPolicy {
+    const ALLOW_ALL_ENV: &str = "OBSCURA_ALLOW_ALL_FILE_URLS";
+    const ROOTS_ENV: &str = "OBSCURA_FILE_ACCESS_ROOTS_JSON";
+
+    if std::env::var(ALLOW_ALL_ENV).ok().as_deref() == Some("1") {
+        return FileUrlPolicy::AllowAll;
+    }
+
+    let Ok(roots_json) = std::env::var(ROOTS_ENV) else {
+        return FileUrlPolicy::Deny;
+    };
+
+    let roots = match serde_json::from_str::<Vec<String>>(&roots_json) {
+        Ok(roots) => roots,
+        Err(e) => {
+            eprintln!("Invalid {}: {}", ROOTS_ENV, e);
+            return FileUrlPolicy::Deny;
+        }
+    };
+
+    match FileUrlPolicy::allow_roots(roots.iter()) {
+        Ok(policy) => policy,
+        Err(e) => {
+            eprintln!("Invalid file access roots: {}", e);
+            FileUrlPolicy::Deny
+        }
     }
 }

--- a/crates/obscura-js/src/ops.rs
+++ b/crates/obscura-js/src/ops.rs
@@ -551,15 +551,11 @@ fn glob_match(pattern: &str, url: &str) -> bool {
 
 fn validate_fetch_url(url: &url::Url) -> Result<(), String> {
     let scheme = url.scheme();
-    if scheme != "http" && scheme != "https" && scheme != "file" {
+    if scheme != "http" && scheme != "https" {
         return Err(format!(
-            "Forbidden URL scheme '{}' - only http, https, and file are allowed",
+            "Forbidden URL scheme '{}' - only http and https are allowed",
             scheme
         ));
-    }
-
-    if scheme == "file" {
-        return Ok(());
     }
 
     if let Some(host) = url.host() {

--- a/crates/obscura-net/src/client.rs
+++ b/crates/obscura-net/src/client.rs
@@ -1,5 +1,5 @@
 use std::collections::HashMap;
-use std::net::IpAddr;
+use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -64,6 +64,64 @@ pub enum ResourceType {
 pub type RequestCallback = Arc<dyn Fn(&RequestInfo) + Send + Sync>;
 pub type ResponseCallback = Arc<dyn Fn(&RequestInfo, &Response) + Send + Sync>;
 
+#[derive(Debug, Clone, Default)]
+pub enum FileUrlPolicy {
+    #[default]
+    Deny,
+    AllowAll,
+    AllowRoots(Vec<PathBuf>),
+}
+
+impl FileUrlPolicy {
+    pub fn allow_roots<I, P>(roots: I) -> Result<Self, ObscuraNetError>
+    where
+        I: IntoIterator<Item = P>,
+        P: AsRef<Path>,
+    {
+        let mut canonical_roots = Vec::new();
+        for root in roots {
+            let root = root.as_ref();
+            let canonical = std::fs::canonicalize(root).map_err(|e| {
+                ObscuraNetError::Network(format!(
+                    "Invalid file access root '{}': {}",
+                    root.display(),
+                    e
+                ))
+            })?;
+            canonical_roots.push(canonical);
+        }
+
+        if canonical_roots.is_empty() {
+            Ok(Self::Deny)
+        } else {
+            Ok(Self::AllowRoots(canonical_roots))
+        }
+    }
+
+    async fn authorize(&self, path: &Path) -> Result<PathBuf, ObscuraNetError> {
+        match self {
+            Self::Deny => Err(ObscuraNetError::Network(
+                "file:// URLs are disabled. Use --allow-file-access <DIR> to allow a sandboxed directory, or --allow-all-file-urls for legacy behavior.".to_string(),
+            )),
+            Self::AllowAll => Ok(path.to_path_buf()),
+            Self::AllowRoots(roots) => {
+                let canonical_path = tokio::fs::canonicalize(path).await.map_err(|e| {
+                    ObscuraNetError::Network(format!("Failed to resolve file path: {}", e))
+                })?;
+
+                if roots.iter().any(|root| canonical_path.starts_with(root)) {
+                    Ok(canonical_path)
+                } else {
+                    Err(ObscuraNetError::Network(format!(
+                        "file:// path '{}' is outside the allowed file access roots",
+                        canonical_path.display()
+                    )))
+                }
+            }
+        }
+    }
+}
+
 fn validate_url(url: &Url) -> Result<(), ObscuraNetError> {
     let scheme = url.scheme();
     if scheme != "http" && scheme != "https" && scheme != "file" {
@@ -74,6 +132,11 @@ fn validate_url(url: &Url) -> Result<(), ObscuraNetError> {
     }
 
     if scheme == "file" {
+        if url.host_str().is_some() {
+            return Err(ObscuraNetError::Network(
+                "file:// URLs with hosts are not supported".to_string(),
+            ));
+        }
         return Ok(());
     }
 
@@ -119,10 +182,11 @@ fn validate_url(url: &Url) -> Result<(), ObscuraNetError> {
     Ok(())
 }
 
-async fn fetch_file_url(url: &Url) -> Result<Response, ObscuraNetError> {
+async fn fetch_file_url(url: &Url, policy: &FileUrlPolicy) -> Result<Response, ObscuraNetError> {
     let path = url
         .to_file_path()
         .map_err(|_| ObscuraNetError::Network("Invalid file URL".to_string()))?;
+    let path = policy.authorize(&path).await?;
     let body = tokio::fs::read(&path)
         .await
         .map_err(|e| ObscuraNetError::Network(format!("Failed to read file: {}", e)))?;
@@ -166,6 +230,7 @@ pub struct ObscuraHttpClient {
     pub timeout: Duration,
     pub in_flight: Arc<std::sync::atomic::AtomicU32>,
     pub block_trackers: bool,
+    pub file_url_policy: FileUrlPolicy,
 }
 
 impl ObscuraHttpClient {
@@ -178,6 +243,14 @@ impl ObscuraHttpClient {
     }
 
     pub fn with_options(cookie_jar: Arc<CookieJar>, proxy_url: Option<&str>) -> Self {
+        Self::with_options_and_file_url_policy(cookie_jar, proxy_url, FileUrlPolicy::Deny)
+    }
+
+    pub fn with_options_and_file_url_policy(
+        cookie_jar: Arc<CookieJar>,
+        proxy_url: Option<&str>,
+        file_url_policy: FileUrlPolicy,
+    ) -> Self {
         ObscuraHttpClient {
             client: tokio::sync::OnceCell::new(),
             proxy_url: proxy_url.map(|s| s.to_string()),
@@ -192,6 +265,7 @@ impl ObscuraHttpClient {
             in_flight: Arc::new(std::sync::atomic::AtomicU32::new(0)),
             timeout: Duration::from_secs(30),
             block_trackers: false,
+            file_url_policy,
         }
     }
 
@@ -230,7 +304,7 @@ impl ObscuraHttpClient {
         validate_url(url)?;
 
         if url.scheme() == "file" {
-            return fetch_file_url(url).await;
+            return fetch_file_url(url, &self.file_url_policy).await;
         }
 
         let mut method = initial_method;
@@ -255,6 +329,12 @@ impl ObscuraHttpClient {
         let max_redirects = 20;
 
         for _redirect_count in 0..max_redirects {
+            if current_url.scheme() == "file" {
+                let mut response = fetch_file_url(&current_url, &self.file_url_policy).await?;
+                response.redirected_from = redirects;
+                return Ok(response);
+            }
+
             let request_info = RequestInfo {
                 url: current_url.clone(),
                 method: method.to_string(),
@@ -455,4 +535,142 @@ pub enum ObscuraNetError {
 
     #[error("Request blocked: {0}")]
     Blocked(String),
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn test_dir() -> PathBuf {
+        let nanos = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        std::env::temp_dir().join(format!(
+            "obscura-file-policy-{}-{}",
+            std::process::id(),
+            nanos
+        ))
+    }
+
+    fn client_for_root(root: &Path) -> ObscuraHttpClient {
+        ObscuraHttpClient::with_options_and_file_url_policy(
+            Arc::new(CookieJar::new()),
+            None,
+            FileUrlPolicy::allow_roots([root]).unwrap(),
+        )
+    }
+
+    fn error_text(result: Result<Response, ObscuraNetError>) -> String {
+        result.unwrap_err().to_string()
+    }
+
+    #[tokio::test]
+    async fn file_url_policy_denies_by_default() {
+        let root = test_dir();
+        std::fs::create_dir_all(&root).unwrap();
+        let path = root.join("secret.txt");
+        std::fs::write(&path, "secret").unwrap();
+
+        let url = Url::from_file_path(&path).unwrap();
+        let err = error_text(ObscuraHttpClient::new().fetch(&url).await);
+
+        assert!(err.contains("file:// URLs are disabled"));
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[tokio::test]
+    async fn file_url_policy_allows_canonical_root() {
+        let root = test_dir();
+        let allowed = root.join("allowed");
+        std::fs::create_dir_all(&allowed).unwrap();
+        let path = allowed.join("page.txt");
+        std::fs::write(&path, "inside").unwrap();
+
+        let url = Url::from_file_path(&path).unwrap();
+        let resp = client_for_root(&allowed).fetch(&url).await.unwrap();
+
+        assert_eq!(resp.body, b"inside");
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[tokio::test]
+    async fn file_url_policy_blocks_relative_traversal_outside_root() {
+        let root = test_dir();
+        let allowed = root.join("allowed");
+        let outside = root.join("outside");
+        std::fs::create_dir_all(&allowed).unwrap();
+        std::fs::create_dir_all(&outside).unwrap();
+        std::fs::write(outside.join("secret.txt"), "secret").unwrap();
+
+        let url = Url::from_file_path(allowed.join("../outside/secret.txt")).unwrap();
+        let err = error_text(client_for_root(&allowed).fetch(&url).await);
+
+        assert!(err.contains("outside the allowed file access roots"));
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[tokio::test]
+    async fn file_url_policy_blocks_percent_encoded_traversal_outside_root() {
+        let root = test_dir();
+        let allowed = root.join("allowed");
+        let outside = root.join("outside");
+        std::fs::create_dir_all(&allowed).unwrap();
+        std::fs::create_dir_all(&outside).unwrap();
+        std::fs::write(outside.join("secret.txt"), "secret").unwrap();
+
+        let base = Url::from_directory_path(&allowed).unwrap();
+        let url = Url::parse(&format!("{}%2e%2e/outside/secret.txt", base)).unwrap();
+        let err = error_text(client_for_root(&allowed).fetch(&url).await);
+
+        assert!(err.contains("outside the allowed file access roots"));
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[tokio::test]
+    async fn file_url_policy_allows_relative_paths_inside_root() {
+        let root = test_dir();
+        let allowed = root.join("allowed");
+        let nested = allowed.join("nested");
+        std::fs::create_dir_all(&nested).unwrap();
+        std::fs::write(allowed.join("style.css"), "body{}").unwrap();
+        let page = nested.join("page.html");
+        std::fs::write(&page, "<link rel=\"stylesheet\" href=\"../style.css\">").unwrap();
+
+        let base = Url::from_file_path(&page).unwrap();
+        let url = base.join("../style.css").unwrap();
+        let resp = client_for_root(&allowed).fetch(&url).await.unwrap();
+
+        assert_eq!(resp.body, b"body{}");
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[tokio::test]
+    async fn file_url_policy_rejects_file_urls_with_hosts() {
+        let root = test_dir();
+        std::fs::create_dir_all(&root).unwrap();
+        let url = Url::parse("file://example.com/etc/passwd").unwrap();
+        let err = error_text(client_for_root(&root).fetch(&url).await);
+
+        assert!(err.contains("file:// URLs with hosts are not supported"));
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn file_url_policy_blocks_symlink_escape_outside_root() {
+        let root = test_dir();
+        let allowed = root.join("allowed");
+        let outside = root.join("outside");
+        std::fs::create_dir_all(&allowed).unwrap();
+        std::fs::create_dir_all(&outside).unwrap();
+        std::fs::write(outside.join("secret.txt"), "secret").unwrap();
+        std::os::unix::fs::symlink(&outside, allowed.join("link")).unwrap();
+
+        let url = Url::from_file_path(allowed.join("link/secret.txt")).unwrap();
+        let err = error_text(client_for_root(&allowed).fetch(&url).await);
+
+        assert!(err.contains("outside the allowed file access roots"));
+        let _ = std::fs::remove_dir_all(root);
+    }
 }

--- a/crates/obscura-net/src/lib.rs
+++ b/crates/obscura-net/src/lib.rs
@@ -6,7 +6,9 @@ pub mod blocklist;
 #[cfg(feature = "stealth")]
 pub mod wreq_client;
 
-pub use client::{ObscuraHttpClient, ObscuraNetError, RequestInfo, ResourceType, Response};
+pub use client::{
+    FileUrlPolicy, ObscuraHttpClient, ObscuraNetError, RequestInfo, ResourceType, Response,
+};
 pub use cookies::{CookieInfo, CookieJar};
 pub use robots::RobotsCache;
 pub use blocklist::is_blocked as is_tracker_blocked;

--- a/docs/container.md
+++ b/docs/container.md
@@ -1,0 +1,152 @@
+# Running Obscura In A Container
+
+Running Obscura in a container is the recommended way to browse untrusted pages. Obscura only needs outbound network access and a CDP port. `file://` URLs are denied by default. If you explicitly allow them, and you do not mount host directories, they can only read files inside the container image and its writable runtime filesystem.
+
+## Why File Access Is Restricted
+
+Obscura fetches page subresources itself. A malicious page could otherwise reference local files with `file://` URLs, for example from a stylesheet or script tag, and then expose the loaded bytes back to page JavaScript. The default-deny policy removes that exfiltration path for normal web browsing.
+
+Use the file access options only for workflows that intentionally browse local fixtures:
+
+| Option | Use |
+|--------|-----|
+| `--allow-file-access <DIR>` | Allow `file://` reads under one canonicalized directory. Repeat it for multiple fixture roots. Relative path segments, percent-encoded traversal, and symlink escapes are resolved before the root check. |
+| `--allow-all-file-urls` | Restore unrestricted legacy `file://` reads. Use only in disposable containers or other isolated environments. |
+
+JavaScript `fetch()` remains limited to `http` and `https` even when browser-engine `file://` access is explicitly allowed.
+
+## Install Rust On Artix Linux
+
+You do not need host Rust to build the container image, because the `Containerfile` uses a Rust builder image. Install Rust locally only if you want to run `cargo build` or `cargo test` outside the container.
+
+Using Artix packages:
+
+```bash
+sudo pacman -Syu base-devel rust cargo clang cmake pkgconf
+rustc --version
+cargo --version
+```
+
+Using rustup:
+
+```bash
+sudo pacman -Syu base-devel curl ca-certificates clang cmake pkgconf
+curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
+. "$HOME/.cargo/env"
+rustup default stable
+rustc --version
+cargo --version
+```
+
+## Build From Source
+
+```bash
+cargo build --release --bin obscura --bin obscura-worker
+./target/release/obscura serve --host 127.0.0.1 --port 9222
+```
+
+Use `--host 0.0.0.0` only when Obscura is already isolated, such as inside a container, VM, or locked-down network namespace.
+
+## Build The Container Image
+
+With Podman:
+
+```bash
+podman build -t obscura:dev -f Containerfile .
+```
+
+With Docker:
+
+```bash
+docker build -t obscura:dev -f Containerfile .
+```
+
+## Run The CDP Server With Podman
+
+This starts Obscura inside the container, publishes the CDP port only on host loopback, drops Linux capabilities, and makes the container root filesystem read-only.
+
+```bash
+podman run --rm \
+  --name obscura \
+  --read-only \
+  --tmpfs /tmp:rw,nosuid,nodev,noexec,size=64m \
+  --cap-drop=all \
+  --security-opt=no-new-privileges \
+  --pids-limit=256 \
+  --memory=512m \
+  -p 127.0.0.1:9222:9222 \
+  obscura:dev
+```
+
+## Run The CDP Server With Docker
+
+```bash
+docker run --rm \
+  --name obscura \
+  --read-only \
+  --tmpfs /tmp:rw,nosuid,nodev,noexec,size=64m \
+  --cap-drop=ALL \
+  --security-opt=no-new-privileges \
+  --pids-limit=256 \
+  --memory=512m \
+  -p 127.0.0.1:9222:9222 \
+  obscura:dev
+```
+
+Check the server:
+
+```bash
+curl http://127.0.0.1:9222/json/version
+```
+
+Connect Playwright from the host:
+
+```javascript
+import { chromium } from 'playwright-core';
+
+const browser = await chromium.connectOverCDP('http://127.0.0.1:9222');
+const page = await browser.newPage();
+await page.goto('https://example.com');
+console.log(await page.title());
+await browser.close();
+```
+
+## File Access Model
+
+By default, Obscura rejects `file://` URLs. This applies to page navigation and subresources loaded by the browser engine.
+
+If a workflow needs local fixtures, allow only the smallest directory:
+
+```bash
+obscura fetch \
+  --allow-file-access "$PWD/fixtures" \
+  "file://$PWD/fixtures/page.html"
+```
+
+Do not add volume mounts unless the pages you browse need them. With no `-v` or `--mount`, even explicitly allowed `file://` reads are limited to the container filesystem. If you need to mount local test fixtures, mount the smallest possible directory read-only and allow that container path:
+
+```bash
+podman run --rm \
+  --read-only \
+  --tmpfs /tmp:rw,nosuid,nodev,noexec,size=64m \
+  --cap-drop=all \
+  --security-opt=no-new-privileges \
+  -p 127.0.0.1:9222:9222 \
+  -v "$PWD/fixtures:/fixtures:ro,Z" \
+  obscura:dev \
+  serve --host 0.0.0.0 --port 9222 --allow-file-access /fixtures
+```
+
+The equivalent Docker command is:
+
+```bash
+docker run --rm \
+  --read-only \
+  --tmpfs /tmp:rw,nosuid,nodev,noexec,size=64m \
+  --cap-drop=ALL \
+  --security-opt=no-new-privileges \
+  -p 127.0.0.1:9222:9222 \
+  -v "$PWD/fixtures:/fixtures:ro" \
+  obscura:dev \
+  serve --host 0.0.0.0 --port 9222 --allow-file-access /fixtures
+```


### PR DESCRIPTION
This adds container support for running Obscura under Podman or Docker, including a Containerfile, ignore files, and documentation for hardened container usage.

It also tightens file:// handling to reduce local file exfiltration risk from untrusted pages. file:// URLs are now denied by default, with explicit opt-ins via --allow-file-access <DIR> for canonicalized allowlisted roots or --allow-all-file-urls for legacy behavior. JavaScript fetch() remains limited to http and https.

Tested with:

- podman build -t obscura:host-option -f Containerfile .
- cargo test -p obscura-net file_url_policy -- --nocapture
- Container smoke tests for CDP startup and default-deny/allowlisted file:// behavior.
