### PR TITLE
Allow trusted localhost targets

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,9 @@ obscura fetch https://example.com --wait-until networkidle0
 
 # Bound navigation time for slow or broken pages
 obscura fetch https://example.com --timeout 10
+
+# Trusted local development targets
+obscura fetch http://localhost:3000/app/ --allow-private-network --dump text
 ```
 
 ### Start the CDP server
@@ -99,6 +102,9 @@ obscura serve --port 9222
 
 # With stealth mode (anti-detection + tracker blocking)
 obscura serve --port 9222 --stealth
+
+# Allow CDP clients to load localhost/private network URLs
+obscura serve --port 9222 --allow-private-network
 ```
 
 ### Scrape in parallel
@@ -108,6 +114,17 @@ obscura scrape url1 url2 url3 ... \
   --concurrency 25 \
   --eval "document.querySelector('h1').textContent" \
   --format json
+```
+
+### Localhost and private networks
+
+Obscura blocks localhost and private network targets by default as an SSRF guard.
+For trusted local development, pass `--allow-private-network` or set
+`OBSCURA_ALLOW_PRIVATE_NETWORK=1`.
+
+```bash
+OBSCURA_ALLOW_PRIVATE_NETWORK=1 obscura serve --port 9222
+obscura fetch http://localhost:3000/app/settings --allow-private-network --dump text
 ```
 
 ## Puppeteer / Playwright
@@ -225,6 +242,7 @@ Start a CDP WebSocket server.
 | `--stealth` | off | Enable anti-detection + tracker blocking |
 | `--workers` | `1` | Number of parallel worker processes |
 | `--obey-robots` | off | Respect robots.txt |
+| `--allow-private-network` | off | Allow localhost/private network targets for trusted local development |
 
 ### `obscura fetch <URL>`
 
@@ -239,6 +257,7 @@ Fetch and render a single page.
 | `--selector` | — | Wait for CSS selector |
 | `--stealth` | off | Anti-detection mode |
 | `--quiet` | off | Suppress banner |
+| `--allow-private-network` | off | Allow localhost/private network targets for trusted local development |
 
 ### `obscura scrape <URL...>`
 
@@ -249,6 +268,7 @@ Scrape multiple URLs in parallel with worker processes.
 | `--concurrency` | `10` | Parallel workers |
 | `--eval` | — | JS expression per page |
 | `--format` | `json` | Output: `json` or `text` |
+| `--allow-private-network` | off | Allow localhost/private network targets for trusted local development |
 
 ## License
 

--- a/crates/obscura-browser/src/context.rs
+++ b/crates/obscura-browser/src/context.rs
@@ -11,12 +11,15 @@ pub struct BrowserContext {
     pub robots_cache: Arc<RobotsCache>,
     pub obey_robots: bool,
     pub stealth: bool,
+    pub allow_private_network: bool,
 }
 
 impl BrowserContext {
     pub fn new(id: String) -> Self {
         let cookie_jar = Arc::new(CookieJar::new());
-        let http_client = Arc::new(ObscuraHttpClient::with_cookie_jar(cookie_jar.clone()));
+        let client = ObscuraHttpClient::with_cookie_jar(cookie_jar.clone());
+        let allow_private_network = client.allow_private_network;
+        let http_client = Arc::new(client);
         BrowserContext {
             id,
             cookie_jar,
@@ -26,6 +29,7 @@ impl BrowserContext {
             robots_cache: Arc::new(RobotsCache::new()),
             obey_robots: false,
             stealth: false,
+            allow_private_network,
         }
     }
 
@@ -39,11 +43,28 @@ impl BrowserContext {
         stealth: bool,
         user_agent: Option<String>,
     ) -> Self {
+        Self::with_runtime_options(
+            id,
+            proxy_url,
+            stealth,
+            obscura_net::env_allows_private_network(),
+            user_agent,
+        )
+    }
+
+    pub fn with_runtime_options(
+        id: String,
+        proxy_url: Option<String>,
+        stealth: bool,
+        allow_private_network: bool,
+        user_agent: Option<String>,
+    ) -> Self {
         let cookie_jar = Arc::new(CookieJar::new());
         let mut client = ObscuraHttpClient::with_options(
             cookie_jar.clone(),
             proxy_url.as_deref(),
         );
+        client.set_allow_private_network(allow_private_network);
         if stealth {
             client.block_trackers = true;
         }
@@ -66,6 +87,7 @@ impl BrowserContext {
             robots_cache: Arc::new(RobotsCache::new()),
             obey_robots: false,
             stealth,
+            allow_private_network,
         }
     }
 

--- a/crates/obscura-browser/src/page.rs
+++ b/crates/obscura-browser/src/page.rs
@@ -54,7 +54,11 @@ impl Page {
         let frame_id = id.clone();
         #[cfg(feature = "stealth")]
         let stealth_client = if context.stealth {
-            Some(Arc::new(StealthHttpClient::new(context.cookie_jar.clone())))
+            Some(Arc::new(StealthHttpClient::with_options(
+                context.cookie_jar.clone(),
+                context.proxy_url.as_deref(),
+                context.allow_private_network,
+            )))
         } else {
             None
         };

--- a/crates/obscura-cdp/src/dispatch.rs
+++ b/crates/obscura-cdp/src/dispatch.rs
@@ -47,10 +47,25 @@ impl CdpContext {
         stealth: bool,
         user_agent: Option<String>,
     ) -> Self {
-        let default_context = Arc::new(BrowserContext::with_full_options(
+        Self::new_with_runtime_options(
+            proxy,
+            stealth,
+            obscura_net::env_allows_private_network(),
+            user_agent,
+        )
+    }
+
+    pub fn new_with_runtime_options(
+        proxy: Option<String>,
+        stealth: bool,
+        allow_private_network: bool,
+        user_agent: Option<String>,
+    ) -> Self {
+        let default_context = Arc::new(BrowserContext::with_runtime_options(
             "default".to_string(),
             proxy,
             stealth,
+            allow_private_network,
             user_agent,
         ));
         CdpContext {

--- a/crates/obscura-cdp/src/lib.rs
+++ b/crates/obscura-cdp/src/lib.rs
@@ -3,4 +3,4 @@ pub mod dispatch;
 pub mod types;
 pub mod domains;
 
-pub use server::{start, start_with_full_options, start_with_options};
+pub use server::{start, start_with_full_options, start_with_options, start_with_runtime_options};

--- a/crates/obscura-cdp/src/server.rs
+++ b/crates/obscura-cdp/src/server.rs
@@ -41,6 +41,23 @@ pub async fn start_with_full_options(
     stealth: bool,
     user_agent: Option<String>,
 ) -> anyhow::Result<()> {
+    start_with_runtime_options(
+        port,
+        proxy,
+        stealth,
+        obscura_net::env_allows_private_network(),
+        user_agent,
+    )
+    .await
+}
+
+pub async fn start_with_runtime_options(
+    port: u16,
+    proxy: Option<String>,
+    stealth: bool,
+    allow_private_network: bool,
+    user_agent: Option<String>,
+) -> anyhow::Result<()> {
     let addr = SocketAddr::from(([127, 0, 0, 1], port));
     let listener = TcpListener::bind(&addr).await?;
 
@@ -55,7 +72,13 @@ pub async fn start_with_full_options(
         .run_until(async {
             let (msg_tx, msg_rx) = mpsc::unbounded_channel::<ServerMessage>();
 
-            let processor_handle = tokio::task::spawn_local(cdp_processor(msg_rx, proxy, stealth, user_agent));
+            let processor_handle = tokio::task::spawn_local(cdp_processor(
+                msg_rx,
+                proxy,
+                stealth,
+                allow_private_network,
+                user_agent,
+            ));
 
             loop {
                 match listener.accept().await {
@@ -81,9 +104,10 @@ async fn cdp_processor(
     mut rx: mpsc::UnboundedReceiver<ServerMessage>,
     proxy: Option<String>,
     stealth: bool,
+    allow_private_network: bool,
     user_agent: Option<String>,
 ) {
-    let mut ctx = CdpContext::new_with_full_options(proxy, stealth, user_agent);
+    let mut ctx = CdpContext::new_with_runtime_options(proxy, stealth, allow_private_network, user_agent);
     let (itx, irx) = mpsc::unbounded_channel::<obscura_js::ops::InterceptedRequest>();
     ctx.intercept_tx = Some(itx);
     let mut intercept_rx: Option<mpsc::UnboundedReceiver<obscura_js::ops::InterceptedRequest>> = Some(irx);

--- a/crates/obscura-cli/src/main.rs
+++ b/crates/obscura-cli/src/main.rs
@@ -13,6 +13,13 @@ struct Args {
     #[arg(short, long, global = true)]
     verbose: bool,
 
+    #[arg(
+        long,
+        global = true,
+        help = "Allow localhost/private network targets for trusted local development"
+    )]
+    allow_private_network: bool,
+
     #[command(subcommand)]
     command: Option<Command>,
 
@@ -122,6 +129,7 @@ fn print_banner(port: u16) {
 #[tokio::main(flavor = "current_thread")]
 async fn main() -> anyhow::Result<()> {
     let args = Args::parse();
+    let allow_private_network = args.allow_private_network;
 
     let filter = if args.verbose { "debug" } else { "warn" };
     tracing_subscriber::fmt()
@@ -152,23 +160,23 @@ async fn main() -> anyhow::Result<()> {
 
             if workers > 1 {
                 tracing::info!("{} worker processes", workers);
-                run_multi_worker_serve(port, workers, proxy, stealth, user_agent).await?;
+                run_multi_worker_serve(port, workers, proxy, stealth, user_agent, allow_private_network).await?;
             } else {
-                obscura_cdp::start_with_full_options(port, proxy, stealth, user_agent).await?;
+                obscura_cdp::start_with_runtime_options(port, proxy, stealth, allow_private_network, user_agent).await?;
             }
         }
         Some(Command::Fetch { url, dump, selector, wait, timeout, wait_until, user_agent, stealth, eval, quiet }) => {
-            run_fetch(&url, dump, selector, wait, timeout, &wait_until, user_agent, stealth, eval, quiet).await?;
+            run_fetch(&url, dump, selector, wait, timeout, &wait_until, user_agent, stealth, eval, quiet, allow_private_network).await?;
         }
         Some(Command::Scrape { urls, eval, concurrency, format, timeout }) => {
-            run_parallel_scrape(urls, eval, concurrency.get(), &format, timeout).await?;
+            run_parallel_scrape(urls, eval, concurrency.get(), &format, timeout, allow_private_network).await?;
         }
         None => {
             print_banner(args.port);
             if let Some(ref proxy) = args.proxy {
                 tracing::info!("Using proxy: {}", proxy);
             }
-            obscura_cdp::start_with_options(args.port, args.proxy, false).await?;
+            obscura_cdp::start_with_runtime_options(args.port, args.proxy, false, allow_private_network, args.user_agent).await?;
         }
     }
 
@@ -181,6 +189,7 @@ async fn run_multi_worker_serve(
     proxy: Option<String>,
     stealth: bool,
     user_agent: Option<String>,
+    allow_private_network: bool,
 ) -> anyhow::Result<()> {
     use tokio::net::TcpListener;
     use tokio::io::AsyncWriteExt as _;
@@ -200,6 +209,9 @@ async fn run_multi_worker_serve(
         }
         if stealth {
             cmd.arg("--stealth");
+        }
+        if allow_private_network {
+            cmd.arg("--allow-private-network");
         }
         cmd.stdout(std::process::Stdio::null());
         cmd.stderr(std::process::Stdio::null());
@@ -313,8 +325,15 @@ async fn run_fetch(
     stealth: bool,
     eval: Option<String>,
     quiet: bool,
+    allow_private_network: bool,
 ) -> anyhow::Result<()> {
-    let context = Arc::new(BrowserContext::with_options("fetch".to_string(), None, stealth));
+    let context = Arc::new(BrowserContext::with_runtime_options(
+        "fetch".to_string(),
+        None,
+        stealth,
+        allow_private_network,
+        user_agent.clone(),
+    ));
     let mut page = Page::new("fetch-page".to_string(), context);
 
     if let Some(ref ua) = user_agent {
@@ -474,6 +493,7 @@ async fn run_parallel_scrape(
     concurrency: usize,
     format: &str,
     timeout_secs: u64,
+    allow_private_network: bool,
 ) -> anyhow::Result<()> {
     let total = urls.len();
     let start = Instant::now();
@@ -517,12 +537,16 @@ async fn run_parallel_scrape(
             let _permit = sem.acquire().await.unwrap();
             let task_start = Instant::now();
 
-            let mut child = match TokioCommand::new(worker_path.as_ref())
+            let mut command = TokioCommand::new(worker_path.as_ref());
+            command
                 .stdin(std::process::Stdio::piped())
                 .stdout(std::process::Stdio::piped())
-                .stderr(std::process::Stdio::null())
-                .spawn()
-            {
+                .stderr(std::process::Stdio::null());
+            if allow_private_network {
+                command.env("OBSCURA_ALLOW_PRIVATE_NETWORK", "1");
+            }
+
+            let mut child = match command.spawn() {
                 Ok(c) => c,
                 Err(e) => {
                     return serde_json::json!({

--- a/crates/obscura-js/src/ops.rs
+++ b/crates/obscura-js/src/ops.rs
@@ -304,8 +304,18 @@ async fn op_fetch_url(
 ) -> Result<String, deno_error::JsErrorBox> {
     tracing::debug!("op_fetch_url called: {} {} (intercept check pending)", method, url);
 
+    let allow_private_network = {
+        let state_borrow = state.borrow();
+        let gs = state_borrow.borrow::<SharedState>().clone();
+        let gs = gs.borrow();
+        gs.http_client
+            .as_ref()
+            .map(|client| client.allow_private_network)
+            .unwrap_or_else(obscura_net::env_allows_private_network)
+    };
+
     if let Ok(parsed_url) = url::Url::parse(&url) {
-        if let Err(e) = validate_fetch_url(&parsed_url) {
+        if let Err(e) = validate_fetch_url(&parsed_url, allow_private_network) {
             return Ok(serde_json::json!({
                 "status": 0,
                 "body": "",
@@ -558,7 +568,7 @@ fn glob_match(pattern: &str, url: &str) -> bool {
     url == pattern
 }
 
-fn validate_fetch_url(url: &url::Url) -> Result<(), String> {
+fn validate_fetch_url(url: &url::Url, allow_private_network: bool) -> Result<(), String> {
     let scheme = url.scheme();
     if scheme != "http" && scheme != "https" && scheme != "file" {
         return Err(format!(
@@ -568,6 +578,10 @@ fn validate_fetch_url(url: &url::Url) -> Result<(), String> {
     }
 
     if scheme == "file" {
+        return Ok(());
+    }
+
+    if allow_private_network {
         return Ok(());
     }
 

--- a/crates/obscura-net/src/client.rs
+++ b/crates/obscura-net/src/client.rs
@@ -63,7 +63,17 @@ pub enum ResourceType {
 pub type RequestCallback = Arc<dyn Fn(&RequestInfo) + Send + Sync>;
 pub type ResponseCallback = Arc<dyn Fn(&RequestInfo, &Response) + Send + Sync>;
 
-fn validate_url(url: &Url) -> Result<(), ObscuraNetError> {
+pub fn env_allows_private_network() -> bool {
+    matches!(
+        std::env::var("OBSCURA_ALLOW_PRIVATE_NETWORK").as_deref(),
+        Ok("1") | Ok("true") | Ok("TRUE") | Ok("yes") | Ok("YES") | Ok("on") | Ok("ON")
+    )
+}
+
+pub(crate) fn validate_url(
+    url: &Url,
+    allow_private_network: bool,
+) -> Result<(), ObscuraNetError> {
     let scheme = url.scheme();
     if scheme != "http" && scheme != "https" && scheme != "file" {
         return Err(ObscuraNetError::Network(format!(
@@ -73,6 +83,10 @@ fn validate_url(url: &Url) -> Result<(), ObscuraNetError> {
     }
 
     if scheme == "file" {
+        return Ok(());
+    }
+
+    if allow_private_network {
         return Ok(());
     }
 
@@ -165,6 +179,7 @@ pub struct ObscuraHttpClient {
     pub timeout: Duration,
     pub in_flight: Arc<std::sync::atomic::AtomicU32>,
     pub block_trackers: bool,
+    pub allow_private_network: bool,
 }
 
 impl ObscuraHttpClient {
@@ -191,7 +206,12 @@ impl ObscuraHttpClient {
             in_flight: Arc::new(std::sync::atomic::AtomicU32::new(0)),
             timeout: Duration::from_secs(30),
             block_trackers: false,
+            allow_private_network: env_allows_private_network(),
         }
+    }
+
+    pub fn set_allow_private_network(&mut self, allow_private_network: bool) {
+        self.allow_private_network = allow_private_network;
     }
 
     async fn get_client(&self) -> &Client {
@@ -226,7 +246,7 @@ impl ObscuraHttpClient {
         url: &Url,
         initial_body: Option<Vec<u8>>,
     ) -> Result<Response, ObscuraNetError> {
-        validate_url(url)?;
+        validate_url(url, self.allow_private_network)?;
 
         if url.scheme() == "file" {
             return fetch_file_url(url).await;
@@ -385,7 +405,7 @@ impl ObscuraHttpClient {
                     let next_url = current_url.join(location_str).map_err(|e| {
                         ObscuraNetError::Network(format!("Invalid redirect URL: {}", e))
                     })?;
-                    validate_url(&next_url)?;
+                    validate_url(&next_url, self.allow_private_network)?;
                     redirects.push(current_url.clone());
                     current_url = next_url;
                     if status == reqwest::StatusCode::MOVED_PERMANENTLY

--- a/crates/obscura-net/src/lib.rs
+++ b/crates/obscura-net/src/lib.rs
@@ -6,7 +6,7 @@ pub mod blocklist;
 #[cfg(feature = "stealth")]
 pub mod wreq_client;
 
-pub use client::{ObscuraHttpClient, ObscuraNetError, RequestInfo, ResourceType, Response};
+pub use client::{env_allows_private_network, ObscuraHttpClient, ObscuraNetError, RequestInfo, ResourceType, Response};
 pub use cookies::{CookieInfo, CookieJar};
 pub use robots::RobotsCache;
 pub use blocklist::is_blocked as is_tracker_blocked;

--- a/crates/obscura-net/src/wreq_client.rs
+++ b/crates/obscura-net/src/wreq_client.rs
@@ -15,7 +15,7 @@ use url::Url;
 #[cfg(feature = "stealth")]
 use crate::cookies::CookieJar;
 #[cfg(feature = "stealth")]
-use crate::client::{Response, ObscuraNetError};
+use crate::client::{env_allows_private_network, validate_url, ObscuraNetError, Response};
 
 #[cfg(feature = "stealth")]
 pub const STEALTH_USER_AGENT: &str =
@@ -27,6 +27,7 @@ pub struct StealthHttpClient {
     pub cookie_jar: Arc<CookieJar>,
     pub extra_headers: RwLock<HashMap<String, String>>,
     pub in_flight: Arc<std::sync::atomic::AtomicU32>,
+    pub allow_private_network: bool,
 }
 
 #[cfg(feature = "stealth")]
@@ -36,6 +37,14 @@ impl StealthHttpClient {
     }
 
     pub fn with_proxy(cookie_jar: Arc<CookieJar>, proxy_url: Option<&str>) -> Self {
+        Self::with_options(cookie_jar, proxy_url, env_allows_private_network())
+    }
+
+    pub fn with_options(
+        cookie_jar: Arc<CookieJar>,
+        proxy_url: Option<&str>,
+        allow_private_network: bool,
+    ) -> Self {
         let cert_store = wreq::tls::CertStore::builder()
             .set_default_paths()
             .build()
@@ -65,10 +74,13 @@ impl StealthHttpClient {
             cookie_jar,
             extra_headers: RwLock::new(HashMap::new()),
             in_flight: Arc::new(std::sync::atomic::AtomicU32::new(0)),
+            allow_private_network,
         }
     }
 
     pub async fn fetch(&self, url: &Url) -> Result<Response, ObscuraNetError> {
+        validate_url(url, self.allow_private_network)?;
+
         let mut current_url = url.clone();
         let mut redirects = Vec::new();
 
@@ -113,6 +125,7 @@ impl StealthHttpClient {
                     let next_url = current_url.join(location_str).map_err(|e| {
                         ObscuraNetError::Network(format!("Invalid redirect URL: {}", e))
                     })?;
+                    validate_url(&next_url, self.allow_private_network)?;
                     redirects.push(current_url.clone());
                     current_url = next_url;
                     continue;


### PR DESCRIPTION
## Summary
- add an explicit --allow-private-network CLI flag for trusted localhost/private network targets
- propagate the opt-in through BrowserContext, CDP, JS fetch, regular HTTP, stealth HTTP, and scrape workers
- document localhost usage and the OBSCURA_ALLOW_PRIVATE_NETWORK env var

## Validation
- cargo check -p obscura-cli --no-default-features
- target/debug/obscura fetch http://localhost:3000/app/ --allow-private-network --dump text --quiet
- confirmed localhost still fails without the flag

## Notes
- stealth feature check was blocked locally because cmake is not installed for boring-sys2