### PR TITLE
fix: enable request interception when Fetch.enable is called

### DIFF
--- a/crates/obscura-cdp/src/domains/fetch.rs
+++ b/crates/obscura-cdp/src/domains/fetch.rs
@@ -82,8 +82,8 @@ pub async fn handle(
             ctx.fetch_intercept.patterns = patterns.clone();
             let tx_clone = ctx.intercept_tx.clone();
             if let Some(page) = ctx.get_session_page_mut(session_id) {
-                page.intercept_enabled = false;
-                page.intercept_block_patterns.clear();
+                page.intercept_enabled = true;
+                page.intercept_block_patterns = patterns.clone();
                 if let Some(tx) = tx_clone {
                     page.set_intercept_tx(tx);
                 }


### PR DESCRIPTION
## Summary

Fixes #49 - `Fetch.enable` was incorrectly setting `page.intercept_enabled = false`, which prevented network request interception from working with Playwright/Puppeteer.

**Changes:**
- Set `page.intercept_enabled = true` (was `false`)
- Propagate URL patterns to `page.intercept_block_patterns` (was cleared)

## Root Cause

When `Fetch.enable` was called:
1. It set `page.intercept_enabled = false` instead of `true`
2. It cleared `page.intercept_block_patterns` instead of propagating the patterns
3. This caused `should_block_url()` to always return `false`
4. Network requests were never sent to the intercept channel
5. `Fetch.requestPaused` events were never triggered
6. Playwright's `page.route()` handlers never executed

## Test Plan

Before this fix:
```python
from playwright.sync_api import sync_playwright

with sync_playwright() as p:
    browser = p.chromium.connect_over_cdp("ws://127.0.0.1:9222/devtools/browser")
    page = browser.new_context().new_page()
    
    intercepted = []
    page.route("**/*", lambda route: (intercepted.append(route.request.url), route.continue_()))
    page.goto("https://httpbin.org/html")
    
    print(f"Intercepted: {len(intercepted)}")  # Was: 0
```

After this fix, `intercepted` should contain the intercepted request URLs.

## Impact

This fix enables:
- ✅ Request/response modification via `page.route()`
- ✅ Network mocking for testing
- ✅ Request blocking
- ✅ Custom headers injection
- ✅ Full Playwright/Puppeteer interception API compatibility

🤖 Generated with [Claude Code](https://claude.com/claude-code)