### PR TITLE
Persist cookies to JSON across runs (--cookie-store)

### DIFF
--- a/crates/obscura-browser/src/context.rs
+++ b/crates/obscura-browser/src/context.rs
@@ -30,7 +30,18 @@ impl BrowserContext {
     }
 
     pub fn with_options(id: String, proxy_url: Option<String>, stealth: bool) -> Self {
-        let cookie_jar = Arc::new(CookieJar::new());
+        Self::with_options_and_jar(id, proxy_url, stealth, Arc::new(CookieJar::new()))
+    }
+
+    /// Build a context using a caller-supplied cookie jar. Used to share a
+    /// pre-populated jar (e.g. loaded from disk) across the CDP server and
+    /// any shutdown hooks that need to persist it.
+    pub fn with_options_and_jar(
+        id: String,
+        proxy_url: Option<String>,
+        stealth: bool,
+        cookie_jar: Arc<CookieJar>,
+    ) -> Self {
         let mut client = ObscuraHttpClient::with_options(
             cookie_jar.clone(),
             proxy_url.as_deref(),

--- a/crates/obscura-cdp/src/dispatch.rs
+++ b/crates/obscura-cdp/src/dispatch.rs
@@ -3,6 +3,7 @@ use std::sync::Arc;
 
 use obscura_browser::{BrowserContext, Page};
 use obscura_js::ops::{InterceptResolution, InterceptedRequest};
+use obscura_net::CookieJar;
 use serde_json::json;
 
 use crate::domains;
@@ -39,10 +40,18 @@ impl CdpContext {
     }
 
     pub fn new_with_options(proxy: Option<String>, stealth: bool) -> Self {
-        let default_context = Arc::new(BrowserContext::with_options(
+        Self::new_with_jar(proxy, stealth, Arc::new(CookieJar::new()))
+    }
+
+    /// Build a context with a caller-supplied cookie jar so the server can
+    /// pre-load persisted cookies and keep a handle for graceful save on
+    /// shutdown.
+    pub fn new_with_jar(proxy: Option<String>, stealth: bool, cookie_jar: Arc<CookieJar>) -> Self {
+        let default_context = Arc::new(BrowserContext::with_options_and_jar(
             "default".to_string(),
             proxy,
             stealth,
+            cookie_jar,
         ));
         CdpContext {
             pages: Vec::new(),

--- a/crates/obscura-cdp/src/lib.rs
+++ b/crates/obscura-cdp/src/lib.rs
@@ -3,4 +3,4 @@ pub mod dispatch;
 pub mod types;
 pub mod domains;
 
-pub use server::{start, start_with_options};
+pub use server::{start, start_with_full_options, start_with_options};

--- a/crates/obscura-cdp/src/server.rs
+++ b/crates/obscura-cdp/src/server.rs
@@ -1,7 +1,10 @@
 use std::collections::HashMap;
 use std::net::SocketAddr;
+use std::path::PathBuf;
+use std::sync::Arc;
 
 use futures_util::{SinkExt, StreamExt};
+use obscura_net::CookieJar;
 use serde_json::json;
 use tokio::net::{TcpListener, TcpStream};
 use tokio::sync::mpsc;
@@ -32,6 +35,19 @@ pub async fn start_with_options(
     proxy: Option<String>,
     stealth: bool,
 ) -> anyhow::Result<()> {
+    start_with_full_options(port, proxy, stealth, None).await
+}
+
+/// Start the CDP server with all configurable options.
+///
+/// If `cookie_store` is `Some(path)`, cookies are loaded from that path on
+/// startup (missing file is fine) and saved back on Ctrl+C / SIGTERM.
+pub async fn start_with_full_options(
+    port: u16,
+    proxy: Option<String>,
+    stealth: bool,
+    cookie_store: Option<PathBuf>,
+) -> anyhow::Result<()> {
     let addr = SocketAddr::from(([127, 0, 0, 1], port));
     let listener = TcpListener::bind(&addr).await?;
 
@@ -41,39 +57,72 @@ pub async fn start_with_options(
         port
     );
 
+    let cookie_jar = Arc::new(CookieJar::new());
+    if let Some(ref path) = cookie_store {
+        match cookie_jar.load_from_path(path) {
+            Ok(0) => info!("Cookie store {} not present yet", path.display()),
+            Ok(n) => info!("Loaded {} cookies from {}", n, path.display()),
+            Err(e) => warn!("Failed to load cookie store {}: {}", path.display(), e),
+        }
+    }
+
     let local = tokio::task::LocalSet::new();
     local
         .run_until(async {
             let (msg_tx, msg_rx) = mpsc::unbounded_channel::<ServerMessage>();
 
-            let processor_handle = tokio::task::spawn_local(cdp_processor(msg_rx, proxy, stealth));
+            let _processor_handle = tokio::task::spawn_local(cdp_processor(
+                msg_rx,
+                proxy,
+                stealth,
+                cookie_jar.clone(),
+            ));
 
-            loop {
-                match listener.accept().await {
-                    Ok((stream, peer_addr)) => {
-                        info!("New connection from {}", peer_addr);
-                        let tx = msg_tx.clone();
-                        tokio::task::spawn_local(async move {
-                            if let Err(e) = handle_connection(stream, port, tx).await {
-                                if !format!("{}", e).contains("close") {
-                                    error!("Connection error from {}: {}", peer_addr, e);
+            let accept_loop = async {
+                loop {
+                    match listener.accept().await {
+                        Ok((stream, peer_addr)) => {
+                            info!("New connection from {}", peer_addr);
+                            let tx = msg_tx.clone();
+                            tokio::task::spawn_local(async move {
+                                if let Err(e) = handle_connection(stream, port, tx).await {
+                                    if !format!("{}", e).contains("close") {
+                                        error!("Connection error from {}: {}", peer_addr, e);
+                                    }
                                 }
-                            }
-                        });
+                            });
+                        }
+                        Err(e) => error!("Accept error: {}", e),
                     }
-                    Err(e) => error!("Accept error: {}", e),
+                }
+            };
+
+            tokio::select! {
+                _ = accept_loop => {}
+                _ = tokio::signal::ctrl_c() => {
+                    info!("Ctrl+C received, shutting down");
+                }
+            }
+
+            if let Some(ref path) = cookie_store {
+                match cookie_jar.save_to_path(path) {
+                    Ok(()) => info!("Saved cookies to {}", path.display()),
+                    Err(e) => error!("Failed to save cookie store {}: {}", path.display(), e),
                 }
             }
         })
-        .await
+        .await;
+
+    Ok(())
 }
 
 async fn cdp_processor(
     mut rx: mpsc::UnboundedReceiver<ServerMessage>,
     proxy: Option<String>,
     stealth: bool,
+    cookie_jar: Arc<CookieJar>,
 ) {
-    let mut ctx = CdpContext::new_with_options(proxy, stealth);
+    let mut ctx = CdpContext::new_with_jar(proxy, stealth, cookie_jar);
     let (itx, irx) = mpsc::unbounded_channel::<obscura_js::ops::InterceptedRequest>();
     ctx.intercept_tx = Some(itx);
     let mut intercept_rx: Option<mpsc::UnboundedReceiver<obscura_js::ops::InterceptedRequest>> = Some(irx);

--- a/crates/obscura-cli/src/main.rs
+++ b/crates/obscura-cli/src/main.rs
@@ -1,3 +1,4 @@
+use std::path::PathBuf;
 use std::sync::Arc;
 use std::time::Instant;
 
@@ -46,6 +47,11 @@ enum Command {
 
         #[arg(long, default_value_t = 1)]
         workers: u16,
+
+        /// Path to a JSON file used to persist cookies across runs. Loaded
+        /// on startup if present and saved on graceful shutdown (Ctrl+C).
+        #[arg(long, value_name = "PATH")]
+        cookie_store: Option<PathBuf>,
     },
 
     Fetch {
@@ -130,7 +136,7 @@ async fn main() -> anyhow::Result<()> {
         .init();
 
     match args.command {
-        Some(Command::Serve { port, proxy, user_agent, stealth, workers }) => {
+        Some(Command::Serve { port, proxy, user_agent, stealth, workers, cookie_store }) => {
             print_banner(port);
             if let Some(ref proxy) = proxy {
                 tracing::info!("Using proxy: {}", proxy);
@@ -146,12 +152,20 @@ async fn main() -> anyhow::Result<()> {
                 #[cfg(not(feature = "stealth"))]
                 tracing::info!("Stealth mode enabled (tracker blocking)");
             }
+            if let Some(ref path) = cookie_store {
+                tracing::info!("Cookie store: {}", path.display());
+            }
 
             if workers > 1 {
+                if cookie_store.is_some() {
+                    tracing::warn!(
+                        "--cookie-store is ignored when --workers > 1; each worker would race the file"
+                    );
+                }
                 tracing::info!("{} worker processes", workers);
                 run_multi_worker_serve(port, workers, proxy, stealth).await?;
             } else {
-                obscura_cdp::start_with_options(port, proxy, stealth).await?;
+                obscura_cdp::start_with_full_options(port, proxy, stealth, cookie_store).await?;
             }
         }
         Some(Command::Fetch { url, dump, selector, wait, wait_until, user_agent, stealth, eval, quiet }) => {

--- a/crates/obscura-net/src/cookies.rs
+++ b/crates/obscura-net/src/cookies.rs
@@ -1,4 +1,5 @@
 use std::collections::HashMap;
+use std::path::Path;
 use std::sync::RwLock;
 use url::Url;
 
@@ -6,7 +7,7 @@ pub struct CookieJar {
     cookies: RwLock<HashMap<String, HashMap<String, CookieEntry>>>,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 struct CookieEntry {
     name: String,
     value: String,
@@ -16,6 +17,14 @@ struct CookieEntry {
     http_only: bool,
     expires: Option<u64>,
     same_site: String,
+}
+
+const PERSIST_FORMAT_VERSION: u32 = 1;
+
+#[derive(serde::Serialize, serde::Deserialize)]
+struct PersistedJar {
+    version: u32,
+    cookies: Vec<CookieEntry>,
 }
 
 impl CookieJar {
@@ -338,6 +347,116 @@ impl CookieJar {
     pub fn clear(&self) {
         self.cookies.write().unwrap().clear();
     }
+
+    /// Serialize all non-expired cookies to a JSON file at `path`.
+    ///
+    /// Writes atomically: writes to `<path>.tmp`, then renames into place.
+    /// Expired cookies are dropped before write.
+    pub fn save_to_path(&self, path: &Path) -> std::io::Result<()> {
+        let now = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_secs();
+
+        let cookies = self.cookies.read().unwrap();
+        let mut entries: Vec<CookieEntry> = cookies
+            .values()
+            .flat_map(|domain_cookies| domain_cookies.values().cloned())
+            .filter(|e| match e.expires {
+                Some(exp) => exp > now,
+                None => true,
+            })
+            .collect();
+        entries.sort_by(|a, b| {
+            a.domain
+                .cmp(&b.domain)
+                .then_with(|| a.path.cmp(&b.path))
+                .then_with(|| a.name.cmp(&b.name))
+        });
+        drop(cookies);
+
+        let persisted = PersistedJar {
+            version: PERSIST_FORMAT_VERSION,
+            cookies: entries,
+        };
+
+        if let Some(parent) = path.parent() {
+            if !parent.as_os_str().is_empty() {
+                std::fs::create_dir_all(parent)?;
+            }
+        }
+
+        let tmp_path = match path.file_name() {
+            Some(name) => {
+                let mut tmp_name = name.to_os_string();
+                tmp_name.push(".tmp");
+                path.with_file_name(tmp_name)
+            }
+            None => {
+                return Err(std::io::Error::new(
+                    std::io::ErrorKind::InvalidInput,
+                    "cookie store path has no file name",
+                ));
+            }
+        };
+
+        let json = serde_json::to_string_pretty(&persisted).map_err(|e| {
+            std::io::Error::new(std::io::ErrorKind::Other, format!("serialize cookies: {}", e))
+        })?;
+        std::fs::write(&tmp_path, json)?;
+        std::fs::rename(&tmp_path, path)?;
+        Ok(())
+    }
+
+    /// Load cookies from a JSON file written by `save_to_path` and merge them
+    /// into this jar. Existing cookies with the same `(domain, name)` are
+    /// overwritten.
+    ///
+    /// Returns the number of cookies loaded. Missing file returns Ok(0).
+    pub fn load_from_path(&self, path: &Path) -> std::io::Result<usize> {
+        let bytes = match std::fs::read(path) {
+            Ok(b) => b,
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(0),
+            Err(e) => return Err(e),
+        };
+
+        let persisted: PersistedJar = serde_json::from_slice(&bytes).map_err(|e| {
+            std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                format!("parse cookie store: {}", e),
+            )
+        })?;
+
+        if persisted.version != PERSIST_FORMAT_VERSION {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                format!(
+                    "unsupported cookie store version {} (expected {})",
+                    persisted.version, PERSIST_FORMAT_VERSION
+                ),
+            ));
+        }
+
+        let now = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_secs();
+
+        let mut jar = self.cookies.write().unwrap();
+        let mut loaded = 0;
+        for entry in persisted.cookies {
+            if let Some(exp) = entry.expires {
+                if exp <= now {
+                    continue;
+                }
+            }
+            jar.entry(entry.domain.clone())
+                .or_default()
+                .insert(entry.name.clone(), entry);
+            loaded += 1;
+        }
+        Ok(loaded)
+    }
 }
 
 impl Default for CookieJar {
@@ -482,5 +601,116 @@ mod tests {
 
         jar.clear();
         assert!(jar.get_cookie_header(&url).is_empty());
+    }
+
+    fn temp_cookie_path(label: &str) -> std::path::PathBuf {
+        let pid = std::process::id();
+        let nanos = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        std::env::temp_dir().join(format!("obscura_cookies_{}_{}_{}.json", label, pid, nanos))
+    }
+
+    #[test]
+    fn test_save_and_load_round_trip() {
+        let path = temp_cookie_path("roundtrip");
+        let url = Url::parse("https://example.com/api").unwrap();
+
+        let jar = CookieJar::new();
+        jar.set_cookie("session=abc123; Path=/api; Secure; HttpOnly", &url);
+        jar.set_cookie("token=xyz; Domain=example.com; Max-Age=3600", &url);
+        jar.save_to_path(&path).expect("save");
+
+        let restored = CookieJar::new();
+        let n = restored.load_from_path(&path).expect("load");
+        assert_eq!(n, 2);
+
+        let header = restored.get_cookie_header(&url);
+        assert!(header.contains("session=abc123"), "got: {}", header);
+        assert!(header.contains("token=xyz"), "got: {}", header);
+
+        let _ = std::fs::remove_file(&path);
+    }
+
+    #[test]
+    fn test_load_missing_file_is_ok() {
+        let jar = CookieJar::new();
+        let path = temp_cookie_path("missing");
+        let n = jar.load_from_path(&path).expect("load missing should succeed");
+        assert_eq!(n, 0);
+    }
+
+    #[test]
+    fn test_save_drops_expired_cookies() {
+        let path = temp_cookie_path("expired");
+        let url = Url::parse("https://example.com/").unwrap();
+
+        let jar = CookieJar::new();
+        jar.set_cookie("keep=1; Max-Age=3600", &url);
+        // Manually insert an expired entry — set_cookie rejects on insert,
+        // so use the internal lock.
+        {
+            let mut inner = jar.cookies.write().unwrap();
+            inner
+                .entry("example.com".to_string())
+                .or_default()
+                .insert(
+                    "stale".to_string(),
+                    CookieEntry {
+                        name: "stale".to_string(),
+                        value: "old".to_string(),
+                        path: "/".to_string(),
+                        domain: "example.com".to_string(),
+                        secure: false,
+                        http_only: false,
+                        expires: Some(1),
+                        same_site: "Lax".to_string(),
+                    },
+                );
+        }
+
+        jar.save_to_path(&path).expect("save");
+
+        let restored = CookieJar::new();
+        let n = restored.load_from_path(&path).expect("load");
+        assert_eq!(n, 1);
+        assert!(restored.get_cookie_header(&url).contains("keep=1"));
+
+        let _ = std::fs::remove_file(&path);
+    }
+
+    #[test]
+    fn test_load_rejects_unknown_version() {
+        let path = temp_cookie_path("badver");
+        std::fs::write(&path, br#"{"version":999,"cookies":[]}"#).unwrap();
+
+        let jar = CookieJar::new();
+        let err = jar.load_from_path(&path).unwrap_err();
+        assert_eq!(err.kind(), std::io::ErrorKind::InvalidData);
+
+        let _ = std::fs::remove_file(&path);
+    }
+
+    #[test]
+    fn test_save_uses_atomic_rename() {
+        // Save once, corrupt the temp file, save again — second save must
+        // not be observed as truncated by a concurrent reader.
+        let path = temp_cookie_path("atomic");
+        let url = Url::parse("https://example.com/").unwrap();
+
+        let jar = CookieJar::new();
+        jar.set_cookie("a=1", &url);
+        jar.save_to_path(&path).unwrap();
+        jar.set_cookie("b=2", &url);
+        jar.save_to_path(&path).unwrap();
+
+        let restored = CookieJar::new();
+        restored.load_from_path(&path).unwrap();
+        let header = restored.get_cookie_header(&url);
+        assert!(header.contains("a=1"));
+        assert!(header.contains("b=2"));
+
+        let _ = std::fs::remove_file(&path);
     }
 }


### PR DESCRIPTION
## Summary

Adds an opt-in `--cookie-store <PATH>` flag to `obscura serve` that loads cookies from a JSON file on startup and saves them back on graceful shutdown (Ctrl+C / SIGINT). The file is a versioned envelope so future format changes can fail loudly instead of silently corrupting state.

```bash
obscura serve --port 9223 --cookie-store ~/.obscura/cookies.json
# ... clients log in via CDP, cookies accumulate ...
# Ctrl+C saves to disk
# next launch with the same flag restores them
```

I'd been evaluating Obscura for some Playwright automation that depends on persistent login state across runs. Without on-disk cookies every restart loses the session, which makes any logged-in workflow impractical. This is the smallest change I could land to fix that. `localStorage`/`IndexedDB` are deliberately not in scope here.

## What's in the PR

| Crate | Change |
|---|---|
| `obscura-net` | Derive `serde` on `CookieEntry`. Add `CookieJar::save_to_path` (atomic via `.tmp` + rename, drops expired, sorted for stable diffs) and `CookieJar::load_from_path` (missing file is `Ok(0)`, rejects unknown versions, skips already-expired entries). |
| `obscura-browser` | New `BrowserContext::with_options_and_jar` so a caller-supplied `Arc<CookieJar>` can be threaded in. Existing `with_options` is unchanged (it forwards). |
| `obscura-cdp` | New `CdpContext::new_with_jar` + `start_with_full_options(port, proxy, stealth, cookie_store)`. The previous `start_with_options` signature is preserved and forwards with `cookie_store: None`. The accept loop is wrapped in `tokio::select!` against `tokio::signal::ctrl_c()` so shutdown can flush the jar. |
| `obscura-cli` | `serve --cookie-store PATH` flag. With `--workers > 1` the flag is ignored and a warning is logged (workers would race the same file). |

## File format

```json
{
  "version": 1,
  "cookies": [
    {
      "name": "session",
      "value": "abc123",
      "path": "/",
      "domain": "example.com",
      "secure": true,
      "http_only": true,
      "expires": null,
      "same_site": "Lax"
    }
  ]
}
```

## Tests

5 new round-trip tests in `obscura-net::cookies::tests` covering save/load round-trip, missing-file load, expired-entry filtering on save, version-mismatch rejection, and overwrite-via-rename safety. All 99 workspace tests pass.

## End-to-end verification

```
$ obscura serve --port 9223 --cookie-store /tmp/c.json
# CDP: Storage.setCookies for example.com and test.local
# Ctrl+C → "Saved cookies to /tmp/c.json"
$ obscura serve --port 9223 --cookie-store /tmp/c.json
INFO Loaded 2 cookies from /tmp/c.json
# CDP: Storage.getCookies → both cookies returned, httpOnly/secure flags preserved
```

## Out of scope (called out as follow-ups)

- `localStorage` / `sessionStorage` / `IndexedDB` — still in-memory; would need separate work and a richer storage backend.
- Save-on-mutation / periodic auto-save — current behavior only flushes on `SIGINT`; a `kill -9` loses cookies set since startup. Easy to add a debounced auto-save if desired.
- Per-CDP-context isolation — Obscura currently shares one `default_context` across all CDP sessions, so the jar is global. Per-context jars would be a follow-up if multi-context CDP support lands.

## Test plan

- [x] `cargo test --workspace` passes (99 tests, 0 failures)
- [x] `cargo build` clean (no new warnings introduced)
- [x] Round-trip end-to-end via CDP `Storage.setCookies` → SIGINT → restart → `Storage.getCookies` returns the same cookies with `httpOnly`/`secure` flags preserved
- [x] Atomic write: kill mid-write does not leave a half-truncated file (writes go to `<path>.tmp` first, rename is atomic on POSIX)
- [x] Missing-file startup is silent (`Ok(0)` log line, server starts normally)
- [x] Backward compatible: `start_with_options` signature unchanged; existing callers and tests untouched