### PR TITLE
Fix CDP click submit navigation parity

### DIFF
--- a/crates/obscura-browser/src/page.rs
+++ b/crates/obscura-browser/src/page.rs
@@ -683,13 +683,14 @@ impl Page {
         }
     }
 
-    pub fn evaluate_for_cdp(
+    pub async fn evaluate_for_cdp(
         &mut self,
         expression: &str,
         return_by_value: bool,
+        await_promise: bool,
     ) -> obscura_js::runtime::RemoteObjectInfo {
         if let Some(js) = &mut self.js {
-            match js.evaluate_for_cdp(expression, return_by_value) {
+            match js.evaluate_for_cdp(expression, return_by_value, await_promise).await {
                 Ok(info) => info,
                 Err(e) => {
                     tracing::debug!("evaluate_for_cdp error: {}", e);

--- a/crates/obscura-browser/src/page.rs
+++ b/crates/obscura-browser/src/page.rs
@@ -838,6 +838,21 @@ impl Page {
         }
     }
 
+    pub async fn process_pending_navigation(&mut self) -> Result<bool, PageError> {
+        if let Some((url, method, body)) = self.take_pending_navigation() {
+            self.navigate_with_wait_post(
+                &url,
+                crate::lifecycle::WaitUntil::Load,
+                &method,
+                &body,
+            )
+            .await?;
+            Ok(true)
+        } else {
+            Ok(false)
+        }
+    }
+
     pub fn set_intercept_tx(&mut self, tx: tokio::sync::mpsc::UnboundedSender<obscura_js::ops::InterceptedRequest>) {
         self.intercept_tx = Some(tx.clone());
         if let Some(js) = &self.js {

--- a/crates/obscura-cdp/src/domains/input.rs
+++ b/crates/obscura-cdp/src/domains/input.rs
@@ -40,6 +40,7 @@ pub async fn handle(
                         x = x, y = y,
                     );
                     page.evaluate(&code);
+                    page.process_pending_navigation().await.map_err(|e| e.to_string())?;
                 }
             } else if event_type == "mouseReleased" {
                 if let Some(page) = ctx.get_session_page_mut(session_id) {

--- a/crates/obscura-cdp/src/domains/runtime.rs
+++ b/crates/obscura-cdp/src/domains/runtime.rs
@@ -51,6 +51,7 @@ pub async fn handle(
                 .get_session_page_mut(session_id)
                 .ok_or("No page")?;
             let info = page.evaluate_for_cdp(expression, return_by_value, await_promise).await;
+            page.process_pending_navigation().await.map_err(|e| e.to_string())?;
 
             Ok(json!({ "result": remote_object_from_info(&info) }))
         }
@@ -79,6 +80,7 @@ pub async fn handle(
                 .ok_or("No page")?;
             let info =
                 page.call_function_on_for_cdp(function_declaration, object_id, &arguments, return_by_value, await_promise).await;
+            page.process_pending_navigation().await.map_err(|e| e.to_string())?;
 
             Ok(json!({ "result": remote_object_from_info(&info) }))
         }

--- a/crates/obscura-cdp/src/domains/runtime.rs
+++ b/crates/obscura-cdp/src/domains/runtime.rs
@@ -42,10 +42,15 @@ pub async fn handle(
                 .and_then(|v| v.as_bool())
                 .unwrap_or(false);
 
+            let await_promise = params
+                .get("awaitPromise")
+                .and_then(|v| v.as_bool())
+                .unwrap_or(false);
+
             let page = ctx
                 .get_session_page_mut(session_id)
                 .ok_or("No page")?;
-            let info = page.evaluate_for_cdp(expression, return_by_value);
+            let info = page.evaluate_for_cdp(expression, return_by_value, await_promise).await;
 
             Ok(json!({ "result": remote_object_from_info(&info) }))
         }

--- a/crates/obscura-cdp/tests/cdp_click_submit_parity.rs
+++ b/crates/obscura-cdp/tests/cdp_click_submit_parity.rs
@@ -20,10 +20,21 @@ async fn serve_once() -> String {
                     (
                         "200 OK",
                         r#"<html><body>
-<form id="f"><input name="q" value="abc"><button id="submit" type="submit">Go</button></form>
+<form id="f" action="/submitted">
+  <input type="hidden" name="vacancy_id" value="123">
+  <textarea name="message">hello</textarea>
+  <input type="checkbox" name="agree" value="yes" checked>
+  <button id="submit" type="submit">Go</button>
+</form>
 <script>
 function submitCompat() {
-  location.href = '/submitted';
+  const form = document.getElementById('f');
+  const params = new URLSearchParams();
+  form.querySelectorAll('input, textarea').forEach(function(field) {
+    if (field.type === 'checkbox' && !field.checked) return;
+    params.append(field.name, field.value);
+  });
+  location.href = form.action + '?' + params.toString();
 }
 document.querySelector('button').addEventListener('click', function(e) {
   e.preventDefault();
@@ -118,6 +129,10 @@ async fn runtime_click_submit_prevent_default_navigation_updates_page() {
 
     let page = ctx.get_page_mut(&page_id).unwrap();
     assert_eq!(page.url.as_ref().unwrap().path(), "/submitted");
+    assert_eq!(
+        page.url.as_ref().unwrap().query(),
+        Some("vacancy_id=123&message=hello&agree=yes")
+    );
     assert!(page
         .evaluate("document.body.textContent")
         .as_str()

--- a/crates/obscura-cdp/tests/cdp_click_submit_parity.rs
+++ b/crates/obscura-cdp/tests/cdp_click_submit_parity.rs
@@ -1,0 +1,112 @@
+use obscura_cdp::dispatch::{dispatch, CdpContext};
+use obscura_cdp::types::CdpRequest;
+use serde_json::{json, Value};
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::TcpListener;
+
+async fn serve_once() -> String {
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    tokio::spawn(async move {
+        for _ in 0..2 {
+            let (mut socket, _) = listener.accept().await.unwrap();
+            tokio::spawn(async move {
+                let mut buf = [0u8; 2048];
+                let n = socket.read(&mut buf).await.unwrap();
+                let req = String::from_utf8_lossy(&buf[..n]);
+                let (status, body) = if req.starts_with("GET /submitted") {
+                    ("200 OK", "<html><body>submitted</body></html>")
+                } else {
+                    (
+                        "200 OK",
+                        r#"<html><body>
+<form id="f"><input name="q" value="abc"><button id="submit" type="submit">Go</button></form>
+<script>
+document.getElementById('f').addEventListener('submit', function(e) {
+  e.preventDefault();
+  location.href = '/submitted';
+});
+</script>
+</body></html>"#,
+                    )
+                };
+                let resp = format!(
+                    "HTTP/1.1 {status}\r\nContent-Type: text/html\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{body}",
+                    body.len()
+                );
+                socket.write_all(resp.as_bytes()).await.unwrap();
+            });
+        }
+    });
+    format!("http://{addr}/")
+}
+
+async fn cdp(
+    ctx: &mut CdpContext,
+    id: u64,
+    method: &str,
+    params: Value,
+    session_id: &str,
+) -> Value {
+    let resp = dispatch(
+        &CdpRequest {
+            id,
+            method: method.to_string(),
+            params,
+            session_id: Some(session_id.to_string()),
+        },
+        ctx,
+    )
+    .await;
+    assert!(
+        resp.error.is_none(),
+        "CDP {method} failed: {:?}",
+        resp.error
+    );
+    resp.result.unwrap_or_else(|| json!({}))
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn runtime_click_submit_prevent_default_navigation_updates_page() {
+    std::env::set_var("OBSCURA_ALLOW_PRIVATE_NETWORK", "1");
+    let url = serve_once().await;
+    let mut ctx = CdpContext::new();
+    let page_id = ctx.create_page();
+    let session_id = "session-1";
+    ctx.sessions.insert(session_id.to_string(), page_id.clone());
+
+    cdp(
+        &mut ctx,
+        1,
+        "Page.navigate",
+        json!({"url": url}),
+        session_id,
+    )
+    .await;
+    let button = cdp(
+        &mut ctx,
+        2,
+        "Runtime.evaluate",
+        json!({"expression": "document.getElementById('submit')"}),
+        session_id,
+    )
+    .await;
+    let object_id = button["result"]["objectId"].as_str().unwrap().to_string();
+
+    cdp(
+        &mut ctx,
+        3,
+        "Runtime.callFunctionOn",
+        json!({"objectId": object_id, "functionDeclaration": "function() { this.click(); }"}),
+        session_id,
+    )
+    .await;
+
+    let page = ctx.get_page_mut(&page_id).unwrap();
+    assert_eq!(page.url.as_ref().unwrap().path(), "/submitted");
+    assert!(page
+        .evaluate("document.body.textContent")
+        .as_str()
+        .unwrap()
+        .contains("submitted"));
+}

--- a/crates/obscura-cdp/tests/cdp_click_submit_parity.rs
+++ b/crates/obscura-cdp/tests/cdp_click_submit_parity.rs
@@ -22,9 +22,12 @@ async fn serve_once() -> String {
                         r#"<html><body>
 <form id="f"><input name="q" value="abc"><button id="submit" type="submit">Go</button></form>
 <script>
-document.getElementById('f').addEventListener('submit', function(e) {
-  e.preventDefault();
+function submitCompat() {
   location.href = '/submitted';
+}
+document.querySelector('button').addEventListener('click', function(e) {
+  e.preventDefault();
+  submitCompat();
 });
 </script>
 </body></html>"#,
@@ -83,9 +86,20 @@ async fn runtime_click_submit_prevent_default_navigation_updates_page() {
         session_id,
     )
     .await;
-    let button = cdp(
+
+    let submit_compat_type = cdp(
         &mut ctx,
         2,
+        "Runtime.evaluate",
+        json!({"expression": "typeof submitCompat", "returnByValue": true}),
+        session_id,
+    )
+    .await;
+    assert_eq!(submit_compat_type["result"]["value"], "function");
+
+    let button = cdp(
+        &mut ctx,
+        3,
         "Runtime.evaluate",
         json!({"expression": "document.getElementById('submit')"}),
         session_id,
@@ -95,7 +109,7 @@ async fn runtime_click_submit_prevent_default_navigation_updates_page() {
 
     cdp(
         &mut ctx,
-        3,
+        4,
         "Runtime.callFunctionOn",
         json!({"objectId": object_id, "functionDeclaration": "function() { this.click(); }"}),
         session_id,

--- a/crates/obscura-js/js/bootstrap.js
+++ b/crates/obscura-js/js/bootstrap.js
@@ -472,12 +472,14 @@ class Element extends Node {
   }
   dispatchEvent(event) {
     if (!event) return true;
-    event.target = this;
+    if (!event.target) event.target = this;
     event.currentTarget = this;
     const handlers = (_eventRegistry[this._nid] || {})[event.type] || [];
-    for (const h of handlers) { try { h.call(this, event); } catch(e) { console.error(e); } }
-    if (event.bubbles && !event.defaultPrevented && this.parentNode) {
-      event.currentTarget = this.parentNode;
+    for (const h of handlers) {
+      try { h.call(this, event); } catch(e) { console.error(e); }
+      if (event._immediatePropagationStopped) break;
+    }
+    if (event.bubbles && !event._propagationStopped && this.parentNode) {
       this.parentNode.dispatchEvent(event);
     }
     return !event.defaultPrevented;
@@ -1836,10 +1838,10 @@ globalThis.IntersectionObserver = class {
 globalThis.PerformanceObserver = class { constructor(){} observe(){} disconnect(){} };
 
 globalThis.Event = class Event {
-  constructor(t,o={}) { this.type=t;this.bubbles=!!o.bubbles;this.cancelable=!!o.cancelable;this.composed=!!o.composed;this.defaultPrevented=false;this.target=null;this.currentTarget=null;this.eventPhase=0;this.timeStamp=Date.now(); }
+  constructor(t,o={}) { this.type=t;this.bubbles=!!o.bubbles;this.cancelable=!!o.cancelable;this.composed=!!o.composed;this.defaultPrevented=false;this.target=null;this.currentTarget=null;this.eventPhase=0;this.timeStamp=Date.now();this._propagationStopped=false;this._immediatePropagationStopped=false; }
   get isTrusted() { return true; }
-  preventDefault() { this.defaultPrevented=true; } stopPropagation(){} stopImmediatePropagation(){}
-  initEvent(type,bubbles,cancelable) { this.type=type;this.bubbles=!!bubbles;this.cancelable=!!cancelable; }
+  preventDefault() { if (this.cancelable) this.defaultPrevented=true; } stopPropagation(){ this._propagationStopped=true; } stopImmediatePropagation(){ this._propagationStopped=true; this._immediatePropagationStopped=true; }
+  initEvent(type,bubbles,cancelable) { this.type=type;this.bubbles=!!bubbles;this.cancelable=!!cancelable;this.defaultPrevented=false;this._propagationStopped=false;this._immediatePropagationStopped=false; }
 };
 globalThis.CustomEvent = class extends Event { constructor(t,o={}) { super(t,o);this.detail=o.detail; } };
 globalThis.MouseEvent = class extends Event { constructor(t,o={}) { super(t,o);this.clientX=o.clientX||0;this.clientY=o.clientY||0; } };

--- a/crates/obscura-js/js/bootstrap.js
+++ b/crates/obscura-js/js/bootstrap.js
@@ -598,7 +598,10 @@ class Element extends Node {
     }
     return this._iframeWin;
   }
-  get action() { return this.getAttribute("action") || ""; }
+  get action() {
+    const action = this.getAttribute("action") || _domParse("document_url") || "";
+    try { return new URL(action, _domParse("document_url") || "about:blank").href; } catch(e) { return action; }
+  }
   set action(v) { this.setAttribute("action", v); }
   get method() { return this.getAttribute("method") || "get"; }
   set method(v) { this.setAttribute("method", v); }
@@ -1865,7 +1868,25 @@ globalThis.AbortSignal = { timeout(ms){return {aborted:false,addEventListener(){
 if (typeof Blob === "undefined") globalThis.Blob = class Blob { constructor(parts=[],opts={}){this._data=parts.join("");this.size=this._data.length;this.type=opts.type||"";} async text(){return this._data;} };
 if (typeof File === "undefined") globalThis.File = class extends Blob { constructor(parts,name,opts){super(parts,opts);this.name=name;} };
 if (typeof FormData === "undefined") globalThis.FormData = class FormData { constructor(){this._d=[];} append(k,v){this._d.push([k,v]);} get(k){const e=this._d.find(([a])=>a===k);return e?e[1]:null;} getAll(k){return this._d.filter(([a])=>a===k).map(([,v])=>v);} has(k){return this._d.some(([a])=>a===k);} entries(){return this._d[Symbol.iterator]();} forEach(cb){this._d.forEach(([k,v])=>cb(v,k));} };
-if (typeof URLSearchParams === "undefined") globalThis.URLSearchParams = class { constructor(init=""){this._p=new Map();if(typeof init==="string"){init.replace(/^\?/,"").split("&").forEach(p=>{const[k,...v]=p.split("=");if(k)this._p.set(decodeURIComponent(k),decodeURIComponent(v.join("=")));});}} get(k){return this._p.get(k)??null;} set(k,v){this._p.set(k,String(v));} has(k){return this._p.has(k);} toString(){return[...this._p].map(([k,v])=>`${encodeURIComponent(k)}=${encodeURIComponent(v)}`).join("&");} forEach(cb){this._p.forEach((v,k)=>cb(v,k));} };
+if (typeof URLSearchParams === "undefined") globalThis.URLSearchParams = class {
+  constructor(init=""){
+    this._p=[];
+    if(typeof init==="string"){
+      init.replace(/^\?/,"").split("&").forEach(p=>{const[k,...v]=p.split("=");if(k)this.append(decodeURIComponent(k),decodeURIComponent(v.join("=")));});
+    } else if (init && typeof init[Symbol.iterator] === 'function') {
+      for (const pair of init) if (pair && pair.length >= 2) this.append(pair[0], pair[1]);
+    } else if (init && typeof init === 'object') {
+      Object.keys(init).forEach(k => this.append(k, init[k]));
+    }
+  }
+  append(k,v){this._p.push([String(k),String(v)]);}
+  get(k){const p=this._p.find(([key])=>key===String(k)); return p?p[1]:null;}
+  set(k,v){this.delete(k); this.append(k,v);}
+  delete(k){k=String(k); this._p=this._p.filter(([key])=>key!==k);}
+  has(k){k=String(k); return this._p.some(([key])=>key===k);}
+  toString(){return this._p.map(([k,v])=>`${encodeURIComponent(k)}=${encodeURIComponent(v)}`).join("&");}
+  forEach(cb){this._p.forEach(([k,v])=>cb(v,k,this));}
+};
 
 globalThis.DOMParser = class { parseFromString(s,t) { return globalThis.document; } };
 globalThis.XMLSerializer = class XMLSerializer {

--- a/crates/obscura-js/src/ops.rs
+++ b/crates/obscura-js/src/ops.rs
@@ -643,6 +643,7 @@ fn op_set_cookie(state: &OpState, #[string] cookie_str: &str) {
 fn op_navigate(state: &OpState, #[string] url: &str, #[string] method: &str, #[string] body: &str) {
     let gs = state.borrow::<SharedState>().clone();
     let mut gs = gs.borrow_mut();
+    gs.url = url.to_string();
     gs.pending_navigation = Some((url.to_string(), method.to_string(), body.to_string()));
 }
 

--- a/crates/obscura-js/src/runtime.rs
+++ b/crates/obscura-js/src/runtime.rs
@@ -114,12 +114,13 @@ impl ObscuraJsRuntime {
         self.v8_to_json(result)
     }
 
-    pub fn evaluate_for_cdp(
+    pub async fn evaluate_for_cdp(
         &mut self,
         expression: &str,
         return_by_value: bool,
+        await_promise: bool,
     ) -> Result<RemoteObjectInfo, String> {
-        if return_by_value {
+        if !await_promise && return_by_value {
             let val = self.evaluate(expression)?;
             return Ok(Self::info_from_json(&val));
         }
@@ -134,24 +135,59 @@ impl ObscuraJsRuntime {
             .trim()
             .trim_end_matches(|c: char| c == ';' || c.is_whitespace());
 
-        let meta_code = format!(
-            "(function() {{\n\
-                var __result;\n\
-                try {{ __result = ({expr}); }} catch(e) {{ __result = undefined; }}\n\
-                globalThis.__obscura_objects['{oid}'] = __result;\n\
-                return {meta_fn};\n\
-            }})()",
-            expr = cleaned_expr,
-            oid = oid,
-            meta_fn = Self::meta_extract_js("__result"),
-        );
+        let meta_code = if await_promise {
+            format!(
+                "(async function() {{\n\
+                    try {{\n\
+                        var __result = await ({expr});\n\
+                        globalThis.__obscura_objects['{oid}'] = __result;\n\
+                        globalThis.__obscura_await_meta = {meta_fn};\n\
+                        globalThis.__obscura_await_rejected = false;\n\
+                    }} catch(e) {{\n\
+                        globalThis.__obscura_objects['{oid}'] = e;\n\
+                        globalThis.__obscura_await_meta = {err_meta_fn};\n\
+                        globalThis.__obscura_await_rejected = true;\n\
+                    }}\n\
+                }})()",
+                expr = cleaned_expr,
+                oid = oid,
+                meta_fn = Self::meta_extract_js("__result"),
+                err_meta_fn = Self::meta_extract_js("e"),
+            )
+        } else {
+            format!(
+                "(function() {{\n\
+                    var __result;\n\
+                    try {{ __result = ({expr}); }} catch(e) {{ __result = undefined; }}\n\
+                    globalThis.__obscura_objects['{oid}'] = __result;\n\
+                    return {meta_fn};\n\
+                }})()",
+                expr = cleaned_expr,
+                oid = oid,
+                meta_fn = Self::meta_extract_js("__result"),
+            )
+        };
 
         let result = self
             .runtime
             .execute_script("<eval-remote>", meta_code)
             .map_err(|e| format!("JS error: {}", e))?;
 
-        let meta_str = self.v8_to_json(result)?;
+        let meta_str = if await_promise {
+            self.resolve_promises().await;
+            let rejected = self.runtime.execute_script("<readRejected>", "globalThis.__obscura_await_rejected".to_string())
+                .map_err(|e| format!("JS error: {}", e))?;
+            if self.v8_to_json(rejected)?.as_bool().unwrap_or(false) {
+                let err = self.runtime.execute_script("<readError>", format!("String(globalThis.__obscura_objects['{0}'] && (globalThis.__obscura_objects['{0}'].message || globalThis.__obscura_objects['{0}']))", oid))
+                    .map_err(|e| format!("JS error: {}", e))?;
+                return Err(format!("Promise rejected: {}", self.v8_to_json(err)?.as_str().unwrap_or("")));
+            }
+            self.runtime.execute_script("<readMeta>", "globalThis.__obscura_await_meta".to_string())
+                .map_err(|e| format!("JS error: {}", e))?
+        } else {
+            result
+        };
+        let meta_str = self.v8_to_json(meta_str)?;
         let meta_json = if let serde_json::Value::String(s) = &meta_str {
             serde_json::from_str(s).unwrap_or(meta_str)
         } else {
@@ -161,6 +197,13 @@ impl ObscuraJsRuntime {
             oid.clone(),
             format!("globalThis.__obscura_objects['{}']", oid),
         );
+
+        if await_promise && return_by_value {
+            let read = self.runtime.execute_script("<readResult>", format!("globalThis.__obscura_objects['{}']", oid))
+                .map_err(|e| format!("JS error: {}", e))?;
+            let json_val = self.v8_to_json(read)?;
+            return Ok(Self::info_from_json(&json_val));
+        }
 
         Ok(Self::info_from_meta(&meta_json, Some(oid)))
     }
@@ -524,7 +567,7 @@ impl ObscuraJsRuntime {
 
     pub async fn resolve_promises(&mut self) {
         let _ = tokio::time::timeout(
-            tokio::time::Duration::from_millis(100),
+            tokio::time::Duration::from_secs(5),
             self.runtime.run_event_loop(deno_core::PollEventLoopOptions::default()),
         ).await;
     }
@@ -981,23 +1024,52 @@ mod tests {
         assert_eq!(result2.value.unwrap().as_f64().unwrap() as i64, 3);
     }
 
-    #[test]
-    fn test_evaluate_for_cdp_detects_node() {
+    #[tokio::test(flavor = "current_thread")]
+    async fn test_evaluate_for_cdp_detects_node() {
         let mut rt = setup_runtime("<html><body><h1>Hello</h1></body></html>");
         let result = rt
-            .evaluate_for_cdp("document.querySelector('h1')", false)
-            .unwrap();
+            .evaluate_for_cdp("document.querySelector('h1')", false, false)
+            .await.unwrap();
         assert_eq!(result.subtype.as_deref(), Some("node"));
         assert_eq!(result.js_type, "object");
         assert!(result.object_id.is_some());
     }
 
-    #[test]
-    fn test_evaluate_for_cdp_detects_document() {
+    #[tokio::test(flavor = "current_thread")]
+    async fn test_evaluate_for_cdp_detects_document() {
         let mut rt = setup_runtime("<html><body></body></html>");
-        let result = rt.evaluate_for_cdp("document", false).unwrap();
+        let result = rt.evaluate_for_cdp("document", false, false).await.unwrap();
         assert_eq!(result.subtype.as_deref(), Some("node"));
         assert_eq!(result.class_name, "HTMLDocument");
+    }
+
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn test_evaluate_for_cdp_awaits_resolved_promise() {
+        let mut rt = setup_runtime("<html><body></body></html>");
+        let result = rt.evaluate_for_cdp("Promise.resolve(42)", true, true).await.unwrap();
+        assert_eq!(result.value.unwrap().as_f64().unwrap() as i64, 42);
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn test_evaluate_for_cdp_awaits_timer_promise() {
+        let mut rt = setup_runtime("<html><body></body></html>");
+        let result = rt.evaluate_for_cdp("new Promise(resolve => setTimeout(() => resolve('done'), 1))", true, true).await.unwrap();
+        assert_eq!(result.value.unwrap().as_str().unwrap(), "done");
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn test_evaluate_for_cdp_awaits_async_function() {
+        let mut rt = setup_runtime("<html><body></body></html>");
+        let result = rt.evaluate_for_cdp("(async () => 'async-ok')()", true, true).await.unwrap();
+        assert_eq!(result.value.unwrap().as_str().unwrap(), "async-ok");
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn test_evaluate_for_cdp_reports_promise_rejection() {
+        let mut rt = setup_runtime("<html><body></body></html>");
+        let err = rt.evaluate_for_cdp("Promise.reject(new Error('boom'))", true, true).await.unwrap_err();
+        assert!(err.contains("boom"));
     }
 
     #[tokio::test(flavor = "current_thread")]

--- a/crates/obscura-js/src/runtime.rs
+++ b/crates/obscura-js/src/runtime.rs
@@ -943,6 +943,61 @@ mod tests {
     }
 
     #[test]
+    fn test_button_click_dispatches_listener() {
+        let mut rt = setup_runtime(r#"<button id="go">Go</button>"#);
+        let result = rt.evaluate(r#"
+            const button = document.getElementById('go');
+            button.addEventListener('click', () => { button.dataset.clicked = 'yes'; });
+            button.click();
+            return button.dataset.clicked;
+        "#).unwrap();
+        assert_eq!(result, serde_json::json!("yes"));
+    }
+
+    #[test]
+    fn test_dispatch_mouse_event_runs_listener() {
+        let mut rt = setup_runtime(r#"<button id="go">Go</button>"#);
+        let result = rt.evaluate(r#"
+            const button = document.getElementById('go');
+            let count = 0;
+            button.addEventListener('click', () => { count += 1; });
+            button.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+            return count;
+        "#).unwrap();
+        assert_eq!(result.as_f64().unwrap() as i64, 1);
+    }
+
+    #[test]
+    fn test_location_href_assignment_updates_navigation_state() {
+        let mut rt = setup_runtime("<html><body></body></html>");
+        let href = rt.evaluate("const next = '/next'; location.href = next; return location.href;").unwrap();
+        assert_eq!(href, serde_json::json!("http://example.com/next"));
+        assert_eq!(
+            rt.take_pending_navigation(),
+            Some(("http://example.com/next".to_string(), "GET".to_string(), "".to_string()))
+        );
+    }
+
+    #[test]
+    fn test_submit_button_click_handler_can_prevent_default_and_navigate() {
+        let mut rt = setup_runtime(r#"<form><button type="submit" id="submit">Submit</button></form>"#);
+        let href = rt.evaluate(r#"
+            const form = document.querySelector('form');
+            form.addEventListener('submit', (event) => {
+                event.preventDefault();
+                location.href = '/submitted';
+            });
+            document.getElementById('submit').click();
+            return location.href;
+        "#).unwrap();
+        assert_eq!(href, serde_json::json!("http://example.com/submitted"));
+        assert_eq!(
+            rt.take_pending_navigation(),
+            Some(("http://example.com/submitted".to_string(), "GET".to_string(), "".to_string()))
+        );
+    }
+
+    #[test]
     fn test_navigator() {
         let mut rt = setup_runtime("<html><body></body></html>");
         let ua = rt.evaluate("navigator.userAgent").unwrap();

--- a/crates/obscura-net/src/client.rs
+++ b/crates/obscura-net/src/client.rs
@@ -65,6 +65,7 @@ pub type RequestCallback = Arc<dyn Fn(&RequestInfo) + Send + Sync>;
 pub type ResponseCallback = Arc<dyn Fn(&RequestInfo, &Response) + Send + Sync>;
 
 fn validate_url(url: &Url) -> Result<(), ObscuraNetError> {
+    let allow_private_network = std::env::var_os("OBSCURA_ALLOW_PRIVATE_NETWORK").is_some();
     let scheme = url.scheme();
     if scheme != "http" && scheme != "https" && scheme != "file" {
         return Err(ObscuraNetError::Network(format!(
@@ -73,7 +74,7 @@ fn validate_url(url: &Url) -> Result<(), ObscuraNetError> {
         )));
     }
 
-    if scheme == "file" {
+    if scheme == "file" || allow_private_network {
         return Ok(());
     }
 

--- a/obscura-await-promise-report.md
+++ b/obscura-await-promise-report.md
@@ -1,0 +1,38 @@
+# Obscura Runtime.evaluate awaitPromise report
+
+## Summary
+- Branch: `fix/runtime-evaluate-await-promise`
+- Implemented async `Runtime.evaluate` CDP path support for the `awaitPromise` parameter.
+- `obscura-js` now wraps awaited CDP evaluation in an async function, awaits the expression, runs the Deno event loop, stores the settled value, and returns either by-value metadata or remote-object metadata.
+- Promise rejection is detected in the JS runtime path and returned as an error from `ObscuraJsRuntime::evaluate_for_cdp`.
+- `obscura-cdp` now reads `awaitPromise` for `Runtime.evaluate` and awaits the browser/page evaluation path.
+
+## Tests added
+Added Obscura-side JS runtime tests for:
+- `Promise.resolve(42)` with `awaitPromise`
+- delayed `setTimeout` promise with `awaitPromise`
+- async function result with `awaitPromise`
+- rejected promise error propagation in the runtime helper
+
+## Validation
+Attempted to run:
+
+```bash
+cargo test -p obscura-js evaluate_for_cdp -- --nocapture
+```
+
+but this environment does not have `cargo` on PATH (`cargo: command not found`). No Rust tests/builds could be executed locally from this shell.
+
+## Remaining gaps
+- Fetch-specific awaitPromise coverage was not added because it would require a reliable local HTTP fixture and network/client setup; the core event-loop settling path used by fetch promises is now exercised by awaited async promises and timer promises.
+- CDP-level rejection formatting is still minimal because the existing page wrapper converts runtime errors to an undefined remote object rather than returning CDP `exceptionDetails`.
+
+## PR status
+GitHub remote is configured, but pushing the branch failed with HTTP 403 for the current credentials:
+
+```text
+remote: Permission to h4ckf0r0day/obscura.git denied to blockedby.
+fatal: unable to access 'https://github.com/h4ckf0r0day/obscura.git/': The requested URL returned error: 403
+```
+
+No PR was opened. Commit exists locally.

--- a/obscura-dom-event-navigation-report.md
+++ b/obscura-dom-event-navigation-report.md
@@ -1,0 +1,33 @@
+# Obscura DOM Event + Navigation Side Effects Report
+
+Status: Completed locally on branch `fix/dom-event-navigation-side-effects`.
+
+Base/dependency note: branch was created from current `fix/runtime-evaluate-await-promise` state as requested, so this work depends on that branch until it is merged/rebased.
+
+## Changes
+
+- `crates/obscura-js/js/bootstrap.js`
+  - Preserves the original `event.target` during bubbling.
+  - Allows bubbling even when `preventDefault()` was called, matching browser behavior.
+  - Implements propagation stop flags for `stopPropagation()` and `stopImmediatePropagation()`.
+  - Makes `preventDefault()` honor `cancelable`.
+- `crates/obscura-js/src/ops.rs`
+  - `op_navigate` now updates runtime URL state immediately as well as recording pending navigation.
+- `crates/obscura-js/src/runtime.rs`
+  - Added acceptance tests for:
+    1. `button.click()` runs click listener and updates `dataset`.
+    2. `dispatchEvent(new MouseEvent('click', { bubbles: true }))` runs listener.
+    3. `location.href = '/next'` updates URL/navigation state.
+    4. Submit button click runs submit handler; handler `preventDefault(); location.href='/submitted'` updates URL/navigation state.
+
+## Verification
+
+- `cargo test -p obscura-js` — passed, 58 tests.
+- `cargo test -p obscura-cdp` — passed, 0 tests.
+
+Existing warnings remain in `obscura-net`, `obscura-js`, and `obscura-cdp`; no new failure observed.
+
+## Remaining gaps
+
+- I did not open a PR or push because remote permissions were not attempted/confirmed in this environment.
+- `cargo fmt` was tested earlier but it reformats many unrelated existing files in this repo, so I reverted those broad formatting-only changes and kept the final diff scoped to this task.

--- a/obscura-inline-script-click-report.md
+++ b/obscura-inline-script-click-report.md
@@ -1,0 +1,26 @@
+# Obscura inline script click-submit follow-up
+
+## Findings
+
+- The existing CDP click-submit parity test was not strong enough to prove inline page scripts loaded by `Page.navigate` executed in the document.
+- I updated `crates/obscura-cdp/tests/cdp_click_submit_parity.rs` so the served page now includes an inline script with:
+  - a global `function submitCompat() { location.href = '/submitted'; }`
+  - a real `document.querySelector('button').addEventListener('click', ...)` handler that calls `submitCompat()`
+- The test now navigates with CDP `Page.navigate`, verifies `Runtime.evaluate` reports `typeof submitCompat` as `function`, then obtains the real button element and invokes `this.click()` through `Runtime.callFunctionOn`.
+- After the click, the test asserts the page navigated to `/submitted` and the body contains `submitted`.
+
+## Changes made
+
+- Strengthened `crates/obscura-cdp/tests/cdp_click_submit_parity.rs` only.
+- No production code changes were necessary: the strengthened regression test passes against the current implementation.
+- SSRF/private-network behavior remains unchanged. The integration test continues to opt in with `OBSCURA_ALLOW_PRIVATE_NETWORK=1`.
+- Did not touch positions.
+
+## Verification
+
+- `cargo test -p obscura-cdp --test cdp_click_submit_parity -- --nocapture` passed.
+- `cargo test` passed.
+
+## Notes
+
+- This validates inline script execution and real DOM click listener navigation at the direct CDP dispatch layer. If `/home/kcnc/.local/bin/obscura-cdp-click` still fails against a live CDP server, the remaining gap is likely in the CLI/server/client path rather than inline script execution during `Page.navigate` itself.


### PR DESCRIPTION
## Summary\n- process JS-triggered navigation after CDP Runtime.evaluate/callFunctionOn and Input click dispatch\n- add CDP integration coverage for form submit preventDefault + location.href navigation to /submitted\n- add opt-in env flag for local loopback integration tests without changing default private-network blocking\n\n## Tests\n- cargo test -p obscura-js\n- cargo test -p obscura-cdp