### PR TITLE
fix(cli): make --quiet suppress JS console errors on stderr (#56)

### DIFF
--- a/crates/obscura-cli/src/main.rs
+++ b/crates/obscura-cli/src/main.rs
@@ -119,11 +119,22 @@ fn print_banner(port: u16) {
 "#, port);
 }
 
+fn select_log_filter(verbose: bool, quiet: bool) -> &'static str {
+    if verbose {
+        "debug"
+    } else if quiet {
+        "off"
+    } else {
+        "warn"
+    }
+}
+
 #[tokio::main(flavor = "current_thread")]
 async fn main() -> anyhow::Result<()> {
     let args = Args::parse();
 
-    let filter = if args.verbose { "debug" } else { "warn" };
+    let quiet = matches!(&args.command, Some(Command::Fetch { quiet: true, .. }));
+    let filter = select_log_filter(args.verbose, quiet);
     tracing_subscriber::fmt()
         .with_env_filter(
             tracing_subscriber::EnvFilter::try_from_default_env()
@@ -724,4 +735,28 @@ fn dump_links(page: &Page) {
             }
         }
     });
+}
+#[cfg(test)]
+mod tests {
+    use super::select_log_filter;
+
+    #[test]
+    fn default_filter_is_warn() {
+        assert_eq!(select_log_filter(false, false), "warn");
+    }
+
+    #[test]
+    fn verbose_filter_is_debug() {
+        assert_eq!(select_log_filter(true, false), "debug");
+    }
+
+    #[test]
+    fn quiet_filter_is_off() {
+        assert_eq!(select_log_filter(false, true), "off");
+    }
+
+    #[test]
+    fn verbose_wins_over_quiet() {
+        assert_eq!(select_log_filter(true, true), "debug");
+    }
 }

--- a/crates/obscura-cli/src/main.rs
+++ b/crates/obscura-cli/src/main.rs
@@ -129,11 +129,15 @@ fn select_log_filter(verbose: bool, quiet: bool) -> &'static str {
     }
 }
 
+fn is_quiet_command(cmd: &Option<Command>) -> bool {
+    matches!(cmd, Some(Command::Fetch { quiet: true, .. }))
+}
+
 #[tokio::main(flavor = "current_thread")]
 async fn main() -> anyhow::Result<()> {
     let args = Args::parse();
 
-    let quiet = matches!(&args.command, Some(Command::Fetch { quiet: true, .. }));
+    let quiet = is_quiet_command(&args.command);
     let filter = select_log_filter(args.verbose, quiet);
     tracing_subscriber::fmt()
         .with_env_filter(
@@ -738,7 +742,8 @@ fn dump_links(page: &Page) {
 }
 #[cfg(test)]
 mod tests {
-    use super::select_log_filter;
+    use super::{is_quiet_command, select_log_filter, Args, Command};
+    use clap::Parser;
 
     #[test]
     fn default_filter_is_warn() {
@@ -758,5 +763,66 @@ mod tests {
     #[test]
     fn verbose_wins_over_quiet() {
         assert_eq!(select_log_filter(true, true), "debug");
+    }
+
+    #[test]
+    fn parsed_fetch_with_quiet_flag_is_detected() {
+        let args = Args::try_parse_from([
+            "obscura",
+            "fetch",
+            "--quiet",
+            "https://example.com",
+        ])
+        .expect("clap should accept --quiet on fetch");
+        assert!(is_quiet_command(&args.command));
+    }
+
+    #[test]
+    fn parsed_fetch_without_quiet_is_not_detected() {
+        let args = Args::try_parse_from(["obscura", "fetch", "https://example.com"])
+            .expect("clap should accept fetch without --quiet");
+        assert!(!is_quiet_command(&args.command));
+    }
+
+    #[test]
+    fn parsed_serve_command_is_not_quiet() {
+        let args = Args::try_parse_from(["obscura", "serve"])
+            .expect("clap should accept serve");
+        assert!(!is_quiet_command(&args.command));
+    }
+
+    #[test]
+    fn no_subcommand_is_not_quiet() {
+        assert!(!is_quiet_command(&None));
+    }
+
+    #[test]
+    fn parsed_fetch_quiet_resolves_to_off_filter() {
+        let args = Args::try_parse_from([
+            "obscura",
+            "fetch",
+            "--quiet",
+            "https://example.com",
+        ])
+        .unwrap();
+        let filter = select_log_filter(args.verbose, is_quiet_command(&args.command));
+        assert_eq!(filter, "off");
+    }
+
+    #[test]
+    fn matcher_still_uses_fetch_variant() {
+        let cmd = Some(Command::Fetch {
+            url: "https://x".to_string(),
+            dump: super::DumpFormat::Html,
+            selector: None,
+            wait: 5,
+            timeout: 30,
+            wait_until: "load".to_string(),
+            user_agent: None,
+            stealth: false,
+            eval: None,
+            quiet: true,
+        });
+        assert!(is_quiet_command(&cmd));
     }
 }


### PR DESCRIPTION
## Summary

Fixes #56 — `obscura fetch --quiet` was still leaking ERROR-level JS console output to stderr because the `--quiet` flag only gated banner prints inside `run_fetch`, not the global `tracing_subscriber`.

## Root Cause

`tracing_subscriber` is initialized in `main()` before the command match is performed, so it never sees the per-subcommand `quiet` field on `Command::Fetch`. The filter was hardcoded to `\"warn\"` (or `\"debug\"` with `--verbose`), and `obscura::console` errors come through tracing at ERROR level, which `\"warn\"` keeps enabled.

Result: the user-facing fetch output (page dump via `println!`) was clean, but the noise band on stderr was identical to a non-quiet run.

## Fix

`crates/obscura-cli/src/main.rs`:

- Peek at `args.command` before initializing the subscriber and detect `Command::Fetch { quiet: true, .. }`.
- Extract the filter selection into a small pure helper `select_log_filter(verbose, quiet) -> &'static str`:
  - `verbose` → `\"debug\"` (unchanged, wins over quiet so debug diagnostics stay usable)
  - `quiet`   → `\"off\"`   (silences all tracing output, including JS console errors)
  - else     → `\"warn\"`  (current default)
- Pass the result into the existing `EnvFilter` chain. `RUST_LOG` still overrides via `try_from_default_env()`.

Net diff: +37 / −2 in one file. No behavior change for `serve` / `scrape` / non-quiet fetch.

## Verification

```bash
# Before
$ obscura fetch --dump text --quiet \"https://en.wikipedia.org/wiki/Example\"
ERROR obscura::console: Dynamic script error (https://en.wikipedia.org/w/load.php?...): Unexpected token 'set'
ERROR obscura::console: Dynamic script error (https://en.wikipedia.org/w/load.php?...): Unexpected token 'set'
<page text dump>

# After
$ obscura fetch --dump text --quiet \"https://en.wikipedia.org/wiki/Example\"
<page text dump>
```

\`-v / --verbose\` still beats \`--quiet\` so debug runs continue to surface everything.

## Test plan

- [x] \`cargo check -p obscura-cli\` passes clean (1 pre-existing warning unrelated to this PR).
- [x] \`cargo test -p obscura-cli\` — 4 new unit tests for \`select_log_filter\` covering default / verbose / quiet / verbose+quiet pass.
- [x] No regressions — pre-existing warnings unchanged, no behavior change for \`serve\` / \`scrape\` / non-quiet fetch.
- [ ] Stealth build skipped (no macOS host).

## Risk

Low. One file touched, helper is pure, tracing subscriber init is the only side effect and the change is gated behind the user explicitly passing \`--quiet\`.

Generated by Ora Studio
Vibe coded by ousamabenyounes