### PR TITLE
fix(js): add elementFromPoint / elementsFromPoint stubs (#63)

### DIFF
--- a/crates/obscura-js/js/bootstrap.js
+++ b/crates/obscura-js/js/bootstrap.js
@@ -2998,6 +2998,36 @@ if (typeof Document !== 'undefined' && !Document.prototype.importNode) {
   Document.prototype.importNode = function(node, deep) { return node?.cloneNode(!!deep) || null; };
 }
 
+// Document.elementFromPoint / elementsFromPoint — no layout engine, so this is a stub:
+// in-viewport coords return <body> (or <html> as fallback), out-of-viewport returns null.
+// Wrong-but-non-throwing beats "undefined", which traps ad/analytics bootstraps in retry loops
+// (see issue #63).
+if (typeof Document !== 'undefined' && !Document.prototype.elementFromPoint) {
+  Document.prototype.elementFromPoint = function(x, y) {
+    if (typeof x !== 'number' || typeof y !== 'number' || !isFinite(x) || !isFinite(y)) {
+      return null;
+    }
+    var w = (typeof window !== 'undefined' && window.innerWidth) || 0;
+    var h = (typeof window !== 'undefined' && window.innerHeight) || 0;
+    if (x < 0 || y < 0 || x > w || y > h) {
+      return null;
+    }
+    return this.body || this.documentElement || null;
+  };
+  Document.prototype.elementsFromPoint = function(x, y) {
+    var el = this.elementFromPoint(x, y);
+    return el ? [el] : [];
+  };
+}
+if (typeof ShadowRoot !== 'undefined' && !ShadowRoot.prototype.elementFromPoint) {
+  ShadowRoot.prototype.elementFromPoint = function(x, y) {
+    return Document.prototype.elementFromPoint.call(globalThis.document || this, x, y);
+  };
+  ShadowRoot.prototype.elementsFromPoint = function(x, y) {
+    return Document.prototype.elementsFromPoint.call(globalThis.document || this, x, y);
+  };
+}
+
 globalThis.__obscura_init = function() {
   _fpSeed = Date.now() ^ (Math.random() * 0xFFFFFFFF >>> 0);
   _fpCache = null;

--- a/crates/obscura-js/src/runtime.rs
+++ b/crates/obscura-js/src/runtime.rs
@@ -1420,4 +1420,49 @@ mod tests {
         assert!(html.contains("<p>Test</p>"));
     }
 
+    #[test]
+    fn test_element_from_point_is_function() {
+        let mut rt = setup_runtime("<html><body></body></html>");
+        let kind = rt.evaluate("typeof document.elementFromPoint").unwrap();
+        assert_eq!(kind, serde_json::json!("function"));
+        let kind2 = rt.evaluate("typeof document.elementsFromPoint").unwrap();
+        assert_eq!(kind2, serde_json::json!("function"));
+    }
+
+    #[test]
+    fn test_element_from_point_in_viewport_returns_body() {
+        let mut rt = setup_runtime("<html><body><h1>Hi</h1></body></html>");
+        let tag = rt.evaluate("document.elementFromPoint(10, 10)?.tagName").unwrap();
+        assert_eq!(tag, serde_json::json!("BODY"));
+    }
+
+    #[test]
+    fn test_element_from_point_out_of_viewport_returns_null() {
+        let mut rt = setup_runtime("<html><body></body></html>");
+        let neg_x = rt.evaluate("document.elementFromPoint(-1, 10)").unwrap();
+        assert_eq!(neg_x, serde_json::Value::Null);
+        let neg_y = rt.evaluate("document.elementFromPoint(10, -1)").unwrap();
+        assert_eq!(neg_y, serde_json::Value::Null);
+        let huge = rt.evaluate("document.elementFromPoint(99999, 99999)").unwrap();
+        assert_eq!(huge, serde_json::Value::Null);
+    }
+
+    #[test]
+    fn test_elements_from_point_returns_array() {
+        let mut rt = setup_runtime("<html><body></body></html>");
+        let len_in = rt.evaluate("document.elementsFromPoint(10, 10).length").unwrap();
+        assert_eq!(len_in.as_f64().unwrap() as i64, 1);
+        let len_out = rt.evaluate("document.elementsFromPoint(-1, -1).length").unwrap();
+        assert_eq!(len_out.as_f64().unwrap() as i64, 0);
+    }
+
+    #[test]
+    fn test_element_from_point_non_numeric_returns_null() {
+        let mut rt = setup_runtime("<html><body></body></html>");
+        let nan = rt.evaluate("document.elementFromPoint(NaN, 10)").unwrap();
+        assert_eq!(nan, serde_json::Value::Null);
+        let inf = rt.evaluate("document.elementFromPoint(Infinity, 10)").unwrap();
+        assert_eq!(inf, serde_json::Value::Null);
+    }
+
 }


### PR DESCRIPTION
## Summary

Fixes #63 — `document.elementFromPoint` was undefined, throwing on bootstrap for any page that runs Google Publisher Tag, viewability tracking, intersection-observer hit-testing or React-style synthetic event hit detection. The throw is caught by the surrounding ad framework, which then retries in a loop and wedges the runtime (issue #62 cites this as a contributor).

## Root Cause

`crates/obscura-js/js/bootstrap.js` had no polyfill for `Document.prototype.elementFromPoint` or `elementsFromPoint`. Calls returned `undefined`, callers do `el.elementFromPoint(...)` followed by attribute access on the result, which throws `TypeError: a.elementFromPoint is not a function`.

## Fix

Add a no-throw stub matching the issue's proposal. Without a layout engine we can't return the actual topmost element, but "wrong but quiet" is the difference between "framework wedges in a retry loop" and "framework silently no-ops viewability tracking and the page renders" — the second is the desired headless-scraping behavior.

`crates/obscura-js/js/bootstrap.js` (+30 lines, near the existing `Document.prototype.importNode` polyfill):

- `Document.prototype.elementFromPoint(x, y)`:
  - non-numeric / NaN / Infinity → `null`
  - out-of-viewport (negative, or beyond `window.innerWidth` / `innerHeight`) → `null`
  - in-viewport → `this.body || this.documentElement || null`
- `Document.prototype.elementsFromPoint(x, y)` returns a length-0 or length-1 array depending on the above.
- `ShadowRoot.prototype.elementFromPoint` / `elementsFromPoint` delegate to the document for completeness.

Both stubs are guarded by `!Document.prototype.elementFromPoint` so a future real layout-aware implementation overrides cleanly.

## Verification

```bash
$ obscura serve --port 9223
# in another shell:
$ python -c \"
from playwright.sync_api import sync_playwright
with sync_playwright() as p:
    b = p.chromium.connect_over_cdp('http://127.0.0.1:9223')
    page = b.contexts[0].new_page()
    page.goto('about:blank')
    print(page.evaluate('typeof document.elementFromPoint'))
\"
# Before: undefined
# After:  function

$ obscura fetch 'about:blank' --eval 'return document.elementFromPoint(10, 10)?.tagName'
# Before: throws
# After:  \"BODY\"
```

Tested against the minimal repro from the issue. Real-world: ad-tech bootstraps that previously threw `a.elementFromPoint is not a function` no longer enter their retry loop.

## Test plan

- [x] `cargo test -p obscura-js --lib` — 55 pass / 0 fail (5 new tests covering function presence, in-viewport hit returns BODY, out-of-viewport returns null, non-numeric returns null, `elementsFromPoint` returns 0/1-length array).
- [x] `cargo check -p obscura-cli` clean.
- [ ] Stealth build skipped (no macOS host).

## Risk

Low. Polyfill is gated behind `!Document.prototype.elementFromPoint`, only fires when missing, never throws, returns spec-shaped values. Any future real implementation (when a layout engine lands) will override it untouched.

## Related

- #62 — runtime/HTTP wedge fed by this throw
- #45 — broader layout-engine gap (out of scope; this is the no-throw bandage)
- #58 — test suite roll-up

Generated by Ora Studio
Vibe coded by ousamabenyounes