### PR TITLE
fix(serve): plumb --user-agent through CDP server (#71)

### DIFF
--- a/crates/obscura-browser/src/context.rs
+++ b/crates/obscura-browser/src/context.rs
@@ -30,6 +30,15 @@ impl BrowserContext {
     }
 
     pub fn with_options(id: String, proxy_url: Option<String>, stealth: bool) -> Self {
+        Self::with_full_options(id, proxy_url, stealth, None)
+    }
+
+    pub fn with_full_options(
+        id: String,
+        proxy_url: Option<String>,
+        stealth: bool,
+        user_agent: Option<String>,
+    ) -> Self {
         let cookie_jar = Arc::new(CookieJar::new());
         let mut client = ObscuraHttpClient::with_options(
             cookie_jar.clone(),
@@ -38,12 +47,21 @@ impl BrowserContext {
         if stealth {
             client.block_trackers = true;
         }
+        let resolved_ua = user_agent.unwrap_or_else(|| {
+            "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/145.0.0.0 Safari/537.36".to_string()
+        });
+        // Sync the http client's UA at construction so navigation requests pick it
+        // up before any async setup runs. The lock has no other holders here, so
+        // try_write always succeeds; we fall back silently if it ever fails.
+        if let Ok(mut guard) = client.user_agent.try_write() {
+            *guard = resolved_ua.clone();
+        }
         let http_client = Arc::new(client);
         BrowserContext {
             id,
             cookie_jar,
             http_client,
-            user_agent: "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/145.0.0.0 Safari/537.36".to_string(),
+            user_agent: resolved_ua,
             proxy_url,
             robots_cache: Arc::new(RobotsCache::new()),
             obey_robots: false,
@@ -53,5 +71,43 @@ impl BrowserContext {
 
     pub fn with_proxy(id: String, proxy_url: Option<String>) -> Self {
         Self::with_options(id, proxy_url, false)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn with_full_options_propagates_user_agent_to_http_client() {
+        let ctx = BrowserContext::with_full_options(
+            "test".to_string(),
+            None,
+            false,
+            Some("Custom-UA/1.0".to_string()),
+        );
+        assert_eq!(ctx.user_agent, "Custom-UA/1.0");
+        let client_ua = ctx.http_client.user_agent.read().await.clone();
+        assert_eq!(client_ua, "Custom-UA/1.0");
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn with_full_options_falls_back_to_chrome_default() {
+        let ctx = BrowserContext::with_full_options(
+            "test".to_string(),
+            None,
+            false,
+            None,
+        );
+        assert!(ctx.user_agent.contains("Chrome"));
+        let client_ua = ctx.http_client.user_agent.read().await.clone();
+        assert!(client_ua.contains("Chrome"));
+        assert_eq!(ctx.user_agent, client_ua);
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn with_options_keeps_default_user_agent() {
+        let ctx = BrowserContext::with_options("test".to_string(), None, false);
+        assert!(ctx.user_agent.contains("Chrome"));
     }
 }

--- a/crates/obscura-cdp/src/dispatch.rs
+++ b/crates/obscura-cdp/src/dispatch.rs
@@ -39,10 +39,19 @@ impl CdpContext {
     }
 
     pub fn new_with_options(proxy: Option<String>, stealth: bool) -> Self {
-        let default_context = Arc::new(BrowserContext::with_options(
+        Self::new_with_full_options(proxy, stealth, None)
+    }
+
+    pub fn new_with_full_options(
+        proxy: Option<String>,
+        stealth: bool,
+        user_agent: Option<String>,
+    ) -> Self {
+        let default_context = Arc::new(BrowserContext::with_full_options(
             "default".to_string(),
             proxy,
             stealth,
+            user_agent,
         ));
         CdpContext {
             pages: Vec::new(),

--- a/crates/obscura-cdp/src/lib.rs
+++ b/crates/obscura-cdp/src/lib.rs
@@ -3,4 +3,4 @@ pub mod dispatch;
 pub mod types;
 pub mod domains;
 
-pub use server::{start, start_with_options};
+pub use server::{start, start_with_full_options, start_with_options};

--- a/crates/obscura-cdp/src/server.rs
+++ b/crates/obscura-cdp/src/server.rs
@@ -32,6 +32,15 @@ pub async fn start_with_options(
     proxy: Option<String>,
     stealth: bool,
 ) -> anyhow::Result<()> {
+    start_with_full_options(port, proxy, stealth, None).await
+}
+
+pub async fn start_with_full_options(
+    port: u16,
+    proxy: Option<String>,
+    stealth: bool,
+    user_agent: Option<String>,
+) -> anyhow::Result<()> {
     let addr = SocketAddr::from(([127, 0, 0, 1], port));
     let listener = TcpListener::bind(&addr).await?;
 
@@ -46,7 +55,7 @@ pub async fn start_with_options(
         .run_until(async {
             let (msg_tx, msg_rx) = mpsc::unbounded_channel::<ServerMessage>();
 
-            let processor_handle = tokio::task::spawn_local(cdp_processor(msg_rx, proxy, stealth));
+            let processor_handle = tokio::task::spawn_local(cdp_processor(msg_rx, proxy, stealth, user_agent));
 
             loop {
                 match listener.accept().await {
@@ -72,8 +81,9 @@ async fn cdp_processor(
     mut rx: mpsc::UnboundedReceiver<ServerMessage>,
     proxy: Option<String>,
     stealth: bool,
+    user_agent: Option<String>,
 ) {
-    let mut ctx = CdpContext::new_with_options(proxy, stealth);
+    let mut ctx = CdpContext::new_with_full_options(proxy, stealth, user_agent);
     let (itx, irx) = mpsc::unbounded_channel::<obscura_js::ops::InterceptedRequest>();
     ctx.intercept_tx = Some(itx);
     let mut intercept_rx: Option<mpsc::UnboundedReceiver<obscura_js::ops::InterceptedRequest>> = Some(irx);

--- a/crates/obscura-cli/src/main.rs
+++ b/crates/obscura-cli/src/main.rs
@@ -149,9 +149,9 @@ async fn main() -> anyhow::Result<()> {
 
             if workers > 1 {
                 tracing::info!("{} worker processes", workers);
-                run_multi_worker_serve(port, workers, proxy, stealth).await?;
+                run_multi_worker_serve(port, workers, proxy, stealth, user_agent).await?;
             } else {
-                obscura_cdp::start_with_options(port, proxy, stealth).await?;
+                obscura_cdp::start_with_full_options(port, proxy, stealth, user_agent).await?;
             }
         }
         Some(Command::Fetch { url, dump, selector, wait, wait_until, user_agent, stealth, eval, quiet }) => {
@@ -177,6 +177,7 @@ async fn run_multi_worker_serve(
     workers: u16,
     proxy: Option<String>,
     stealth: bool,
+    user_agent: Option<String>,
 ) -> anyhow::Result<()> {
     use tokio::net::TcpListener;
     use tokio::io::{AsyncReadExt as _, AsyncWriteExt as _};
@@ -190,6 +191,9 @@ async fn run_multi_worker_serve(
         cmd.arg("serve").arg("--port").arg(worker_port.to_string());
         if let Some(ref p) = proxy {
             cmd.arg("--proxy").arg(p);
+        }
+        if let Some(ref ua) = user_agent {
+            cmd.arg("--user-agent").arg(ua);
         }
         if stealth {
             cmd.arg("--stealth");


### PR DESCRIPTION
## Summary

Fixes #71 — `obscura serve --user-agent <ua>` ignored the override. Every navigation kept using the default Chrome UA string, so `https://httpbin.org/user-agent` returned the default UA rather than the user-supplied one.

## Root Cause

`Command::Serve { ..., user_agent, .. }` is parsed correctly in `crates/obscura-cli/src/main.rs`, but the value was only logged via `tracing::info!(\"User-Agent: {}\", ua)` and never threaded into the CDP server. `obscura_cdp::start_with_options(port, proxy, stealth)` had no UA parameter and `CdpContext::new_with_options` constructed a `BrowserContext::with_options(...)` that hardcoded the Chrome UA in both `BrowserContext::user_agent` and the inner `ObscuraHttpClient::user_agent` RwLock.

## Fix

Plumb `Option<String>` end-to-end without breaking existing callers:

- `crates/obscura-browser/src/context.rs`
  - New `BrowserContext::with_full_options(id, proxy, stealth, user_agent)` initializes both `BrowserContext::user_agent` and the inner `ObscuraHttpClient::user_agent` RwLock at construction (via a non-blocking `try_write` that always succeeds on a fresh client).
  - Existing `with_options` becomes a shim that calls `with_full_options(..., None)`.
- `crates/obscura-cdp/src/dispatch.rs`
  - New `CdpContext::new_with_full_options(proxy, stealth, user_agent)`. `new_with_options` keeps signature.
- `crates/obscura-cdp/src/server.rs`
  - New public `start_with_full_options(port, proxy, stealth, user_agent)`. `start_with_options` and `start` keep signatures and delegate.
  - `cdp_processor` accepts and forwards the UA.
- `crates/obscura-cdp/src/lib.rs` re-exports `start_with_full_options`.
- `crates/obscura-cli/src/main.rs`
  - The `Serve` arm calls `start_with_full_options(port, proxy, stealth, user_agent)`.
  - `run_multi_worker_serve` accepts the UA and forwards `--user-agent <ua>` to each spawned worker subprocess so multi-worker mode honors the flag too.

Net diff: +86 / −7 across five files. Public API stays source-compatible: every previous entry point (`BrowserContext::with_options`, `BrowserContext::with_proxy`, `CdpContext::new_with_options`, `obscura_cdp::start`, `obscura_cdp::start_with_options`) keeps its signature.

## Verification

```bash
# Before
$ obscura serve --port 9222 --user-agent xxx-user
# (in python)
$ uv run main.py
<html><head></head><body>{
  \"user-agent\": \"Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 ...\"
}</body></html>

# After
$ obscura serve --port 9222 --user-agent xxx-user
$ uv run main.py
<html><head></head><body>{
  \"user-agent\": \"xxx-user\"
}</body></html>
```

Same Playwright `connect_over_cdp` script from the issue, same `httpbin.org/user-agent` target.

## Test plan

- [x] `cargo build --release` clean (only the same pre-existing warnings as on `main`).
- [x] `cargo test -p obscura-browser --lib` — 3 new unit tests pass:
  - `with_full_options_propagates_user_agent_to_http_client` — custom UA shows up on both the context and the http client.
  - `with_full_options_falls_back_to_chrome_default` — `None` keeps the existing default.
  - `with_options_keeps_default_user_agent` — legacy three-arg path unchanged.
- [x] `cargo test -p obscura-net --lib` — 16 pass, 0 fail (regression check on the touched HTTP client).
- [x] `cargo test -p obscura-cli` / `obscura-cdp` — both compile and run cleanly (no tests in those crates).
- [ ] Stealth build skipped (no macOS host).

## Risk

Low. The change is opt-in (only fires when the user passes `--user-agent`), every previous entry point keeps its signature, and the new constructor uses `try_write` on a freshly-built lock so it can never panic at runtime even if a future refactor calls it from inside a Tokio runtime.

Generated by Ora Studio
Vibe coded by ousamabenyounes