### PR TITLE
fix(js): make createEvent type-aware + add initCustomEvent (#41)

### DIFF
--- a/crates/obscura-js/js/bootstrap.js
+++ b/crates/obscura-js/js/bootstrap.js
@@ -778,7 +778,28 @@ class Document extends Node {
     _cache.set(nid, frag);
     return frag;
   }
-  createEvent(type) { return new Event(type); }
+  // Legacy DOM Level 2 event factory. Spec returns an event of the requested
+  // class with an empty type until init*Event() is called. We previously
+  // returned a generic Event for every type, which broke libraries that call
+  // createEvent('CustomEvent').initCustomEvent(...) — see issue #41.
+  createEvent(type) {
+    const map = {
+      'customevent': CustomEvent, 'customevents': CustomEvent,
+      'mouseevent': MouseEvent,   'mouseevents': MouseEvent,
+      'keyboardevent': KeyboardEvent, 'keyboardevents': KeyboardEvent,
+      'focusevent': FocusEvent,
+      'inputevent': InputEvent,
+      'uievent': UIEvent, 'uievents': UIEvent,
+      'wheelevent': WheelEvent,
+      'pointerevent': PointerEvent,
+      'errorevent': ErrorEvent,
+      'popstateevent': PopStateEvent,
+      'animationevent': AnimationEvent,
+      'transitionevent': TransitionEvent,
+    };
+    const Cls = map[String(type || '').toLowerCase()] || Event;
+    return new Cls('');
+  }
   createRange() { return { setStart(){}, setEnd(){}, collapse(){}, selectNodeContents(){}, cloneContents(){ return document.createDocumentFragment(); } }; }
   addEventListener(type, fn, opts) {} removeEventListener() {} dispatchEvent() { return true; }
   createTreeWalker(root, whatToShow, filter) {
@@ -1841,7 +1862,18 @@ globalThis.Event = class Event {
   preventDefault() { this.defaultPrevented=true; } stopPropagation(){} stopImmediatePropagation(){}
   initEvent(type,bubbles,cancelable) { this.type=type;this.bubbles=!!bubbles;this.cancelable=!!cancelable; }
 };
-globalThis.CustomEvent = class extends Event { constructor(t,o={}) { super(t,o);this.detail=o.detail; } };
+globalThis.CustomEvent = class extends Event {
+  constructor(t,o={}) { super(t,o);this.detail=o.detail; }
+  // Legacy DOM Level 2 init; some libraries (Starbucks China bundle, older
+  // analytics shims) still call createEvent('CustomEvent') + initCustomEvent
+  // instead of new CustomEvent(...). See issue #41.
+  initCustomEvent(type,bubbles,cancelable,detail) {
+    this.type = type;
+    this.bubbles = !!bubbles;
+    this.cancelable = !!cancelable;
+    this.detail = detail;
+  }
+};
 globalThis.MouseEvent = class extends Event { constructor(t,o={}) { super(t,o);this.clientX=o.clientX||0;this.clientY=o.clientY||0; } };
 globalThis.KeyboardEvent = class extends Event { constructor(t,o={}) { super(t,o);this.key=o.key||"";this.code=o.code||""; } };
 globalThis.FocusEvent = class extends Event {};
@@ -2104,7 +2136,7 @@ class _IframeDocument {
   createTextNode(text) { return document.createTextNode(text); }
   createComment(text) { return document.createComment(text); }
   createDocumentFragment() { return document.createDocumentFragment(); }
-  createEvent(type) { return new Event(type); }
+  createEvent(type) { return document.createEvent(type); }
   hasFocus() { return false; }
 
   get cookie() { return ''; }

--- a/crates/obscura-js/src/runtime.rs
+++ b/crates/obscura-js/src/runtime.rs
@@ -1409,6 +1409,66 @@ mod tests {
     }
 
     #[test]
+    fn test_create_event_custom_event_has_init_method() {
+        let mut rt = setup_runtime("<html><body></body></html>");
+        let kind = rt
+            .evaluate("typeof document.createEvent('CustomEvent').initCustomEvent")
+            .unwrap();
+        assert_eq!(kind, serde_json::json!("function"));
+    }
+
+    #[test]
+    fn test_init_custom_event_sets_fields() {
+        let mut rt = setup_runtime("<html><body></body></html>");
+        rt.execute_script(
+            "test",
+            r#"
+            globalThis.__e = document.createEvent('CustomEvent');
+            globalThis.__e.initCustomEvent('myevent', true, false, {hello: 'world'});
+        "#,
+        )
+        .unwrap();
+        let t = rt.evaluate("globalThis.__e.type").unwrap();
+        assert_eq!(t, serde_json::json!("myevent"));
+        let b = rt.evaluate("globalThis.__e.bubbles").unwrap();
+        assert_eq!(b, serde_json::json!(true));
+        let c = rt.evaluate("globalThis.__e.cancelable").unwrap();
+        assert_eq!(c, serde_json::json!(false));
+        let d = rt.evaluate("globalThis.__e.detail.hello").unwrap();
+        assert_eq!(d, serde_json::json!("world"));
+    }
+
+    #[test]
+    fn test_create_event_returns_correct_class() {
+        let mut rt = setup_runtime("<html><body></body></html>");
+        let cust = rt
+            .evaluate("document.createEvent('CustomEvent') instanceof CustomEvent")
+            .unwrap();
+        assert_eq!(cust, serde_json::json!(true));
+        let mouse = rt
+            .evaluate("document.createEvent('MouseEvent') instanceof MouseEvent")
+            .unwrap();
+        assert_eq!(mouse, serde_json::json!(true));
+        let mouses = rt
+            .evaluate("document.createEvent('MouseEvents') instanceof MouseEvent")
+            .unwrap();
+        assert_eq!(mouses, serde_json::json!(true));
+        let kb = rt
+            .evaluate("document.createEvent('KeyboardEvent') instanceof KeyboardEvent")
+            .unwrap();
+        assert_eq!(kb, serde_json::json!(true));
+    }
+
+    #[test]
+    fn test_create_event_unknown_type_returns_event() {
+        let mut rt = setup_runtime("<html><body></body></html>");
+        let kind = rt
+            .evaluate("document.createEvent('NotARealType') instanceof Event")
+            .unwrap();
+        assert_eq!(kind, serde_json::json!(true));
+    }
+
+    #[test]
     fn test_page_content_puppeteer_pattern() {
         let mut rt = setup_runtime("<!DOCTYPE html><html><head></head><body><p>Test</p></body></html>");
         let result = rt.evaluate(


### PR DESCRIPTION
## Summary

Fixes #41 — the legacy DOM Level 2 pattern

```js
var e = document.createEvent('CustomEvent');
e.initCustomEvent('foo', true, false, payload);
```

threw `TypeError: e.initCustomEvent is not a function` on Obscura, killing bootstrap for the Starbucks China app bundle and similar CDN scripts (`r.default.create is not a function` is the surrounding noise — same root cause).

## Root Cause

In `crates/obscura-js/js/bootstrap.js`:

1. `Document.prototype.createEvent(type)` always returned `new Event(type)`, regardless of `type`. So calling `createEvent('CustomEvent')` got back a plain `Event`, not a `CustomEvent`.
2. `CustomEvent` had no `initCustomEvent` method anyway. Even if `(1)` had returned the right class, the second line still would have thrown.

## Fix

Two small changes in `crates/obscura-js/js/bootstrap.js`:

1. **Add `initCustomEvent` to `CustomEvent`** — matches the legacy DOM Level 2 spec (sets `type`, `bubbles`, `cancelable`, `detail`).
2. **Rewrite `createEvent`** — dispatches to the correct event constructor by lowercased type string, with `'Events'` aliases (`'MouseEvents'`, `'KeyboardEvents'`, `'UIEvents'`, `'CustomEvents'`). Returns the event with an empty type until `init*Event()` is called, exactly as the spec requires. The second `createEvent` (on the inner Document class around line 2118) just delegates to the canonical impl on `document`.

Supported type strings: `CustomEvent`, `MouseEvent`/`MouseEvents`, `KeyboardEvent`/`KeyboardEvents`, `FocusEvent`, `InputEvent`, `UIEvent`/`UIEvents`, `WheelEvent`, `PointerEvent`, `ErrorEvent`, `PopStateEvent`, `AnimationEvent`, `TransitionEvent`. Anything else falls through to `Event`.

Net diff: +38 / −3 in `bootstrap.js`, +60 in `runtime.rs` for tests.

## Verification

```bash
# Before
$ obscura fetch 'https://www.starbucks.com.cn/account/#/' \
    --wait-until networkidle \
    --eval 'return window.__xr_bmobdb'
WARN obscura_browser::page: Script error (...esabxubs5h.js): JS error: TypeError: e.initCustomEvent is not a function
null

# After
$ obscura fetch 'https://www.starbucks.com.cn/account/#/' \
    --wait-until networkidle \
    --eval 'return window.__xr_bmobdb'
function(){"use strict";var q=e.L();var I=new PT(D,N,q,this);...}
```

Minimal repro that doesn't require Starbucks:

```bash
$ obscura fetch 'about:blank' \
    --eval 'var e=document.createEvent("CustomEvent"); e.initCustomEvent("x",true,false,{a:1}); return e.detail.a'
1
```

## Test plan

- [x] `cargo test -p obscura-js --lib` — 54 pass / 0 fail. Four new tests cover:
  - `test_create_event_custom_event_has_init_method`
  - `test_init_custom_event_sets_fields` (type / bubbles / cancelable / detail propagated)
  - `test_create_event_returns_correct_class` (CustomEvent / MouseEvent / MouseEvents / KeyboardEvent)
  - `test_create_event_unknown_type_returns_event` (fallback)
- [x] `cargo build` clean.
- [x] No regressions across existing 50 obscura-js tests.
- [ ] Stealth build skipped (no macOS host).

## Risk

Low. `initCustomEvent` is additive; the only behavior change in `createEvent` is that it now returns the class the spec demands instead of always-`Event`. Code that relied on `createEvent('CustomEvent')` returning a plain `Event` would have been an unusual bet, and the two-class instanceof tests confirm new behavior.

Generated by Ora Studio
Vibe coded by ousamabenyounes