### PR TITLE
fix(cdp): accept Audits domain as no-op for Puppeteer (#57)

### DIFF
--- a/crates/obscura-cdp/src/dispatch.rs
+++ b/crates/obscura-cdp/src/dispatch.rs
@@ -136,9 +136,13 @@ pub async fn dispatch(req: &CdpRequest, ctx: &mut CdpContext) -> CdpResponse {
         "Storage" => domains::storage::handle(method, &req.params, ctx, &req.session_id).await,
         "LP" => domains::lp::handle(method, &req.params, ctx, &req.session_id).await,
         "Accessibility" => domains::accessibility::handle(method, &req.params, ctx, &req.session_id).await,
+        // Accepted but no-op. Puppeteer's FrameManager.initialize calls
+        // Audits.enable on connect — refusing it breaks puppeteer.connect()
+        // before any user code runs.
         "Emulation" | "Log" | "Performance" | "Security" | "CSS"
         | "ServiceWorker" | "Inspector"
-        | "Debugger" | "Profiler" | "HeapProfiler" | "Overlay" => {
+        | "Debugger" | "Profiler" | "HeapProfiler" | "Overlay"
+        | "Audits" => {
             Ok(json!({}))
         }
         _ => Err(format!("Unknown domain: {}", domain)),
@@ -150,5 +154,37 @@ pub async fn dispatch(req: &CdpRequest, ctx: &mut CdpContext) -> CdpResponse {
             tracing::warn!("CDP error for {}: {}", req.method, msg);
             CdpResponse::error(req.id, -32601, msg, req.session_id.clone())
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::types::CdpRequest;
+
+    fn req(method: &str) -> CdpRequest {
+        CdpRequest {
+            id: 1,
+            method: method.into(),
+            params: json!({}),
+            session_id: None,
+        }
+    }
+
+    #[tokio::test]
+    async fn audits_enable_returns_empty_success() {
+        let mut ctx = CdpContext::new();
+        let resp = dispatch(&req("Audits.enable"), &mut ctx).await;
+        assert!(resp.error.is_none(), "Audits.enable should not error: {:?}", resp.error);
+        assert_eq!(resp.result, Some(json!({})));
+    }
+
+    #[tokio::test]
+    async fn unknown_domain_still_errors() {
+        let mut ctx = CdpContext::new();
+        let resp = dispatch(&req("DefinitelyNotADomain.enable"), &mut ctx).await;
+        let err = resp.error.expect("unknown domain must surface as error");
+        assert_eq!(err.code, -32601);
+        assert!(err.message.contains("Unknown domain"));
     }
 }


### PR DESCRIPTION
## Summary

Fixes #57

`puppeteer.connect()` against Obscura fails immediately with:

```
ProtocolError: Protocol error (Audits.enable): Unknown domain: Audits
```

## Root Cause

Puppeteer's `FrameManager.initialize` calls `Audits.enable` on every connection. Obscura's CDP dispatcher had no `Audits` arm, so the call fell through to `Unknown domain: <D>` and Puppeteer aborted before any user code ran. Playwright doesn't touch `Audits`, which is why the issue's workaround sidesteps the problem.

## Fix

Add `Audits` to the existing accepted-but-no-op domain list in `crates/obscura-cdp/src/dispatch.rs`, alongside `Log`, `Performance`, `Security`, `CSS`, etc. that already swallow Puppeteer's connect chatter. No new module, no behavior change for any working CDP method.

## Verification

```bash
cargo test -p obscura-cdp --lib
# running 2 tests
# test dispatch::tests::audits_enable_returns_empty_success ... ok
# test dispatch::tests::unknown_domain_still_errors ... ok
# test result: ok. 2 passed; 0 failed
cargo check --workspace        # clean
```

Repro from the issue:

```javascript
const puppeteer = require('puppeteer-core');
const browser = await puppeteer.connect({
  browserWSEndpoint: 'ws://127.0.0.1:9222/devtools/browser',
});
// Before: throws Audits.enable Unknown domain
// After:  connects cleanly
```

## Test plan

- [x] New unit test asserts `Audits.enable` returns success with `{}` body
- [x] New regression test asserts dispatcher still errors on truly unknown domains (so we don't accidentally swallow real bugs)
- [x] `cargo check --workspace` clean
- [x] Stealth build skipped — no stealth code touched

## Risk

Low. Single-line addition to the accepted-domain list, identical pattern to 10 other domains already there.

Generated by Ora Studio
Vibe coded by ousamabenyounes