### PR TITLE
fix(cdp): implement Target.attachToBrowserTarget (#64)

### DIFF
--- a/crates/obscura-cdp/src/domains/target.rs
+++ b/crates/obscura-cdp/src/domains/target.rs
@@ -104,6 +104,31 @@ pub async fn handle(method: &str, params: &Value, ctx: &mut CdpContext) -> Resul
 
             Ok(json!({ "targetId": page_id }))
         }
+        "attachToBrowserTarget" => {
+            // Playwright calls this on connect to obtain a session for the
+            // implicit "browser" target. Returning Unknown method aborts
+            // the connect handshake before any user code runs.
+            let session_id = "browser-session".to_string();
+            ctx.sessions.insert(session_id.clone(), "browser".to_string());
+
+            ctx.pending_events.push(CdpEvent::new(
+                "Target.attachedToTarget",
+                json!({
+                    "sessionId": session_id,
+                    "targetInfo": {
+                        "targetId": "browser",
+                        "type": "browser",
+                        "title": "",
+                        "url": "",
+                        "attached": true,
+                        "browserContextId": "",
+                    },
+                    "waitingForDebugger": false,
+                }),
+            ));
+
+            Ok(json!({ "sessionId": session_id }))
+        }
         "attachToTarget" => {
             let target_id = params.get("targetId").and_then(|v| v.as_str())
                 .ok_or("targetId required")?;
@@ -192,5 +217,44 @@ pub async fn handle(method: &str, params: &Value, ctx: &mut CdpContext) -> Resul
             }
         }
         _ => Err(format!("Unknown Target method: {}", method)),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn attach_to_browser_target_returns_session_id() {
+        let mut ctx = CdpContext::new();
+        let result = handle("attachToBrowserTarget", &json!({}), &mut ctx)
+            .await
+            .expect("attachToBrowserTarget should succeed");
+
+        assert_eq!(result["sessionId"], "browser-session");
+        assert_eq!(
+            ctx.sessions.get("browser-session").map(String::as_str),
+            Some("browser")
+        );
+
+        // Playwright/Puppeteer expect a Target.attachedToTarget event before
+        // they finish wiring up the session — without it the connect promise
+        // hangs.
+        let attached_evt = ctx
+            .pending_events
+            .iter()
+            .find(|e| e.method == "Target.attachedToTarget")
+            .expect("attachedToTarget event must be emitted");
+        assert_eq!(attached_evt.params["sessionId"], "browser-session");
+        assert_eq!(attached_evt.params["targetInfo"]["type"], "browser");
+    }
+
+    #[tokio::test]
+    async fn unknown_target_method_still_errors() {
+        let mut ctx = CdpContext::new();
+        let err = handle("notARealMethod", &json!({}), &mut ctx)
+            .await
+            .expect_err("unknown methods must surface as errors");
+        assert!(err.contains("Unknown Target method"));
     }
 }


### PR DESCRIPTION
## Summary

Addresses item (1) from #64 — Playwright cannot connect to Obscura because the CDP `Target.attachToBrowserTarget` method is not implemented:

```
WARN obscura_cdp::dispatch: CDP error for Target.attachToBrowserTarget: Unknown Target method: attachToBrowserTarget
```

The other two items in #64:
- `Page.getLayoutMetrics` — fixed in PR #79
- Rocket Loader / Cloudflare JS execution — out of scope, much larger work; tracking separately

## Root Cause

`crates/obscura-cdp/src/domains/target.rs` had handlers for `attachToTarget`, `createTarget`, etc., but no `attachToBrowserTarget`. Playwright calls this on connect to obtain a session for the implicit "browser" target — without it the connect handshake aborts before any user code runs.

## Fix

Add an `attachToBrowserTarget` handler that mirrors `attachToTarget` but for the browser target:

1. Register a `"browser-session"` → `"browser"` mapping in `ctx.sessions`
2. Emit a `Target.attachedToTarget` event with `targetInfo.type = "browser"`
3. Return `{ sessionId: "browser-session" }`

Same shape Chrome's CDP returns, so Playwright's connect promise resolves and subsequent calls (already keyed by session) route correctly.

## Verification

```bash
cargo test -p obscura-cdp --lib
# running 2 tests
# test domains::target::tests::attach_to_browser_target_returns_session_id ... ok
# test domains::target::tests::unknown_target_method_still_errors ... ok
# test result: ok. 2 passed; 0 failed
cargo check --workspace        # clean
```

Repro from the issue:

```python
from playwright.sync_api import sync_playwright
with sync_playwright() as p:
    browser = p.chromium.connect_over_cdp("ws://127.0.0.1:9222")
    # Before: CDP warning + Playwright connect hangs / times out
    # After:  connect resolves, browser.contexts() works
```

## Test plan

- [x] New unit test asserts the response shape, the session-table mutation, and the emitted `attachedToTarget` event with `type=browser`
- [x] New regression test asserts unknown Target methods still error (so we don't accidentally swallow real bugs)
- [x] `cargo check --workspace` clean
- [x] Stealth build skipped — no stealth code touched

## Risk

Low. Pure addition of a new dispatcher arm and a synthetic session entry; no existing code paths altered. The new session id `"browser-session"` doesn't map to a real `Page` (since the browser target has no DOM), but `get_session_page_mut` already returns `None` for unknown ids and every caller handles that case.

Generated by Ora Studio
Vibe coded by ousamabenyounes