### PR TITLE
fix(cli): strip nav/header/footer/aside from --dump text (#55)

### DIFF
--- a/crates/obscura-cli/src/main.rs
+++ b/crates/obscura-cli/src/main.rs
@@ -442,7 +442,13 @@ fn extract_readable_text(dom: &obscura_dom::DomTree, node_id: obscura_dom::NodeI
                     | "ul" | "ol"
             );
 
-            if tag == "script" || tag == "style" {
+            // Boilerplate elements rarely contain content the user wants to
+            // scrape — strip them so `--dump text` returns the article body
+            // instead of menus, footers, and cookie banners.
+            if matches!(
+                tag,
+                "script" | "style" | "nav" | "header" | "footer" | "aside"
+            ) {
                 return result;
             }
 
@@ -724,4 +730,55 @@ fn dump_links(page: &Page) {
             }
         }
     });
+}
+
+#[cfg(test)]
+mod tests {
+    use super::extract_readable_text;
+    use obscura_dom::parse_html;
+
+    fn body_text(html: &str) -> String {
+        let dom = parse_html(html);
+        let body = dom
+            .query_selector("body")
+            .ok()
+            .flatten()
+            .expect("body must exist");
+        extract_readable_text(&dom, body).split_whitespace().collect::<Vec<_>>().join(" ")
+    }
+
+    #[test]
+    fn skips_nav_header_footer_aside() {
+        let text = body_text(
+            r#"<html><body>
+                <header>SITE HEADER</header>
+                <nav>NAV LINKS</nav>
+                <aside>SIDEBAR</aside>
+                <main><p>Article body.</p></main>
+                <footer>FOOTER</footer>
+            </body></html>"#,
+        );
+        assert!(text.contains("Article body."), "main content kept: {text}");
+        for boilerplate in ["SITE HEADER", "NAV LINKS", "SIDEBAR", "FOOTER"] {
+            assert!(
+                !text.contains(boilerplate),
+                "boilerplate '{boilerplate}' leaked through: {text}"
+            );
+        }
+    }
+
+    #[test]
+    fn still_skips_script_and_style() {
+        // Regression guard for the original skip list.
+        let text = body_text(
+            r#"<html><body>
+                <p>Hello.</p>
+                <script>console.log("nope")</script>
+                <style>.x { color: red }</style>
+            </body></html>"#,
+        );
+        assert!(text.contains("Hello."));
+        assert!(!text.contains("console.log"));
+        assert!(!text.contains("color: red"));
+    }
 }


### PR DESCRIPTION
## Summary

Fixes #55

`obscura fetch --dump text` returns the full body text including navigation, sidebars, and footers. For most scraping use cases users only want the article body. This PR adds the four standard semantic-boilerplate tags (`<nav>`, `<header>`, `<footer>`, `<aside>`) to the existing skip list inside `extract_readable_text`, alongside the `<script>` / `<style>` exclusion that's already there.

## Fix

Single-line change to `crates/obscura-cli/src/main.rs`:

```rust
// before
if tag == "script" || tag == "style" { return result; }

// after
if matches!(tag, "script" | "style" | "nav" | "header" | "footer" | "aside") {
    return result;
}
```

Implements the issue's first proposal (unconditional skip). I considered adding a `--content-only` flag instead, but the boilerplate tags are universal: anything inside `<nav>` / `<footer>` is by HTML semantics not the page's content. Anyone needing the original noisy output can still use `--dump html` and post-process.

## Verification

```bash
cargo test -p obscura-cli --bin obscura
# running 2 tests
# test tests::skips_nav_header_footer_aside ... ok
# test tests::still_skips_script_and_style ... ok
# test result: ok. 2 passed; 0 failed
cargo check --workspace        # clean
```

Manual repro from the issue:

```bash
cargo build --release
./target/release/obscura fetch --dump text https://en.wikipedia.org/wiki/Deep_fried_ice_cream
# Before: "Jump to content / Main menu / Donate / Create account / ... <article body> / Privacy policy / About Wikipedia ..."
# After:  article body, no Wikipedia chrome
```

## Test plan

- [x] New unit test feeds a synthetic page with header/nav/aside/footer + article body, asserts only the article remains
- [x] New regression test re-asserts script/style still get stripped (so we don't accidentally break the existing skip)
- [x] `cargo check --workspace` clean
- [x] Stealth build skipped — no stealth code touched

## Risk

Low. The skip list is purely additive at the top of `extract_readable_text`; nothing else in the call chain reads or writes those tag names.

## Related

A `--dump markdown` variant (#54) is in flight as PR #78. The two are independent — both edit `extract_readable_text` callers but in different code paths.

Generated by Ora Studio
Vibe coded by ousamabenyounes