### PR TITLE
fix(cdp): implement Target.sendMessageToTarget for headless_chrome (#26)

### DIFF
--- a/crates/obscura-cdp/src/dispatch.rs
+++ b/crates/obscura-cdp/src/dispatch.rs
@@ -121,6 +121,14 @@ impl CdpContext {
 }
 
 pub async fn dispatch(req: &CdpRequest, ctx: &mut CdpContext) -> CdpResponse {
+    // headless_chrome (and older Puppeteer) wrap every CDP call inside
+    // Target.sendMessageToTarget. Unwrap and recurse BEFORE acquiring the
+    // V8 lock — the recursive dispatch will acquire it for the inner call,
+    // and tokio Mutex is not reentrant.
+    if req.method == "Target.sendMessageToTarget" {
+        return dispatch_send_message_to_target(req, ctx).await;
+    }
+
     // Issue #19: V8 fatal abort under concurrent CDP work.
     //
     // Every CDP handler below may end up calling into a per-Page `JsRuntime`
@@ -187,6 +195,63 @@ pub async fn dispatch(req: &CdpRequest, ctx: &mut CdpContext) -> CdpResponse {
     }
 }
 
+async fn dispatch_send_message_to_target(req: &CdpRequest, ctx: &mut CdpContext) -> CdpResponse {
+    let session_id = req
+        .params
+        .get("sessionId")
+        .and_then(|v| v.as_str())
+        .map(str::to_string);
+    let message = match req.params.get("message").and_then(|v| v.as_str()) {
+        Some(m) => m,
+        None => {
+            return CdpResponse::error(
+                req.id,
+                -32602,
+                "sendMessageToTarget requires a message string".into(),
+                req.session_id.clone(),
+            );
+        }
+    };
+
+    let inner: CdpRequest = match serde_json::from_str(message) {
+        Ok(r) => r,
+        Err(e) => {
+            return CdpResponse::error(
+                req.id,
+                -32700,
+                format!("sendMessageToTarget message is not a valid CDP request: {e}"),
+                req.session_id.clone(),
+            );
+        }
+    };
+
+    // Override the inner session with the one supplied by the wrapper so
+    // the inner dispatch routes against the right page. Boxing the future
+    // sidesteps the async-fn recursion limit.
+    let inner_with_session = CdpRequest {
+        id: inner.id,
+        method: inner.method.clone(),
+        params: inner.params,
+        session_id: session_id.clone().or(inner.session_id),
+    };
+    let inner_response = Box::pin(dispatch(&inner_with_session, ctx)).await;
+
+    // Re-emit the inner response as the legacy event headless_chrome (and
+    // older Puppeteer) listen for instead of correlating responses by id.
+    let inner_serialized = serde_json::to_string(&inner_response).unwrap_or_else(|_| "{}".into());
+    ctx.pending_events.push(CdpEvent {
+        method: "Target.receivedMessageFromTarget".to_string(),
+        params: json!({
+            "sessionId": session_id.clone().unwrap_or_default(),
+            "message": inner_serialized,
+            "targetId": session_id.clone().unwrap_or_default(),
+        }),
+        session_id: req.session_id.clone(),
+    });
+
+    CdpResponse::success(req.id, json!({}), req.session_id.clone())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -216,5 +281,61 @@ mod tests {
         let err = resp.error.expect("unknown domain must surface as error");
         assert_eq!(err.code, -32601);
         assert!(err.message.contains("Unknown domain"));
+    }
+
+    #[tokio::test]
+    async fn send_message_to_target_unwraps_inner_call() {
+        let mut ctx = CdpContext::new();
+        let inner = json!({
+            "id": 42,
+            "method": "Browser.getVersion",
+            "params": {},
+        });
+        let outer = CdpRequest {
+            id: 99,
+            method: "Target.sendMessageToTarget".into(),
+            params: json!({
+                "sessionId": "sess-1",
+                "message": inner.to_string(),
+            }),
+            session_id: None,
+        };
+
+        let resp = dispatch(&outer, &mut ctx).await;
+        assert!(resp.error.is_none(), "wrapper must succeed: {:?}", resp.error);
+        assert_eq!(resp.id, 99);
+        assert_eq!(resp.result, Some(json!({})));
+
+        // headless_chrome reads the inner response from the
+        // receivedMessageFromTarget event, not from the wrapper response.
+        let evt = ctx
+            .pending_events
+            .iter()
+            .find(|e| e.method == "Target.receivedMessageFromTarget")
+            .expect("receivedMessageFromTarget event must be emitted");
+        assert_eq!(evt.params["sessionId"], "sess-1");
+        let inner_msg = evt.params["message"].as_str().expect("message is a string");
+        let parsed: serde_json::Value = serde_json::from_str(inner_msg).unwrap();
+        assert_eq!(parsed["id"], 42);
+        // Browser.getVersion returns a populated result object, not an error.
+        assert!(parsed.get("result").is_some(), "inner response carries result");
+        assert!(parsed.get("error").is_none(), "inner response is not an error");
+    }
+
+    #[tokio::test]
+    async fn send_message_to_target_rejects_invalid_message() {
+        let mut ctx = CdpContext::new();
+        let outer = CdpRequest {
+            id: 5,
+            method: "Target.sendMessageToTarget".into(),
+            params: json!({
+                "sessionId": "sess-1",
+                "message": "{not valid json",
+            }),
+            session_id: None,
+        };
+        let resp = dispatch(&outer, &mut ctx).await;
+        let err = resp.error.expect("malformed inner messages must error");
+        assert_eq!(err.code, -32700);
     }
 }


### PR DESCRIPTION
## Summary

Addresses the headless_chrome leg of #26. After this change, Rust CDP clients that wrap their calls inside `Target.sendMessageToTarget` (notably `headless_chrome`, and older Puppeteer versions) can drive Obscura through their high-level APIs instead of failing with "Unknown Target method".

## Root Cause

`crates/obscura-cdp/src/domains/target.rs` had handlers for `attachToTarget` / `createTarget` / etc., but no `sendMessageToTarget`. That method is the legacy CDP wire format Chrome itself still honours: clients send their actual CDP method as a JSON-encoded string inside `params.message`, and the server is expected to dispatch the inner request and emit the response as a `Target.receivedMessageFromTarget` event (rather than as a normal response correlated by id).

`headless_chrome` connected, then sent its very first navigation through this wrapper, got the unknown-method error, and gave up.

## Fix

Intercept `Target.sendMessageToTarget` in `dispatch()` before the per-domain match and:

1. Parse the inner JSON-encoded CDP request from `params.message`
2. Recursively dispatch it using the wrapper's `sessionId` so routing lands on the right page (the future is boxed to sidestep the async-fn recursion limit)
3. Re-emit the inner response as a `Target.receivedMessageFromTarget` event with the inner payload re-serialised as a string — the contract these clients actually listen on
4. Return `{}` for the wrapper itself

No existing call paths change; clients that don't use the wrapper (Playwright, recent Puppeteer over `connect_over_cdp`) keep using the regular request/response flow.

## What this does NOT fix

The `chromiumoxide` half of #26 — `data did not match any variant of untagged enum Message` — is an event/response *shape* issue, not a routing issue. It needs a focused investigation against a chromiumoxide repro that the issue doesn't include (which exact message fails to decode? a server-emitted event? a response missing a field?). Left out of this PR rather than guessing.

## Verification

```bash
cargo test -p obscura-cdp --lib
# running 3 tests
# test dispatch::tests::send_message_to_target_unwraps_inner_call ... ok
# test dispatch::tests::send_message_to_target_rejects_invalid_message ... ok
# test dispatch::tests::unknown_domain_still_errors ... ok
# test result: ok. 3 passed; 0 failed
cargo check --workspace        # clean
```

Manual repro from the issue:

```rust
use headless_chrome::Browser;
let browser = Browser::connect("ws://127.0.0.1:9222/devtools/browser/...".into())?;
let tab = browser.new_tab()?;
tab.navigate_to("https://example.com")?;
// Before: "Unknown Target method: sendMessageToTarget" — nav fails immediately
// After:  inner Page.navigate dispatched; receivedMessageFromTarget event carries the response
```

## Test plan

- [x] New unit test wraps a `Browser.getVersion` request, asserts the wrapper succeeds and the inner response is emitted via `Target.receivedMessageFromTarget` with the inner method's `result` populated
- [x] New regression test asserts malformed inner JSON surfaces as a parse error (-32700) instead of silently swallowing the request
- [x] Existing "Unknown domain still errors" regression test kept
- [x] `cargo check --workspace` clean
- [x] Stealth build skipped — no stealth code touched

## Risk

Low-to-medium. New code path only activates for callers that send `Target.sendMessageToTarget`. The recursion is bounded by the inner message's own dispatch (and an inner `Target.sendMessageToTarget` would just box another future the same way). Boxed dispatch is required for async recursion in Rust — without it the future type would be infinite.

Generated by Ora Studio
Vibe coded by ousamabenyounes