### PR TITLE
Build Linux release on Ubuntu 22.04

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,10 @@ jobs:
       matrix:
         include:
           - target: x86_64-unknown-linux-gnu
-            os: ubuntu-latest
+            # Build on Ubuntu 22.04 so the Linux release binary works on
+            # common LTS servers with glibc 2.35 instead of requiring the
+            # newer glibc shipped by ubuntu-latest.
+            os: ubuntu-22.04
             name: obscura-x86_64-linux
           - target: aarch64-apple-darwin
             os: macos-latest

--- a/README.md
+++ b/README.md
@@ -53,6 +53,9 @@ Download the `.zip` from the releases page and extract it manually.
 
 Single binary. No Chrome, no Node.js, no dependencies.
 
+Linux release builds target Ubuntu 22.04 so the downloaded binary remains
+usable on common LTS servers with glibc 2.35+.
+
 ### Build from source
 
 ```bash


### PR DESCRIPTION
 The current Linux release is built on ubuntu-latest, which can produce binaries requiring newer glibc versions than common LTS
  servers provide.

  This changes only the Linux x86_64 release job to ubuntu-22.04 so the prebuilt binary remains compatible with Ubuntu 22.04 /
  glibc 2.35 environments.

  macOS and Windows release jobs are unchanged.

  Also adds a short README note explaining the Linux LTS compatibility target.