### PR TITLE
Fix license metadata and README heading

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ members = [
 [workspace.package]
 version = "0.1.0"
 edition = "2021"
-license = "MIT"
+license = "Apache-2.0"
 repository = "https://github.com/h4ckf0r0day/obscura"
 
 [workspace.dependencies]

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
   <img src="https://raw.githubusercontent.com/h4ckf0r0day/obscura/main/assets/icon.png" alt="Obscura" width="80" />
 </p>
 
-<h2 align="center">Obscura</h1>
+<h2 align="center">Obscura</h2>
 
 <p align="center">
   <strong>The open-source headless browser for AI agents and web scraping.</strong><br>


### PR DESCRIPTION
Aligns package license metadata and fixes the README heading typo.

  Verification:
  - cargo check -p obscura-cli