### PR TITLE
Package obscura-worker in release archives

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,14 +47,14 @@ jobs:
         if: runner.os != 'Windows'
         run: |
           cd target/${{ matrix.target }}/release
-          tar czf ../../../${{ matrix.name }}.tar.gz obscura
+          tar czf ../../../${{ matrix.name }}.tar.gz obscura obscura-worker
           cd ../../..
 
       - name: Package (Windows)
         if: runner.os == 'Windows'
         run: |
           cd target/${{ matrix.target }}/release
-          7z a ../../../${{ matrix.name }}.zip obscura.exe
+          7z a ../../../${{ matrix.name }}.zip obscura.exe obscura-worker.exe
           cd ../../..
 
       - name: Upload

--- a/README.md
+++ b/README.md
@@ -51,7 +51,9 @@ tar xzf obscura-x86_64-macos.tar.gz
 Download the `.zip` from the releases page and extract it manually.
 ```
 
-Single binary. No Chrome, no Node.js, no dependencies.
+No Chrome, no Node.js, no dependencies. Release archives include both
+`obscura` and `obscura-worker`; keep them in the same directory for the
+parallel `scrape` command.
 
 ### Build from source
 


### PR DESCRIPTION
Includes the obscura-worker binary in release archives so packaged CLI workflows have the worker executable available.

  Verification:
  - cargo check -p obscura-cli