### PR TITLE
Remove unused IpAddr import

### DIFF
--- a/crates/obscura-net/src/client.rs
+++ b/crates/obscura-net/src/client.rs
@@ -1,5 +1,4 @@
 use std::collections::HashMap;
-use std::net::IpAddr;
 use std::sync::Arc;
 use std::time::Duration;
 


### PR DESCRIPTION
 Removes the unused std::net::IpAddr import from obscura-net.

  Verification:
  - cargo check -p obscura-cli
  - Confirmed the previous unused IpAddr warning no longer appears.