### PR TITLE
Remove unused AsyncReadExt import

### DIFF
--- a/crates/obscura-cli/src/main.rs
+++ b/crates/obscura-cli/src/main.rs
@@ -179,7 +179,7 @@ async fn run_multi_worker_serve(
     stealth: bool,
 ) -> anyhow::Result<()> {
     use tokio::net::TcpListener;
-    use tokio::io::{AsyncReadExt as _, AsyncWriteExt as _};
+    use tokio::io::AsyncWriteExt as _;
 
     let exe = std::env::current_exe()?;
     let mut children = Vec::new();


### PR DESCRIPTION
Removes the unused AsyncReadExt as _ import from the CLI multi-worker serve path.

  Verification:
  - cargo check -p obscura-cli
  - Confirmed the previous unused AsyncReadExt warning no longer appears.