### PR TITLE
feat(serve): add --host flag to configure bind address

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+target/
+.git/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,30 @@
+# Step 1: Use the latest stable Rust version
+FROM rust:1.95-slim AS builder
+
+# Step 2: Install system dependencies
+RUN apt-get update && apt-get install -y \
+    git \
+    python3 \
+    build-essential \
+    cmake \
+    clang \
+    curl \
+    && rm -rf /var/lib/apt/lists/*
+
+# Step 3: Copy local source instead of cloning from GitHub
+WORKDIR /usr/src/obscura
+COPY . .
+
+# Step 4: Build from source
+RUN cargo build --release --features stealth
+
+# Step 5: Use Debian Trixie (Matches GLIBC 2.39/2.40)
+FROM debian:trixie-slim
+RUN apt-get update && apt-get install -y libssl-dev ca-certificates && rm -rf /var/lib/apt/lists/*
+COPY --from=builder /usr/src/obscura/target/release/obscura /usr/local/bin/obscura
+
+# Step 6: Set the default command
+# --host 0.0.0.0 is required so the server binds on all interfaces inside Docker,
+# allowing the host to reach it through the published port (-p 9222:9222).
+ENTRYPOINT ["obscura"]
+CMD ["serve", "--port", "9222", "--host", "0.0.0.0"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,6 @@ FROM rust:1.95-slim AS builder
 
 # Step 2: Install system dependencies
 RUN apt-get update && apt-get install -y \
-    git \
     python3 \
     build-essential \
     cmake \
@@ -20,8 +19,10 @@ RUN cargo build --release --features stealth
 
 # Step 5: Use Debian Trixie (Matches GLIBC 2.39/2.40)
 FROM debian:trixie-slim
-RUN apt-get update && apt-get install -y libssl-dev ca-certificates && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get install -y libssl3 ca-certificates && rm -rf /var/lib/apt/lists/*
 COPY --from=builder /usr/src/obscura/target/release/obscura /usr/local/bin/obscura
+
+EXPOSE 9222
 
 # Step 6: Set the default command
 # --host 0.0.0.0 is required so the server binds on all interfaces inside Docker,

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,7 @@ FROM rust:1.95-slim AS builder
 
 # Step 2: Install system dependencies
 RUN apt-get update && apt-get install -y \
+    git \
     python3 \
     build-essential \
     cmake \

--- a/crates/obscura-cdp/src/lib.rs
+++ b/crates/obscura-cdp/src/lib.rs
@@ -3,4 +3,4 @@ pub mod dispatch;
 pub mod types;
 pub mod domains;
 
-pub use server::{start, start_with_full_options, start_with_options};
+pub use server::{start, start_with_options, start_with_full_options, start_with_host};

--- a/crates/obscura-cdp/src/server.rs
+++ b/crates/obscura-cdp/src/server.rs
@@ -41,7 +41,17 @@ pub async fn start_with_full_options(
     stealth: bool,
     user_agent: Option<String>,
 ) -> anyhow::Result<()> {
-    let addr = SocketAddr::from(([127, 0, 0, 1], port));
+    start_with_host(port, proxy, stealth, [127, 0, 0, 1], user_agent).await
+}
+
+pub async fn start_with_host(
+    port: u16,
+    proxy: Option<String>,
+    stealth: bool,
+    host: [u8; 4],
+    user_agent: Option<String>,
+) -> anyhow::Result<()> {
+    let addr = SocketAddr::from((host, port));
     let listener = TcpListener::bind(&addr).await?;
 
     info!("Obscura CDP server listening on ws://127.0.0.1:{}", port);

--- a/crates/obscura-cli/src/main.rs
+++ b/crates/obscura-cli/src/main.rs
@@ -35,6 +35,9 @@ enum Command {
         #[arg(short, long, default_value_t = 9222)]
         port: u16,
 
+        #[arg(long, default_value = "127.0.0.1")]
+        host: String,
+
         #[arg(long)]
         proxy: Option<String>,
 
@@ -133,7 +136,7 @@ async fn main() -> anyhow::Result<()> {
         .init();
 
     match args.command {
-        Some(Command::Serve { port, proxy, user_agent, stealth, workers }) => {
+        Some(Command::Serve { port, host, proxy, user_agent, stealth, workers }) => {
             print_banner(port);
             if let Some(ref proxy) = proxy {
                 tracing::info!("Using proxy: {}", proxy);
@@ -150,11 +153,13 @@ async fn main() -> anyhow::Result<()> {
                 tracing::info!("Stealth mode enabled (tracker blocking)");
             }
 
+            let host_octets = parse_host(&host)?;
+
             if workers > 1 {
                 tracing::info!("{} worker processes", workers);
                 run_multi_worker_serve(port, workers, proxy, stealth, user_agent).await?;
             } else {
-                obscura_cdp::start_with_full_options(port, proxy, stealth, user_agent).await?;
+                obscura_cdp::start_with_host(port, proxy, stealth, host_octets, user_agent).await?;
             }
         }
         Some(Command::Fetch { url, dump, selector, wait, timeout, wait_until, user_agent, stealth, eval, quiet }) => {
@@ -694,6 +699,12 @@ async fn run_parallel_scrape(
     }
 
     Ok(())
+}
+
+fn parse_host(host: &str) -> anyhow::Result<[u8; 4]> {
+    let addr: std::net::Ipv4Addr = host.parse()
+        .map_err(|_| anyhow::anyhow!("Invalid host address '{}'. Use an IPv4 address like 0.0.0.0 or 127.0.0.1", host))?;
+    Ok(addr.octets())
 }
 
 fn dump_links(page: &Page) {


### PR DESCRIPTION
 The CDP server was hardcoded to bind on 127.0.0.1, making it unreachable through Docker port forwarding on Linux where iptables routes to the container's eth0 interface, not loopback.

Adds a --host <IPv4> flag to the serve subcommand (default: 127.0.0.1 to preserve existing behaviour) so users can pass 
--host 0.0.0.0 when running in Docker or any remote deployment.

Also adds a Dockerfile and .dockerignore to the repo root.