### PR TITLE
fix(stealth): gate wreq's prefix-symbols feature to Linux/Android (closes #39)

### DIFF
--- a/crates/obscura-net/Cargo.toml
+++ b/crates/obscura-net/Cargo.toml
@@ -16,5 +16,14 @@ serde_json = { workspace = true }
 tracing = { workspace = true }
 thiserror = { workspace = true }
 async-trait = "0.1"
-wreq = { version = "6.0.0-rc.28", optional = true, features = ["prefix-symbols"] }
 wreq-util = { version = "3.0.0-rc.10", optional = true }
+
+# `prefix-symbols` renames BoringSSL exports to avoid clashes with system OpenSSL,
+# but the renaming is only correct on Linux and Android (per wreq's README).
+# Enabling it on other platforms produces unresolved `build_script_main_*`
+# symbols at link time (see issue #39).
+[target.'cfg(any(target_os = "linux", target_os = "android"))'.dependencies]
+wreq = { version = "6.0.0-rc.28", optional = true, features = ["prefix-symbols"] }
+
+[target.'cfg(not(any(target_os = "linux", target_os = "android")))'.dependencies]
+wreq = { version = "6.0.0-rc.28", optional = true }


### PR DESCRIPTION
Closes #39.

`wreq`'s `prefix-symbols` feature is documented as Linux/Android only — quoting wreq's README:

> On Linux and Android, this issue can be avoided by enabling the `prefix-symbols` feature.

`obscura-net` enables it unconditionally, which fails to link on macOS with unresolved `build_script_main_*` BoringSSL symbols (multiple reporters on macOS 26 arm64).

This PR moves `wreq` into target-conditional tables so `prefix-symbols` is on for Linux/Android and off elsewhere. `wreq-util` stays unconditional.

### Verification

- macOS 26 arm64, Rust 1.88: `cargo build --release --features stealth` builds clean. `obscura fetch <url> --stealth --eval "document.title"` returns the expected title; `--eval "navigator.webdriver"` returns `null` (matching real Chrome).
- Linux/Android behavior unchanged from current `main`.

### Why not just drop the feature?

Removing it unconditionally would re-introduce the symbol-conflict risk on Linux that motivated the original feature. Gating by OS keeps the existing protection where it works and turns it off where it doesn't.