### PR TITLE
fix(cdp): return descriptive error for Page.printToPDF instead of generic Unknown Page method (#53)

### DIFF
--- a/crates/obscura-cdp/src/domains/page.rs
+++ b/crates/obscura-cdp/src/domains/page.rs
@@ -273,6 +273,20 @@ pub async fn handle(
                 }]
             }))
         }
+        "printToPDF" => {
+            // Obscura has no layout/rendering engine, so PDF generation is
+            // intentionally not implemented. Returning a distinct, descriptive
+            // error (rather than the generic "Unknown Page method" fallback)
+            // tells Playwright/Puppeteer/headless_chrome clients exactly why
+            // the call failed and what to do instead.
+            Err(
+                "Page.printToPDF is not supported by Obscura: no layout engine. \
+                 Use Runtime.evaluate (e.g. page.evaluate) to extract the rendered \
+                 HTML, then render to PDF in your client (wkhtmltopdf, weasyprint, \
+                 a separate headless Chromium pipeline, etc.)."
+                    .to_string(),
+            )
+        }
         _ => Err(format!("Unknown Page method: {}", method)),
     }
 }
@@ -332,5 +346,30 @@ mod tests {
             .await
             .expect_err("unknown methods must surface as errors");
         assert!(err.contains("Unknown Page method"));
+    }
+
+    #[tokio::test]
+    async fn print_to_pdf_returns_descriptive_unsupported_error() {
+        // Regression for #53: Page.printToPDF must be handled explicitly so
+        // Playwright clients receive a descriptive error rather than the
+        // generic "Unknown Page method" fallback.
+        let mut ctx = CdpContext::new();
+        let err = handle("printToPDF", &json!({}), &mut ctx, &None)
+            .await
+            .expect_err("printToPDF must error until a real renderer exists");
+        assert!(
+            !err.contains("Unknown Page method"),
+            "printToPDF must NOT fall through to the catch-all: {err}"
+        );
+        assert!(
+            err.contains("not supported by Obscura"),
+            "error must clearly state PDF is unsupported: {err}"
+        );
+        // Direct user to a workaround so the message is actionable.
+        assert!(
+            err.to_lowercase().contains("evaluate")
+                || err.to_lowercase().contains("html"),
+            "error must point to a workaround: {err}"
+        );
     }
 }


### PR DESCRIPTION
## Summary

Fixes #53

Playwright's `page.pdf()` issues a `Page.printToPDF` CDP request which Obscura was not handling, so the dispatcher fell through to its catch-all and clients saw:

```
Page.pdf: Protocol error (Page.printToPDF): Unknown Page method: printToPDF
```

This reads like an oversight, not a deliberate limitation.

## Root Cause

`crates/obscura-cdp/src/domains/page.rs` has no `"printToPDF"` arm in its `match`, so any caller hits the `_ => Err(format!("Unknown Page method: {}", method))` fallback.

## Fix

Implements the issue's option (2): handle `Page.printToPDF` explicitly and return a descriptive error stating that PDF generation is intentionally unsupported (Obscura has no layout engine), with an actionable workaround pointer (use `Runtime.evaluate` / `page.evaluate()` to extract HTML and render in the client).

The JSON-RPC error code stays `-32601` (the dispatcher's mapping for `Err(_)`), but the human-readable `message` is now actionable instead of looking like a forgotten stub.

Option (1) — wrapping rendered HTML inside a minimal valid PDF — was explored but punts the visual layout problem to a font-less PDF that would mislead users into thinking PDF support exists. The error path keeps Obscura honest.

## Verification

Behavior on the issue's repro (Playwright `page.pdf()`):

Before:
```
playwright._impl._errors.Error: Page.pdf: Protocol error (Page.printToPDF): Unknown Page method: printToPDF
```

After:
```
playwright._impl._errors.Error: Page.pdf: Protocol error (Page.printToPDF): Page.printToPDF is not supported by Obscura: no layout engine. Use Runtime.evaluate (e.g. page.evaluate) to extract the rendered HTML, then render to PDF in your client (wkhtmltopdf, weasyprint, a separate headless Chromium pipeline, etc.).
```

New unit test pins the regression:

```
$ cargo test -p obscura-cdp --lib domains::page::tests
test domains::page::tests::get_layout_metrics_returns_chrome_default_viewport ... ok
test domains::page::tests::print_to_pdf_returns_descriptive_unsupported_error ... ok
test domains::page::tests::unknown_page_method_still_errors ... ok
test result: ok. 3 passed; 0 failed
```

JS runtime regression suite still green (no behavior change there):

```
$ cargo test -p obscura-js
test result: ok. 59 passed; 0 failed
```

## Test plan

- [x] `cargo test -p obscura-cdp --lib` — 7/7 passing including the new test
- [x] `cargo test -p obscura-js` — 59/59 baseline preserved
- [x] `cargo check --workspace` clean
- [ ] Stealth build not exercised — no stealth-relevant code touched

## Risk

**Low.** Adds one match arm in `domains/page.rs`. No behavioral change for any existing CDP method. Method is now formally registered which is a strict improvement over the catch-all.

If the maintainer prefers option (1) (minimal stub PDF), this PR can serve as the dispatch-side scaffold and a follow-up can swap the `Err` for an `Ok({"data": <base64>})`. Splitting it that way keeps the stub-PDF design conversation separate from the dispatch-routing fix.

Generated by Ora Studio
Vibe coded by ousamabenyounes