### PR TITLE
Fix CDP connection timeout by bypassing processor queue for context initialization

### DIFF
--- a/crates/obscura-cdp/src/server.rs
+++ b/crates/obscura-cdp/src/server.rs
@@ -502,6 +502,15 @@ fn fast_path_response(text: &str) -> Option<String> {
         "Browser.setDownloadBehavior" | "Browser.getWindowBounds" => {
             Some(json!({}))
         }
+        // Critical: Puppeteer calls this as the *first* CDP command on connect
+        // (`BrowserConnector._connectToCdpBrowser`). If another client or a long
+        // `Page.navigate` / interception holds the single `cdp_processor` task,
+        // queued Target commands starve and Puppeteer hits protocolTimeout on
+        // `Target.getBrowserContexts`. Fast-path bypasses the queue — same payload
+        // as `domains::target::handle` when default context id is `"default"`.
+        "Target.getBrowserContexts" => {
+            Some(json!({ "browserContextIds": ["default"] }))
+        }
         _ => None,
     };
 


### PR DESCRIPTION
Hello team. I have been utilizing Obscura for extensive browser automation and encountered consistent connection timeouts when attempting to attach Puppeteer to the websocket endpoint.

Upon analyzing the internal CDP processing architecture, I discovered the root cause. The initial target initialization request from Puppeteer is placed in the main processor queue. When the browser is handling navigation or other blocking events, this initialization request remains pending. Consequently, the Puppeteer client times out before the handshake is completed.

To resolve this bottleneck, I introduced a fast path mechanism for this specific initialization request. By intercepting it before it enters the main processing queue and returning the default context array immediately, Puppeteer can complete its connection handshake instantly. This change does not affect the standard execution flow of other commands.

I have compiled and tested this locally under heavy concurrent load. The connection is now perfectly stable and all existing unit tests pass successfully. Please review the implementation and let me know if any further adjustments are required. Thank you for the excellent work on this headless engine.
