### PR TITLE
chore: silence unused import/variable/dead-code warnings (#101)

### DIFF
--- a/crates/obscura-cdp/src/dispatch.rs
+++ b/crates/obscura-cdp/src/dispatch.rs
@@ -2,7 +2,7 @@ use std::collections::HashMap;
 use std::sync::Arc;
 
 use obscura_browser::{BrowserContext, Page};
-use obscura_js::ops::{InterceptResolution, InterceptedRequest};
+use obscura_js::ops::InterceptedRequest;
 use serde_json::json;
 
 use crate::domains;

--- a/crates/obscura-cdp/src/domains/fetch.rs
+++ b/crates/obscura-cdp/src/domains/fetch.rs
@@ -1,11 +1,8 @@
 use std::collections::HashMap;
-use std::sync::Arc;
 
 use serde_json::{json, Value};
-use tokio::sync::Mutex;
 
 use crate::dispatch::CdpContext;
-use crate::types::CdpEvent;
 
 pub struct PausedRequest {
     pub request_id: String,

--- a/crates/obscura-cdp/src/domains/input.rs
+++ b/crates/obscura-cdp/src/domains/input.rs
@@ -13,8 +13,8 @@ pub async fn handle(
             let event_type = params.get("type").and_then(|v| v.as_str()).unwrap_or("");
             let x = params.get("x").and_then(|v| v.as_f64()).unwrap_or(0.0);
             let y = params.get("y").and_then(|v| v.as_f64()).unwrap_or(0.0);
-            let button = params.get("button").and_then(|v| v.as_str()).unwrap_or("left");
-            let click_count = params.get("clickCount").and_then(|v| v.as_u64()).unwrap_or(1);
+            let _button = params.get("button").and_then(|v| v.as_str()).unwrap_or("left");
+            let _click_count = params.get("clickCount").and_then(|v| v.as_u64()).unwrap_or(1);
 
             if event_type == "mousePressed" {
                 if let Some(page) = ctx.get_session_page_mut(session_id) {

--- a/crates/obscura-cdp/src/server.rs
+++ b/crates/obscura-cdp/src/server.rs
@@ -55,7 +55,7 @@ pub async fn start_with_full_options(
         .run_until(async {
             let (msg_tx, msg_rx) = mpsc::unbounded_channel::<ServerMessage>();
 
-            let processor_handle = tokio::task::spawn_local(cdp_processor(msg_rx, proxy, stealth, user_agent));
+            let _processor_handle = tokio::task::spawn_local(cdp_processor(msg_rx, proxy, stealth, user_agent));
 
             loop {
                 match listener.accept().await {
@@ -120,7 +120,7 @@ async fn cdp_processor(
 
 fn handle_fetch_resolution(
     text: &str,
-    ctx: &mut CdpContext,
+    _ctx: &mut CdpContext,
     reply_tx: &mpsc::UnboundedSender<String>,
     intercepted_paused: &mut HashMap<String, tokio::sync::oneshot::Sender<obscura_js::ops::InterceptResolution>>,
 ) {
@@ -247,8 +247,8 @@ async fn process_with_interception(
         let _ = nav_done_tx.send((page, result)).await;
     });
 
-    let mut navigate_result: Result<(), String> = Ok(());
-    let mut page_back: Option<obscura_browser::Page> = None;
+    let navigate_result: Result<(), String>;
+    let page_back: Option<obscura_browser::Page>;
 
     loop {
         let has_irx = intercept_rx.is_some();

--- a/crates/obscura-js/src/ops.rs
+++ b/crates/obscura-js/src/ops.rs
@@ -376,7 +376,7 @@ async fn op_fetch_url(
                         "error": reason,
                     }).to_string());
                 }
-                Ok(InterceptResolution::Continue { url: new_url, method: new_method, headers: new_headers, body: new_body }) => {
+                Ok(InterceptResolution::Continue { url: _new_url, method: _new_method, headers: _new_headers, body: _new_body }) => {
                     tracing::debug!("Interception: continue request {}", url);
                 }
                 Err(_) => {

--- a/crates/obscura-js/src/runtime.rs
+++ b/crates/obscura-js/src/runtime.rs
@@ -10,8 +10,6 @@ use crate::ops::{build_extension, ObscuraState};
 
 static SNAPSHOT: &[u8] = include_bytes!(env!("OBSCURA_SNAPSHOT_PATH"));
 
-const BOOTSTRAP_JS: &str = include_str!("../js/bootstrap.js");
-
 #[derive(Debug, Clone)]
 pub struct RemoteObjectInfo {
     pub js_type: String,

--- a/crates/obscura-net/src/cookies.rs
+++ b/crates/obscura-net/src/cookies.rs
@@ -15,6 +15,7 @@ struct CookieEntry {
     secure: bool,
     http_only: bool,
     expires: Option<u64>,
+    #[allow(dead_code)]
     same_site: String,
 }
 


### PR DESCRIPTION
Closes #101.

## Summary

The 16 remaining warnings reported in #101 (two were already cleared by merged PRs #97 `IpAddr` and #98 `AsyncReadExt`). Build is now silent across all four affected crates.

## Per-file rationale

| File | Fix | Why this and not deletion |
|---|---|---|
| `obscura-net/src/cookies.rs:18` | `#[allow(dead_code)]` on `same_site` field | Field is parsed and stored from `Set-Cookie`; preserved for the eventual SameSite enforcement on outgoing requests. |
| `obscura-js/src/runtime.rs:13` | Delete `const BOOTSTRAP_JS` | `bootstrap.js` is already compiled into the V8 snapshot via `build.rs` (`execute_script("<obscura:bootstrap>", bootstrap_js)`). The runtime const was unreferenced. |
| `obscura-js/src/ops.rs:379` | `_new_url`, `_new_method`, `_new_headers`, `_new_body` | The `Continue` variant logs and falls through today; keeping the destructure documents the variant's payload for whoever wires it through. |
| `obscura-cdp/src/dispatch.rs:5` | Drop `InterceptResolution` from `use` list | Genuinely unused. |
| `obscura-cdp/src/domains/fetch.rs:2,5,8` | Drop `Arc`, `Mutex`, `CdpEvent` imports | Genuinely unused. |
| `obscura-cdp/src/domains/input.rs:16-17` | `_button`, `_click_count` | CDP `Input.dispatchMouseEvent` parses these from params; the current JS click stub hardcodes `button:0` and ignores click count. Prefix preserves the parse as a TODO marker. |
| `obscura-cdp/src/server.rs:58` | `_processor_handle` | `tokio::task::spawn_local` returns a `JoinHandle` that's intentionally fire-and-forget here. |
| `obscura-cdp/src/server.rs:123` | `_ctx` parameter | `handle_fetch_resolution` only needs `intercepted_paused` and `reply_tx` today; keeping the param matches the broader CDP handler signature and avoids a churn-y signature change. |
| `obscura-cdp/src/server.rs:250-251` | Remove `Ok(())`/`None` initialisers, declare bindings only | The `nav_done_rx.recv()` arm is the only one that breaks the loop, and it unconditionally assigns both. The initial values were always overwritten. |

## Verification

\`\`\`
$ cargo build --workspace
    Finished \`dev\` profile [unoptimized + debuginfo] target(s) in 1.33s
    (0 warnings)

$ cargo test --workspace --no-fail-fast
    test result: ok. 113 passed; 0 failed
\`\`\`

## Risk

**Very low.** No behaviour changes: every `_`-prefix or `#[allow(dead_code)]` keeps the parse/binding in place; the two deletions (`BOOTSTRAP_JS` const and the four `obscura-cdp` imports) were genuinely unreferenced. The only flow-affecting change is dropping the dead `Ok(())`/`None` initialisers — Rust now confirms via definite-assignment that `navigate_result` and `page_back` are set on the only break path.