### PR TITLE
docs: add Arch Linux AUR install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,12 @@ parallel `scrape` command.
 Linux release builds target Ubuntu 22.04 so the downloaded binary remains
 usable on common LTS servers with glibc 2.35+.
 
+### Arch Linux (AUR)
+
+```bash
+yay -S obscura-browser
+```
+
 ### Build from source
 
 ```bash


### PR DESCRIPTION
Adds install instructions for Arch Linux via the AUR package obscura-browser.

AUR: https://aur.archlinux.org/packages/obscura-browser