### PR TITLE
docs: add Arch Linux AUR install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,9 @@ curl -LO https://github.com/h4ckf0r0day/obscura/releases/latest/download/obscura
 tar xzf obscura-x86_64-linux.tar.gz
 ./obscura fetch https://example.com --eval "document.title"
 
+# Arch Linux (AUR)
+yay -S obscura-browser
+
 # macOS Apple Silicon
 curl -LO https://github.com/h4ckf0r0day/obscura/releases/latest/download/obscura-aarch64-macos.tar.gz
 tar xzf obscura-aarch64-macos.tar.gz


### PR DESCRIPTION
Adds install instructions for Arch Linux via the AUR package obscura-browser.

AUR: https://aur.archlinux.org/packages/obscura-browser