### PR TITLE
fix: set CXXFLAGS/SDKROOT so boring-sys compiles on macOS 26 (Tahoe)

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,2 +1,12 @@
 [env]
 RUST_TEST_THREADS = "1"
+
+# macOS 26 (Tahoe) moved libc++ headers inside the SDK; Apple clang 17 no longer
+# finds them at the old search path. This causes boring-sys's cmake step to fail
+# when building with --features stealth. Setting CXXFLAGS and SDKROOT here makes
+# them visible to all build scripts (including boring-sys's) so cmake can locate
+# the headers. force=false lets CI or developers override via their shell env.
+# Non-macOS platforms ignore SDKROOT; the -isystem path is silently skipped if
+# it doesn't exist. See: https://github.com/h4ckf0r0day/obscura/issues/136
+CXXFLAGS = { value = "-isystem /Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/include/c++/v1", force = false }
+SDKROOT  = { value = "/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk", force = false }


### PR DESCRIPTION
There's probably a better way...this worked nicely for me, however.

## Summary

Fixes #136.

- macOS 26 (Tahoe) moved libc++ headers inside the SDK, breaking Apple clang 17's default header search path
- `boring-sys`'s cmake step fails with `fatal error: 'memory' file not found` when building `--features stealth`
- Adding `CXXFLAGS` and `SDKROOT` to `.cargo/config.toml` `[env]` propagates them to all build scripts (Cargo's documented mechanism for this), so cmake picks up the SDK's C++ include path automatically

`force = false` preserves any overrides set in the shell (CI, Xcode users who already have `SDKROOT` set). Non-macOS platforms ignore `SDKROOT`; clang silently skips `-isystem` paths that don't exist on disk, so this is safe across all platforms.