### PR TITLE
fix(stealth): pass proxy config to StealthHttpClient

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ servo_arc = "0.4"
 cssparser = "0.34"
 tokio = { version = "1", features = ["full"] }
 tokio-tungstenite = "0.26"
-reqwest = { version = "0.12", features = ["cookies", "gzip", "brotli", "deflate", "native-tls-vendored"], default-features = false }
+reqwest = { version = "0.12", features = ["cookies", "gzip", "brotli", "deflate", "native-tls-vendored", "socks"], default-features = false }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 url = "2"

--- a/crates/obscura-browser/src/page.rs
+++ b/crates/obscura-browser/src/page.rs
@@ -54,7 +54,14 @@ impl Page {
         let frame_id = id.clone();
         #[cfg(feature = "stealth")]
         let stealth_client = if context.stealth {
-            Some(Arc::new(StealthHttpClient::new(context.cookie_jar.clone())))
+            // wreq doesn't support SOCKS5; Clash mixed port handles both.
+            let stealth_proxy = context.proxy_url.as_ref().map(|u| {
+                u.replacen("socks5://", "http://", 1)
+            });
+            Some(Arc::new(StealthHttpClient::with_proxy(
+                context.cookie_jar.clone(),
+                stealth_proxy.as_deref(),
+            )))
         } else {
             None
         };


### PR DESCRIPTION
## Problem

When `obscura serve --stealth --proxy socks5://...` is used, the proxy configuration is **ignored** in stealth mode. All HTTP requests bypass the proxy and connect directly.

## Root Cause

In `page.rs`, the `StealthHttpClient` was constructed using `StealthHttpClient::new()` which never received the proxy URL from `context.proxy_url`. The non-stealth path via `reqwest` had no such issue because the proxy was already configured on the shared `ObscuraHttpClient`.

## Fix

1. **Pass proxy to StealthHttpClient** — Changed `StealthHttpClient::new()` to `StealthHttpClient::with_proxy()` and forwarded `context.proxy_url`.
2. **SOCKS5 → HTTP conversion** — `wreq` does not support SOCKS5 proxy protocol. Since Clash's mixed port (7890) handles both HTTP and SOCKS5 on the same port, the proxy URL is converted from `socks5://` to `http://` for the stealth client.
3. **Reqwest SOCKS5 support** — Added `socks` feature to the `reqwest` dependency in `Cargo.toml` (for non-stealth path).

## Testing

### Before (stealth + proxy):
```
4.ident.me returned: 183.193.7.138  (proxy bypassed)
```

### After (stealth + proxy):
```
4.ident.me returned: 122.10.198.157  (proxy working correctly)
```

`curl --socks5 127.0.0.1:7890 4.ident.me` also returns `122.10.198.157` confirming the proxy node is correct.