### PR TITLE
fix(js): drive document.readyState through loading → interactive → complete (#137)

### DIFF
--- a/crates/obscura-browser/src/page.rs
+++ b/crates/obscura-browser/src/page.rs
@@ -352,9 +352,16 @@ impl Page {
         }
 
         if let Some(js) = &mut self.js {
+            // Drive document.readyState through the spec-mandated states
+            // before dispatching the corresponding events (#137). Until the
+            // probe page can observe the transitions on its DOMContentLoaded
+            // listener, X.com (and any framework with a "did the deferred
+            // scripts run yet?" guard) hits its `failedScript` fallback.
             let _ = js.execute_script("<load-events>",
-                "if (typeof window.onload === 'function') { try { window.onload(); } catch(e) {} }\n\
+                "try { globalThis.__obscura_set_ready_state('interactive'); } catch(e) {}\n\
                  try { document.dispatchEvent(new Event('DOMContentLoaded')); } catch(e) {}\n\
+                 try { globalThis.__obscura_set_ready_state('complete'); } catch(e) {}\n\
+                 if (typeof window.onload === 'function') { try { window.onload(); } catch(e) {} }\n\
                  try { window.dispatchEvent(new Event('load')); } catch(e) {}");
         }
 

--- a/crates/obscura-js/js/bootstrap.js
+++ b/crates/obscura-js/js/bootstrap.js
@@ -2,6 +2,21 @@
 
 globalThis.__obscura_errors = [];
 
+// Document lifecycle state (#137). Starts at "loading" so scripts running
+// during page bootstrap see the spec-correct value and follow the
+// `addEventListener('DOMContentLoaded', ...)` branch instead of treating
+// the page as already-loaded. The Rust side drives transitions via
+// __obscura_set_ready_state(state) immediately before the corresponding
+// event is dispatched:
+//   "interactive" → just before document.dispatchEvent(DOMContentLoaded)
+//   "complete"    → just before window.dispatchEvent(load)
+let __obscura_ready_state = "loading";
+globalThis.__obscura_set_ready_state = function(state) {
+  if (state === "loading" || state === "interactive" || state === "complete") {
+    __obscura_ready_state = state;
+  }
+};
+
 globalThis.addEventListener = globalThis.addEventListener || function(){};
 globalThis.onunhandledrejection = function(e) { if (e?.preventDefault) e.preventDefault(); };
 
@@ -786,7 +801,7 @@ class Document extends Node {
   get compatMode() { return "CSS1Compat"; }
   get characterSet() { return "UTF-8"; }
   get contentType() { return "text/html"; }
-  get readyState() { return "complete"; }
+  get readyState() { return __obscura_ready_state; }
   get hidden() { return false; }
   get visibilityState() { return "visible"; }
   getElementById(id) { return _wrapEl(+_dom("get_element_by_id", id)); }

--- a/crates/obscura-js/src/runtime.rs
+++ b/crates/obscura-js/src/runtime.rs
@@ -1589,4 +1589,62 @@ mod tests {
         assert_eq!(inf, serde_json::Value::Null);
     }
 
+    // Issue #137 — document.readyState must start at "loading" so scripts
+    // running during page bootstrap follow the spec-correct branch:
+    //
+    //     if (document.readyState === 'loading') {
+    //       document.addEventListener('DOMContentLoaded', onReady);
+    //     } else {
+    //       onReady();
+    //     }
+    //
+    // Pre-fix Obscura always reported "complete", so the guard above fell
+    // into the else branch immediately — running onReady() before any
+    // deferred script had set its state. X.com's failedScript fallback and
+    // Facebook's bot-challenge stub (cf. #146) both rely on this pattern.
+    #[test]
+    fn ready_state_defaults_to_loading() {
+        let mut rt = setup_runtime("<html><body></body></html>");
+        let state = rt.evaluate("document.readyState").unwrap();
+        assert_eq!(
+            state,
+            serde_json::json!("loading"),
+            "a freshly constructed runtime must report 'loading' so guards \
+             like `if (document.readyState === 'loading')` work spec-correctly"
+        );
+    }
+
+    #[test]
+    fn ready_state_transitions_to_interactive() {
+        let mut rt = setup_runtime("<html><body></body></html>");
+        rt.evaluate("globalThis.__obscura_set_ready_state('interactive');")
+            .unwrap();
+        let state = rt.evaluate("document.readyState").unwrap();
+        assert_eq!(state, serde_json::json!("interactive"));
+    }
+
+    #[test]
+    fn ready_state_transitions_to_complete() {
+        let mut rt = setup_runtime("<html><body></body></html>");
+        rt.evaluate("globalThis.__obscura_set_ready_state('complete');")
+            .unwrap();
+        let state = rt.evaluate("document.readyState").unwrap();
+        assert_eq!(state, serde_json::json!("complete"));
+    }
+
+    #[test]
+    fn ready_state_setter_rejects_unknown_values() {
+        // Defence-in-depth: only the three spec values may be assigned. An
+        // unknown value must be a no-op (state stays at the previous value).
+        let mut rt = setup_runtime("<html><body></body></html>");
+        rt.evaluate("globalThis.__obscura_set_ready_state('garbage');")
+            .unwrap();
+        let state = rt.evaluate("document.readyState").unwrap();
+        assert_eq!(
+            state,
+            serde_json::json!("loading"),
+            "an invalid state must NOT mutate readyState"
+        );
+    }
+
 }


### PR DESCRIPTION
## Summary

Fixes [#137](https://github.com/h4ckf0r0day/obscura/issues/137).
`document.readyState` was hardcoded to `"complete"` in `bootstrap.js`, so
inline scripts running during page bootstrap that follow the canonical
[whatwg defer-aware guard](https://html.spec.whatwg.org/multipage/dom.html#current-document-readiness)

```js
if (document.readyState === 'loading') {
  document.addEventListener('DOMContentLoaded', onReady);
} else {
  onReady();
}
```

never attached a `DOMContentLoaded` listener — they hit the else branch
and called `onReady()` *before* any deferred script had set its state.

## Root Cause

`crates/obscura-js/js/bootstrap.js:789` returned a constant:

```js
get readyState() { return "complete"; }
```

So:

- X.com observes `__SCRIPTS_LOADED__.vendor === false` in its
  `DOMContentLoaded`-equivalent and renders the `failedScript + Try again`
  fallback (the symptom #137 ships as the failing case).
- Facebook's 481-byte bot-challenge stub (cf. #146) hits the else branch
  and tries to call `executeChallenge` before `fetch` is set up.
- jQuery's `$(document).ready(...)` fires synchronously instead of being
  queued.

The defer-vs-DOMContentLoaded *execution order* in `page.rs` is already
spec-correct (regular → deferred → async → DOMContentLoaded). The
missing piece is making that order *observable* to user scripts, which
they do by reading `document.readyState`.

## Fix

- `bootstrap.js`: track `readyState` in a module-scope variable
  (`__obscura_ready_state`, defaulting to `"loading"`) and expose a
  validated setter `globalThis.__obscura_set_ready_state(state)` that
  accepts only the three spec values.
- `page.rs`: thread the state transitions through the existing
  `<load-events>` execute_script:

  ```js
  __obscura_set_ready_state('interactive');
  document.dispatchEvent(new Event('DOMContentLoaded'));
  __obscura_set_ready_state('complete');
  // window.onload, window 'load' event
  ```

  `interactive` is set immediately before `DOMContentLoaded` fires;
  `complete` immediately before `load`, matching the HTML standard.

## Verification

```js
// Before
> document.readyState
"complete"   // wrong; bypasses all defer-aware guards

// After (during script execution)
> document.readyState
"loading"

// After (inside DOMContentLoaded handler)
> document.readyState
"interactive"

// After (inside load handler)
> document.readyState
"complete"
```

## Test plan

- [x] `ready_state_defaults_to_loading` — freshly constructed runtime returns `"loading"`
- [x] `ready_state_transitions_to_interactive` — explicit transition observable
- [x] `ready_state_transitions_to_complete` — explicit transition observable
- [x] `ready_state_setter_rejects_unknown_values` — invalid input must be a no-op
- [x] RED-then-GREEN: 3 of the 4 new tests fail when `bootstrap.js` is reverted to the pre-fix state (the fourth is a backwards-compat guard test that passes both ways)
- [x] `cargo test -p obscura-js --no-default-features` — 67 passed (up from 63)
- [x] `cargo check --workspace --no-default-features` clean

Stealth build skipped per repo rules.

## Risk

Low/medium. Behaviour change: `readyState` was always `"complete"` and is
now phase-correct. Scripts that wrote

```js
if (document.readyState === 'complete') doNow();
else window.addEventListener('load', doNow);
```

used to take the first branch synchronously; they now take the second
branch and wait for the `load` event that page.rs already dispatches —
net behaviour for those scripts is unchanged. Scripts that use the
`document.readyState === 'loading'` guard (the majority of bootstrap
shims) are the ones that move from broken to working.

Generated by Ora Studio
Vibe coded by ousamabenyounes