### PR TITLE
fix(target): emit canAccessOpener in all TargetInfo payloads

### DIFF
--- a/crates/obscura-cdp/src/domains/target.rs
+++ b/crates/obscura-cdp/src/domains/target.rs
@@ -16,6 +16,7 @@ pub async fn handle(method: &str, params: &Value, ctx: &mut CdpContext) -> Resul
                         "title": "",
                         "url": "",
                         "attached": true,
+                        "canAccessOpener": false,
                         "browserContextId": "",
                     }
                 }),
@@ -30,6 +31,7 @@ pub async fn handle(method: &str, params: &Value, ctx: &mut CdpContext) -> Resul
                             "title": page.title,
                             "url": page.url_string(),
                             "attached": false,
+                            "canAccessOpener": false,
                             "browserContextId": page.context.id,
                         }
                     }),
@@ -48,6 +50,7 @@ pub async fn handle(method: &str, params: &Value, ctx: &mut CdpContext) -> Resul
                         "title": page.title,
                         "url": page.url_string(),
                         "attached": true,
+                        "canAccessOpener": false,
                         "browserContextId": page.context.id,
                     })
                 })
@@ -90,6 +93,7 @@ pub async fn handle(method: &str, params: &Value, ctx: &mut CdpContext) -> Resul
                             "title": page.title,
                             "url": page.url_string(),
                             "attached": false,
+                            "canAccessOpener": false,
                             "browserContextId": page.context.id,
                         }
                     }),
@@ -107,6 +111,7 @@ pub async fn handle(method: &str, params: &Value, ctx: &mut CdpContext) -> Resul
                             "title": page.title,
                             "url": page.url_string(),
                             "attached": true,
+                            "canAccessOpener": false,
                             "browserContextId": page.context.id,
                         },
                         "waitingForDebugger": false,
@@ -133,6 +138,7 @@ pub async fn handle(method: &str, params: &Value, ctx: &mut CdpContext) -> Resul
                         "title": "",
                         "url": "",
                         "attached": true,
+                        "canAccessOpener": false,
                         "browserContextId": "",
                     },
                     "waitingForDebugger": false,
@@ -158,6 +164,7 @@ pub async fn handle(method: &str, params: &Value, ctx: &mut CdpContext) -> Resul
                             "title": page.title,
                             "url": page.url_string(),
                             "attached": true,
+                            "canAccessOpener": false,
                             "browserContextId": page.context.id,
                         },
                         "waitingForDebugger": false,
@@ -211,6 +218,7 @@ pub async fn handle(method: &str, params: &Value, ctx: &mut CdpContext) -> Resul
                             "title": page.title,
                             "url": page.url_string(),
                             "attached": true,
+                            "canAccessOpener": false,
                             "browserContextId": page.context.id,
                         }
                     }))
@@ -223,6 +231,7 @@ pub async fn handle(method: &str, params: &Value, ctx: &mut CdpContext) -> Resul
                             "title": "",
                             "url": "",
                             "attached": true,
+                            "canAccessOpener": false,
                         }
                     }))
                 }


### PR DESCRIPTION
The CDP spec marks Target.TargetInfo.canAccessOpener as a required boolean, but Obscura was omitting it from every event and response that carries a TargetInfo (setDiscoverTargets, getTargets, createTarget, attachToBrowserTarget, attachToTarget, getTargetInfo).

JS clients (Puppeteer, Playwright) tolerate the missing field via lenient deserialization. Strict Rust clients like chromiumoxide reject the event - its serde deserializer routes the payload to CdpEvent::Other, so on_target_created never runs, and the subsequent createTarget response panics with "Created target not present" when the target lookup against an empty map fails.

Obscura doesn't model window.open opener chains, so false is the correct value for every page it creates.

Spec: https://chromedevtools.github.io/devtools-protocol/tot/Target/#type-TargetInfo