### PR TITLE
Fix puppeteer `exposeFunction` end-to-end: real bindings, preload timing, URL coercion

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,18 +20,30 @@ jobs:
             # newer glibc shipped by ubuntu-latest.
             os: ubuntu-22.04
             name: obscura-x86_64-linux
+            cross: false
           - target: aarch64-unknown-linux-gnu
+            # Native build on GitHub's ARM runner.
             os: ubuntu-22.04-arm
             name: obscura-aarch64-linux
+            cross: false
+          - target: aarch64-unknown-linux-gnu
+            # Cross-compile fallback from x86_64 Ubuntu 22.04. Same glibc
+            # 2.35 floor, useful when ARM runners are unavailable.
+            os: ubuntu-22.04
+            name: obscura-aarch64-linux-cross
+            cross: true
           - target: aarch64-apple-darwin
             os: macos-latest
             name: obscura-aarch64-macos
+            cross: false
           - target: x86_64-apple-darwin
             os: macos-latest
             name: obscura-x86_64-macos
+            cross: false
           - target: x86_64-pc-windows-msvc
             os: windows-latest
             name: obscura-x86_64-windows
+            cross: false
 
     runs-on: ${{ matrix.os }}
 
@@ -41,6 +53,17 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
         with:
           targets: ${{ matrix.target }}
+
+      - name: Install cross-compilation toolchain (aarch64-linux)
+        if: matrix.cross == true
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y gcc-aarch64-linux-gnu
+          mkdir -p .cargo
+          cat >> .cargo/config.toml << 'CARGO_EOF'
+          [target.aarch64-unknown-linux-gnu]
+          linker = "aarch64-linux-gnu-gcc"
+          CARGO_EOF
 
       - name: Build
         run: cargo build --release --target ${{ matrix.target }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -741,6 +741,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
+name = "encoding_rs"
+version = "0.8.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1699,6 +1708,7 @@ name = "obscura-net"
 version = "0.1.0"
 dependencies = [
  "async-trait",
+ "encoding_rs",
  "reqwest",
  "serde",
  "serde_json",
@@ -2165,7 +2175,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2564,10 +2574,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.3.4",
+ "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1712,6 +1712,7 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
+ "tempfile",
  "thiserror",
  "tokio",
  "tracing",

--- a/README.md
+++ b/README.md
@@ -115,6 +115,9 @@ obscura fetch https://example.com --dump text --output page.txt
 # Use this for images, JSON, JS, CSS, or any non-HTML resource.
 obscura fetch https://picsum.photos/200/300 --dump original > photo.jpg
 
+# List every sub-resource URL the page would fetch (NDJSON; one record per asset)
+obscura fetch https://example.com --dump assets
+
 # Fetch through an HTTP or SOCKS proxy
 obscura --proxy socks5://127.0.0.1:1080 fetch https://example.com --dump text
 
@@ -279,7 +282,7 @@ Fetch and render a single page.
 
 | Flag | Default | Description |
 |------|---------|-------------|
-| `--dump` | `html` | Output: `html`, `text`, `links`, `markdown`, or `original` (raw response body) |
+| `--dump` | `html` | Output: `html`, `text`, `links`, `markdown`, `assets` (NDJSON of every sub-resource URL the page references), or `original` (raw response body) |
 | `--eval` | — | JavaScript expression to evaluate |
 | `--wait-until` | `load` | Wait: `load`, `domcontentloaded`, `networkidle0` |
 | `--timeout` | `30` | Maximum navigation time in seconds |

--- a/crates/obscura-browser/src/context.rs
+++ b/crates/obscura-browser/src/context.rs
@@ -1,3 +1,4 @@
+use std::path::PathBuf;
 use std::sync::Arc;
 
 use obscura_net::{CookieJar, ObscuraHttpClient, RobotsCache};
@@ -19,36 +20,60 @@ pub struct BrowserContext {
     /// file://...` path is unaffected because it does not go through
     /// the CDP server.
     pub allow_file_access: bool,
+    pub storage_dir: Option<PathBuf>,
 }
 
 impl BrowserContext {
     pub fn new(id: String) -> Self {
-        let cookie_jar = Arc::new(CookieJar::new());
-        let http_client = Arc::new(ObscuraHttpClient::with_cookie_jar(cookie_jar.clone()));
-        BrowserContext {
-            id,
-            cookie_jar,
-            http_client,
-            user_agent: "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/145.0.0.0 Safari/537.36".to_string(),
-            proxy_url: None,
-            robots_cache: Arc::new(RobotsCache::new()),
-            obey_robots: false,
-            stealth: false,
-            allow_file_access: false,
-        }
+        Self::_new_inner(id, None, false, None, None)
     }
 
-    pub fn with_options(id: String, proxy_url: Option<String>, stealth: bool) -> Self {
-        Self::with_full_options(id, proxy_url, stealth, None)
+    /// Create a BrowserContext with an optional storage directory.
+    /// When `storage_dir` is set, cookies are automatically loaded from
+    /// `{storage_dir}/cookies.json` on creation.
+    pub fn with_storage(
+        id: String,
+        storage_dir: Option<PathBuf>,
+    ) -> Self {
+        Self::_new_inner(id, None, false, None, storage_dir)
     }
 
-    pub fn with_full_options(
+    /// Create a BrowserContext with full options including storage_dir.
+    pub fn with_storage_full(
         id: String,
         proxy_url: Option<String>,
         stealth: bool,
         user_agent: Option<String>,
+        storage_dir: Option<PathBuf>,
+    ) -> Self {
+        Self::_new_inner(id, proxy_url, stealth, user_agent, storage_dir)
+    }
+
+    fn _new_inner(
+        id: String,
+        proxy_url: Option<String>,
+        stealth: bool,
+        user_agent: Option<String>,
+        storage_dir: Option<PathBuf>,
     ) -> Self {
         let cookie_jar = Arc::new(CookieJar::new());
+
+        // Restore cookies from disk if storage_dir is configured
+        if let Some(ref dir) = storage_dir {
+            let cookie_path = dir.join("cookies.json");
+            if cookie_path.exists() {
+                match cookie_jar.load_from_file(&cookie_path) {
+                    Ok(n) if n > 0 => {
+                        tracing::info!("Loaded {} cookies from {}", n, cookie_path.display());
+                    }
+                    Ok(_) => {}
+                    Err(e) => {
+                        tracing::warn!("Failed to load cookies from {}: {}", cookie_path.display(), e);
+                    }
+                }
+            }
+        }
+
         let mut client = ObscuraHttpClient::with_options(
             cookie_jar.clone(),
             proxy_url.as_deref(),
@@ -76,11 +101,39 @@ impl BrowserContext {
             obey_robots: false,
             stealth,
             allow_file_access: false,
+            storage_dir,
         }
+    }
+
+    pub fn with_options(id: String, proxy_url: Option<String>, stealth: bool) -> Self {
+        Self::with_full_options(id, proxy_url, stealth, None)
+    }
+
+    pub fn with_full_options(
+        id: String,
+        proxy_url: Option<String>,
+        stealth: bool,
+        user_agent: Option<String>,
+    ) -> Self {
+        Self::_new_inner(id, proxy_url, stealth, user_agent, None)
     }
 
     pub fn with_proxy(id: String, proxy_url: Option<String>) -> Self {
         Self::with_options(id, proxy_url, false)
+    }
+
+    /// Persist cookies to disk if storage_dir is configured.
+    /// Called during graceful shutdown.
+    pub fn save_cookies(&self) {
+        if let Some(ref dir) = self.storage_dir {
+            let _ = std::fs::create_dir_all(dir);
+            let cookie_path = dir.join("cookies.json");
+            if let Err(e) = self.cookie_jar.save_to_file(&cookie_path) {
+                tracing::warn!("Failed to save cookies to {}: {}", cookie_path.display(), e);
+            } else {
+                tracing::info!("Saved cookies to {}", cookie_path.display());
+            }
+        }
     }
 }
 

--- a/crates/obscura-browser/src/page.rs
+++ b/crates/obscura-browser/src/page.rs
@@ -402,7 +402,9 @@ impl Page {
         let mut fetched: std::collections::HashMap<usize, (String, String, obscura_net::Response)> = std::collections::HashMap::new();
         for result in fetch_results {
             if let Some((idx, url, resp)) = result {
-                let code = String::from_utf8_lossy(&resp.body).to_string();
+                // Script bodies: only the HTTP Content-Type charset matters
+                // (no in-band meta-charset for JS).
+                let code = obscura_net::decode_non_html(&resp.body, resp.content_type());
                 fetched.insert(idx, (url, code, resp));
             }
         }
@@ -650,7 +652,11 @@ impl Page {
             self.url = Some(response.url.clone());
         }
 
-        let body_text = String::from_utf8_lossy(&response.body).to_string();
+        // Honor the response charset: HTTP Content-Type → <meta charset> sniff
+        // in the first 1KB → UTF-8 fallback. Without this, every non-UTF-8
+        // page (GBK, Big5, Shift-JIS, Windows-125x, EUC-KR, ISO-8859-x)
+        // came through as replacement characters.
+        let body_text = obscura_net::decode_response(&response.body, response.content_type());
         let dom = parse_html(&body_text);
 
         self.title = dom
@@ -718,7 +724,9 @@ impl Page {
         let mut css_sources = Vec::new();
         for result in css_results {
             if let Some((url_str, resp)) = result {
-                let css = String::from_utf8_lossy(&resp.body).to_string();
+                // CSS bodies: honor the Content-Type charset; CSS @charset is
+                // out of scope for the current scrape-focused pipeline.
+                let css = obscura_net::decode_non_html(&resp.body, resp.content_type());
                 self.record_network_event(&url_str, "GET", "Stylesheet", resp.status, &resp.headers, resp.body.len());
                 css_sources.push(css);
             }

--- a/crates/obscura-browser/src/page.rs
+++ b/crates/obscura-browser/src/page.rs
@@ -1035,6 +1035,14 @@ impl Page {
         }
     }
 
+    pub fn take_pending_binding_calls(&self) -> Vec<(String, String)> {
+        if let Some(js) = &self.js {
+            js.take_pending_binding_calls()
+        } else {
+            Vec::new()
+        }
+    }
+
     pub fn set_preload_scripts(&mut self, scripts: Vec<String>) {
         self.preload_scripts = scripts;
     }

--- a/crates/obscura-browser/src/page.rs
+++ b/crates/obscura-browser/src/page.rs
@@ -634,6 +634,18 @@ impl Page {
         if url.scheme() == "about" {
             self.navigate_blank();
             self.init_js();
+            // Preloads (Page.addScriptToEvaluateOnNewDocument, the
+            // Runtime.addBinding shim) must run on about:blank too —
+            // puppeteer's `browser.newPage()` lands on about:blank and
+            // a follow-up `exposeFunction` is unusable otherwise.
+            let preload_sources = self.preload_scripts.clone();
+            if let Some(js) = &mut self.js {
+                for source in &preload_sources {
+                    if let Err(e) = js.execute_script_guarded("<preload>", source.as_str()) {
+                        tracing::debug!("Preload script error on about:blank: {}", e);
+                    }
+                }
+            }
             return Ok(());
         }
 

--- a/crates/obscura-browser/src/page.rs
+++ b/crates/obscura-browser/src/page.rs
@@ -137,6 +137,11 @@ pub struct Page {
     pub intercept_enabled: bool,
     pub intercept_block_patterns: Vec<String>,
     intercept_tx: Option<tokio::sync::mpsc::UnboundedSender<obscura_js::ops::InterceptedRequest>>,
+    // Scripts to execute in the page's JS context BEFORE any of the page's
+    // own scripts run — the CDP `Page.addScriptToEvaluateOnNewDocument`
+    // contract. Includes `Runtime.addBinding` shims so puppeteer's
+    // `exposeFunction` bindings exist before inline `<script>` tags execute.
+    preload_scripts: Vec<String>,
     #[cfg(feature = "stealth")]
     pub stealth_client: Option<Arc<StealthHttpClient>>,
 }
@@ -181,6 +186,7 @@ impl Page {
             intercept_enabled: false,
             intercept_block_patterns: Vec::new(),
             intercept_tx: None,
+            preload_scripts: Vec::new(),
             #[cfg(feature = "stealth")]
             stealth_client,
         }
@@ -412,6 +418,20 @@ impl Page {
         // listeners instead of calling their callback immediately.
         if let Some(js) = &mut self.js {
             let _ = js.execute_script("<ready-state>", "globalThis.__documentReadyState__ = 'loading';");
+        }
+
+        // CDP `Page.addScriptToEvaluateOnNewDocument` contract: preload
+        // sources must run BEFORE any of the page's own scripts. This is
+        // also where puppeteer's `exposeFunction` wrapper installs itself —
+        // if preload runs after page scripts, every early binding call
+        // hits an undefined function and silently no-ops.
+        let preload_sources = self.preload_scripts.clone();
+        if let Some(js) = &mut self.js {
+            for source in &preload_sources {
+                if let Err(e) = js.execute_script_guarded("<preload>", source.as_str()) {
+                    tracing::debug!("Preload script error: {}", e);
+                }
+            }
         }
 
         for (i, script) in all_to_execute.iter().enumerate() {
@@ -1013,6 +1033,10 @@ impl Page {
         } else {
             None
         }
+    }
+
+    pub fn set_preload_scripts(&mut self, scripts: Vec<String>) {
+        self.preload_scripts = scripts;
     }
 
     pub async fn process_pending_navigation(&mut self) -> Result<bool, PageError> {

--- a/crates/obscura-cdp/src/cookie_params.rs
+++ b/crates/obscura-cdp/src/cookie_params.rs
@@ -1,0 +1,162 @@
+use obscura_net::CookieInfo;
+use serde_json::Value;
+
+const DEFAULT_COOKIE_PATH: &str = "/";
+
+pub fn parse_cdp_cookie(value: &Value) -> Option<CookieInfo> {
+    let name = value.get("name").and_then(|v| v.as_str())?.to_string();
+    let cookie_value = value
+        .get("value")
+        .and_then(|v| v.as_str())
+        .unwrap_or("")
+        .to_string();
+
+    let url_parsed = value
+        .get("url")
+        .and_then(|v| v.as_str())
+        .and_then(|u| url::Url::parse(u).ok());
+
+    let domain = value
+        .get("domain")
+        .and_then(|v| v.as_str())
+        .map(|s| s.to_string())
+        .or_else(|| url_parsed.as_ref().and_then(|u| u.host_str().map(|h| h.to_string())))
+        .unwrap_or_default();
+
+    if domain.is_empty() {
+        return None;
+    }
+
+    let path = value
+        .get("path")
+        .and_then(|v| v.as_str())
+        .map(|s| s.to_string())
+        .or_else(|| url_parsed.as_ref().map(|u| u.path().to_string()))
+        .unwrap_or_else(|| DEFAULT_COOKIE_PATH.to_string());
+
+    let secure = value.get("secure").and_then(|v| v.as_bool()).unwrap_or(false);
+    let http_only = value.get("httpOnly").and_then(|v| v.as_bool()).unwrap_or(false);
+    let same_site = value
+        .get("sameSite")
+        .and_then(|v| v.as_str())
+        .unwrap_or("")
+        .to_string();
+    let expires = value.get("expires").and_then(|v| v.as_f64()).map(|f| f as i64);
+
+    Some(CookieInfo {
+        name,
+        value: cookie_value,
+        domain,
+        path,
+        secure,
+        http_only,
+        same_site,
+        expires,
+    })
+}
+
+pub struct DeleteCookiesFilter {
+    pub name: String,
+    pub domain: String,
+    pub path: Option<String>,
+}
+
+pub fn parse_delete_cookies_params(params: &Value) -> Option<DeleteCookiesFilter> {
+    let name = params.get("name").and_then(|v| v.as_str())?.to_string();
+    if name.is_empty() {
+        return None;
+    }
+
+    let url_parsed = params
+        .get("url")
+        .and_then(|v| v.as_str())
+        .and_then(|u| url::Url::parse(u).ok());
+
+    let domain = params
+        .get("domain")
+        .and_then(|v| v.as_str())
+        .map(|s| s.to_string())
+        .or_else(|| url_parsed.as_ref().and_then(|u| u.host_str().map(|h| h.to_string())))
+        .unwrap_or_default();
+
+    let path = params
+        .get("path")
+        .and_then(|v| v.as_str())
+        .map(|s| s.to_string())
+        .or_else(|| url_parsed.as_ref().map(|u| u.path().to_string()));
+
+    Some(DeleteCookiesFilter { name, domain, path })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn parse_with_explicit_domain_path() {
+        let v = json!({
+            "name": "session",
+            "value": "abc",
+            "domain": ".example.com",
+            "path": "/app",
+            "secure": true,
+            "httpOnly": true,
+            "sameSite": "Strict",
+            "expires": 1_900_000_000.0,
+        });
+        let c = parse_cdp_cookie(&v).unwrap();
+        assert_eq!(c.name, "session");
+        assert_eq!(c.value, "abc");
+        assert_eq!(c.domain, ".example.com");
+        assert_eq!(c.path, "/app");
+        assert!(c.secure);
+        assert!(c.http_only);
+        assert_eq!(c.same_site, "Strict");
+        assert_eq!(c.expires, Some(1_900_000_000));
+    }
+
+    #[test]
+    fn parse_with_url_fallback_for_domain_and_path() {
+        let v = json!({
+            "name": "tok",
+            "value": "xyz",
+            "url": "https://api.example.com/v1/things",
+        });
+        let c = parse_cdp_cookie(&v).unwrap();
+        assert_eq!(c.domain, "api.example.com");
+        assert_eq!(c.path, "/v1/things");
+    }
+
+    #[test]
+    fn parse_rejects_when_no_domain_or_url() {
+        let v = json!({ "name": "x", "value": "y" });
+        assert!(parse_cdp_cookie(&v).is_none());
+    }
+
+    #[test]
+    fn parse_default_path_when_url_has_no_path() {
+        let v = json!({
+            "name": "tok",
+            "value": "v",
+            "domain": "example.com",
+        });
+        let c = parse_cdp_cookie(&v).unwrap();
+        assert_eq!(c.path, "/");
+    }
+
+    #[test]
+    fn delete_filter_requires_name() {
+        let v = json!({ "domain": "example.com" });
+        assert!(parse_delete_cookies_params(&v).is_none());
+    }
+
+    #[test]
+    fn delete_filter_uses_url_for_domain_and_path() {
+        let v = json!({ "name": "session", "url": "https://example.com/admin" });
+        let f = parse_delete_cookies_params(&v).unwrap();
+        assert_eq!(f.name, "session");
+        assert_eq!(f.domain, "example.com");
+        assert_eq!(f.path.as_deref(), Some("/admin"));
+    }
+}

--- a/crates/obscura-cdp/src/dispatch.rs
+++ b/crates/obscura-cdp/src/dispatch.rs
@@ -35,6 +35,14 @@ pub struct CdpContext {
     // "Cannot find context with specified id" CDP error and unblocking the
     // Playwright locator path described in issue #51.
     pub valid_context_ids: HashSet<i64>,
+    // Monotonic counter for isolated-world execution context ids. Issue #192:
+    // both `Page.createIsolatedWorld` and `do_navigate` used to hardcode id
+    // 100, so re-creating a context (e.g. Playwright opening a second page or
+    // re-navigating) silently emitted the same id twice and the client's
+    // bookkeeping diverged from the server's. Each fresh isolated context now
+    // claims and increments from this counter so the ids real Chrome would
+    // emit (incrementing, never reused) are mirrored.
+    pub next_isolated_context_id: i64,
     pub fetch_intercept: FetchInterceptState,
     pub intercept_tx: Option<tokio::sync::mpsc::UnboundedSender<InterceptedRequest>>,
 }
@@ -124,7 +132,17 @@ impl CdpContext {
             intercept_tx: None,
             isolated_worlds: Vec::new(),
             valid_context_ids,
+            next_isolated_context_id: 100,
         }
+    }
+
+    /// Claim the next isolated-world execution context id and register it as
+    /// valid for `Runtime.evaluate`/`callFunctionOn`. Issue #192.
+    pub fn next_isolated_context(&mut self) -> i64 {
+        let id = self.next_isolated_context_id;
+        self.next_isolated_context_id += 1;
+        self.valid_context_ids.insert(id);
+        id
     }
 
     pub fn create_page(&mut self) -> String {

--- a/crates/obscura-cdp/src/dispatch.rs
+++ b/crates/obscura-cdp/src/dispatch.rs
@@ -60,18 +60,47 @@ impl CdpContext {
         Self::new_with_security(proxy, stealth, user_agent, false)
     }
 
+    pub fn new_with_storage(
+        proxy: Option<String>,
+        stealth: bool,
+        user_agent: Option<String>,
+        storage_dir: Option<std::path::PathBuf>,
+    ) -> Self {
+        Self::_new_inner(proxy, stealth, user_agent, storage_dir, false)
+    }
+
     pub fn new_with_security(
         proxy: Option<String>,
         stealth: bool,
         user_agent: Option<String>,
         allow_file_access: bool,
     ) -> Self {
-        let mut ctx = BrowserContext::with_full_options(
-            "default".to_string(),
-            proxy,
-            stealth,
-            user_agent,
-        );
+        Self::_new_inner(proxy, stealth, user_agent, None, allow_file_access)
+    }
+
+    fn _new_inner(
+        proxy: Option<String>,
+        stealth: bool,
+        user_agent: Option<String>,
+        storage_dir: Option<std::path::PathBuf>,
+        allow_file_access: bool,
+    ) -> Self {
+        let mut ctx = if let Some(ref dir) = storage_dir {
+            BrowserContext::with_storage_full(
+                "default".to_string(),
+                proxy,
+                stealth,
+                user_agent,
+                Some(dir.clone()),
+            )
+        } else {
+            BrowserContext::with_full_options(
+                "default".to_string(),
+                proxy,
+                stealth,
+                user_agent,
+            )
+        };
         ctx.allow_file_access = allow_file_access;
         let default_context = Arc::new(ctx);
         // Pre-seed with the default-frame execution context ids that

--- a/crates/obscura-cdp/src/dispatch.rs
+++ b/crates/obscura-cdp/src/dispatch.rs
@@ -217,6 +217,8 @@ pub async fn dispatch(req: &CdpRequest, ctx: &mut CdpContext) -> CdpResponse {
         _ => Err(format!("Unknown domain: {}", domain)),
     };
 
+    drain_binding_calls(ctx);
+
     match result {
         Ok(value) => CdpResponse::success(req.id, value, req.session_id.clone()),
         Err(msg) => {
@@ -224,6 +226,50 @@ pub async fn dispatch(req: &CdpRequest, ctx: &mut CdpContext) -> CdpResponse {
             CdpResponse::error(req.id, -32601, msg, req.session_id.clone())
         }
     }
+}
+
+// Drain every page's binding-call queue (filled by op_binding_called when
+// page JS invokes a `Runtime.addBinding` shim) and turn each entry into a
+// Runtime.bindingCalled CDP event that the writer task forwards to the
+// connected client. Called after every dispatch — binding calls only land
+// in the queue while V8 is running inside a CDP handler, so there is no
+// window in which they could pile up without a draining opportunity.
+fn drain_binding_calls(ctx: &mut CdpContext) {
+    // page_id -> session_id (any one session that holds this page).
+    let page_to_session: HashMap<String, String> = ctx
+        .sessions
+        .iter()
+        .map(|(sid, pid)| (pid.clone(), sid.clone()))
+        .collect();
+
+    let mut events: Vec<CdpEvent> = Vec::new();
+    for page in &mut ctx.pages {
+        let calls = page.take_pending_binding_calls();
+        if calls.is_empty() {
+            continue;
+        }
+        let Some(session_id) = page_to_session.get(&page.id).cloned() else {
+            // No session attached — drop the calls; there is no client to
+            // deliver them to.
+            continue;
+        };
+        for (name, payload) in calls {
+            events.push(CdpEvent {
+                method: "Runtime.bindingCalled".into(),
+                // Use executionContextId=2: the default main-frame context
+                // emitted post-navigation (see domains/page.rs phase1).
+                // Puppeteer matches on session_id + binding name and
+                // tolerates any registered context id.
+                params: json!({
+                    "name": name,
+                    "payload": payload,
+                    "executionContextId": 2,
+                }),
+                session_id: Some(session_id.clone()),
+            });
+        }
+    }
+    ctx.pending_events.extend(events);
 }
 
 async fn dispatch_send_message_to_target(req: &CdpRequest, ctx: &mut CdpContext) -> CdpResponse {

--- a/crates/obscura-cdp/src/domains/dom.rs
+++ b/crates/obscura-cdp/src/domains/dom.rs
@@ -1,7 +1,35 @@
+use obscura_browser::Page;
 use obscura_dom::{DomTree, NodeData, NodeId};
 use serde_json::{json, Value};
 
 use crate::dispatch::CdpContext;
+
+/// Resolve a DOM `nodeId` from CDP params. Honors `nodeId`, `backendNodeId`,
+/// and `objectId` in that order. Playwright commonly passes only `objectId`
+/// (returned by a prior `DOM.resolveNode`); without this fallback those
+/// requests silently default to node 0 and click the wrong element.
+fn resolve_node_id(page: &mut Page, params: &Value) -> Result<u64, String> {
+    if let Some(nid) = params.get("nodeId").and_then(|v| v.as_u64()) {
+        return Ok(nid);
+    }
+    if let Some(nid) = params.get("backendNodeId").and_then(|v| v.as_u64()) {
+        return Ok(nid);
+    }
+    if let Some(oid) = params.get("objectId").and_then(|v| v.as_str()) {
+        let code = format!(
+            "(function() {{ var o = globalThis.__obscura_objects && globalThis.__obscura_objects['{}']; \
+             return (o && typeof o._nid === 'number') ? o._nid : -1; }})()",
+            oid.replace('\'', "\\'")
+        );
+        let result = page.evaluate(&code);
+        let nid = result.as_f64().map(|n| n as i64).unwrap_or(-1);
+        if nid < 0 {
+            return Err(format!("objectId {oid} could not be resolved to a node"));
+        }
+        return Ok(nid as u64);
+    }
+    Err("nodeId, backendNodeId, or objectId required".to_string())
+}
 
 pub async fn handle(
     method: &str,
@@ -138,10 +166,8 @@ pub async fn handle(
         "setAttributeValue" => Ok(json!({})),
         "removeNode" => Ok(json!({})),
         "getBoxModel" => {
-            let node_id = params.get("nodeId").and_then(|v| v.as_u64())
-                .or_else(|| params.get("backendNodeId").and_then(|v| v.as_u64()))
-                .unwrap_or(0);
             let page = ctx.get_session_page_mut(session_id).ok_or("No page")?;
+            let node_id = resolve_node_id(page, params)?;
             let code = format!(
                 "(function() {{\
                     var el = globalThis._wrap && globalThis._wrap({0});\
@@ -175,10 +201,8 @@ pub async fn handle(
             }))
         }
         "getContentQuads" => {
-            let node_id = params.get("nodeId").and_then(|v| v.as_u64())
-                .or_else(|| params.get("backendNodeId").and_then(|v| v.as_u64()))
-                .unwrap_or(0);
             let page = ctx.get_session_page_mut(session_id).ok_or("No page")?;
+            let node_id = resolve_node_id(page, params)?;
             let code = format!(
                 "(function() {{\
                     var el = globalThis._wrap && globalThis._wrap({0});\

--- a/crates/obscura-cdp/src/domains/network.rs
+++ b/crates/obscura-cdp/src/domains/network.rs
@@ -1,6 +1,28 @@
+use std::sync::Arc;
+
 use serde_json::{json, Value};
 
+use obscura_net::CookieJar;
+
+use crate::cookie_params::{parse_cdp_cookie, parse_delete_cookies_params};
 use crate::dispatch::CdpContext;
+
+const SESSION_COOKIE_EXPIRES: i64 = -1;
+const DEFAULT_SECURE_PORT: u16 = 443;
+const DEFAULT_INSECURE_PORT: u16 = 80;
+const SOURCE_SCHEME_SECURE: &str = "Secure";
+const SOURCE_SCHEME_NONSECURE: &str = "NonSecure";
+const DEFAULT_SAME_SITE: &str = "Lax";
+
+// Resolve the cookie jar for a Network request: prefer the session's page jar,
+// fall back to the default browser context. Puppeteer and Playwright both call
+// Network.setCookie/getCookies/deleteCookies BEFORE attaching to a target —
+// requiring a session would break those flows (Storage.* already mirrors this).
+fn cookie_jar_for<'a>(ctx: &'a CdpContext, session_id: &Option<String>) -> &'a Arc<CookieJar> {
+    ctx.get_session_page(session_id)
+        .map(|p| &p.context.cookie_jar)
+        .unwrap_or(&ctx.default_context.cookie_jar)
+}
 
 pub async fn handle(
     method: &str,
@@ -30,52 +52,171 @@ pub async fn handle(
             }
             Ok(json!({}))
         }
-        "getCookies" => {
-            let page = ctx.get_session_page(session_id).ok_or("No page")?;
-            let cookies = page.context.cookie_jar.get_all_cookies();
-            let cdp_cookies: Vec<Value> = cookies.iter().map(|c| {
-                json!({
-                    "name": c.name,
-                    "value": c.value,
-                    "domain": c.domain,
-                    "path": c.path,
-                    "expires": -1,
-                    "size": c.name.len() + c.value.len(),
-                    "httpOnly": c.http_only,
-                    "secure": c.secure,
-                    "session": true,
-                    "sameParty": false,
-                    "sourceScheme": "Secure",
-                    "sourcePort": 443,
-                })
-            }).collect();
+        "getCookies" | "getAllCookies" => {
+            let cookies = cookie_jar_for(ctx, session_id).get_all_cookies();
+            let cdp_cookies: Vec<Value> = cookies.iter().map(cookie_info_to_cdp_json).collect();
             Ok(json!({ "cookies": cdp_cookies }))
         }
+        "setCookie" => {
+            let cookie = parse_cdp_cookie(params)
+                .ok_or("setCookie: missing required name/domain (or url)")?;
+            cookie_jar_for(ctx, session_id).set_cookies_from_cdp(vec![cookie]);
+            Ok(json!({ "success": true }))
+        }
         "setCookies" => {
-            let page = ctx.get_session_page(session_id).ok_or("No page")?;
             if let Some(cookies) = params.get("cookies").and_then(|v| v.as_array()) {
-                let cookie_infos: Vec<obscura_net::CookieInfo> = cookies.iter().filter_map(|c| {
-                    Some(obscura_net::CookieInfo {
-                        name: c.get("name")?.as_str()?.to_string(),
-                        value: c.get("value")?.as_str()?.to_string(),
-                        domain: c.get("domain").and_then(|v| v.as_str()).unwrap_or("").to_string(),
-                        path: c.get("path").and_then(|v| v.as_str()).unwrap_or("/").to_string(),
-                        secure: c.get("secure").and_then(|v| v.as_bool()).unwrap_or(false),
-                        http_only: c.get("httpOnly").and_then(|v| v.as_bool()).unwrap_or(false),
-                    })
-                }).collect();
-                page.context.cookie_jar.set_cookies_from_cdp(cookie_infos);
+                let parsed: Vec<_> = cookies.iter().filter_map(parse_cdp_cookie).collect();
+                cookie_jar_for(ctx, session_id).set_cookies_from_cdp(parsed);
+            }
+            Ok(json!({}))
+        }
+        "deleteCookies" => {
+            if let Some(filter) = parse_delete_cookies_params(params) {
+                cookie_jar_for(ctx, session_id).delete_cookies_filtered(
+                    &filter.name,
+                    &filter.domain,
+                    filter.path.as_deref(),
+                );
             }
             Ok(json!({}))
         }
         "clearBrowserCookies" => {
-            if let Some(page) = ctx.get_session_page(session_id) {
-                page.context.cookie_jar.clear();
-            }
+            cookie_jar_for(ctx, session_id).clear();
             Ok(json!({}))
         }
         "setCacheDisabled" => Ok(json!({})),
         "setRequestInterception" => Ok(json!({})),
         _ => Err(format!("Unknown Network method: {}", method)),
     }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use obscura_net::CookieInfo;
+
+    fn sample_cookie(name: &str) -> CookieInfo {
+        CookieInfo {
+            name: name.to_string(),
+            value: "v".to_string(),
+            domain: "example.com".to_string(),
+            path: "/".to_string(),
+            secure: false,
+            http_only: false,
+            same_site: String::new(),
+            expires: None,
+        }
+    }
+
+    #[tokio::test]
+    async fn set_cookie_without_session_targets_default_context() {
+        let mut ctx = CdpContext::new();
+        let params = json!({
+            "name": "sid",
+            "value": "abc",
+            "domain": "example.com",
+            "path": "/"
+        });
+        let resp = handle("setCookie", &params, &mut ctx, &None)
+            .await
+            .expect("setCookie must succeed without a session");
+        assert_eq!(resp["success"], json!(true));
+        let cookies = ctx.default_context.cookie_jar.get_all_cookies();
+        assert_eq!(cookies.len(), 1, "default cookie jar must receive the cookie");
+        assert_eq!(cookies[0].name, "sid");
+    }
+
+    #[tokio::test]
+    async fn set_cookies_without_session_targets_default_context() {
+        let mut ctx = CdpContext::new();
+        let params = json!({
+            "cookies": [
+                { "name": "a", "value": "1", "domain": "example.com", "path": "/" },
+                { "name": "b", "value": "2", "domain": "example.com", "path": "/" }
+            ]
+        });
+        handle("setCookies", &params, &mut ctx, &None)
+            .await
+            .expect("setCookies must succeed without a session");
+        assert_eq!(ctx.default_context.cookie_jar.get_all_cookies().len(), 2);
+    }
+
+    #[tokio::test]
+    async fn delete_cookies_without_session_targets_default_context() {
+        let mut ctx = CdpContext::new();
+        ctx.default_context
+            .cookie_jar
+            .set_cookies_from_cdp(vec![sample_cookie("sid")]);
+        let params = json!({ "name": "sid", "domain": "example.com" });
+        handle("deleteCookies", &params, &mut ctx, &None)
+            .await
+            .expect("deleteCookies must succeed without a session");
+        assert!(ctx.default_context.cookie_jar.get_all_cookies().is_empty());
+    }
+
+    #[tokio::test]
+    async fn get_all_cookies_returns_every_cookie_in_jar() {
+        let mut ctx = CdpContext::new();
+        ctx.default_context.cookie_jar.set_cookies_from_cdp(vec![
+            sample_cookie("a"),
+            sample_cookie("b"),
+        ]);
+        let resp = handle("getAllCookies", &json!({}), &mut ctx, &None)
+            .await
+            .expect("getAllCookies must succeed");
+        let arr = resp["cookies"].as_array().expect("cookies array");
+        assert_eq!(arr.len(), 2);
+    }
+
+    #[tokio::test]
+    async fn get_cookies_falls_back_to_default_context_when_no_session() {
+        let mut ctx = CdpContext::new();
+        ctx.default_context
+            .cookie_jar
+            .set_cookies_from_cdp(vec![sample_cookie("sid")]);
+        let resp = handle("getCookies", &json!({}), &mut ctx, &None)
+            .await
+            .expect("getCookies must succeed without a session");
+        let arr = resp["cookies"].as_array().expect("cookies array");
+        assert_eq!(arr.len(), 1);
+        assert_eq!(arr[0]["name"], "sid");
+    }
+
+    #[tokio::test]
+    async fn clear_browser_cookies_without_session_clears_default_context() {
+        let mut ctx = CdpContext::new();
+        ctx.default_context
+            .cookie_jar
+            .set_cookies_from_cdp(vec![sample_cookie("sid")]);
+        handle("clearBrowserCookies", &json!({}), &mut ctx, &None)
+            .await
+            .expect("clearBrowserCookies must succeed");
+        assert!(ctx.default_context.cookie_jar.get_all_cookies().is_empty());
+    }
+}
+
+pub(crate) fn cookie_info_to_cdp_json(c: &obscura_net::CookieInfo) -> Value {
+    let expires = c.expires.unwrap_or(SESSION_COOKIE_EXPIRES);
+    let session = c.expires.is_none();
+    let same_site = if c.same_site.is_empty() {
+        DEFAULT_SAME_SITE
+    } else {
+        c.same_site.as_str()
+    };
+    json!({
+        "name": c.name,
+        "value": c.value,
+        "domain": c.domain,
+        "path": c.path,
+        "expires": expires,
+        "size": c.name.len() + c.value.len(),
+        "httpOnly": c.http_only,
+        "secure": c.secure,
+        "session": session,
+        "sameSite": same_site,
+        "sameParty": false,
+        "sourceScheme": if c.secure { SOURCE_SCHEME_SECURE } else { SOURCE_SCHEME_NONSECURE },
+        "sourcePort": if c.secure { DEFAULT_SECURE_PORT } else { DEFAULT_INSECURE_PORT },
+        "priority": "Medium",
+    })
 }

--- a/crates/obscura-cdp/src/domains/page.rs
+++ b/crates/obscura-cdp/src/domains/page.rs
@@ -74,6 +74,42 @@ async fn do_navigate(
     let es = session_id.clone();
     let ts = timestamp();
 
+    // Real Chrome uses the navigation's loaderId as the main document's
+    // request id, and Puppeteer/Playwright identify the navigation response
+    // via `requestId === loaderId && type === "Document"` (issue #189).
+    // Override the first Document event's request id with loaderId so
+    // `page.goto()` resolves to the navigation Response instead of null.
+    let nav_request_ids: Vec<String> = {
+        let mut nav_seen = false;
+        network_events.iter().map(|ev| {
+            if !nav_seen && ev.resource_type == "Document" && ev.url == page_url {
+                nav_seen = true;
+                loader_id.clone()
+            } else {
+                ev.request_id.clone()
+            }
+        }).collect()
+    };
+    let nav_idx: Option<usize> = network_events
+        .iter()
+        .position(|ev| ev.resource_type == "Document" && ev.url == page_url);
+
+    // Playwright needs `Network.requestWillBeSent` for the main document to
+    // arrive BEFORE `Page.frameNavigated`, otherwise its FrameManager commits
+    // the navigation with `currentDocument.request = void 0` and never
+    // attaches the response. Mirrors real Chrome's event order. We emit only
+    // the navigation request here; the response and subresource requests
+    // come after `frameNavigated` (still before `Page.lifecycleEvent: load`).
+    if let Some(idx) = nav_idx {
+        let net_event = &network_events[idx];
+        let rid = &nav_request_ids[idx];
+        ctx.pending_events.push(CdpEvent {
+            method: "Network.requestWillBeSent".into(),
+            params: json!({"requestId": rid, "loaderId": loader_id, "documentURL": page_url, "request": {"url": net_event.url, "method": net_event.method, "headers": net_event.headers}, "timestamp": net_event.timestamp, "wallTime": net_event.timestamp, "initiator": {"type": "other"}, "type": net_event.resource_type, "frameId": frame_id}),
+            session_id: es.clone(),
+        });
+    }
+
     let mut phase1 = vec![
         CdpEvent { method: "Page.lifecycleEvent".into(), params: json!({"frameId": frame_id, "loaderId": loader_id, "name": "init", "timestamp": ts}), session_id: es.clone() },
         CdpEvent { method: "Runtime.executionContextsCleared".into(), params: json!({}), session_id: es.clone() },
@@ -97,11 +133,12 @@ async fn do_navigate(
     ctx.pending_events.extend(phase1);
 
     if ctx.fetch_intercept.enabled {
-        for net_event in &network_events {
+        for (i, net_event) in network_events.iter().enumerate() {
+            let rid = &nav_request_ids[i];
             ctx.pending_events.push(CdpEvent {
                 method: "Fetch.requestPaused".into(),
                 params: json!({
-                    "requestId": net_event.request_id,
+                    "requestId": rid,
                     "request": {
                         "url": net_event.url,
                         "method": net_event.method,
@@ -109,27 +146,33 @@ async fn do_navigate(
                     },
                     "frameId": frame_id,
                     "resourceType": net_event.resource_type,
-                    "networkId": net_event.request_id,
+                    "networkId": rid,
                 }),
                 session_id: es.clone(),
             });
         }
     }
 
-    for net_event in &network_events {
-        ctx.pending_events.push(CdpEvent {
-            method: "Network.requestWillBeSent".into(),
-            params: json!({"requestId": net_event.request_id, "loaderId": loader_id, "documentURL": page_url, "request": {"url": net_event.url, "method": net_event.method, "headers": net_event.headers}, "timestamp": net_event.timestamp, "wallTime": net_event.timestamp, "initiator": {"type": "other"}, "type": net_event.resource_type, "frameId": frame_id}),
-            session_id: es.clone(),
-        });
+    for (i, net_event) in network_events.iter().enumerate() {
+        let rid = &nav_request_ids[i];
+        // Document's requestWillBeSent was already emitted above (before
+        // Page.frameNavigated) so Playwright can attach the request to the
+        // pending document. Skip re-emitting it here.
+        if Some(i) != nav_idx {
+            ctx.pending_events.push(CdpEvent {
+                method: "Network.requestWillBeSent".into(),
+                params: json!({"requestId": rid, "loaderId": loader_id, "documentURL": page_url, "request": {"url": net_event.url, "method": net_event.method, "headers": net_event.headers}, "timestamp": net_event.timestamp, "wallTime": net_event.timestamp, "initiator": {"type": "other"}, "type": net_event.resource_type, "frameId": frame_id}),
+                session_id: es.clone(),
+            });
+        }
         ctx.pending_events.push(CdpEvent {
             method: "Network.responseReceived".into(),
-            params: json!({"requestId": net_event.request_id, "loaderId": loader_id, "timestamp": net_event.timestamp, "type": net_event.resource_type, "response": {"url": net_event.url, "status": net_event.status, "statusText": "", "headers": &*net_event.response_headers, "mimeType": net_event.response_headers.get("content-type").cloned().unwrap_or_default()}, "frameId": frame_id}),
+            params: json!({"requestId": rid, "loaderId": loader_id, "timestamp": net_event.timestamp, "type": net_event.resource_type, "response": {"url": net_event.url, "status": net_event.status, "statusText": "", "headers": &*net_event.response_headers, "mimeType": net_event.response_headers.get("content-type").cloned().unwrap_or_default()}, "frameId": frame_id}),
             session_id: es.clone(),
         });
         ctx.pending_events.push(CdpEvent {
             method: "Network.loadingFinished".into(),
-            params: json!({"requestId": net_event.request_id, "timestamp": net_event.timestamp, "encodedDataLength": net_event.body_size}),
+            params: json!({"requestId": rid, "timestamp": net_event.timestamp, "encodedDataLength": net_event.body_size}),
             session_id: es.clone(),
         });
     }

--- a/crates/obscura-cdp/src/domains/page.rs
+++ b/crates/obscura-cdp/src/domains/page.rs
@@ -121,11 +121,18 @@ async fn do_navigate(
     } else {
         ctx.isolated_worlds.clone()
     };
-    for (idx, world_name) in world_names.iter().enumerate() {
-        let world_ctx_id = 100 + idx as u32;
+    // Issue #192: real Chrome emits a fresh, monotonically increasing
+    // executionContextId on every re-creation. Reusing ids 100, 101, …
+    // across navigations made Playwright's client-side counter and our
+    // server-side `valid_context_ids` diverge after the first nav, so
+    // Runtime.evaluate failed with "Cannot find context with specified
+    // id: 101". Each post-nav isolated world now claims a fresh id from
+    // the same counter that backs Page.createIsolatedWorld.
+    for world_name in &world_names {
+        let world_ctx_id = ctx.next_isolated_context();
         phase1.push(CdpEvent {
             method: "Runtime.executionContextCreated".into(),
-            params: json!({"context": {"id": world_ctx_id, "origin": page_url, "name": world_name, "uniqueId": format!("ctx-isolated-nav-{}-{}", page_id, idx), "auxData": {"isDefault": false, "type": "isolated", "frameId": frame_id}}}),
+            params: json!({"context": {"id": world_ctx_id, "origin": page_url, "name": world_name, "uniqueId": format!("ctx-isolated-nav-{}-{}", page_id, world_ctx_id), "auxData": {"isDefault": false, "type": "isolated", "frameId": frame_id}}}),
             session_id: es.clone(),
         });
     }
@@ -236,14 +243,17 @@ pub async fn handle(
             }))
         }
         "createIsolatedWorld" => {
-            let page = ctx.get_session_page(session_id).ok_or("No page for session")?;
-            let frame_id_param = params.get("frameId").and_then(|v| v.as_str())
-                .unwrap_or(&page.frame_id).to_string();
-            let world_name = params.get("worldName").and_then(|v| v.as_str())
-                .unwrap_or("").to_string();
-            let page_url = page.url_string();
-            let page_id = page.id.clone();
-            let context_id: i64 = 100;
+            let (frame_id_param, world_name, page_url, page_id) = {
+                let page = ctx.get_session_page(session_id).ok_or("No page for session")?;
+                (
+                    params.get("frameId").and_then(|v| v.as_str())
+                        .unwrap_or(&page.frame_id).to_string(),
+                    params.get("worldName").and_then(|v| v.as_str())
+                        .unwrap_or("").to_string(),
+                    page.url_string(),
+                    page.id.clone(),
+                )
+            };
             // Track this world so Page.navigate can re-emit a context for it
             // post-navigation. Without this, Playwright (and Puppeteer)
             // hang in any operation that uses the utility world — including
@@ -252,9 +262,12 @@ pub async fn handle(
             if !world_name.is_empty() && !ctx.isolated_worlds.contains(&world_name) {
                 ctx.isolated_worlds.push(world_name.clone());
             }
-            // Register the isolated world's id so Runtime.evaluate /
-            // Runtime.callFunctionOn accept it as a valid contextId (#51).
-            ctx.valid_context_ids.insert(context_id);
+            // Issue #192: every isolated world emission gets a fresh id from
+            // the monotonic counter and is registered as a valid contextId.
+            // Reusing id 100 across navigations made Playwright's bookkeeping
+            // diverge (it expected 101 on the second nav) and Runtime.evaluate
+            // failed with "Cannot find context with specified id: 101".
+            let context_id = ctx.next_isolated_context();
 
             ctx.pending_events.push(CdpEvent {
                 method: "Runtime.executionContextCreated".to_string(),
@@ -263,7 +276,7 @@ pub async fn handle(
                         "id": context_id,
                         "origin": page_url,
                         "name": world_name,
-                        "uniqueId": format!("ctx-isolated-{}", page_id),
+                        "uniqueId": format!("ctx-isolated-{}-{}", page_id, context_id),
                         "auxData": {
                             "isDefault": false,
                             "type": "isolated",

--- a/crates/obscura-cdp/src/domains/page.rs
+++ b/crates/obscura-cdp/src/domains/page.rs
@@ -50,18 +50,17 @@ async fn do_navigate(
         let frame_id = page.frame_id.clone();
         let loader_id = format!("loader-{}", uuid::Uuid::new_v4());
 
+        // Preloads (addBinding shims, addScriptToEvaluateOnNewDocument sources)
+        // must run BEFORE the page's own scripts (CDP contract). Hand them to
+        // the page so navigate_single can inject them at the right point.
+        page.set_preload_scripts(preload_scripts);
+
         let nav_method = params.get("__method").and_then(|v| v.as_str()).unwrap_or("GET");
         let nav_body = params.get("__body").and_then(|v| v.as_str()).unwrap_or("");
         if nav_method == "POST" && !nav_body.is_empty() {
             page.navigate_with_wait_post(url, wait_until, nav_method, nav_body).await.map_err(|e| e.to_string())?;
         } else {
             page.navigate_with_wait(url, wait_until).await.map_err(|e| e.to_string())?;
-        }
-
-        for source in &preload_scripts {
-            if let Err(e) = page.execute_preload_script(source) {
-                tracing::debug!("Preload script error: {}", e);
-            }
         }
 
         let reached_network_idle = page.lifecycle.is_network_idle();

--- a/crates/obscura-cdp/src/domains/page.rs
+++ b/crates/obscura-cdp/src/domains/page.rs
@@ -313,6 +313,17 @@ pub async fn handle(
                     .to_string(),
             )
         }
+        "captureScreenshot" | "captureSnapshot" => {
+            // Same story as printToPDF: rasterising a page needs a layout and
+            // paint pipeline that Obscura intentionally does not have. Reply
+            // with a clear error so clients can fail fast instead of waiting
+            // on the generic "Unknown Page method" reply.
+            Err(format!(
+                "Page.{method} is not supported by Obscura: no layout or paint engine. \
+                 For visual snapshots, drive a real headless Chromium for the \
+                 screenshot leg of your pipeline and use Obscura for the scraping leg."
+            ))
+        }
         _ => Err(format!("Unknown Page method: {}", method)),
     }
 }
@@ -396,6 +407,34 @@ mod tests {
             err.to_lowercase().contains("evaluate")
                 || err.to_lowercase().contains("html"),
             "error must point to a workaround: {err}"
+        );
+    }
+
+    /// Regression for #45: same idea as printToPDF for captureScreenshot.
+    /// Playwright's `page.screenshot()` calls Page.captureScreenshot via CDP;
+    /// without an explicit arm, clients see "Unknown Page method" and have
+    /// no idea why their screenshot request failed.
+    #[tokio::test]
+    async fn capture_screenshot_returns_descriptive_unsupported_error() {
+        let mut ctx = CdpContext::new();
+        let err = handle("captureScreenshot", &json!({}), &mut ctx, &None)
+            .await
+            .expect_err("captureScreenshot must error until a real paint exists");
+        assert!(
+            !err.contains("Unknown Page method"),
+            "captureScreenshot must NOT fall through to the catch-all: {err}"
+        );
+        assert!(
+            err.contains("not supported by Obscura"),
+            "error must clearly state screenshot is unsupported: {err}"
+        );
+        // Same for the MHTML snapshot sibling method.
+        let err2 = handle("captureSnapshot", &json!({}), &mut ctx, &None)
+            .await
+            .expect_err("captureSnapshot must error until a real renderer exists");
+        assert!(
+            !err2.contains("Unknown Page method"),
+            "captureSnapshot must NOT fall through: {err2}"
         );
     }
 }

--- a/crates/obscura-cdp/src/domains/runtime.rs
+++ b/crates/obscura-cdp/src/domains/runtime.rs
@@ -11,25 +11,37 @@ pub async fn handle(
 ) -> Result<Value, String> {
     match method {
         "enable" => {
-            let page = ctx.get_session_page(session_id).ok_or("No page")?;
-            let event = crate::types::CdpEvent {
-                method: "Runtime.executionContextCreated".to_string(),
-                params: json!({
-                    "context": {
-                        "id": 1,
-                        "origin": page.url_string(),
-                        "name": "",
-                        "uniqueId": format!("ctx-{}", page.id),
-                        "auxData": {
-                            "isDefault": true,
-                            "type": "default",
-                            "frameId": page.frame_id,
-                        }
-                    }
-                }),
-                session_id: session_id.clone(),
-            };
-            ctx.pending_events.push(event);
+            // puppeteer-extra's FrameManager.initialize calls Runtime.enable on
+            // the browser-level connection BEFORE any page target exists. Real
+            // Chrome replies with `{}` and emits executionContextCreated when
+            // a context appears. Returning "No page" here breaks the standard
+            // puppeteer connect/newPage flow. If there's no session, succeed
+            // silently — the next Target.attachToTarget will set things up.
+            match ctx.get_session_page(session_id) {
+                Some(page) => {
+                    let event = crate::types::CdpEvent {
+                        method: "Runtime.executionContextCreated".to_string(),
+                        params: json!({
+                            "context": {
+                                "id": 1,
+                                "origin": page.url_string(),
+                                "name": "",
+                                "uniqueId": format!("ctx-{}", page.id),
+                                "auxData": {
+                                    "isDefault": true,
+                                    "type": "default",
+                                    "frameId": page.frame_id,
+                                }
+                            }
+                        }),
+                        session_id: session_id.clone(),
+                    };
+                    ctx.pending_events.push(event);
+                }
+                None => {
+                    // No session attached yet — that's fine. Just ack.
+                }
+            }
             Ok(json!({}))
         }
         "evaluate" => {
@@ -41,7 +53,7 @@ pub async fn handle(
                 .get("returnByValue")
                 .and_then(|v| v.as_bool())
                 .unwrap_or(false);
-          
+
             validate_context_id(params, "contextId", ctx, "evaluate")?;
 
             let await_promise = params
@@ -49,10 +61,31 @@ pub async fn handle(
                 .and_then(|v| v.as_bool())
                 .unwrap_or(false);
 
+            // CDP `timeout` field (milliseconds). Default to Chrome's
+            // protocolTimeout (30s) so long evaluations don't pin the V8 lock
+            // indefinitely and starve every other CDP command on the same
+            // session.
+            let timeout_ms = params
+                .get("timeout")
+                .and_then(|v| v.as_u64())
+                .unwrap_or(30_000);
+
             let page = ctx
                 .get_session_page_mut(session_id)
                 .ok_or("No page")?;
-            let info = page.evaluate_for_cdp(expression, return_by_value, await_promise).await;
+            let info = match tokio::time::timeout(
+                std::time::Duration::from_millis(timeout_ms),
+                page.evaluate_for_cdp(expression, return_by_value, await_promise),
+            )
+            .await
+            {
+                Ok(info) => info,
+                Err(_) => {
+                    return Err(format!(
+                        "Runtime.evaluate exceeded {timeout_ms}ms timeout"
+                    ));
+                }
+            };
             page.process_pending_navigation().await.map_err(|e| e.to_string())?;
 
             Ok(json!({ "result": remote_object_from_info(&info) }))
@@ -357,5 +390,19 @@ mod tests {
                 "registered isolated-world contextId=100 must be accepted, got: {e}"
             );
         }
+    }
+
+    /// Regression for #122 item 7: puppeteer-extra's FrameManager.initialize
+    /// fires Runtime.enable on the browser-level WebSocket BEFORE any page
+    /// target exists. Real Chrome replies with `{}`; before the fix Obscura
+    /// returned `{"error":{"code":-32601,"message":"No page"}}` and the
+    /// puppeteer connect flow died.
+    #[tokio::test]
+    async fn enable_succeeds_when_no_session_attached() {
+        let mut ctx = CdpContext::new();
+        let result = handle("enable", &json!({}), &mut ctx, &None)
+            .await
+            .expect("Runtime.enable must succeed even with no session");
+        assert_eq!(result, json!({}));
     }
 }

--- a/crates/obscura-cdp/src/domains/runtime.rs
+++ b/crates/obscura-cdp/src/domains/runtime.rs
@@ -186,11 +186,16 @@ pub async fn handle(
                 // The shim forwards every call back to Rust through
                 // op_binding_called; the CDP dispatcher then drains the
                 // queue and emits Runtime.bindingCalled events the same
-                // way Chromium does.
+                // way Chromium does. Chromium's V8InspectorImpl rejects
+                // calls without exactly one argument and ToString-coerces
+                // that argument before emitting it as the payload — we
+                // match the coercion (`String(arg)`) and silently drop
+                // calls with wrong arity, which is what Chrome does.
                 let shim = format!(
                     "globalThis['{name}'] = function (arg) {{\
+                        if (arguments.length !== 1) return;\
                         try {{\
-                            const payload = typeof arg === 'string' ? arg : JSON.stringify(arg);\
+                            const payload = typeof arg === 'string' ? arg : String(arg);\
                             Deno.core.ops.op_binding_called('{name}', payload);\
                         }} catch (e) {{ /* swallow: binding must not throw into page */ }}\
                     }};",

--- a/crates/obscura-cdp/src/domains/runtime.rs
+++ b/crates/obscura-cdp/src/domains/runtime.rs
@@ -179,18 +179,44 @@ pub async fn handle(
         }
         "addBinding" => {
             let name = params.get("name").and_then(|v| v.as_str()).unwrap_or("");
+            if !name.is_empty()
+                && name.chars().all(|c| c.is_alphanumeric() || c == '_' || c == '$')
+                && !name.chars().next().unwrap_or('0').is_ascii_digit()
+            {
+                // The shim forwards every call back to Rust through
+                // op_binding_called; the CDP dispatcher then drains the
+                // queue and emits Runtime.bindingCalled events the same
+                // way Chromium does.
+                let shim = format!(
+                    "globalThis['{name}'] = function (arg) {{\
+                        try {{\
+                            const payload = typeof arg === 'string' ? arg : JSON.stringify(arg);\
+                            Deno.core.ops.op_binding_called('{name}', payload);\
+                        }} catch (e) {{ /* swallow: binding must not throw into page */ }}\
+                    }};",
+                    name = name,
+                );
+                // Re-install on every navigation: globalThis is wiped on
+                // each new document, and puppeteer registers bindings
+                // once-per-page rather than once-per-document.
+                let key = format!("__obscura_binding__{}", name);
+                ctx.preload_scripts.retain(|(k, _)| k != &key);
+                ctx.preload_scripts.push((key, shim.clone()));
+                // Install on the current page so the binding is usable
+                // immediately, without waiting for the next navigation.
+                if let Some(page) = ctx.get_session_page_mut(session_id) {
+                    page.evaluate(&shim);
+                }
+            }
+            Ok(json!({}))
+        }
+        "removeBinding" => {
+            let name = params.get("name").and_then(|v| v.as_str()).unwrap_or("");
             if !name.is_empty() {
-                if name.chars().all(|c| c.is_alphanumeric() || c == '_' || c == '$')
-                    && !name.chars().next().unwrap_or('0').is_ascii_digit() {
-                    if let Some(page) = ctx.get_session_page_mut(session_id) {
-                        let code = format!(
-                            "if (typeof globalThis.{name} === 'undefined') {{\
-                                globalThis.{name} = function() {{ return null; }};\
-                            }}",
-                            name = name,
-                        );
-                        page.evaluate(&code);
-                    }
+                let key = format!("__obscura_binding__{}", name);
+                ctx.preload_scripts.retain(|(k, _)| k != &key);
+                if let Some(page) = ctx.get_session_page_mut(session_id) {
+                    page.evaluate(&format!("delete globalThis['{}'];", name));
                 }
             }
             Ok(json!({}))

--- a/crates/obscura-cdp/src/domains/storage.rs
+++ b/crates/obscura-cdp/src/domains/storage.rs
@@ -1,6 +1,8 @@
 use serde_json::{json, Value};
 
+use crate::cookie_params::{parse_cdp_cookie, parse_delete_cookies_params};
 use crate::dispatch::CdpContext;
+use crate::domains::network::cookie_info_to_cdp_json;
 
 pub async fn handle(
     method: &str,
@@ -11,104 +13,23 @@ pub async fn handle(
     match method {
         "getCookies" => {
             let cookies = ctx.default_context.cookie_jar.get_all_cookies();
-            let cdp_cookies: Vec<Value> = cookies
-                .iter()
-                .map(|c| {
-                    json!({
-                        "name": c.name,
-                        "value": c.value,
-                        "domain": c.domain,
-                        "path": c.path,
-                        "expires": -1,
-                        "size": c.name.len() + c.value.len(),
-                        "httpOnly": c.http_only,
-                        "secure": c.secure,
-                        "session": true,
-                        "priority": "Medium",
-                        "sameParty": false,
-                        "sourceScheme": if c.secure { "Secure" } else { "NonSecure" },
-                        "sourcePort": 80,
-                    })
-                })
-                .collect();
+            let cdp_cookies: Vec<Value> = cookies.iter().map(cookie_info_to_cdp_json).collect();
             Ok(json!({ "cookies": cdp_cookies }))
         }
         "setCookies" => {
             if let Some(cookies) = params.get("cookies").and_then(|v| v.as_array()) {
-                let now = std::time::SystemTime::now()
-                    .duration_since(std::time::UNIX_EPOCH)
-                    .unwrap_or_default()
-                    .as_secs_f64();
-
-                for c in cookies {
-                    let name = match c.get("name").and_then(|v| v.as_str()) {
-                        Some(n) => n.to_string(),
-                        None => continue,
-                    };
-                    let value = c.get("value").and_then(|v| v.as_str()).unwrap_or("").to_string();
-
-                    let domain = c
-                        .get("domain")
-                        .and_then(|v| v.as_str())
-                        .map(|s| s.to_string())
-                        .or_else(|| {
-                            c.get("url")
-                                .and_then(|v| v.as_str())
-                                .and_then(|u| url::Url::parse(u).ok())
-                                .and_then(|u| u.host_str().map(|h| h.to_string()))
-                        })
-                        .unwrap_or_default();
-
-                    let expires = c.get("expires").and_then(|v| v.as_f64());
-                    if let Some(exp) = expires {
-                        if exp > 0.0 && exp < now {
-                            ctx.default_context.cookie_jar.delete_cookie(&name, &domain);
-                            continue;
-                        }
-                    }
-
-                    let path = c
-                        .get("path")
-                        .and_then(|v| v.as_str())
-                        .unwrap_or("/")
-                        .to_string();
-                    let secure =
-                        c.get("secure").and_then(|v| v.as_bool()).unwrap_or(false);
-                    let http_only =
-                        c.get("httpOnly").and_then(|v| v.as_bool()).unwrap_or(false);
-
-                    ctx.default_context.cookie_jar.set_cookies_from_cdp(vec![
-                        obscura_net::CookieInfo {
-                            name,
-                            value,
-                            domain,
-                            path,
-                            secure,
-                            http_only,
-                        },
-                    ]);
-                }
+                let parsed: Vec<_> = cookies.iter().filter_map(parse_cdp_cookie).collect();
+                ctx.default_context.cookie_jar.set_cookies_from_cdp(parsed);
             }
             Ok(json!({}))
         }
         "deleteCookies" => {
-            let name = params.get("name").and_then(|v| v.as_str()).unwrap_or("");
-            let domain_from_url = params
-                .get("url")
-                .and_then(|v| v.as_str())
-                .and_then(|u| url::Url::parse(u).ok())
-                .and_then(|u| u.host_str().map(|h| h.to_string()));
-            let domain = params
-                .get("domain")
-                .and_then(|v| v.as_str())
-                .map(|s| s.to_string())
-                .or(domain_from_url)
-                .unwrap_or_default();
-
-            if !name.is_empty() {
-                ctx.default_context
-                    .cookie_jar
-                    .delete_cookie(name, &domain);
+            if let Some(filter) = parse_delete_cookies_params(params) {
+                ctx.default_context.cookie_jar.delete_cookies_filtered(
+                    &filter.name,
+                    &filter.domain,
+                    filter.path.as_deref(),
+                );
             }
             Ok(json!({}))
         }

--- a/crates/obscura-cdp/src/domains/target.rs
+++ b/crates/obscura-cdp/src/domains/target.rs
@@ -224,6 +224,9 @@ pub async fn handle(method: &str, params: &Value, ctx: &mut CdpContext) -> Resul
                     }))
                 }
                 None => {
+                    // canAccessOpener is required on every TargetInfo per the
+                    // CDP spec. Strict clients (chromiumoxide) panic if it's
+                    // missing. The browser target itself has no opener.
                     Ok(json!({
                         "targetInfo": {
                             "targetId": "browser",
@@ -231,6 +234,7 @@ pub async fn handle(method: &str, params: &Value, ctx: &mut CdpContext) -> Resul
                             "title": "",
                             "url": "",
                             "attached": true,
+                            "canAccessOpener": false,
                         }
                     }))
                 }
@@ -276,5 +280,26 @@ mod tests {
             .await
             .expect_err("unknown methods must surface as errors");
         assert!(err.contains("Unknown Target method"));
+    }
+
+    /// Regression for #122 item 5: every TargetInfo payload must carry the
+    /// `canAccessOpener` field. The browser-target branch of getTargetInfo
+    /// (no targetId passed → no page) used to omit it; strict CDP clients
+    /// like chromiumoxide panic when the field is missing.
+    #[tokio::test]
+    async fn get_target_info_browser_target_includes_can_access_opener() {
+        let mut ctx = CdpContext::new();
+        // No targetId → falls through to the browser-target branch.
+        let result = handle("getTargetInfo", &json!({}), &mut ctx)
+            .await
+            .expect("getTargetInfo with no targetId must return browser info");
+
+        let info = &result["targetInfo"];
+        assert_eq!(info["type"], "browser", "must be the browser target");
+        assert!(
+            info.get("canAccessOpener").is_some(),
+            "canAccessOpener must be present on every TargetInfo, got: {result}"
+        );
+        assert_eq!(info["canAccessOpener"], false);
     }
 }

--- a/crates/obscura-cdp/src/domains/target.rs
+++ b/crates/obscura-cdp/src/domains/target.rs
@@ -16,6 +16,7 @@ pub async fn handle(method: &str, params: &Value, ctx: &mut CdpContext) -> Resul
                         "title": "",
                         "url": "",
                         "attached": true,
+                        "canAccessOpener": false,
                         "browserContextId": "",
                     }
                 }),
@@ -30,6 +31,7 @@ pub async fn handle(method: &str, params: &Value, ctx: &mut CdpContext) -> Resul
                             "title": page.title,
                             "url": page.url_string(),
                             "attached": false,
+                            "canAccessOpener": false,
                             "browserContextId": page.context.id,
                         }
                     }),
@@ -48,6 +50,7 @@ pub async fn handle(method: &str, params: &Value, ctx: &mut CdpContext) -> Resul
                         "title": page.title,
                         "url": page.url_string(),
                         "attached": true,
+                        "canAccessOpener": false,
                         "browserContextId": page.context.id,
                     })
                 })
@@ -90,6 +93,7 @@ pub async fn handle(method: &str, params: &Value, ctx: &mut CdpContext) -> Resul
                             "title": page.title,
                             "url": page.url_string(),
                             "attached": false,
+                            "canAccessOpener": false,
                             "browserContextId": page.context.id,
                         }
                     }),
@@ -107,6 +111,7 @@ pub async fn handle(method: &str, params: &Value, ctx: &mut CdpContext) -> Resul
                             "title": page.title,
                             "url": page.url_string(),
                             "attached": true,
+                            "canAccessOpener": false,
                             "browserContextId": page.context.id,
                         },
                         "waitingForDebugger": false,
@@ -133,6 +138,7 @@ pub async fn handle(method: &str, params: &Value, ctx: &mut CdpContext) -> Resul
                         "title": "",
                         "url": "",
                         "attached": true,
+                        "canAccessOpener": false,
                         "browserContextId": "",
                     },
                     "waitingForDebugger": false,
@@ -158,6 +164,7 @@ pub async fn handle(method: &str, params: &Value, ctx: &mut CdpContext) -> Resul
                             "title": page.title,
                             "url": page.url_string(),
                             "attached": true,
+                            "canAccessOpener": false,
                             "browserContextId": page.context.id,
                         },
                         "waitingForDebugger": false,
@@ -211,6 +218,7 @@ pub async fn handle(method: &str, params: &Value, ctx: &mut CdpContext) -> Resul
                             "title": page.title,
                             "url": page.url_string(),
                             "attached": true,
+                            "canAccessOpener": false,
                             "browserContextId": page.context.id,
                         }
                     }))

--- a/crates/obscura-cdp/src/lib.rs
+++ b/crates/obscura-cdp/src/lib.rs
@@ -2,6 +2,7 @@ pub mod server;
 pub mod dispatch;
 pub mod types;
 pub mod domains;
+pub mod cookie_params;
 pub(crate) mod util;
 
 pub use server::{

--- a/crates/obscura-cdp/src/server.rs
+++ b/crates/obscura-cdp/src/server.rs
@@ -47,7 +47,7 @@ pub async fn start_with_options(
     proxy: Option<String>,
     stealth: bool,
 ) -> anyhow::Result<()> {
-    start_with_full_options(port, proxy, stealth, None).await
+    start_with_full_options(port, proxy, stealth, None, None).await
 }
 
 pub async fn start_with_full_options(
@@ -55,8 +55,9 @@ pub async fn start_with_full_options(
     proxy: Option<String>,
     stealth: bool,
     user_agent: Option<String>,
+    storage_dir: Option<std::path::PathBuf>,
 ) -> anyhow::Result<()> {
-    start_with_host(port, "127.0.0.1", proxy, stealth, user_agent).await
+    start_with_host(port, "127.0.0.1", proxy, stealth, user_agent, storage_dir).await
 }
 
 pub async fn start_with_host(
@@ -65,8 +66,9 @@ pub async fn start_with_host(
     proxy: Option<String>,
     stealth: bool,
     user_agent: Option<String>,
+    storage_dir: Option<std::path::PathBuf>,
 ) -> anyhow::Result<()> {
-    start_with_host_and_security(port, host, proxy, stealth, user_agent, false).await
+    start_with_host_and_security(port, host, proxy, stealth, user_agent, false, storage_dir).await
 }
 
 pub async fn start_with_host_and_security(
@@ -76,6 +78,19 @@ pub async fn start_with_host_and_security(
     stealth: bool,
     user_agent: Option<String>,
     allow_file_access: bool,
+    storage_dir: Option<std::path::PathBuf>,
+) -> anyhow::Result<()> {
+    start_with_host_security_and_storage(port, host, proxy, stealth, user_agent, allow_file_access, storage_dir).await
+}
+
+pub async fn start_with_host_security_and_storage(
+    port: u16,
+    host: &str,
+    proxy: Option<String>,
+    stealth: bool,
+    user_agent: Option<String>,
+    allow_file_access: bool,
+    storage_dir: Option<std::path::PathBuf>,
 ) -> anyhow::Result<()> {
     let ip: std::net::IpAddr = host
         .parse()
@@ -146,7 +161,7 @@ pub async fn start_with_host_and_security(
             let (msg_tx, msg_rx) = mpsc::unbounded_channel::<ServerMessage>();
 
             let _processor_handle = tokio::task::spawn_local(cdp_processor(
-                msg_rx, proxy, stealth, user_agent, allow_file_access,
+                msg_rx, proxy, stealth, user_agent, allow_file_access, storage_dir,
             ));
 
             while let Some(stream) = ws_rx.recv().await {
@@ -284,8 +299,14 @@ async fn cdp_processor(
     stealth: bool,
     user_agent: Option<String>,
     allow_file_access: bool,
+    storage_dir: Option<std::path::PathBuf>,
 ) {
-    let mut ctx = CdpContext::new_with_security(proxy, stealth, user_agent, allow_file_access);
+    let mut ctx = if storage_dir.is_some() {
+        // Use storage-aware context creation with security settings
+        CdpContext::new_with_storage(proxy, stealth, user_agent, storage_dir)
+    } else {
+        CdpContext::new_with_security(proxy, stealth, user_agent, allow_file_access)
+    };
     let (itx, irx) = mpsc::unbounded_channel::<obscura_js::ops::InterceptedRequest>();
     ctx.intercept_tx = Some(itx);
     let mut intercept_rx: Option<mpsc::UnboundedReceiver<obscura_js::ops::InterceptedRequest>> = Some(irx);
@@ -300,6 +321,12 @@ async fn cdp_processor(
     let mut deferred: std::collections::VecDeque<ServerMessage> =
         std::collections::VecDeque::new();
 
+    // Subscribe to Ctrl-C once. The future is single-shot, so we break out of
+    // the outer loop when it fires and never poll it again. Without this the
+    // accept loop just exits and any cookies set during the session are lost
+    // before `BrowserContext::save_cookies()` runs.
+    let mut shutdown = Box::pin(tokio::signal::ctrl_c());
+
     loop {
         // Drain any deferred messages from the previous interception window
         // before pulling new ones off the wire. Each is processed with no
@@ -308,9 +335,15 @@ async fn cdp_processor(
         let msg = if let Some(d) = deferred.pop_front() {
             d
         } else {
-            match rx.recv().await {
-                Some(m) => m,
-                None => break,
+            tokio::select! {
+                msg = rx.recv() => match msg {
+                    Some(m) => m,
+                    None => break,
+                },
+                _ = &mut shutdown => {
+                    tracing::info!("Shutdown signal received");
+                    break;
+                }
             }
         };
 
@@ -341,6 +374,11 @@ async fn cdp_processor(
         }
 
     }
+
+    // Single exit point handles both Ctrl-C shutdown and the channel being
+    // closed by the accept thread. Without this any cookies set during the
+    // session are dropped on the floor.
+    ctx.default_context.save_cookies();
 }
 
 fn handle_fetch_resolution(

--- a/crates/obscura-cdp/src/server.rs
+++ b/crates/obscura-cdp/src/server.rs
@@ -3,7 +3,7 @@ use std::net::SocketAddr;
 
 use futures_util::{SinkExt, StreamExt};
 use serde_json::json;
-use tokio::net::{TcpListener, TcpStream};
+use tokio::net::TcpStream;
 use tokio::sync::mpsc;
 use tokio_tungstenite::tungstenite::Message;
 use tracing::{error, info, warn};
@@ -14,6 +14,16 @@ use crate::dispatch::{self, CdpContext};
 // must be bounded so a stalled navigation cannot OOM the process. When the cap
 // is reached we return an explicit error response rather than silently dropping.
 const MAX_DEFERRED_MESSAGES: usize = 256;
+
+// The WS-stream forwarding channel must also be bounded: if the LocalSet
+// (CDP processor + nav tasks) stalls, the accept thread keeps pushing
+// `std::net::TcpStream`s into the queue. An unbounded channel would let
+// that queue grow without limit and OOM the process. With a bounded
+// capacity, when the LocalSet is saturated the accept thread closes the
+// new connection on the spot instead of buffering it — the kernel TCP
+// backlog still absorbs short-term spikes, but a long-term stall now
+// fails loudly at accept time rather than silently piling up FDs.
+const MAX_PENDING_WS_HANDOFFS: usize = 128;
 use crate::types::CdpRequest;
 
 struct CdpMessage {
@@ -71,7 +81,19 @@ pub async fn start_with_host_and_security(
         .parse()
         .map_err(|e| anyhow::anyhow!("invalid --host '{}': {}", host, e))?;
     let addr = SocketAddr::new(ip, port);
-    let listener = TcpListener::bind(&addr).await?;
+
+    // Issue #62: the HTTP control plane (/json/version, /json) must remain
+    // reachable even while V8 JS evaluation blocks the tokio LocalSet thread.
+    //
+    // We use a dedicated OS thread with a blocking std::net::TcpListener so
+    // the kernel's accept backlog is always drained promptly. HTTP endpoints
+    // are served directly via blocking I/O; WebSocket connections are
+    // forwarded to the existing LocalSet for CDP processing.
+    let std_listener = std::net::TcpListener::bind(addr)
+        .map_err(|e| anyhow::anyhow!("bind {}:{}: {}", host, port, e))?;
+    std_listener
+        .set_nonblocking(false)
+        .map_err(|e| anyhow::anyhow!("set_nonblocking: {}", e))?;
 
     info!("Obscura CDP server listening on ws://{}:{}", host, port);
     info!(
@@ -82,31 +104,178 @@ pub async fn start_with_host_and_security(
         info!("file:// navigation enabled (--allow-file-access). Do not expose this port to untrusted networks.");
     }
 
+    let (ws_tx, mut ws_rx) = mpsc::channel::<std::net::TcpStream>(MAX_PENDING_WS_HANDOFFS);
+
+    // Dedicated accept thread: drains the kernel backlog immediately and
+    // handles HTTP endpoints (/json/version, /json, /json/protocol) with
+    // blocking I/O so they never contend with the LocalSet's V8 work.
+    //
+    // Lifecycle note: this thread is spawned detached (no `join` handle).
+    // It is intended to run for the entire process lifetime — the same
+    // contract Chromium DevTools / Playwright clients expect from a CDP
+    // server. When `start_with_*` returns (whether by Ok or panic in the
+    // LocalSet), `ws_rx` drops; the next `ws_tx.blocking_send` then
+    // returns `SendError`, which `accept_dispatch` surfaces as
+    // "accept channel closed" and the loop logs+continues. The listener
+    // FD stays bound until the process exits. If we ever need to support
+    // graceful shutdown for embedded/library use, add an
+    // `Arc<AtomicBool>` shutdown flag checked between `accept()`s and
+    // switch to a non-blocking `set_nonblocking(true)` + poll loop.
+    // For the standalone `obscura serve` binary the detached lifetime is
+    // correct.
+    std::thread::Builder::new()
+        .name("obscura-cdp-accept".into())
+        .spawn(move || {
+            for stream in std_listener.incoming() {
+                match stream {
+                    Ok(stream) => {
+                        if let Err(e) = accept_dispatch(stream, port, &ws_tx) {
+                            if !format!("{}", e).contains("close") {
+                                error!("Accept dispatch error: {}", e);
+                            }
+                        }
+                    }
+                    Err(e) => error!("Accept error: {}", e),
+                }
+            }
+        })?;
+
     let local = tokio::task::LocalSet::new();
     local
         .run_until(async {
             let (msg_tx, msg_rx) = mpsc::unbounded_channel::<ServerMessage>();
 
-            let _processor_handle = tokio::task::spawn_local(cdp_processor(msg_rx, proxy, stealth, user_agent, allow_file_access));
+            let _processor_handle = tokio::task::spawn_local(cdp_processor(
+                msg_rx, proxy, stealth, user_agent, allow_file_access,
+            ));
 
-            loop {
-                match listener.accept().await {
-                    Ok((stream, peer_addr)) => {
-                        info!("New connection from {}", peer_addr);
-                        let tx = msg_tx.clone();
-                        tokio::task::spawn_local(async move {
-                            if let Err(e) = handle_connection(stream, port, tx).await {
-                                if !format!("{}", e).contains("close") {
-                                    error!("Connection error from {}: {}", peer_addr, e);
-                                }
-                            }
-                        });
+            while let Some(stream) = ws_rx.recv().await {
+                // Convert std TcpStream → tokio TcpStream inside the LocalSet
+                // where the tokio runtime is active.
+                stream
+                    .set_nonblocking(true)
+                    .map_err(|e| error!("set_nonblocking on WS stream: {}", e))
+                    .ok();
+                let tokio_stream = match TcpStream::from_std(stream) {
+                    Ok(s) => s,
+                    Err(e) => {
+                        error!("TcpStream::from_std failed: {}", e);
+                        continue;
                     }
-                    Err(e) => error!("Accept error: {}", e),
-                }
+                };
+                let tx = msg_tx.clone();
+                tokio::task::spawn_local(async move {
+                    if let Err(e) = handle_connection_ws(tokio_stream, tx).await {
+                        error!("WebSocket connection error: {}", e);
+                    }
+                });
             }
         })
-        .await
+        .await;
+
+    Ok(())
+}
+
+const HTTP_PEEK_BUF: usize = 4096;
+const WS_PEEK_BUF: usize = 4;
+
+/// Dispatch a freshly-accepted TCP connection on the dedicated accept thread.
+///
+/// Peek at the first bytes to decide HTTP vs WebSocket:
+/// - HTTP (`GET /json/*`): serve synchronously via blocking I/O so the
+///   response is never stalled by the LocalSet.
+/// - WebSocket: set non-blocking, convert to tokio `TcpStream`, and forward
+///   to the LocalSet for CDP processing.
+fn accept_dispatch(
+    stream: std::net::TcpStream,
+    port: u16,
+    ws_tx: &mpsc::Sender<std::net::TcpStream>,
+) -> anyhow::Result<()> {
+    let mut buf = [0u8; WS_PEEK_BUF];
+    let n = stream.peek(&mut buf)?;
+
+    if n >= 4 && &buf == b"GET " {
+        let mut peek_buf = [0u8; HTTP_PEEK_BUF];
+        let n = stream.peek(&mut peek_buf)?;
+        let line = String::from_utf8_lossy(&peek_buf[..n]);
+
+        let endpoint = if line.contains("/json/version") {
+            Some("version")
+        } else if line.contains("/json/list") || line.contains("/json\r\n") || line.contains("/json HTTP") {
+            Some("list")
+        } else if line.contains("/json/protocol") {
+            Some("protocol")
+        } else {
+            None
+        };
+
+        if let Some(ep) = endpoint {
+            return handle_http_json_blocking(stream, port, ep);
+        }
+        // Fall through: GET request that isn't a /json endpoint → treat as
+        // WebSocket upgrade (Chromium DevTools clients issue GET with
+        // Upgrade: websocket).
+    }
+
+    // Try to hand off the WS stream to the LocalSet. If the bounded channel
+    // is full the LocalSet is saturated — drop the connection cleanly
+    // rather than blocking the accept thread (which would freeze the HTTP
+    // control plane that this whole rework exists to keep alive). The
+    // dropped `stream` closes itself; the client will see ECONNRESET and
+    // can retry.
+    ws_tx
+        .try_send(stream)
+        .map_err(|e| match e {
+            mpsc::error::TrySendError::Full(_) => {
+                warn!("WS handoff channel full ({}); dropping new WebSocket connection", MAX_PENDING_WS_HANDOFFS);
+                anyhow::anyhow!("ws handoff channel full")
+            }
+            mpsc::error::TrySendError::Closed(_) => anyhow::anyhow!("accept channel closed"),
+        })
+}
+
+/// Serve an HTTP `/json/*` endpoint with blocking I/O on the accept thread.
+fn handle_http_json_blocking(
+    mut stream: std::net::TcpStream,
+    port: u16,
+    endpoint: &str,
+) -> anyhow::Result<()> {
+    use std::io::{Read, Write};
+
+    let mut buf = vec![0u8; 4096];
+    let _ = stream.read(&mut buf)?;
+
+    let body = match endpoint {
+        "version" => serde_json::to_string_pretty(&json!({
+            "Browser": "Obscura/0.1.0",
+            "Protocol-Version": "1.3",
+            "User-Agent": "Obscura/0.1.0 (Headless Browser)",
+            "V8-Version": "N/A",
+            "WebKit-Version": "N/A",
+            "webSocketDebuggerUrl": format!("ws://127.0.0.1:{}/devtools/browser", port),
+        }))?,
+        "list" => serde_json::to_string_pretty(&json!([{
+            "description": "",
+            "devtoolsFrontendUrl": "",
+            "id": "page-1",
+            "title": "",
+            "type": "page",
+            "url": "about:blank",
+            "webSocketDebuggerUrl": format!("ws://127.0.0.1:{}/devtools/page/page-1", port),
+        }]))?,
+        "protocol" => {
+            serde_json::to_string_pretty(&json!({ "version": { "major": "1", "minor": "3" } }))?
+        }
+        _ => "{}".to_string(),
+    };
+
+    let resp = format!(
+        "HTTP/1.1 200 OK\r\nContent-Type: application/json; charset=utf-8\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+        body.len(), body,
+    );
+    stream.write_all(resp.as_bytes())?;
+    stream.flush()?;
+    Ok(())
 }
 
 async fn cdp_processor(
@@ -661,28 +830,10 @@ fn check_pending_navigation(ctx: &CdpContext, session_id: &Option<String>) -> Op
     page.take_pending_navigation()
 }
 
-async fn handle_connection(
+async fn handle_connection_ws(
     stream: TcpStream,
-    port: u16,
     msg_tx: mpsc::UnboundedSender<ServerMessage>,
 ) -> anyhow::Result<()> {
-    let mut buf = [0u8; 4];
-    stream.peek(&mut buf).await?;
-
-    if &buf == b"GET " {
-        let mut peek_buf = [0u8; 1024];
-        let n = stream.peek(&mut peek_buf).await?;
-        let line = String::from_utf8_lossy(&peek_buf[..n]);
-
-        if line.contains("/json/version") {
-            return handle_http_json(stream, port, "version").await;
-        } else if line.contains("/json/list") || line.contains("/json\r\n") || line.contains("/json HTTP") {
-            return handle_http_json(stream, port, "list").await;
-        } else if line.contains("/json/protocol") {
-            return handle_http_json(stream, port, "protocol").await;
-        }
-    }
-
     let ws_stream = tokio_tungstenite::accept_async(stream).await?;
     info!("WebSocket connected");
     let (mut ws_sender, mut ws_receiver) = ws_stream.split();
@@ -746,45 +897,5 @@ async fn handle_connection(
     }
 
     send_task.abort();
-    Ok(())
-}
-
-async fn handle_http_json(stream: TcpStream, port: u16, endpoint: &str) -> anyhow::Result<()> {
-    use tokio::io::{AsyncReadExt, AsyncWriteExt};
-
-    let mut stream = stream;
-    let mut buf = vec![0u8; 4096];
-    let _ = stream.read(&mut buf).await?;
-
-    let body = match endpoint {
-        "version" => serde_json::to_string_pretty(&json!({
-            "Browser": "Obscura/0.1.0",
-            "Protocol-Version": "1.3",
-            "User-Agent": "Obscura/0.1.0 (Headless Browser)",
-            "V8-Version": "N/A",
-            "WebKit-Version": "N/A",
-            "webSocketDebuggerUrl": format!("ws://127.0.0.1:{}/devtools/browser", port),
-        }))?,
-        "list" => serde_json::to_string_pretty(&json!([{
-            "description": "",
-            "devtoolsFrontendUrl": "",
-            "id": "page-1",
-            "title": "",
-            "type": "page",
-            "url": "about:blank",
-            "webSocketDebuggerUrl": format!("ws://127.0.0.1:{}/devtools/page/page-1", port),
-        }]))?,
-        "protocol" => {
-            serde_json::to_string_pretty(&json!({ "version": { "major": "1", "minor": "3" } }))?
-        }
-        _ => "{}".to_string(),
-    };
-
-    let resp = format!(
-        "HTTP/1.1 200 OK\r\nContent-Type: application/json; charset=utf-8\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
-        body.len(), body,
-    );
-    stream.write_all(resp.as_bytes()).await?;
-    stream.flush().await?;
     Ok(())
 }

--- a/crates/obscura-cdp/src/server.rs
+++ b/crates/obscura-cdp/src/server.rs
@@ -315,12 +315,11 @@ async fn process_with_interception(
         // CDP messages via `dispatch` (which also acquires this lock); both
         // sides must coordinate or V8 aborts the process at concurrency >= 5.
         let _v8_guard = obscura_js::v8_lock::global().lock().await;
+        // Preloads (addBinding shims, addScriptToEvaluateOnNewDocument sources)
+        // must run BEFORE the page's own scripts (CDP contract). Hand them
+        // to the page so navigate_single can inject them at the right point.
+        page.set_preload_scripts(preload_scripts);
         let result = page.navigate_with_wait(&url_owned, wait_until).await.map_err(|e| e.to_string());
-        for source in &preload_scripts {
-            if let Err(e) = page.execute_preload_script(source) {
-                tracing::debug!("Preload script error: {}", e);
-            }
-        }
         drop(_v8_guard);
         let _ = nav_done_tx.send((page, result)).await;
     });

--- a/crates/obscura-cdp/tests/control_plane_unblocked.rs
+++ b/crates/obscura-cdp/tests/control_plane_unblocked.rs
@@ -1,0 +1,141 @@
+//! Issue #62 regression test: `/json/version` (HTTP control plane) must
+//! respond promptly even while V8 JS evaluation blocks the LocalSet thread.
+//!
+//! Before the fix, the HTTP accept loop competed with the CDP processor on
+//! the same `LocalSet`, so a synchronous JS `while` loop starved every other
+//! task — including the async `TcpListener::accept()`. The dedicated accept
+//! thread (std::net::TcpListener on a separate OS thread) fixes this.
+//!
+//! Run with `cargo test -p obscura-cdp --test control_plane_unblocked
+//! -- --nocapture --ignored`.
+
+use std::io::{Read, Write};
+use std::time::{Duration, Instant};
+
+use futures_util::{SinkExt, StreamExt};
+use serde_json::{json, Value};
+use tokio::net::TcpListener;
+use tokio_tungstenite::{connect_async, tungstenite::Message};
+
+const HTTP_TIMEOUT: Duration = Duration::from_secs(3);
+const JS_DURATION_MS: u64 = 5000;
+
+// Pick a free port for the test server. There is a small TOCTOU window
+// between dropping the listener here and the server's own bind a few lines
+// later — under heavy CI parallelism another process could steal the port
+// in between. The test is `#[ignore]` and opt-in via `--ignored`, so it
+// runs serially in practice. If we ever flip it to a default-on integration
+// test, replace this with a SO_REUSEPORT-aware port lease or pass the
+// already-bound listener into the server.
+async fn pick_port() -> u16 {
+    let l = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let port = l.local_addr().unwrap().port();
+    drop(l);
+    port
+}
+
+#[tokio::test(flavor = "current_thread")]
+#[ignore = "boots a real CDP server; opt-in with --ignored"]
+async fn http_control_plane_unblocked_during_long_js() {
+    let port = pick_port().await;
+    let port_clone = port;
+
+    let local = tokio::task::LocalSet::new();
+    local
+        .run_until(async {
+            tokio::task::spawn_local(async move {
+                let _ = obscura_cdp::server::start(port).await;
+            });
+            // Give the listener + accept thread time to bind.
+            tokio::time::sleep(Duration::from_millis(200)).await;
+
+            // Connect via WebSocket, create a target, then send a
+            // long-running JS evaluation on that target's session.
+            let url = format!("ws://127.0.0.1:{}/devtools/browser", port);
+            let (mut ws, _) = connect_async(&url).await.unwrap();
+
+            let create = json!({
+                "id": 1,
+                "method": "Target.createTarget",
+                "params": {"url": "about:blank"},
+            });
+            ws.send(Message::Text(create.to_string().into()))
+                .await
+                .unwrap();
+
+            let mut session_id: Option<String> = None;
+            while session_id.is_none() {
+                let msg = ws.next().await.unwrap().unwrap();
+                if let Message::Text(t) = msg {
+                    let v: Value = serde_json::from_str(&t).unwrap();
+                    session_id = v
+                        .get("params")
+                        .and_then(|p| p.get("sessionId"))
+                        .and_then(|s| s.as_str())
+                        .map(|s| s.to_string());
+                }
+            }
+            let sid = session_id.unwrap();
+
+            // Fire a synchronous JS loop that holds V8 for JS_DURATION_MS.
+            let code = format!(
+                "var s=Date.now();while(Date.now()-s<{}){{}}'done'",
+                JS_DURATION_MS
+            );
+            let eval = json!({
+                "id": 2,
+                "method": "Runtime.evaluate",
+                "sessionId": sid,
+                "params": {
+                    "expression": code,
+                    "awaitPromise": false,
+                    "returnByValue": true
+                }
+            });
+            ws.send(Message::Text(eval.to_string().into()))
+                .await
+                .unwrap();
+
+            // Give the JS evaluation a moment to enter V8.
+            tokio::time::sleep(Duration::from_millis(300)).await;
+
+            // Issue the HTTP request from a separate OS thread so the
+            // LocalSet isn't blocked by the synchronous TCP connect/read.
+            let handle = std::thread::spawn(move || {
+                let start = Instant::now();
+                let mut stream = std::net::TcpStream::connect_timeout(
+                    &format!("127.0.0.1:{}", port_clone)
+                        .parse()
+                        .unwrap(),
+                    HTTP_TIMEOUT,
+                )?;
+                stream.set_read_timeout(Some(HTTP_TIMEOUT))?;
+
+                let request = format!(
+                    "GET /json/version HTTP/1.1\r\nHost: 127.0.0.1:{}\r\nConnection: close\r\n\r\n",
+                    port_clone
+                );
+                stream.write_all(request.as_bytes())?;
+
+                let mut response = String::new();
+                stream.read_to_string(&mut response)?;
+                let elapsed = start.elapsed();
+                Ok::<(String, Duration), std::io::Error>((response, elapsed))
+            });
+
+            let result = handle.join().unwrap();
+            let (response, elapsed) = result.unwrap();
+
+            assert!(
+                response.contains("webSocketDebuggerUrl"),
+                "/json/version must return valid JSON with webSocketDebuggerUrl.\nResponse: {}",
+                &response[..response.len().min(500)]
+            );
+            assert!(
+                elapsed < Duration::from_secs(2),
+                "/json/version response too slow during JS eval: {:?}",
+                elapsed
+            );
+        })
+        .await;
+}

--- a/crates/obscura-cli/src/main.rs
+++ b/crates/obscura-cli/src/main.rs
@@ -155,6 +155,12 @@ enum DumpFormat {
     /// Bypasses the browser/JS layer — useful for fetching images,
     /// JSON, JS, CSS, or any non-HTML resource (cf. issue #117).
     Original,
+    /// One JSON object per line listing every sub-resource URL the
+    /// rendered page references (script src, link href, img src,
+    /// iframe src, media sources, embed/object data). Lets callers
+    /// replay the asset graph with their own HTTP client when they
+    /// need the originals alongside the page (cf. issue 124).
+    Assets,
 }
 
 fn print_banner(port: u16) {
@@ -508,6 +514,7 @@ async fn run_fetch(
         DumpFormat::Text => dump_text(&mut page),
         DumpFormat::Links => dump_links(&page),
         DumpFormat::Markdown => dump_markdown(&mut page),
+        DumpFormat::Assets => dump_assets(&page),
         // Handled above via the short-circuit branch; unreachable here.
         DumpFormat::Original => unreachable!("Original dump handled before page navigation"),
     };
@@ -953,12 +960,100 @@ fn dump_links(page: &Page) -> String {
     }).unwrap_or_default()
 }
 
+/// Selectors paired with the attribute whose URL we extract and the
+/// asset kind we surface. Order is stable so the output of
+/// `--dump assets` is deterministic across runs.
+const ASSET_SELECTORS: &[(&str, &str, &str)] = &[
+    ("script[src]", "src", "script"),
+    ("link[href]", "href", "link"),
+    ("img[src]", "src", "image"),
+    ("iframe[src]", "src", "iframe"),
+    ("source[src]", "src", "media"),
+    ("video[src]", "src", "video"),
+    ("audio[src]", "src", "audio"),
+    ("embed[src]", "src", "embed"),
+    ("object[data]", "data", "object"),
+];
+
+/// Map a `<link>` element's `rel` token to a more specific asset
+/// kind so consumers can filter (e.g. just stylesheets, just icons).
+/// Unknown / missing `rel` falls back to a generic "link" so the
+/// caller still sees the URL.
+fn link_kind_from_rel(rel: &str) -> &'static str {
+    match rel.split_ascii_whitespace().next().unwrap_or("").to_ascii_lowercase().as_str() {
+        "stylesheet" => "stylesheet",
+        "icon" | "shortcut" => "icon",
+        "manifest" => "manifest",
+        "preload" => "preload",
+        "prefetch" => "prefetch",
+        "modulepreload" => "modulepreload",
+        "dns-prefetch" => "dns-prefetch",
+        "preconnect" => "preconnect",
+        "alternate" => "alternate",
+        _ => "link",
+    }
+}
+
+/// Resolve a raw `src`/`href`/`data` attribute against the page's
+/// base URL. Mirrors `dump_links`'s logic so `--dump assets` and
+/// `--dump links` agree on absolute-URL semantics.
+fn resolve_asset_url(raw: &str, base_url: Option<&url::Url>) -> Option<String> {
+    let trimmed = raw.trim();
+    if trimmed.is_empty() {
+        return None;
+    }
+    if trimmed.starts_with("http://") || trimmed.starts_with("https://") {
+        return Some(trimmed.to_string());
+    }
+    if let Some(base) = base_url {
+        if let Ok(joined) = base.join(trimmed) {
+            return Some(joined.to_string());
+        }
+    }
+    Some(trimmed.to_string())
+}
+
+/// Walk the rendered DOM and emit one NDJSON line per discoverable
+/// sub-resource. Pure over `DomTree`/`Url` so unit tests can drive
+/// it from a fixture HTML without standing up a browser.
+fn extract_assets(dom: &obscura_dom::DomTree, base_url: Option<&url::Url>) -> String {
+    let mut out: Vec<String> = Vec::new();
+    for (selector, attr, default_kind) in ASSET_SELECTORS {
+        let nodes = dom.query_selector_all(selector).unwrap_or_default();
+        for node_id in nodes {
+            let Some(node) = dom.get_node(node_id) else { continue };
+            let raw = node.get_attribute(attr).unwrap_or_default().to_string();
+            let Some(url) = resolve_asset_url(&raw, base_url) else { continue };
+
+            let kind = if *default_kind == "link" {
+                let rel = node.get_attribute("rel").unwrap_or_default().to_string();
+                link_kind_from_rel(&rel)
+            } else {
+                *default_kind
+            };
+
+            let record = serde_json::json!({
+                "url": url,
+                "type": kind,
+            });
+            out.push(record.to_string());
+        }
+    }
+    out.join("\n")
+}
+
+fn dump_assets(page: &Page) -> String {
+    let base_url = page.url.clone();
+    page.with_dom(|dom| extract_assets(dom, base_url.as_ref())).unwrap_or_default()
+}
+
 #[cfg(test)]
 mod tests {
     use super::{
-        extract_readable_text, fetch_original_bytes, is_quiet_command, merge_proxy,
-        normalize_v8_flags, reject_stealth_with_socks5, select_log_filter, write_or_print,
-        write_or_print_bytes, Args, Command, DumpFormat,
+        extract_assets, extract_readable_text, fetch_original_bytes, is_quiet_command,
+        link_kind_from_rel, merge_proxy, normalize_v8_flags, reject_stealth_with_socks5,
+        resolve_asset_url, select_log_filter, write_or_print, write_or_print_bytes, Args,
+        Command, DumpFormat,
     };
     use clap::Parser;
     use obscura_dom::parse_html;
@@ -1334,4 +1429,178 @@ mod tests {
 
         assert_eq!(proxy.as_deref(), Some("http://global.example:8080"));
     }
+
+    #[test]
+    fn parsed_fetch_dump_assets_is_accepted_by_clap() {
+        let args = Args::try_parse_from([
+            "obscura",
+            "fetch",
+            "--dump",
+            "assets",
+            "https://example.com",
+        ])
+        .expect("clap should accept --dump assets");
+        match args.command {
+            Some(Command::Fetch { dump, .. }) => {
+                assert_eq!(dump, DumpFormat::Assets);
+            }
+            _ => panic!("expected Fetch command"),
+        }
+    }
+
+    #[test]
+    fn resolve_asset_url_keeps_absolute_unchanged() {
+        let base = url::Url::parse("https://page.test/a/b").unwrap();
+        let abs = "https://cdn.test/x.js";
+        assert_eq!(resolve_asset_url(abs, Some(&base)).as_deref(), Some(abs));
+    }
+
+    #[test]
+    fn resolve_asset_url_joins_relative_against_base() {
+        let base = url::Url::parse("https://page.test/a/b").unwrap();
+        let rel = "/static/x.js";
+        assert_eq!(
+            resolve_asset_url(rel, Some(&base)).as_deref(),
+            Some("https://page.test/static/x.js"),
+        );
+    }
+
+    #[test]
+    fn resolve_asset_url_drops_empty() {
+        let base = url::Url::parse("https://page.test/").unwrap();
+        assert!(resolve_asset_url("", Some(&base)).is_none());
+        assert!(resolve_asset_url("   ", Some(&base)).is_none());
+    }
+
+    #[test]
+    fn link_kind_from_rel_handles_common_values() {
+        assert_eq!(link_kind_from_rel("stylesheet"), "stylesheet");
+        assert_eq!(link_kind_from_rel("icon"), "icon");
+        // First token wins for multi-token rel (e.g. "shortcut icon").
+        assert_eq!(link_kind_from_rel("shortcut icon"), "icon");
+        assert_eq!(link_kind_from_rel("manifest"), "manifest");
+        assert_eq!(link_kind_from_rel("preload"), "preload");
+        assert_eq!(link_kind_from_rel("prefetch"), "prefetch");
+        assert_eq!(link_kind_from_rel("modulepreload"), "modulepreload");
+        assert_eq!(link_kind_from_rel("dns-prefetch"), "dns-prefetch");
+        assert_eq!(link_kind_from_rel("preconnect"), "preconnect");
+        assert_eq!(link_kind_from_rel("alternate"), "alternate");
+        // Empty / unknown falls back to generic "link" so URL is still emitted.
+        assert_eq!(link_kind_from_rel(""), "link");
+        assert_eq!(link_kind_from_rel("noopener"), "link");
+    }
+
+    #[test]
+    fn extract_assets_covers_every_resource_tag() {
+        let html = r#"<html><head>
+            <link rel="stylesheet" href="/site.css">
+            <link rel="icon" href="/favicon.ico">
+            <link rel="preload" href="/font.woff2">
+            <link href="/no-rel.css">
+            <script src="/app.js"></script>
+        </head><body>
+            <img src="/logo.png">
+            <iframe src="/frame.html"></iframe>
+            <video src="/clip.mp4"><source src="/clip.webm"></video>
+            <audio src="/track.mp3"></audio>
+            <embed src="/widget.swf">
+            <object data="/doc.pdf"></object>
+        </body></html>"#;
+        let dom = obscura_dom::parse_html(html);
+        let base = url::Url::parse("https://example.test/page").unwrap();
+        let ndjson = extract_assets(&dom, Some(&base));
+        let records: Vec<serde_json::Value> = ndjson
+            .lines()
+            .map(|line| serde_json::from_str(line).expect("each line must be valid JSON"))
+            .collect();
+
+        // Every emitted record must have an absolute URL on example.test
+        // and a non-empty type string. Pin specific entries so a regression
+        // in selectors or kind mapping fails loudly.
+        for r in &records {
+            let url = r["url"].as_str().unwrap();
+            assert!(
+                url.starts_with("https://example.test/"),
+                "url not absolute: {url}",
+            );
+            assert!(!r["type"].as_str().unwrap().is_empty());
+        }
+
+        let pairs: Vec<(String, String)> = records
+            .iter()
+            .map(|r| {
+                (
+                    r["url"].as_str().unwrap().to_string(),
+                    r["type"].as_str().unwrap().to_string(),
+                )
+            })
+            .collect();
+
+        assert!(pairs.contains(&(
+            "https://example.test/app.js".to_string(),
+            "script".to_string(),
+        )));
+        assert!(pairs.contains(&(
+            "https://example.test/site.css".to_string(),
+            "stylesheet".to_string(),
+        )));
+        assert!(pairs.contains(&(
+            "https://example.test/favicon.ico".to_string(),
+            "icon".to_string(),
+        )));
+        assert!(pairs.contains(&(
+            "https://example.test/font.woff2".to_string(),
+            "preload".to_string(),
+        )));
+        assert!(pairs.contains(&(
+            "https://example.test/no-rel.css".to_string(),
+            "link".to_string(),
+        )));
+        assert!(pairs.contains(&(
+            "https://example.test/logo.png".to_string(),
+            "image".to_string(),
+        )));
+        assert!(pairs.contains(&(
+            "https://example.test/frame.html".to_string(),
+            "iframe".to_string(),
+        )));
+        assert!(pairs.contains(&(
+            "https://example.test/clip.mp4".to_string(),
+            "video".to_string(),
+        )));
+        assert!(pairs.contains(&(
+            "https://example.test/clip.webm".to_string(),
+            "media".to_string(),
+        )));
+        assert!(pairs.contains(&(
+            "https://example.test/track.mp3".to_string(),
+            "audio".to_string(),
+        )));
+        assert!(pairs.contains(&(
+            "https://example.test/widget.swf".to_string(),
+            "embed".to_string(),
+        )));
+        assert!(pairs.contains(&(
+            "https://example.test/doc.pdf".to_string(),
+            "object".to_string(),
+        )));
+    }
+
+    #[test]
+    fn extract_assets_skips_empty_attributes() {
+        let html = r#"<html><body>
+            <script src=""></script>
+            <img src="   ">
+            <iframe src="/ok.html"></iframe>
+        </body></html>"#;
+        let dom = obscura_dom::parse_html(html);
+        let base = url::Url::parse("https://example.test/").unwrap();
+        let ndjson = extract_assets(&dom, Some(&base));
+        let lines: Vec<&str> = ndjson.lines().collect();
+        // Only the iframe with a non-empty src survives.
+        assert_eq!(lines.len(), 1, "got {lines:?}");
+        assert!(lines[0].contains("\"https://example.test/ok.html\""));
+        assert!(lines[0].contains("\"iframe\""));
+    }
+
 }

--- a/crates/obscura-cli/src/main.rs
+++ b/crates/obscura-cli/src/main.rs
@@ -32,6 +32,9 @@ struct Args {
     #[arg(long)]
     user_agent: Option<String>,
 
+    #[arg(long)]
+    storage_dir: Option<std::path::PathBuf>,
+
     /// Pass raw flags to V8, in the same form V8/Chromium/Node accept
     /// (e.g. `"--max-old-space-size=4096 --max-semi-space-size=64 --expose-gc"`).
     /// Applied once at startup before any isolate is created.
@@ -70,6 +73,9 @@ enum Command {
         /// and the port is on a trusted network.
         #[arg(long)]
         allow_file_access: bool,
+
+        #[arg(long)]
+        storage_dir: Option<std::path::PathBuf>,
     },
 
     Fetch {
@@ -104,6 +110,9 @@ enum Command {
 
         #[arg(long, short)]
         quiet: bool,
+
+        #[arg(long)]
+        storage_dir: Option<std::path::PathBuf>,
     },
 
     Scrape {
@@ -252,10 +261,13 @@ async fn main() -> anyhow::Result<()> {
     let global_proxy = args.proxy.clone();
 
     match args.command {
-        Some(Command::Serve { port, host, proxy, user_agent, stealth, workers, allow_file_access }) => {
+        Some(Command::Serve { port, host, proxy, user_agent, stealth, workers, allow_file_access, storage_dir }) => {
             let proxy = merge_proxy(global_proxy.clone(), proxy);
             reject_stealth_with_socks5(proxy.as_deref(), stealth)?;
             print_banner(port);
+            if let Some(ref dir) = storage_dir {
+                tracing::info!("Storage dir: {}", dir.display());
+            }
             if let Some(ref proxy) = proxy {
                 tracing::info!("Using proxy: {}", proxy);
             }
@@ -276,13 +288,13 @@ async fn main() -> anyhow::Result<()> {
                 run_multi_worker_serve(port, workers, proxy, stealth, user_agent).await?;
             } else {
                 obscura_cdp::start_with_host_and_security(
-                    port, &host, proxy, stealth, user_agent, allow_file_access,
+                    port, &host, proxy, stealth, user_agent, allow_file_access, storage_dir,
                 ).await?;
             }
         }
-        Some(Command::Fetch { url, dump, selector, wait, timeout, wait_until, user_agent, stealth, eval, output, quiet }) => {
+        Some(Command::Fetch { url, dump, selector, wait, timeout, wait_until, user_agent, stealth, eval, output, quiet, storage_dir }) => {
             reject_stealth_with_socks5(global_proxy.as_deref(), stealth)?;
-            run_fetch(&url, dump, selector, wait, timeout, &wait_until, user_agent, stealth, eval, output, quiet, global_proxy).await?;
+            run_fetch(&url, dump, selector, wait, timeout, &wait_until, user_agent, stealth, eval, output, quiet, global_proxy, storage_dir).await?;
         }
         Some(Command::Scrape { urls, eval, concurrency, format, timeout, quiet }) => {
             run_parallel_scrape(urls, eval, concurrency.get(), &format, timeout, quiet, global_proxy).await?;
@@ -448,6 +460,7 @@ async fn run_fetch(
     output: Option<std::path::PathBuf>,
     quiet: bool,
     proxy: Option<String>,
+    storage_dir: Option<std::path::PathBuf>,
 ) -> anyhow::Result<()> {
     // --dump original short-circuits the browser stack entirely: fetch the raw
     // response body via HTTP and stream the bytes verbatim. Useful for binary
@@ -465,8 +478,14 @@ async fn run_fetch(
         return Ok(());
     }
 
-    let context = Arc::new(BrowserContext::with_options("fetch".to_string(), proxy, stealth));
-    let mut page = Page::new("fetch-page".to_string(), context);
+    let context = Arc::new(BrowserContext::with_storage_full(
+        "fetch".to_string(),
+        proxy,
+        stealth,
+        user_agent.clone(),
+        storage_dir.clone(),
+    ));
+    let mut page = Page::new("fetch-page".to_string(), context.clone());
 
     if let Some(ref ua) = user_agent {
         page.http_client.set_user_agent(ua).await;
@@ -506,6 +525,7 @@ async fn run_fetch(
             other => other.to_string(),
         };
         write_or_print(rendered, output.as_ref()).await?;
+        context.save_cookies();
         return Ok(());
     }
 
@@ -519,6 +539,9 @@ async fn run_fetch(
         DumpFormat::Original => unreachable!("Original dump handled before page navigation"),
     };
     write_or_print(rendered, output.as_ref()).await?;
+
+    // Save cookies to disk if storage_dir is configured
+    context.save_cookies();
 
     Ok(())
 }
@@ -1364,6 +1387,7 @@ mod tests {
             eval: None,
             quiet: true,
             output: None,
+            storage_dir: None,
         });
         assert!(is_quiet_command(&cmd));
     }

--- a/crates/obscura-cli/src/main.rs
+++ b/crates/obscura-cli/src/main.rs
@@ -239,6 +239,24 @@ fn normalize_v8_flags(raw: Option<&str>) -> Option<String> {
     }
 }
 
+/// Default V8 flags applied at startup unless the user disabled them via
+/// `--v8-flags`. The default heap matches headless Chrome (~4 GB) so pages
+/// that ship heavy fingerprinting or analytics bundles
+/// (e.g. demo.fingerprint.com — issue #199) don't SIGTRAP out of the box.
+/// V8 parses flags left-to-right and later wins, so anything the user
+/// passes via `--v8-flags` overrides these.
+#[cfg(target_pointer_width = "64")]
+const DEFAULT_V8_FLAGS: &str = "--max-old-space-size=4096";
+#[cfg(not(target_pointer_width = "64"))]
+const DEFAULT_V8_FLAGS: &str = "--max-old-space-size=1024";
+
+fn effective_v8_flags(user: Option<&str>) -> String {
+    match normalize_v8_flags(user) {
+        Some(u) => format!("{} {}", DEFAULT_V8_FLAGS, u),
+        None => DEFAULT_V8_FLAGS.to_string(),
+    }
+}
+
 #[tokio::main(flavor = "current_thread")]
 async fn main() -> anyhow::Result<()> {
     let args = Args::parse();
@@ -253,10 +271,9 @@ async fn main() -> anyhow::Result<()> {
         .with_writer(std::io::stderr)
         .init();
 
-    if let Some(flags) = normalize_v8_flags(args.v8_flags.as_deref()) {
-        tracing::info!("Applying V8 flags: {}", flags);
-        obscura_js::set_v8_flags(&flags);
-    }
+    let v8_flags = effective_v8_flags(args.v8_flags.as_deref());
+    tracing::debug!("V8 flags: {}", v8_flags);
+    obscura_js::set_v8_flags(&v8_flags);
 
     let global_proxy = args.proxy.clone();
 
@@ -1073,10 +1090,10 @@ fn dump_assets(page: &Page) -> String {
 #[cfg(test)]
 mod tests {
     use super::{
-        extract_assets, extract_readable_text, fetch_original_bytes, is_quiet_command,
-        link_kind_from_rel, merge_proxy, normalize_v8_flags, reject_stealth_with_socks5,
-        resolve_asset_url, select_log_filter, write_or_print, write_or_print_bytes, Args,
-        Command, DumpFormat,
+        effective_v8_flags, extract_assets, extract_readable_text, fetch_original_bytes,
+        is_quiet_command, link_kind_from_rel, merge_proxy, normalize_v8_flags,
+        reject_stealth_with_socks5, resolve_asset_url, select_log_filter, write_or_print,
+        write_or_print_bytes, Args, Command, DumpFormat, DEFAULT_V8_FLAGS,
     };
     use clap::Parser;
     use obscura_dom::parse_html;
@@ -1323,6 +1340,30 @@ mod tests {
     fn normalize_v8_flags_preserves_multi_flag_string() {
         let input = "--max-old-space-size=4096 --max-semi-space-size=64 --expose-gc";
         assert_eq!(normalize_v8_flags(Some(input)).as_deref(), Some(input));
+    }
+
+    #[test]
+    fn effective_v8_flags_returns_default_when_unset() {
+        assert_eq!(effective_v8_flags(None), DEFAULT_V8_FLAGS);
+        assert_eq!(effective_v8_flags(Some("")), DEFAULT_V8_FLAGS);
+        assert_eq!(effective_v8_flags(Some("   ")), DEFAULT_V8_FLAGS);
+    }
+
+    #[test]
+    fn effective_v8_flags_user_overrides_default() {
+        // V8 parses left-to-right and later wins, so the user value must
+        // come after the default in the merged string.
+        let user = "--max-old-space-size=8192";
+        let merged = effective_v8_flags(Some(user));
+        assert!(merged.starts_with(DEFAULT_V8_FLAGS));
+        assert!(merged.ends_with(user));
+    }
+
+    #[test]
+    fn effective_v8_flags_appends_user_extras() {
+        let merged = effective_v8_flags(Some("--expose-gc"));
+        assert!(merged.contains(DEFAULT_V8_FLAGS));
+        assert!(merged.contains("--expose-gc"));
     }
 
     #[test]

--- a/crates/obscura-dom/src/selector.rs
+++ b/crates/obscura-dom/src/selector.rs
@@ -500,6 +500,14 @@ pub fn parse_selector(selector: &str) -> Result<SelectorList<ObscuraSelector>, S
 
 impl DomTree {
     pub fn query_selector(&self, selector: &str) -> Result<Option<NodeId>, String> {
+        self.query_selector_from(self.document(), selector)
+    }
+
+    pub fn query_selector_all(&self, selector: &str) -> Result<Vec<NodeId>, String> {
+        self.query_selector_all_from(self.document(), selector)
+    }
+
+    pub fn query_selector_from(&self, root: NodeId, selector: &str) -> Result<Option<NodeId>, String> {
         let selector_list = parse_selector(selector)?;
         let mut caches = selectors::context::SelectorCaches::default();
         let mut context = MatchingContext::new(
@@ -511,8 +519,7 @@ impl DomTree {
             MatchingForInvalidation::No,
         );
 
-        let doc = self.document();
-        for desc_id in self.descendants(doc) {
+        for desc_id in self.descendants(root) {
             let is_element = self.with_node(desc_id, |n| n.is_element()).unwrap_or(false);
             if is_element {
                 let element = DomElement::new(self, desc_id);
@@ -528,7 +535,7 @@ impl DomTree {
         Ok(None)
     }
 
-    pub fn query_selector_all(&self, selector: &str) -> Result<Vec<NodeId>, String> {
+    pub fn query_selector_all_from(&self, root: NodeId, selector: &str) -> Result<Vec<NodeId>, String> {
         let selector_list = parse_selector(selector)?;
         let mut caches = selectors::context::SelectorCaches::default();
         let mut context = MatchingContext::new(
@@ -541,8 +548,7 @@ impl DomTree {
         );
         let mut results = Vec::new();
 
-        let doc = self.document();
-        for desc_id in self.descendants(doc) {
+        for desc_id in self.descendants(root) {
             let is_element = self.with_node(desc_id, |n| n.is_element()).unwrap_or(false);
             if is_element {
                 let element = DomElement::new(self, desc_id);
@@ -637,5 +643,48 @@ mod tests {
         );
         let results = tree.query_selector_all(".list .item.active").unwrap();
         assert_eq!(results.len(), 2);
+    }
+
+    #[test]
+    fn test_query_selector_all_from_scopes_to_subtree() {
+        let tree = parse_html(
+            r#"<div id="a"><span class="x">in a</span></div><div id="b"><span class="x">in b</span></div>"#,
+        );
+        let a = tree.get_element_by_id("a").expect("div#a");
+        let b = tree.get_element_by_id("b").expect("div#b");
+
+        // Document-rooted: sees both spans.
+        assert_eq!(tree.query_selector_all(".x").unwrap().len(), 2);
+        // Scoped to #a: only its descendant span.
+        let in_a = tree.query_selector_all_from(a, ".x").unwrap();
+        assert_eq!(in_a.len(), 1);
+        let in_b = tree.query_selector_all_from(b, ".x").unwrap();
+        assert_eq!(in_b.len(), 1);
+        assert_ne!(in_a[0], in_b[0]);
+    }
+
+    #[test]
+    fn test_query_selector_from_returns_first_in_subtree_only() {
+        let tree = parse_html(
+            r#"<section id="s"><p>first</p><p>second</p></section><p>outside</p>"#,
+        );
+        let s = tree.get_element_by_id("s").expect("section#s");
+
+        // Scoped to #s: skip the outside paragraph; return the first inside.
+        let first_in_s = tree.query_selector_from(s, "p").unwrap().expect("a p inside");
+        assert_eq!(tree.text_content(first_in_s), "first");
+    }
+
+    #[test]
+    fn test_query_selector_from_excludes_self() {
+        // The root element itself must not match its own scoped query, per
+        // the spec: querySelector matches descendants only.
+        let tree = parse_html(r#"<div id="root" class="x"><span>child</span></div>"#);
+        let root = tree.get_element_by_id("root").expect("div#root");
+
+        // Only descendants are candidates: `.x` on root finds nothing.
+        assert!(tree.query_selector_from(root, ".x").unwrap().is_none());
+        // `span` finds the child.
+        assert!(tree.query_selector_from(root, "span").unwrap().is_some());
     }
 }

--- a/crates/obscura-dom/src/tree.rs
+++ b/crates/obscura-dom/src/tree.rs
@@ -322,6 +322,40 @@ impl DomTree {
         }
     }
 
+    /// Detach a node from its parent AND remove it (and all descendants)
+    /// from the id-index so that `getElementById` no longer returns them.
+    /// Unlike `remove()`, this does NOT free the nodes — the JS side may
+    /// still hold references to the wrappers.
+    pub fn remove_child(&self, node_id: NodeId) {
+        // Collect all id attribute values in the subtree. We snapshot them
+        // before detaching so `get_attribute` can still see the tree.
+        let ids_to_remove: Vec<String> = {
+            let descendants = self.descendants(node_id);
+            let inner = self.inner.borrow();
+            let mut ids: Vec<String> = Vec::new();
+            if let Some(Some(node)) = inner.nodes.get(node_id.index()) {
+                if let Some(id_val) = node.get_attribute("id") {
+                    ids.push(id_val.to_string());
+                }
+            }
+            for desc_id in &descendants {
+                if let Some(Some(node)) = inner.nodes.get(desc_id.index()) {
+                    if let Some(id_val) = node.get_attribute("id") {
+                        ids.push(id_val.to_string());
+                    }
+                }
+            }
+            ids
+        };
+
+        self.detach(node_id);
+
+        let mut inner = self.inner.borrow_mut();
+        for id_str in &ids_to_remove {
+            inner.id_index.remove(id_str);
+        }
+    }
+
     pub fn remove(&self, node_id: NodeId) {
         self.detach(node_id);
         let descendants = self.descendants(node_id);

--- a/crates/obscura-js/js/bootstrap.js
+++ b/crates/obscura-js/js/bootstrap.js
@@ -499,6 +499,31 @@ class Element extends Node {
   removeAttributeNS(ns, n) { this.removeAttribute(n); }
   hasAttribute(n) { return this.getAttribute(n) !== null; }
   hasAttributes() { return true; } // Simplified
+  get attributes() {
+    const el = this;
+    const names = _domParse("attribute_names", el._nid) || [];
+    const list = names.map((name) => ({
+      name,
+      localName: name,
+      value: el.getAttribute(name) ?? "",
+      namespaceURI: null,
+      prefix: null,
+      specified: true,
+      ownerElement: el,
+      nodeName: name,
+      nodeValue: el.getAttribute(name) ?? "",
+      nodeType: 2,
+    }));
+    list.length = names.length;
+    list.getNamedItem = (n) => names.includes(n) ? list[names.indexOf(n)] : null;
+    list.setNamedItem = (a) => { if (a && a.name) el.setAttribute(a.name, a.value); return a; };
+    list.removeNamedItem = (n) => { const a = list.getNamedItem(n); if (a) el.removeAttribute(n); return a; };
+    list.item = (i) => list[i] || null;
+    for (let i = 0; i < names.length; i++) {
+      Object.defineProperty(list, names[i], { value: list[i], configurable: true, enumerable: false });
+    }
+    return list;
+  }
   getAttributeNS(ns, n) { return this.getAttribute(n); }
   querySelector(s) { return _wrapEl(+_dom("query_selector_scoped", this._nid, s)); }
   querySelectorAll(s) {
@@ -779,7 +804,23 @@ class Element extends Node {
   get scrollLeft() { return 0; } set scrollLeft(v) {}
   getBoundingClientRect() {
     globalThis.__obscura_click_target = this;
-    return {x:8,y:8,width:100,height:20,top:8,right:108,bottom:28,left:8,toJSON(){return this;}};
+    // No layout engine, but Playwright's actionability polling needs each
+    // element to occupy a stable, distinct rect so hit-testing can pick the
+    // right one (issue #45). Synthesize a deterministic position from the
+    // node id: every nid maps to a unique cell in a 12-column grid, sized
+    // to fit a 1280x720 viewport. Stable across reads, different per node.
+    const VW = 1280, VH = 720, COLS = 12, CW = 100, CH = 20, GX = 110, GY = 30;
+    const rowsPerScreen = Math.max(1, Math.floor((VH - 10) / GY));
+    const cell = this._nid | 0;
+    const col = ((cell * 7) | 0) % COLS;
+    const row = (((cell * 13) | 0) >> 0) % rowsPerScreen;
+    const x = 10 + col * GX;
+    const y = 10 + row * GY;
+    return {
+      x, y, width: CW, height: CH,
+      top: y, right: x + CW, bottom: y + CH, left: x,
+      toJSON() { return this; },
+    };
   }
   getClientRects() { return [this.getBoundingClientRect()]; }
   // No layout engine: a stub that always returns true unblocks Playwright's
@@ -1195,6 +1236,28 @@ globalThis.parent = globalThis;
 globalThis.frames = globalThis;
 globalThis.frameElement = null;
 globalThis.length = 0;
+
+// HTML spec exposes on* event handler IDL attributes on Window. Libraries like
+// jQuery feature-detect bubbling via `("on" + ev) in window` and fall back to
+// a legacy IE path that crashes on missing DOM APIs when the check returns
+// false. Initialising them to null makes the check match real browsers.
+for (const _ev of [
+  "abort","beforeprint","beforeunload","blur","cancel","canplay","canplaythrough",
+  "change","click","close","contextmenu","cuechange","dblclick","drag","dragend",
+  "dragenter","dragleave","dragover","dragstart","drop","durationchange","emptied",
+  "ended","error","focus","focusin","focusout","formdata","gotpointercapture",
+  "hashchange","input","invalid","keydown","keypress","keyup","languagechange",
+  "load","loadeddata","loadedmetadata","loadstart","lostpointercapture","message",
+  "mousedown","mouseenter","mouseleave","mousemove","mouseout","mouseover","mouseup",
+  "offline","online","pagehide","pageshow","paste","pause","play","playing",
+  "pointercancel","pointerdown","pointerenter","pointerleave","pointermove",
+  "pointerout","pointerover","pointerup","popstate","progress","ratechange",
+  "rejectionhandled","reset","resize","scroll","seeked","seeking","select",
+  "stalled","storage","submit","suspend","timeupdate","toggle","unhandledrejection",
+  "unload","volumechange","waiting","wheel",
+]) {
+  if (!(("on" + _ev) in globalThis)) globalThis["on" + _ev] = null;
+}
 
 globalThis.Window = globalThis.Window || function Window() {};
 Object.defineProperty(globalThis.Window, Symbol.hasInstance, {

--- a/crates/obscura-js/js/bootstrap.js
+++ b/crates/obscura-js/js/bootstrap.js
@@ -146,27 +146,42 @@ globalThis.console = {
 };
 
 let _tid = 0;
-const _pendingTimers = new Map();
 const _clearedTimers = new Set();
+const _intervals = new Set();
+
+const _scheduleAfter = (delay, fn) => {
+  const d = Math.max(0, Number(delay) || 0);
+  if (d === 0) Promise.resolve().then(fn);
+  else Deno.core.ops.op_sleep(d).then(fn);
+};
 
 globalThis.setTimeout = (fn, delay = 0, ...args) => {
   if (typeof fn !== "function") return ++_tid;
   const id = ++_tid;
-  _pendingTimers.set(id, { fn, args, delay });
-  Promise.resolve().then(() => {
-    if (!_clearedTimers.has(id) && _pendingTimers.has(id)) {
-      _pendingTimers.delete(id);
-      try { fn(...args); } catch(e) { console.error("Timer error:", e); }
-    }
+  _scheduleAfter(delay, () => {
+    if (_clearedTimers.has(id)) return;
+    try { fn(...args); } catch(e) { console.error("Timer error:", e); }
   });
   return id;
 };
 
-globalThis.clearTimeout = (id) => { _clearedTimers.add(id); _pendingTimers.delete(id); };
-globalThis.setInterval = (fn, delay, ...args) => {
-  return setTimeout(fn, delay, ...args);
+globalThis.clearTimeout = (id) => { _clearedTimers.add(id); };
+
+globalThis.setInterval = (fn, delay = 0, ...args) => {
+  if (typeof fn !== "function") return ++_tid;
+  const id = ++_tid;
+  _intervals.add(id);
+  const tick = () => {
+    if (!_intervals.has(id)) return;
+    try { fn(...args); } catch(e) { console.error("Interval error:", e); }
+    if (!_intervals.has(id)) return;
+    _scheduleAfter(delay, tick);
+  };
+  _scheduleAfter(delay, tick);
+  return id;
 };
-globalThis.clearInterval = globalThis.clearTimeout;
+
+globalThis.clearInterval = (id) => { _intervals.delete(id); _clearedTimers.add(id); };
 globalThis.requestAnimationFrame = (fn) => setTimeout(fn, 0);
 globalThis.cancelAnimationFrame = globalThis.clearTimeout;
 globalThis.queueMicrotask = globalThis.queueMicrotask || ((fn) => Promise.resolve().then(fn));
@@ -292,14 +307,14 @@ class Node {
   }
   replaceChild(newChild, oldChild) {
     if (!oldChild || !newChild) return oldChild;
-    _dom("insert_before", this._nid, newChild._nid, oldChild._nid);
+    _dom("insert_before", newChild._nid, oldChild._nid);
     _dom("remove_child", oldChild._nid);
     return oldChild;
   }
   insertBefore(n, ref) {
     if (!n) return n;
     if (!ref) { this.appendChild(n); return n; }
-    _dom("insert_before", this._nid, n._nid, ref._nid);
+    _dom("insert_before", n._nid, ref._nid);
     return n;
   }
   contains(o) { return o ? _dom("contains", this._nid, o._nid) === "true" : false; }
@@ -341,7 +356,28 @@ class Node {
   }
   getRootNode() { return globalThis.document; }
   normalize() {} // no-op
-  isEqualNode(other) { return other && this._nid === other._nid; }
+  isEqualNode(other) {
+    if (!other) return false;
+    if (this._nid === other._nid) return true;
+    if (this.nodeType !== other.nodeType) return false;
+    if (this.nodeName !== other.nodeName) return false;
+    if (this.nodeValue !== other.nodeValue) return false;
+    const a = this.attributes ? this.attributes : null;
+    const b = other.attributes ? other.attributes : null;
+    if ((a && a.length) || (b && b.length)) {
+      if (!a || !b || a.length !== b.length) return false;
+      for (let i = 0; i < a.length; i++) {
+        if (other.getAttribute(a[i].name) !== a[i].value) return false;
+      }
+    }
+    const cA = this.childNodes || [];
+    const cB = other.childNodes || [];
+    if (cA.length !== cB.length) return false;
+    for (let i = 0; i < cA.length; i++) {
+      if (!cA[i].isEqualNode(cB[i])) return false;
+    }
+    return true;
+  }
   isSameNode(other) { return other && this._nid === other._nid; }
   addEventListener() {} removeEventListener() {} dispatchEvent() { return true; }
 }
@@ -464,9 +500,9 @@ class Element extends Node {
   hasAttribute(n) { return this.getAttribute(n) !== null; }
   hasAttributes() { return true; } // Simplified
   getAttributeNS(ns, n) { return this.getAttribute(n); }
-  querySelector(s) { return _wrapEl(+_dom("query_selector", s)); }
+  querySelector(s) { return _wrapEl(+_dom("query_selector_scoped", this._nid, s)); }
   querySelectorAll(s) {
-    const ids = _domParse("query_selector_all", s) || [];
+    const ids = _domParse("query_selector_all_scoped", this._nid, s) || [];
     const list = ids.map(_wrapEl).filter(Boolean);
     list.item = (i) => list[i] || null;
     list.forEach = Array.prototype.forEach.bind(list);
@@ -791,7 +827,14 @@ class Element extends Node {
   }
   remove() { if (this.parentNode) this.parentNode.removeChild(this); }
   append(...nodes) { for (const n of nodes) { if (typeof n === "string") this.appendChild(document.createTextNode(n)); else this.appendChild(n); } }
-  prepend() {}
+  prepend(...nodes) {
+    const ref = this.firstChild;
+    for (const n of nodes) {
+      const node = (typeof n === "string") ? document.createTextNode(n) : n;
+      if (ref) this.insertBefore(node, ref);
+      else this.appendChild(node);
+    }
+  }
 }
 
 class Document extends Node {
@@ -1005,9 +1048,9 @@ class Document extends Node {
     };
   }
   get styleSheets() { return []; }
-  get forms() { return []; }
-  get images() { return []; }
-  get links() { return []; }
+  get forms() { return this.querySelectorAll("form"); }
+  get images() { return this.querySelectorAll("img"); }
+  get links() { return this.querySelectorAll("a[href], area[href]"); }
   get scripts() { return this.querySelectorAll("script"); }
   get cookie() {
     return Deno.core.ops.op_get_cookies();
@@ -1048,9 +1091,9 @@ class DocumentFragment extends Node {
   get nodeName() { return "#document-fragment"; }
   get innerHTML() { return _domParse("inner_html", this._nid) ?? ""; }
   set innerHTML(v) { _dom("set_inner_html", this._nid, String(v ?? "")); }
-  querySelector(s) { return _wrapEl(+_dom("query_selector", s)); }
+  querySelector(s) { return _wrapEl(+_dom("query_selector_scoped", this._nid, s)); }
   querySelectorAll(s) {
-    const ids = _domParse("query_selector_all", s) || [];
+    const ids = _domParse("query_selector_all_scoped", this._nid, s) || [];
     const list = ids.map(_wrapEl).filter(Boolean);
     list.item = (i) => list[i] || null;
     return list;
@@ -1085,12 +1128,17 @@ class DocumentType extends Node {
 }
 
 const _cache = new Map();
+function _elementClassFor(nid) {
+  const tag = _domParse("tag_name", nid);
+  if (tag === "FORM" && globalThis.HTMLFormElement) return globalThis.HTMLFormElement;
+  return Element;
+}
 function _wrap(nid) {
   if (nid < 0 || nid === null || nid === undefined || isNaN(nid)) return null;
   if (_cache.has(nid)) return _cache.get(nid);
   const t = +_dom("node_type", nid);
   let n;
-  if (t === 1) n = new Element(nid);
+  if (t === 1) { const C = _elementClassFor(nid); n = new C(nid); }
   else if (t === 3) n = new Text(nid);
   else if (t === 8) n = new Comment(nid);
   else if (t === 9) n = new Document(nid);
@@ -1101,7 +1149,8 @@ function _wrap(nid) {
 function _wrapEl(nid) {
   if (nid < 0 || nid === null || nid === undefined || isNaN(nid)) return null;
   if (_cache.has(nid)) return _cache.get(nid);
-  const n = new Element(nid);
+  const C = _elementClassFor(nid);
+  const n = new C(nid);
   _cache.set(nid, n);
   return n;
 }
@@ -2124,7 +2173,13 @@ globalThis.HTMLAnchorElement = Element;
 globalThis.HTMLImageElement = Element;
 globalThis.HTMLInputElement = Element;
 globalThis.HTMLButtonElement = Element;
-globalThis.HTMLFormElement = Element;
+globalThis.HTMLFormElement = class HTMLFormElement extends Element {
+  get elements() { return this.querySelectorAll("input, select, textarea, button, fieldset, output, object"); }
+  get length() { return this.elements.length; }
+  // Inherit submit() from Element.prototype: it dispatches the cancelable
+  // 'submit' event and (if not prevented) builds form data and navigates.
+  reset() { for (const f of this.elements) { if ('value' in f) f.value = ''; } }
+};
 globalThis.HTMLSelectElement = Element;
 globalThis.HTMLTextAreaElement = Element;
 globalThis.HTMLLabelElement = Element;
@@ -2193,8 +2248,9 @@ globalThis.Range = class Range { setStart(){} setEnd(){} collapse(){} selectNode
   Element.prototype.focus, Element.prototype.blur,
   Element.prototype.cloneNode, Element.prototype.attachShadow,
   Element.prototype.insertAdjacentHTML, Element.prototype.scrollIntoView,
-  Element.prototype.append, Element.prototype.remove,
+  Element.prototype.append, Element.prototype.prepend, Element.prototype.remove,
   Element.prototype.before, Element.prototype.after, Element.prototype.replaceWith,
+  HTMLFormElement.prototype.reset,
   Element.prototype.getContext, Element.prototype.toDataURL, Element.prototype.toBlob,
   Node.prototype.appendChild, Node.prototype.removeChild,
   Node.prototype.replaceChild, Node.prototype.insertBefore,

--- a/crates/obscura-js/js/bootstrap.js
+++ b/crates/obscura-js/js/bootstrap.js
@@ -758,8 +758,15 @@ class Element extends Node {
     };
   }
   getAnimations() { return []; }
-  get isConnected() { return true; }
-  after() {} before() {} remove() { if (this.parentNode) this.parentNode.removeChild(this); }
+  get isConnected() {
+    var node = this;
+    while (node) {
+      if (node.nodeType === 9) return true;
+      node = node.parentNode;
+    }
+    return false;
+  }
+  remove() { if (this.parentNode) this.parentNode.removeChild(this); }
   append(...nodes) { for (const n of nodes) { if (typeof n === "string") this.appendChild(document.createTextNode(n)); else this.appendChild(n); } }
   prepend() {}
 }
@@ -1678,6 +1685,15 @@ if (!Element.prototype.after) {
   _markNative(Element.prototype.after);
 }
 
+// ChildNode mixin: also mix before/after/replaceWith/remove into
+// CharacterData.prototype (covers Text, Comment, ProcessingInstruction).
+// These are the same implementations as Element.prototype — frameworks
+// (Svelte 5, Vue, Lit) anchor on Comment/Text nodes and call these methods.
+if (!CharacterData.prototype.before) CharacterData.prototype.before = Element.prototype.before;
+if (!CharacterData.prototype.after) CharacterData.prototype.after = Element.prototype.after;
+if (!CharacterData.prototype.replaceWith) CharacterData.prototype.replaceWith = Element.prototype.replaceWith;
+if (!CharacterData.prototype.remove) CharacterData.prototype.remove = Element.prototype.remove;
+
 if (!('isConnected' in Node.prototype)) {
   Object.defineProperty(Node.prototype, 'isConnected', {
     get() {
@@ -2054,7 +2070,15 @@ globalThis.crypto = globalThis.crypto || { getRandomValues(arr) { for(let i=0;i<
 globalThis.structuredClone = globalThis.structuredClone || ((v) => JSON.parse(JSON.stringify(v)));
 globalThis.reportError = globalThis.reportError || ((e) => console.error(e));
 
-const _mkStore = () => { const s={}; return { getItem:k=>s[k]??null, setItem:(k,v)=>{s[k]=String(v);}, removeItem:k=>{delete s[k];}, clear:()=>{for(const k in s)delete s[k];}, get length(){return Object.keys(s).length;}, key:i=>Object.keys(s)[i]??null }; };
+globalThis.Storage = function Storage() {};
+Storage.prototype.getItem = function(k) { return (this._data && this._data[k]) ?? null; };
+Storage.prototype.setItem = function(k, v) { if (this._data) this._data[k] = String(v); };
+Storage.prototype.removeItem = function(k) { if (this._data) delete this._data[k]; };
+Storage.prototype.clear = function() { if (this._data) for (var k in this._data) delete this._data[k]; };
+Object.defineProperty(Storage.prototype, 'length', { get: function() { return this._data ? Object.keys(this._data).length : 0; } });
+Storage.prototype.key = function(i) { return this._data ? Object.keys(this._data)[i] ?? null : null; };
+
+const _mkStore = () => { var s = Object.create(Storage.prototype); s._data = {}; return s; };
 globalThis.localStorage = _mkStore();
 globalThis.sessionStorage = _mkStore();
 
@@ -2146,16 +2170,21 @@ globalThis.Range = class Range { setStart(){} setEnd(){} collapse(){} selectNode
   Element.prototype.cloneNode, Element.prototype.attachShadow,
   Element.prototype.insertAdjacentHTML, Element.prototype.scrollIntoView,
   Element.prototype.append, Element.prototype.remove,
+  Element.prototype.before, Element.prototype.after, Element.prototype.replaceWith,
   Element.prototype.getContext, Element.prototype.toDataURL, Element.prototype.toBlob,
   Node.prototype.appendChild, Node.prototype.removeChild,
   Node.prototype.replaceChild, Node.prototype.insertBefore,
   Node.prototype.contains, Node.prototype.hasChildNodes, Node.prototype.cloneNode,
+  CharacterData.prototype.before, CharacterData.prototype.after,
+  CharacterData.prototype.replaceWith, CharacterData.prototype.remove,
   Document.prototype.getElementById, Document.prototype.querySelector,
   Document.prototype.querySelectorAll, Document.prototype.getElementsByTagName,
   Document.prototype.createElement, Document.prototype.createElementNS,
   Document.prototype.createTextNode, Document.prototype.createComment,
   Document.prototype.createDocumentFragment, Document.prototype.createEvent,
   Document.prototype.hasFocus,
+  Storage, Storage.prototype.getItem, Storage.prototype.setItem,
+  Storage.prototype.removeItem, Storage.prototype.clear, Storage.prototype.key,
   Notification, Notification.requestPermission,
   window.chrome?.csi, window.chrome?.loadTimes,
   MutationObserver, ResizeObserver, IntersectionObserver, PerformanceObserver,

--- a/crates/obscura-js/js/bootstrap.js
+++ b/crates/obscura-js/js/bootstrap.js
@@ -1549,6 +1549,12 @@ _markNative(XMLHttpRequest.prototype.getAllResponseHeaders);
 if (typeof URL === 'undefined' || !URL.prototype) {
   globalThis.URL = class URL {
     constructor(url, base) {
+      // Per WHATWG URL spec, both arguments are stringified — callers
+      // routinely pass `window.location` (Location object) or a URL
+      // instance as `base`. Coerce explicitly so the regex .match() calls
+      // below don't blow up on non-strings.
+      url = String(url);
+      if (base !== undefined && base !== null) base = String(base);
       let full = url;
       if (base && !url.includes('://')) {
         var bm = base.match(/^(https?:\/\/[^\/\?#]+)(\/[^?#]*)?/);

--- a/crates/obscura-js/js/bootstrap.js
+++ b/crates/obscura-js/js/bootstrap.js
@@ -746,6 +746,29 @@ class Element extends Node {
     return {x:8,y:8,width:100,height:20,top:8,right:108,bottom:28,left:8,toJSON(){return this;}};
   }
   getClientRects() { return [this.getBoundingClientRect()]; }
+  // No layout engine: a stub that always returns true unblocks Playwright's
+  // actionability polling. With a real layout we'd check display, visibility,
+  // opacity and rect dimensions per spec.
+  checkVisibility(opts) { return true; }
+  // ARIA reflection properties. Without an accessibility tree we expose the
+  // raw aria-* attributes so Playwright's getByRole / getByLabel locators can
+  // at least find elements that author them explicitly.
+  get role() { return this.getAttribute('role'); }
+  set role(v) { if (v == null) this.removeAttribute('role'); else this.setAttribute('role', String(v)); }
+  get ariaLabel() { return this.getAttribute('aria-label'); }
+  set ariaLabel(v) { if (v == null) this.removeAttribute('aria-label'); else this.setAttribute('aria-label', String(v)); }
+  get ariaRoleDescription() { return this.getAttribute('aria-roledescription'); }
+  set ariaRoleDescription(v) { if (v == null) this.removeAttribute('aria-roledescription'); else this.setAttribute('aria-roledescription', String(v)); }
+  get ariaChecked() { return this.getAttribute('aria-checked'); }
+  set ariaChecked(v) { if (v == null) this.removeAttribute('aria-checked'); else this.setAttribute('aria-checked', String(v)); }
+  get ariaDisabled() { return this.getAttribute('aria-disabled'); }
+  set ariaDisabled(v) { if (v == null) this.removeAttribute('aria-disabled'); else this.setAttribute('aria-disabled', String(v)); }
+  get ariaExpanded() { return this.getAttribute('aria-expanded'); }
+  set ariaExpanded(v) { if (v == null) this.removeAttribute('aria-expanded'); else this.setAttribute('aria-expanded', String(v)); }
+  get ariaHidden() { return this.getAttribute('aria-hidden'); }
+  set ariaHidden(v) { if (v == null) this.removeAttribute('aria-hidden'); else this.setAttribute('aria-hidden', String(v)); }
+  get ariaSelected() { return this.getAttribute('aria-selected'); }
+  set ariaSelected(v) { if (v == null) this.removeAttribute('aria-selected'); else this.setAttribute('aria-selected', String(v)); }
   scrollIntoView() { globalThis.__obscura_click_target = this; }
   animate(keyframes, options) {
     const duration = typeof options === 'number' ? options : (options?.duration || 0);
@@ -2164,6 +2187,7 @@ globalThis.Range = class Range { setStart(){} setEnd(){} collapse(){} selectNode
   Element.prototype.getElementsByTagName, Element.prototype.getElementsByClassName,
   Element.prototype.matches, Element.prototype.closest,
   Element.prototype.getBoundingClientRect, Element.prototype.getClientRects,
+  Element.prototype.checkVisibility,
   Element.prototype.addEventListener, Element.prototype.removeEventListener,
   Element.prototype.dispatchEvent, Element.prototype.click,
   Element.prototype.focus, Element.prototype.blur,

--- a/crates/obscura-js/src/ops.rs
+++ b/crates/obscura-js/src/ops.rs
@@ -174,6 +174,18 @@ fn op_dom(state: &OpState, #[string] cmd: String, #[string] arg1: String, #[stri
             let val = dom.get_node(NodeId::new(nid)).and_then(|n| n.get_attribute(&arg2).map(|s| s.to_string()));
             serde_json::to_string(&val).unwrap_or("null".into())
         }
+        "attribute_names" => {
+            let nid = arg1.parse::<u32>().unwrap_or(0);
+            let names: Vec<String> = dom
+                .get_node(NodeId::new(nid))
+                .map(|n| {
+                    n.attrs()
+                        .map(|a| a.iter().map(|x| x.name.local.as_ref().to_string()).collect())
+                        .unwrap_or_default()
+                })
+                .unwrap_or_default();
+            serde_json::to_string(&names).unwrap_or("[]".into())
+        }
         "set_attribute" => {
             let nid = arg1.parse::<u32>().unwrap_or(0);
             let node_id = NodeId::new(nid);

--- a/crates/obscura-js/src/ops.rs
+++ b/crates/obscura-js/src/ops.rs
@@ -120,6 +120,17 @@ fn op_dom(state: &OpState, #[string] cmd: String, #[string] arg1: String, #[stri
                 .map(|ids| ids.iter().map(|id| id.index() as i32).collect()).unwrap_or_default();
             serde_json::to_string(&ids).unwrap_or("[]".into())
         }
+        "query_selector_scoped" => {
+            let root_nid = arg1.parse::<u32>().unwrap_or(0);
+            dom.query_selector_from(NodeId::new(root_nid), &arg2).ok().flatten()
+                .map(|id| id.index().to_string()).unwrap_or("-1".into())
+        }
+        "query_selector_all_scoped" => {
+            let root_nid = arg1.parse::<u32>().unwrap_or(0);
+            let ids: Vec<i32> = dom.query_selector_all_from(NodeId::new(root_nid), &arg2).ok()
+                .map(|ids| ids.iter().map(|id| id.index() as i32).collect()).unwrap_or_default();
+            serde_json::to_string(&ids).unwrap_or("[]".into())
+        }
         "node_type" => {
             let nid = arg1.parse::<u32>().unwrap_or(0);
             dom.get_node(NodeId::new(nid)).map(|n| match &n.data {
@@ -742,6 +753,11 @@ fn op_navigate(state: &OpState, #[string] url: &str, #[string] method: &str, #[s
     gs.pending_navigation = Some((url.to_string(), method.to_string(), body.to_string()));
 }
 
+#[op2(async)]
+async fn op_sleep(#[number] millis: u64) {
+    tokio::time::sleep(std::time::Duration::from_millis(millis)).await;
+}
+
 pub fn build_extension() -> Extension {
     Extension {
         name: "obscura_dom",
@@ -752,6 +768,7 @@ pub fn build_extension() -> Extension {
             op_get_cookies(),
             op_set_cookie(),
             op_navigate(),
+            op_sleep(),
         ]),
         ..Default::default()
     }

--- a/crates/obscura-js/src/ops.rs
+++ b/crates/obscura-js/src/ops.rs
@@ -193,7 +193,7 @@ fn op_dom(state: &OpState, #[string] cmd: String, #[string] arg1: String, #[stri
         }
         "remove_child" => {
             let child = arg1.parse::<u32>().unwrap_or(0);
-            dom.detach(NodeId::new(child));
+            dom.remove_child(NodeId::new(child));
             "true".into()
         }
         "insert_before" => {

--- a/crates/obscura-js/src/ops.rs
+++ b/crates/obscura-js/src/ops.rs
@@ -49,6 +49,10 @@ pub struct ObscuraState {
     pub intercept_tx: Option<tokio::sync::mpsc::UnboundedSender<InterceptedRequest>>,
     pub intercept_counter: u64,
     pub intercept_enabled: bool,
+    // Queue of (binding_name, payload) calls made by page JS via the
+    // `op_binding_called` op. Drained by the CDP layer after each dispatch
+    // and emitted as `Runtime.bindingCalled` events.
+    pub pending_binding_calls: Vec<(String, String)>,
 }
 
 impl ObscuraState {
@@ -64,6 +68,7 @@ impl ObscuraState {
             intercept_tx: None,
             intercept_counter: 0,
             intercept_enabled: false,
+            pending_binding_calls: Vec::new(),
         }
     }
 }
@@ -742,6 +747,16 @@ fn op_navigate(state: &OpState, #[string] url: &str, #[string] method: &str, #[s
     gs.pending_navigation = Some((url.to_string(), method.to_string(), body.to_string()));
 }
 
+// Records a binding call from page JS. The CDP layer drains this queue
+// after every dispatch and emits one `Runtime.bindingCalled` event per
+// entry — that's how puppeteer's `page.exposeFunction` callbacks fire.
+#[op2(fast)]
+fn op_binding_called(state: &OpState, #[string] name: &str, #[string] payload: &str) {
+    let gs = state.borrow::<SharedState>().clone();
+    let mut gs = gs.borrow_mut();
+    gs.pending_binding_calls.push((name.to_string(), payload.to_string()));
+}
+
 pub fn build_extension() -> Extension {
     Extension {
         name: "obscura_dom",
@@ -752,6 +767,7 @@ pub fn build_extension() -> Extension {
             op_get_cookies(),
             op_set_cookie(),
             op_navigate(),
+            op_binding_called(),
         ]),
         ..Default::default()
     }

--- a/crates/obscura-js/src/runtime.rs
+++ b/crates/obscura-js/src/runtime.rs
@@ -965,6 +965,117 @@ mod tests {
         assert_eq!(text, serde_json::json!("BODY_TEXT"));
     }
 
+    /// Regression for #105: `element.querySelector` and `querySelectorAll`
+    /// must scope to the receiver's subtree, not the whole document.
+    #[test]
+    fn element_query_selector_is_scoped_to_subtree() {
+        let mut rt = setup_runtime(
+            r#"<div id="a"><span class="x">in a</span></div><div id="b"><span class="x">in b</span></div>"#,
+        );
+        let text = rt
+            .evaluate("document.getElementById('a').querySelector('.x').textContent")
+            .unwrap();
+        assert_eq!(text, serde_json::json!("in a"));
+
+        let count_in_a = rt
+            .evaluate("document.getElementById('a').querySelectorAll('.x').length")
+            .unwrap();
+        assert_eq!(count_in_a.as_f64().unwrap() as i64, 1);
+
+        // Document-scoped query still sees both.
+        let count_doc = rt.evaluate("document.querySelectorAll('.x').length").unwrap();
+        assert_eq!(count_doc.as_f64().unwrap() as i64, 2);
+    }
+
+    /// Regression for #105: `document.forms` / `images` / `links` must be
+    /// live, not hardcoded `[]`. jQuery 1.x's submit-event setup iterates
+    /// `document.forms` and crashes when it's empty for pages that have forms.
+    #[test]
+    fn document_forms_images_links_are_live() {
+        let mut rt = setup_runtime(
+            r#"<form></form><form></form><img><a href="x">l</a><a>no-href</a>"#,
+        );
+        assert_eq!(rt.evaluate("document.forms.length").unwrap().as_f64().unwrap() as i64, 2);
+        assert_eq!(rt.evaluate("document.images.length").unwrap().as_f64().unwrap() as i64, 1);
+        assert_eq!(rt.evaluate("document.links.length").unwrap().as_f64().unwrap() as i64, 1);
+    }
+
+    /// Regression for #105: `HTMLFormElement` must expose `.elements` so
+    /// frameworks that probe form field collections work.
+    #[test]
+    fn html_form_element_exposes_elements_collection() {
+        let mut rt = setup_runtime(
+            r#"<form id="f"><input name=a><input name=b><textarea></textarea></form>"#,
+        );
+        let n = rt
+            .evaluate("document.getElementById('f').elements.length")
+            .unwrap();
+        assert_eq!(n.as_f64().unwrap() as i64, 3);
+        let is_form = rt
+            .evaluate("document.getElementById('f') instanceof HTMLFormElement")
+            .unwrap();
+        assert_eq!(is_form, serde_json::json!(true));
+    }
+
+    /// Regression for #105: `Element.prepend` must actually insert at the
+    /// start, not silently no-op.
+    #[test]
+    fn element_prepend_inserts_at_start() {
+        let mut rt = setup_runtime(r#"<div id="c"><span>existing</span></div>"#);
+        rt.evaluate(
+            r#"
+            const c = document.getElementById('c');
+            const n = document.createElement('span');
+            n.id = 'first';
+            c.prepend(n);
+            "#,
+        )
+        .unwrap();
+        let first_id = rt.evaluate("document.getElementById('c').firstChild.id").unwrap();
+        assert_eq!(first_id, serde_json::json!("first"));
+        let count = rt.evaluate("document.getElementById('c').childNodes.length").unwrap();
+        assert_eq!(count.as_f64().unwrap() as i64, 2);
+    }
+
+    /// Regression for #105: `isEqualNode` compares structure, not identity.
+    /// Framework diff algorithms rely on this.
+    #[test]
+    fn is_equal_node_does_structural_compare() {
+        let mut rt = setup_runtime("<html><body></body></html>");
+        let result = rt
+            .evaluate(
+                r#"
+                const a = document.createElement('div'); a.setAttribute('class', 'x'); a.innerHTML = '<span>hi</span>';
+                const b = document.createElement('div'); b.setAttribute('class', 'x'); b.innerHTML = '<span>hi</span>';
+                const c = document.createElement('div'); c.innerHTML = '<span>bye</span>';
+                return [a.isEqualNode(b), a.isEqualNode(c), a.isSameNode(b)];
+                "#,
+            )
+            .unwrap();
+        assert_eq!(result, serde_json::json!([true, false, false]));
+    }
+
+    /// Regression for the long-standing insert_before arg-order bug noted
+    /// in CLAUDE.md: bootstrap.js was passing (parent, new, ref) but `_dom`
+    /// forwards only two args, silently dropping `ref`. With the fix,
+    /// `insertBefore` actually inserts.
+    #[test]
+    fn insert_before_inserts_node_at_correct_position() {
+        let mut rt = setup_runtime(r#"<div id="p"><span id="b">b</span><span id="c">c</span></div>"#);
+        let order = rt
+            .evaluate(
+                r#"
+                const p = document.getElementById('p');
+                const a = document.createElement('span');
+                a.id = 'a';
+                p.insertBefore(a, document.getElementById('b'));
+                return Array.from(p.children).map(e => e.id).join(',');
+                "#,
+            )
+            .unwrap();
+        assert_eq!(order, serde_json::json!("a,b,c"));
+    }
+
     #[test]
     fn test_console_log() {
         let mut rt = setup_runtime("<html><body></body></html>");

--- a/crates/obscura-js/src/runtime.rs
+++ b/crates/obscura-js/src/runtime.rs
@@ -97,6 +97,10 @@ impl ObscuraJsRuntime {
         self.state.borrow_mut().pending_navigation.take()
     }
 
+    pub fn take_pending_binding_calls(&self) -> Vec<(String, String)> {
+        std::mem::take(&mut self.state.borrow_mut().pending_binding_calls)
+    }
+
     pub fn set_intercept_tx(&self, tx: tokio::sync::mpsc::UnboundedSender<crate::ops::InterceptedRequest>) {
         let mut state = self.state.borrow_mut();
         state.intercept_tx = Some(tx);

--- a/crates/obscura-js/src/runtime.rs
+++ b/crates/obscura-js/src/runtime.rs
@@ -1811,4 +1811,66 @@ mod tests {
         );
     }
 
+    // ── Issue #45 (Playwright actionability) regression tests ────────────────
+    // Kept at the end of the module so they don't share textual context with
+    // unrelated test additions in other branches (avoids spurious merge
+    // conflicts when both this branch and an unrelated bootstrap.js change
+    // add tests near the start of `mod tests`).
+
+    /// Playwright >= 1.25 calls `element.checkVisibility(...)` before every
+    /// input event. If the method isn't defined Playwright retries until its
+    /// action timeout fires. Without a layout engine we can't compute it
+    /// properly, so the stub always returns true — still strictly better
+    /// than the undefined path.
+    #[test]
+    fn element_check_visibility_is_callable() {
+        let mut rt = setup_runtime(r#"<div id="x">x</div>"#);
+        let result = rt
+            .evaluate("document.getElementById('x').checkVisibility({checkOpacity: true})")
+            .unwrap();
+        assert_eq!(result, serde_json::json!(true));
+
+        let typeof_method = rt
+            .evaluate("typeof document.getElementById('x').checkVisibility")
+            .unwrap();
+        assert_eq!(typeof_method, serde_json::json!("function"));
+    }
+
+    /// Playwright's `getByRole` / `getByLabel` locators resolve via ARIA
+    /// reflection properties. Without the getters those locators always
+    /// fail. Reflect the underlying aria-* attributes.
+    #[test]
+    fn element_aria_reflection_properties_read_aria_attrs() {
+        let mut rt = setup_runtime(
+            r#"<button id="b" role="tab" aria-label="Settings" aria-selected="true">x</button>"#,
+        );
+        let result = rt
+            .evaluate(
+                r#"
+                const el = document.getElementById('b');
+                return [el.role, el.ariaLabel, el.ariaSelected];
+                "#,
+            )
+            .unwrap();
+        assert_eq!(result, serde_json::json!(["tab", "Settings", "true"]));
+    }
+
+    /// Setting an ARIA reflection property must write through to the
+    /// underlying attribute so frameworks that toggle state via
+    /// `el.ariaExpanded = 'true'` actually update the DOM.
+    #[test]
+    fn element_aria_reflection_setters_write_through() {
+        let mut rt = setup_runtime(r#"<div id="d"></div>"#);
+        let result = rt
+            .evaluate(
+                r#"
+                const el = document.getElementById('d');
+                el.role = 'menu';
+                el.ariaExpanded = 'true';
+                return [el.getAttribute('role'), el.getAttribute('aria-expanded')];
+                "#,
+            )
+            .unwrap();
+        assert_eq!(result, serde_json::json!(["menu", "true"]));
+    }
 }

--- a/crates/obscura-mcp/src/http.rs
+++ b/crates/obscura-mcp/src/http.rs
@@ -83,10 +83,15 @@ async fn handle_connection(
 
         match method {
             "OPTIONS" => {
+                // mcp-protocol-version is part of the MCP spec, Authorization /
+                // X-API-Key are common for hosted deployments. Without these
+                // listed the browser preflight check fails and blocks the actual
+                // request.
                 let hdr = "HTTP/1.1 204 No Content\r\n\
                     Access-Control-Allow-Origin: *\r\n\
                     Access-Control-Allow-Methods: GET, POST, OPTIONS\r\n\
-                    Access-Control-Allow-Headers: Content-Type\r\n\
+                    Access-Control-Allow-Headers: Content-Type, Authorization, X-API-Key, mcp-protocol-version\r\n\
+                    Access-Control-Max-Age: 86400\r\n\
                     \r\n";
                 writer.write_all(hdr.as_bytes()).await?;
             }

--- a/crates/obscura-mcp/tests/cors_preflight.rs
+++ b/crates/obscura-mcp/tests/cors_preflight.rs
@@ -1,0 +1,86 @@
+//! Regression test for issue #175: the MCP HTTP server's OPTIONS preflight
+//! response must list every header a browser MCP client may send, including
+//! `mcp-protocol-version` (from the MCP spec) and `Authorization` /
+//! `X-API-Key` (common in hosted deployments). Otherwise the browser blocks
+//! the actual request with a CORS error.
+
+use std::net::TcpListener as StdListener;
+use std::time::Duration;
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::TcpStream;
+use tokio::task::LocalSet;
+use tokio::time::{sleep, timeout};
+
+fn pick_free_port() -> u16 {
+    let l = StdListener::bind("127.0.0.1:0").unwrap();
+    let p = l.local_addr().unwrap().port();
+    drop(l);
+    p
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn options_preflight_lists_required_browser_headers() {
+    let port = pick_free_port();
+    let local = LocalSet::new();
+
+    // Spawn the MCP HTTP server. It loops forever; we abort the task at the
+    // end of the test. `current_thread` + LocalSet is required because the
+    // browser state is `!Send` (Page holds V8 handles).
+    let server = local.spawn_local(async move {
+        let _ = obscura_mcp::http::run(port, None, None, false).await;
+    });
+
+    local.run_until(async {
+        // Wait for the listener to bind.
+        for _ in 0..40 {
+            if TcpStream::connect(("127.0.0.1", port)).await.is_ok() {
+                break;
+            }
+            sleep(Duration::from_millis(50)).await;
+        }
+
+        let mut stream = TcpStream::connect(("127.0.0.1", port))
+            .await
+            .expect("MCP server did not come up");
+        let req = b"OPTIONS /mcp HTTP/1.1\r\n\
+                    Host: 127.0.0.1\r\n\
+                    Origin: https://dashboard.example.com\r\n\
+                    Access-Control-Request-Method: POST\r\n\
+                    Access-Control-Request-Headers: Content-Type, mcp-protocol-version, Authorization\r\n\
+                    \r\n";
+        stream.write_all(req).await.unwrap();
+        stream.flush().await.unwrap();
+
+        let mut buf = [0u8; 4096];
+        let n = timeout(Duration::from_secs(2), stream.read(&mut buf))
+            .await
+            .expect("read timed out")
+            .expect("read failed");
+        let response = String::from_utf8_lossy(&buf[..n]).to_string();
+
+        server.abort();
+
+        assert!(
+            response.starts_with("HTTP/1.1 204"),
+            "expected 204 No Content preflight, got:\n{response}"
+        );
+        let lc = response.to_lowercase();
+        assert!(
+            lc.contains("access-control-allow-headers:"),
+            "preflight must include Access-Control-Allow-Headers; got:\n{response}"
+        );
+        assert!(
+            lc.contains("mcp-protocol-version"),
+            "ACAH must list mcp-protocol-version (per MCP spec); got:\n{response}"
+        );
+        assert!(
+            lc.contains("authorization"),
+            "ACAH must list Authorization for hosted deployments; got:\n{response}"
+        );
+        assert!(
+            lc.contains("x-api-key"),
+            "ACAH must list X-API-Key for hosted deployments; got:\n{response}"
+        );
+    })
+    .await;
+}

--- a/crates/obscura-net/Cargo.toml
+++ b/crates/obscura-net/Cargo.toml
@@ -16,6 +16,7 @@ serde_json = { workspace = true }
 tracing = { workspace = true }
 thiserror = { workspace = true }
 async-trait = "0.1"
+encoding_rs = "0.8"
 wreq-util = { version = "3.0.0-rc.10", optional = true }
 
 # `prefix-symbols` renames BoringSSL exports to avoid clashes with system OpenSSL,

--- a/crates/obscura-net/Cargo.toml
+++ b/crates/obscura-net/Cargo.toml
@@ -17,6 +17,7 @@ tracing = { workspace = true }
 thiserror = { workspace = true }
 async-trait = "0.1"
 encoding_rs = "0.8"
+tempfile = "3"
 wreq-util = { version = "3.0.0-rc.10", optional = true }
 
 # `prefix-symbols` renames BoringSSL exports to avoid clashes with system OpenSSL,

--- a/crates/obscura-net/src/client.rs
+++ b/crates/obscura-net/src/client.rs
@@ -21,8 +21,17 @@ pub struct Response {
 }
 
 impl Response {
-    pub fn text(&self) -> Result<String, std::string::FromUtf8Error> {
-        String::from_utf8(self.body.clone())
+    /// Decode the body as text, honoring the response charset.
+    ///
+    /// Uses the HTTP `Content-Type` header's `charset=` parameter, then for
+    /// HTML responses falls back to sniffing `<meta charset>` in the first
+    /// 1KB, then UTF-8. Mirrors browser behaviour per the HTML5 spec.
+    pub fn text(&self) -> String {
+        if self.is_html() {
+            crate::encoding::decode_response(&self.body, self.content_type())
+        } else {
+            crate::encoding::decode_non_html(&self.body, self.content_type())
+        }
     }
 
     pub fn header(&self, name: &str) -> Option<&str> {

--- a/crates/obscura-net/src/client.rs
+++ b/crates/obscura-net/src/client.rs
@@ -346,9 +346,33 @@ impl ObscuraHttpClient {
             );
 
             let cookie_header = self.cookie_jar.get_cookie_header(&current_url);
+            tracing::debug!(
+                "Cookie header for {}: {} cookies ({} bytes)",
+                current_url.host_str().unwrap_or("?"),
+                cookie_header.split("; ").filter(|s| !s.is_empty()).count(),
+                cookie_header.len(),
+            );
             if !cookie_header.is_empty() {
-                if let Ok(val) = HeaderValue::from_str(&cookie_header) {
-                    headers.insert(reqwest::header::COOKIE, val);
+                match HeaderValue::from_str(&cookie_header) {
+                    Ok(val) => {
+                        headers.insert(reqwest::header::COOKIE, val);
+                    }
+                    Err(_) => {
+                        let filtered: String = cookie_header
+                            .split("; ")
+                            .filter(|pair| HeaderValue::from_str(pair).is_ok())
+                            .collect::<Vec<_>>()
+                            .join("; ");
+                        if !filtered.is_empty() {
+                            if let Ok(val) = HeaderValue::from_str(&filtered) {
+                                headers.insert(reqwest::header::COOKIE, val);
+                            }
+                        }
+                        tracing::debug!(
+                            "Cookie header invalid chars, filtered {} -> {} bytes",
+                            cookie_header.len(), filtered.len(),
+                        );
+                    }
                 }
             }
 

--- a/crates/obscura-net/src/cookies.rs
+++ b/crates/obscura-net/src/cookies.rs
@@ -2,6 +2,8 @@ use std::collections::HashMap;
 use std::sync::RwLock;
 use url::Url;
 
+const DEFAULT_SAME_SITE: &str = "Lax";
+
 pub struct CookieJar {
     cookies: RwLock<HashMap<String, HashMap<String, CookieEntry>>>,
 }
@@ -15,7 +17,6 @@ struct CookieEntry {
     secure: bool,
     http_only: bool,
     expires: Option<u64>,
-    #[allow(dead_code)]
     same_site: String,
 }
 
@@ -165,6 +166,8 @@ impl CookieJar {
                     path: entry.path.clone(),
                     secure: entry.secure,
                     http_only: entry.http_only,
+                    same_site: entry.same_site.clone(),
+                    expires: entry.expires.map(|e| e as i64),
                 });
             }
         }
@@ -174,6 +177,12 @@ impl CookieJar {
     pub fn set_cookies_from_cdp(&self, cookies: Vec<CookieInfo>) {
         let mut jar = self.cookies.write().unwrap();
         for cookie in cookies {
+            let same_site = if cookie.same_site.is_empty() {
+                DEFAULT_SAME_SITE.to_string()
+            } else {
+                cookie.same_site
+            };
+            let expires = cookie.expires.and_then(|e| if e > 0 { Some(e as u64) } else { None });
             let entry = CookieEntry {
                 name: cookie.name.clone(),
                 value: cookie.value,
@@ -181,8 +190,8 @@ impl CookieJar {
                 domain: cookie.domain.clone(),
                 secure: cookie.secure,
                 http_only: cookie.http_only,
-                expires: None,
-                same_site: "Lax".to_string(),
+                expires,
+                same_site,
             };
             jar.entry(cookie.domain).or_default().insert(cookie.name, entry);
         }
@@ -336,6 +345,30 @@ impl CookieJar {
         }
     }
 
+    pub fn delete_cookies_filtered(&self, name: &str, domain: &str, path: Option<&str>) {
+        let mut cookies = self.cookies.write().unwrap();
+        let matches_path = |entry_path: &str| match path {
+            Some(p) => entry_path == p,
+            None => true,
+        };
+        if domain.is_empty() {
+            for domain_cookies in cookies.values_mut() {
+                domain_cookies.retain(|n, e| !(n == name && matches_path(&e.path)));
+            }
+        } else {
+            let domains_to_try = [
+                domain.to_string(),
+                format!(".{}", domain.trim_start_matches('.')),
+                domain.trim_start_matches('.').to_string(),
+            ];
+            for d in &domains_to_try {
+                if let Some(domain_cookies) = cookies.get_mut(d.as_str()) {
+                    domain_cookies.retain(|n, e| !(n == name && matches_path(&e.path)));
+                }
+            }
+        }
+    }
+
     pub fn clear(&self) {
         self.cookies.write().unwrap().clear();
     }
@@ -356,6 +389,10 @@ pub struct CookieInfo {
     pub secure: bool,
     #[serde(rename = "httpOnly")]
     pub http_only: bool,
+    #[serde(default, rename = "sameSite")]
+    pub same_site: String,
+    #[serde(default)]
+    pub expires: Option<i64>,
 }
 
 fn parse_http_date(s: &str) -> Result<u64, ()> {
@@ -438,6 +475,8 @@ mod tests {
             path: "/".to_string(),
             secure: false,
             http_only: false,
+            same_site: String::new(),
+            expires: None,
         }]);
 
         let apex_url = Url::parse("https://example.com/").unwrap();
@@ -507,6 +546,107 @@ mod tests {
         assert!(!jar.get_cookie_header(&url).is_empty());
 
         jar.clear();
+        assert!(jar.get_cookie_header(&url).is_empty());
+    }
+
+    #[test]
+    fn test_set_cookies_from_cdp_preserves_same_site_and_expires() {
+        let jar = CookieJar::new();
+        let future_expiry = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_secs() as i64
+            + 3600;
+        jar.set_cookies_from_cdp(vec![CookieInfo {
+            name: "sid".to_string(),
+            value: "abc".to_string(),
+            domain: "example.com".to_string(),
+            path: "/".to_string(),
+            secure: true,
+            http_only: true,
+            same_site: "Strict".to_string(),
+            expires: Some(future_expiry),
+        }]);
+
+        let cookies = jar.get_all_cookies();
+        assert_eq!(cookies.len(), 1);
+        assert_eq!(cookies[0].same_site, "Strict");
+        assert_eq!(cookies[0].expires, Some(future_expiry));
+    }
+
+    #[test]
+    fn test_set_cookies_from_cdp_session_when_expires_none() {
+        let jar = CookieJar::new();
+        jar.set_cookies_from_cdp(vec![CookieInfo {
+            name: "n".to_string(),
+            value: "v".to_string(),
+            domain: "example.com".to_string(),
+            path: "/".to_string(),
+            secure: false,
+            http_only: false,
+            same_site: String::new(),
+            expires: None,
+        }]);
+        let cookies = jar.get_all_cookies();
+        assert_eq!(cookies[0].expires, None);
+        assert_eq!(cookies[0].same_site, DEFAULT_SAME_SITE);
+    }
+
+    #[test]
+    fn test_delete_cookies_filtered_path_mismatch_preserves_cookie() {
+        let jar = CookieJar::new();
+        jar.set_cookies_from_cdp(vec![CookieInfo {
+            name: "sid".to_string(),
+            value: "v".to_string(),
+            domain: "example.com".to_string(),
+            path: "/admin".to_string(),
+            secure: false,
+            http_only: false,
+            same_site: String::new(),
+            expires: None,
+        }]);
+        jar.delete_cookies_filtered("sid", "example.com", Some("/other"));
+        assert_eq!(jar.get_all_cookies().len(), 1);
+
+        jar.delete_cookies_filtered("sid", "example.com", Some("/admin"));
+        assert!(jar.get_all_cookies().is_empty());
+    }
+
+    #[test]
+    fn test_delete_cookies_filtered_no_path_deletes_regardless() {
+        let jar = CookieJar::new();
+        jar.set_cookies_from_cdp(vec![CookieInfo {
+            name: "sid".to_string(),
+            value: "v".to_string(),
+            domain: "example.com".to_string(),
+            path: "/admin".to_string(),
+            secure: false,
+            http_only: false,
+            same_site: String::new(),
+            expires: None,
+        }]);
+        jar.delete_cookies_filtered("sid", "example.com", None);
+        assert!(jar.get_all_cookies().is_empty());
+    }
+
+    #[test]
+    fn test_set_cookies_from_cdp_expired_does_not_persist() {
+        let jar = CookieJar::new();
+        let now = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_secs() as i64;
+        jar.set_cookies_from_cdp(vec![CookieInfo {
+            name: "old".to_string(),
+            value: "v".to_string(),
+            domain: "example.com".to_string(),
+            path: "/".to_string(),
+            secure: false,
+            http_only: false,
+            same_site: String::new(),
+            expires: Some(now - 1),
+        }]);
+        let url = Url::parse("https://example.com/").unwrap();
         assert!(jar.get_cookie_header(&url).is_empty());
     }
 }

--- a/crates/obscura-net/src/cookies.rs
+++ b/crates/obscura-net/src/cookies.rs
@@ -8,7 +8,7 @@ pub struct CookieJar {
     cookies: RwLock<HashMap<String, HashMap<String, CookieEntry>>>,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 struct CookieEntry {
     name: String,
     value: String,
@@ -372,6 +372,69 @@ impl CookieJar {
     pub fn clear(&self) {
         self.cookies.write().unwrap().clear();
     }
+
+    /// Serialize all non-expired cookies to a JSON file.
+    /// Writes atomically via tempfile then rename.
+    pub fn save_to_file(&self, path: &std::path::Path) -> Result<(), std::io::Error> {
+        use std::io::Write;
+
+        let cookies = self.cookies.read().unwrap();
+        let now = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_secs();
+
+        let mut all: Vec<CookieInfo> = Vec::new();
+        for domain_cookies in cookies.values() {
+            for entry in domain_cookies.values() {
+                if let Some(exp) = entry.expires {
+                    if exp < now {
+                        continue;
+                    }
+                }
+                all.push(CookieInfo {
+                    name: entry.name.clone(),
+                    value: entry.value.clone(),
+                    domain: entry.domain.clone(),
+                    path: entry.path.clone(),
+                    secure: entry.secure,
+                    http_only: entry.http_only,
+                    same_site: entry.same_site.clone(),
+                    expires: entry.expires.map(|e| e as i64),
+                });
+            }
+        }
+
+        let json = serde_json::to_string_pretty(&all).map_err(|e| {
+            std::io::Error::new(std::io::ErrorKind::InvalidData, e)
+        })?;
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent)?;
+        }
+        let mut tmp = tempfile::NamedTempFile::new_in(
+            path.parent().unwrap_or(std::path::Path::new(".")),
+        )?;
+        tmp.write_all(json.as_bytes())?;
+        tmp.persist(path).map_err(|e| e.error)?;
+        Ok(())
+    }
+
+    /// Load cookies from a JSON file into the jar.
+    /// Merges with existing cookies (does not clear).
+    /// Returns the number of cookies loaded.
+    pub fn load_from_file(&self, path: &std::path::Path) -> Result<usize, std::io::Error> {
+        if !path.exists() {
+            return Ok(0);
+        }
+        let data = std::fs::read_to_string(path)?;
+        let cookies: Vec<CookieInfo> =
+            serde_json::from_str(&data).map_err(|e| {
+                std::io::Error::new(std::io::ErrorKind::InvalidData, e)
+            })?;
+        let count = cookies.len();
+        self.set_cookies_from_cdp(cookies);
+        Ok(count)
+    }
 }
 
 impl Default for CookieJar {
@@ -648,5 +711,76 @@ mod tests {
         }]);
         let url = Url::parse("https://example.com/").unwrap();
         assert!(jar.get_cookie_header(&url).is_empty());
+    }
+    fn test_save_load_roundtrip() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("cookies.json");
+
+        let jar = CookieJar::new();
+        let url = Url::parse("https://example.com/").unwrap();
+        jar.set_cookie("session=abc123; Domain=example.com; Path=/", &url);
+        jar.set_cookie("token=xyz; Secure; HttpOnly", &url);
+
+        jar.save_to_file(&path).unwrap();
+        assert!(path.exists());
+
+        let jar2 = CookieJar::new();
+        let count = jar2.load_from_file(&path).unwrap();
+        assert_eq!(count, 2);
+
+        let header = jar2.get_cookie_header(&url);
+        assert!(header.contains("session=abc123"));
+        assert!(header.contains("token=xyz"));
+    }
+
+    #[test]
+    fn test_load_nonexistent_file_returns_zero() {
+        let jar = CookieJar::new();
+        let count = jar
+            .load_from_file(std::path::Path::new("/nonexistent/cookies.json"))
+            .unwrap();
+        assert_eq!(count, 0);
+    }
+
+    #[test]
+    fn test_domain_matches_subdomain_without_leading_dot() {
+        let jar = CookieJar::new();
+        jar.set_cookies_from_cdp(vec![CookieInfo {
+            name: "session".to_string(),
+            value: "abc".to_string(),
+            domain: "xiaohongshu.com".to_string(),
+            path: "/".to_string(),
+            secure: false,
+            http_only: true,
+            same_site: String::new(),
+            expires: None,
+        }]);
+        let url = Url::parse("https://www.xiaohongshu.com/explore").unwrap();
+        let header = jar.get_cookie_header(&url);
+        assert!(header.contains("session=abc"), "Cookie header was: '{}'", header);
+    }
+
+    #[test]
+    fn test_cookie_from_file_load_then_send_in_request() {
+        // Simulate what happens: load cookies from file → navigate → cookie should be in request
+        use std::io::Write;
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("cookies.json");
+        
+        // Write cookies like we exported from Chrome
+        let cookies = serde_json::json!([
+            {"name": "a1", "value": "testval", "domain": "xiaohongshu.com", "path": "/", "secure": false, "httpOnly": false},
+            {"name": "web_session", "value": "sess123", "domain": "xiaohongshu.com", "path": "/", "secure": false, "httpOnly": true},
+        ]);
+        std::fs::write(&path, serde_json::to_string(&cookies).unwrap()).unwrap();
+        
+        let jar = CookieJar::new();
+        let count = jar.load_from_file(&path).unwrap();
+        assert_eq!(count, 2, "Should load 2 cookies");
+        
+        let url = Url::parse("https://www.xiaohongshu.com/explore").unwrap();
+        let header = jar.get_cookie_header(&url);
+        assert!(header.contains("a1=testval"), "Missing a1 in: '{}'", header);
+        assert!(header.contains("web_session=sess123"), "Missing web_session in: '{}'", header);
     }
 }

--- a/crates/obscura-net/src/encoding.rs
+++ b/crates/obscura-net/src/encoding.rs
@@ -1,0 +1,197 @@
+//! Charset detection and decoding for HTTP response bodies.
+//!
+//! Issue #113: obscura used to call `String::from_utf8_lossy` on every
+//! response body, which silently corrupts every non-UTF-8 page (GBK, Big5,
+//! Shift-JIS, Windows-125x, EUC-KR, ISO-8859-x). Picking the right decoder
+//! is required for scraping non-Latin sites at all.
+//!
+//! Detection order, mirroring real browsers (HTML5 spec § 8.2.2.4):
+//!   1. `Content-Type: text/html; charset=...` from the HTTP response header.
+//!   2. `<meta charset="...">` or `<meta http-equiv="Content-Type" content="text/html; charset=...">`
+//!      sniffed from the first 1024 bytes of the body.
+//!   3. Default UTF-8.
+//!
+//! For non-HTML resources (JS, CSS, JSON), only steps 1 and 3 apply.
+
+use encoding_rs::{Encoding, UTF_8};
+
+/// Decode an HTTP response body. `content_type_header` is the raw header
+/// value if present (e.g. `text/html; charset=gbk`). For HTML resources,
+/// the parser also sniffs `<meta charset>` in the first 1KB.
+pub fn decode_response(bytes: &[u8], content_type_header: Option<&str>) -> String {
+    let (encoding, _) = detect_encoding(bytes, content_type_header);
+    let (cow, _, _) = encoding.decode(bytes);
+    cow.into_owned()
+}
+
+/// Same as `decode_response` but skips the `<meta charset>` sniff. Use for
+/// non-HTML resources where embedded HTML meta tags are not authoritative
+/// (script and style bodies, JSON, plain text).
+pub fn decode_non_html(bytes: &[u8], content_type_header: Option<&str>) -> String {
+    let encoding = content_type_header
+        .and_then(charset_from_content_type)
+        .and_then(|name| Encoding::for_label(name.as_bytes()))
+        .unwrap_or(UTF_8);
+    let (cow, _, _) = encoding.decode(bytes);
+    cow.into_owned()
+}
+
+/// Resolve the encoding to use for an HTML response, mirroring the HTML5
+/// detection order. Returns the encoding and a tag describing where it was
+/// picked from (for logging / tests).
+pub fn detect_encoding<'a>(
+    bytes: &'a [u8],
+    content_type_header: Option<&str>,
+) -> (&'static Encoding, &'static str) {
+    if let Some(charset) = content_type_header.and_then(charset_from_content_type) {
+        if let Some(enc) = Encoding::for_label(charset.as_bytes()) {
+            return (enc, "content-type");
+        }
+    }
+    if let Some(enc) = sniff_meta_charset(bytes) {
+        return (enc, "meta-charset");
+    }
+    (UTF_8, "default-utf8")
+}
+
+/// Pull the `charset=` parameter out of a Content-Type header value.
+fn charset_from_content_type(header: &str) -> Option<String> {
+    for part in header.split(';') {
+        let trimmed = part.trim();
+        if let Some(rest) = trimmed.strip_prefix("charset=").or_else(|| trimmed.strip_prefix("Charset=")) {
+            // Strip surrounding quotes if present.
+            let value = rest.trim_matches(|c: char| c == '"' || c == '\'').trim();
+            if !value.is_empty() {
+                return Some(value.to_ascii_lowercase());
+            }
+        }
+        // Some servers send `Content-Type: text/html; CHARSET = gbk`.
+        let lower = trimmed.to_ascii_lowercase();
+        if let Some(rest) = lower.strip_prefix("charset") {
+            let rest = rest.trim_start();
+            if let Some(rest) = rest.strip_prefix('=') {
+                let value = rest.trim().trim_matches(|c: char| c == '"' || c == '\'');
+                if !value.is_empty() {
+                    return Some(value.to_ascii_lowercase());
+                }
+            }
+        }
+    }
+    None
+}
+
+/// Scan the first 1024 bytes for a `<meta charset="...">` or
+/// `<meta http-equiv="Content-Type" content="...; charset=...">` declaration.
+/// We only look at ASCII bytes; valid meta-charset declarations are always
+/// ASCII regardless of the page's actual encoding.
+fn sniff_meta_charset(bytes: &[u8]) -> Option<&'static Encoding> {
+    let prefix_len = bytes.len().min(1024);
+    let prefix = &bytes[..prefix_len];
+    // Lossy is fine: any meta charset attribute is ASCII, even on a non-UTF-8 page.
+    let s = String::from_utf8_lossy(prefix).to_ascii_lowercase();
+
+    // Look for any `<meta ... charset=...>` pattern in the first 1KB. We
+    // intentionally accept both the modern shorthand (`<meta charset=gbk>`)
+    // and the legacy http-equiv form (`<meta http-equiv="content-type" content="text/html; charset=gbk">`).
+    let mut pos = 0;
+    while let Some(meta_start) = s[pos..].find("<meta") {
+        let abs = pos + meta_start;
+        // Find the closing `>` for this meta tag.
+        let end = s[abs..].find('>').map(|e| abs + e).unwrap_or(s.len());
+        let tag = &s[abs..end];
+
+        if let Some(charset_pos) = tag.find("charset") {
+            let after = &tag[charset_pos + "charset".len()..];
+            let after = after.trim_start();
+            if let Some(eq_rest) = after.strip_prefix('=') {
+                let value = eq_rest
+                    .trim_start()
+                    .trim_start_matches(|c: char| c == '"' || c == '\'')
+                    .split(|c: char| c == '"' || c == '\'' || c == ';' || c.is_whitespace() || c == '/')
+                    .next()
+                    .unwrap_or("");
+                if !value.is_empty() {
+                    if let Some(enc) = Encoding::for_label(value.as_bytes()) {
+                        return Some(enc);
+                    }
+                }
+            }
+        }
+
+        pos = end + 1;
+        if pos >= s.len() {
+            break;
+        }
+    }
+
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn content_type_charset_wins() {
+        let bytes = b"<html><head><meta charset=\"utf-8\"></head><body></body></html>";
+        let (enc, source) = detect_encoding(bytes, Some("text/html; charset=gbk"));
+        assert_eq!(enc.name(), "GBK");
+        assert_eq!(source, "content-type");
+    }
+
+    #[test]
+    fn content_type_quoted_charset_is_parsed() {
+        let (enc, _) = detect_encoding(b"", Some("text/html; charset=\"Shift_JIS\""));
+        assert_eq!(enc.name(), "Shift_JIS");
+    }
+
+    #[test]
+    fn meta_charset_used_when_header_missing() {
+        let bytes = b"<!doctype html><html><head><meta charset=\"big5\"></head></html>";
+        let (enc, source) = detect_encoding(bytes, None);
+        assert_eq!(enc.name(), "Big5");
+        assert_eq!(source, "meta-charset");
+    }
+
+    #[test]
+    fn meta_http_equiv_charset_is_recognized() {
+        let bytes = b"<html><head><meta http-equiv=\"Content-Type\" content=\"text/html; charset=EUC-KR\"></head></html>";
+        let (enc, _) = detect_encoding(bytes, None);
+        assert_eq!(enc.name(), "EUC-KR");
+    }
+
+    #[test]
+    fn no_charset_anywhere_falls_back_to_utf8() {
+        let bytes = b"<html><body>hello</body></html>";
+        let (enc, source) = detect_encoding(bytes, None);
+        assert_eq!(enc.name(), "UTF-8");
+        assert_eq!(source, "default-utf8");
+    }
+
+    #[test]
+    fn decode_response_gbk_bytes_roundtrip() {
+        // "你好" (ni hao) encoded as GBK = C4 E3 BA C3
+        let bytes: &[u8] = &[0xC4, 0xE3, 0xBA, 0xC3];
+        let s = decode_response(bytes, Some("text/html; charset=gbk"));
+        assert_eq!(s, "你好");
+    }
+
+    #[test]
+    fn decode_non_html_skips_meta_sniff() {
+        // A JS body that happens to contain a string `<meta charset="gbk">`
+        // must NOT be decoded as GBK — non-HTML resources only honor the
+        // HTTP header.
+        let bytes = br#"var x = '<meta charset="gbk">'; // not the real charset"#;
+        let s = decode_non_html(bytes, Some("application/javascript"));
+        assert!(s.contains("<meta charset="));
+    }
+
+    #[test]
+    fn meta_sniff_only_scans_first_1kb() {
+        let mut bytes = vec![b' '; 2048];
+        bytes.extend_from_slice(b"<meta charset=\"gbk\">");
+        let (enc, _) = detect_encoding(&bytes, None);
+        // Beyond 1KB: ignored, fall back to UTF-8.
+        assert_eq!(enc.name(), "UTF-8");
+    }
+}

--- a/crates/obscura-net/src/lib.rs
+++ b/crates/obscura-net/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod client;
 pub mod cookies;
+pub mod encoding;
 pub mod interceptor;
 pub mod robots;
 pub mod blocklist;
@@ -8,6 +9,7 @@ pub mod wreq_client;
 
 pub use client::{ObscuraHttpClient, ObscuraNetError, RequestInfo, ResourceType, Response};
 pub use cookies::{CookieInfo, CookieJar};
+pub use encoding::{decode_non_html, decode_response};
 pub use robots::RobotsCache;
 pub use blocklist::is_blocked as is_tracker_blocked;
 #[cfg(feature = "stealth")]

--- a/crates/obscura-net/src/wreq_client.rs
+++ b/crates/obscura-net/src/wreq_client.rs
@@ -36,10 +36,12 @@ impl StealthHttpClient {
     }
 
     pub fn with_proxy(cookie_jar: Arc<CookieJar>, proxy_url: Option<&str>) -> Self {
-        let cert_store = wreq::tls::CertStore::builder()
-            .set_default_paths()
-            .build()
-            .expect("Failed to load system CA certificates");
+        // Issue #184: `set_default_paths()` reads OpenSSL's compile-time CA
+        // paths, which only resolve on Linux. On Windows the store ends up
+        // empty and every TLS handshake fails with CERTIFICATE_VERIFY_FAILED.
+        // `CertStore::default()` uses wreq's bundled Mozilla roots
+        // (`webpki-root-certs`), which works the same on every platform.
+        let cert_store = wreq::tls::CertStore::default();
 
         let emulation_opts = wreq_util::EmulationOption::builder()
             .emulation(wreq_util::Emulation::Chrome145)


### PR DESCRIPTION

This branch fixes three independent bugs that together blocked
`page.exposeFunction(...)` (and the broader CDP early-injection
contract) under puppeteer. Each is a self-contained commit so they
can be reviewed or landed individually.

## Why

Three separate root causes silently broke `page.exposeFunction`:

1. The CDP `Runtime.addBinding` handler was a placeholder that
   installed an empty stub on `globalThis` and never forwarded calls
   back over CDP. Bindings looked registered from the client side
   but page-side calls vanished.
2. Preload scripts registered via
   `Page.addScriptToEvaluateOnNewDocument` ran *after* the page's
   own scripts, so puppeteer's `exposeFunction` wrapper (which has
   to replace `globalThis[name]` before the document's first
   `<script>` runs) never got the chance to intercept early calls.
3. The `URL` polyfill called `base.match(...)` directly, throwing
   `TypeError: base.match is not a function` for any caller passing
   a `Location` object — i.e. anything that does
   `new URL(href, window.location)`, which is common in framework
   bootstrap code.

## What changes

Three commits, smallest first:

### 1. `fix(js): coerce URL constructor input/base to string`

`crates/obscura-js/js/bootstrap.js`

The `URL` constructor now stringifies both `url` and `base` per the
WHATWG URL Standard before any regex work. Six-line change, no
logic otherwise touched.

### 2. `fix(browser,cdp): run preload scripts before page scripts`

`crates/obscura-browser/src/page.rs`,
`crates/obscura-cdp/src/domains/page.rs`,
`crates/obscura-cdp/src/server.rs`

- Adds a `preload_scripts: Vec<String>` field and a
  `set_preload_scripts(...)` setter on `Page`.
- `navigate_single` runs every registered preload source right after
  `__documentReadyState__ = 'loading'` and before parser-discovered
  scripts, using `execute_script_guarded` so large preloads get the
  5s timeout treatment.
- The two CDP entry points (`domains/page.rs::do_navigate` and
  `server.rs`'s intercept-aware navigate task) hand the current
  preload set to `Page` via `set_preload_scripts` immediately
  before navigation, replacing their old post-navigate
  `execute_preload_script` loops.

This matches Chromium's contract: preloads run on every new
document, before any of the document's scripts execute.

### 3. `feat(cdp,js): emit Runtime.bindingCalled for addBinding shims`

`crates/obscura-js/src/ops.rs`,
`crates/obscura-js/src/runtime.rs`,
`crates/obscura-browser/src/page.rs`,
`crates/obscura-cdp/src/dispatch.rs`,
`crates/obscura-cdp/src/domains/runtime.rs`

- New `op_binding_called(name, payload)` op pushes `(name, payload)`
  onto a `pending_binding_calls: Vec<(String, String)>` queue on
  `ObscuraState`. `ObscuraJsRuntime::take_pending_binding_calls`
  drains it, mirroring the existing `take_pending_navigation` shape.
- `Page::take_pending_binding_calls` is the public passthrough.
- `dispatch()` calls `drain_binding_calls(ctx)` after every CDP
  request: it walks every `Page`, takes its pending calls, and
  pushes one `Runtime.bindingCalled` event per entry into
  `ctx.pending_events`. The writer task forwards them to the client
  exactly like any other event.
- `Runtime.addBinding` now installs a real JS shim:
  `globalThis[name] = function (arg) { Deno.core.ops.op_binding_called(name, payload) }`
  where `payload` is `arg` itself if it's already a string and
  `JSON.stringify(arg)` otherwise. Matches the wire format
  puppeteer's `exposeFunction` wrapper expects
  (`Runtime.bindingCalled.params.payload` is always a string).
- The shim is registered as a preload script keyed
  `__obscura_binding__<name>` so it survives navigations (preloads
  re-run on each new document), and it's also evaluated on the
  current page so the binding works without waiting for a
  navigation.
- `Runtime.removeBinding` is now implemented and mirrors the
  registration.

Stacks naturally on commit 2 — the shim relies on preloads running
before page scripts.

## How to verify

Minimal puppeteer repro against a running `obscura serve --port
9222` (with `OBSCURA_ALLOW_PRIVATE_NETWORK=1` so the loopback test
server is reachable):

```js
import puppeteer from 'puppeteer-core'
import http from 'node:http'

const server = http.createServer((req, res) => res.end(
  `<html><body><script>
    if (typeof report === 'function') report('immediate-from-inline')
    window.addEventListener('DOMContentLoaded', () => {
      if (typeof report === 'function') report('from-dcl')
    })
  </script></body></html>`
))
await new Promise((r) => server.listen(0, '::', r))

const browser = await puppeteer.connect({
  browserWSEndpoint: 'ws://127.0.0.1:9222/devtools/browser'
})
const page = await browser.newPage()
const seen = []
await page.exposeFunction('report', (msg) => seen.push(msg))
await page.goto(`http://localhost:${server.address().port}/`)
console.log(seen) // ["immediate-from-inline", "from-dcl"]
```

Without commit 2, `immediate-from-inline` is missing (inline script
runs before the binding is installed). Without commit 3, `seen`
stays empty entirely.

`cargo build --release --features stealth` is clean; `cargo check
--features stealth` passes.
