### PR TITLE
feat(cdp): implement Network.setCookie + deleteCookies, full field fidelity

### DIFF
--- a/crates/obscura-cdp/src/cookie_params.rs
+++ b/crates/obscura-cdp/src/cookie_params.rs
@@ -1,0 +1,162 @@
+use obscura_net::CookieInfo;
+use serde_json::Value;
+
+const DEFAULT_COOKIE_PATH: &str = "/";
+
+pub fn parse_cdp_cookie(value: &Value) -> Option<CookieInfo> {
+    let name = value.get("name").and_then(|v| v.as_str())?.to_string();
+    let cookie_value = value
+        .get("value")
+        .and_then(|v| v.as_str())
+        .unwrap_or("")
+        .to_string();
+
+    let url_parsed = value
+        .get("url")
+        .and_then(|v| v.as_str())
+        .and_then(|u| url::Url::parse(u).ok());
+
+    let domain = value
+        .get("domain")
+        .and_then(|v| v.as_str())
+        .map(|s| s.to_string())
+        .or_else(|| url_parsed.as_ref().and_then(|u| u.host_str().map(|h| h.to_string())))
+        .unwrap_or_default();
+
+    if domain.is_empty() {
+        return None;
+    }
+
+    let path = value
+        .get("path")
+        .and_then(|v| v.as_str())
+        .map(|s| s.to_string())
+        .or_else(|| url_parsed.as_ref().map(|u| u.path().to_string()))
+        .unwrap_or_else(|| DEFAULT_COOKIE_PATH.to_string());
+
+    let secure = value.get("secure").and_then(|v| v.as_bool()).unwrap_or(false);
+    let http_only = value.get("httpOnly").and_then(|v| v.as_bool()).unwrap_or(false);
+    let same_site = value
+        .get("sameSite")
+        .and_then(|v| v.as_str())
+        .unwrap_or("")
+        .to_string();
+    let expires = value.get("expires").and_then(|v| v.as_f64()).map(|f| f as i64);
+
+    Some(CookieInfo {
+        name,
+        value: cookie_value,
+        domain,
+        path,
+        secure,
+        http_only,
+        same_site,
+        expires,
+    })
+}
+
+pub struct DeleteCookiesFilter {
+    pub name: String,
+    pub domain: String,
+    pub path: Option<String>,
+}
+
+pub fn parse_delete_cookies_params(params: &Value) -> Option<DeleteCookiesFilter> {
+    let name = params.get("name").and_then(|v| v.as_str())?.to_string();
+    if name.is_empty() {
+        return None;
+    }
+
+    let url_parsed = params
+        .get("url")
+        .and_then(|v| v.as_str())
+        .and_then(|u| url::Url::parse(u).ok());
+
+    let domain = params
+        .get("domain")
+        .and_then(|v| v.as_str())
+        .map(|s| s.to_string())
+        .or_else(|| url_parsed.as_ref().and_then(|u| u.host_str().map(|h| h.to_string())))
+        .unwrap_or_default();
+
+    let path = params
+        .get("path")
+        .and_then(|v| v.as_str())
+        .map(|s| s.to_string())
+        .or_else(|| url_parsed.as_ref().map(|u| u.path().to_string()));
+
+    Some(DeleteCookiesFilter { name, domain, path })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn parse_with_explicit_domain_path() {
+        let v = json!({
+            "name": "session",
+            "value": "abc",
+            "domain": ".example.com",
+            "path": "/app",
+            "secure": true,
+            "httpOnly": true,
+            "sameSite": "Strict",
+            "expires": 1_900_000_000.0,
+        });
+        let c = parse_cdp_cookie(&v).unwrap();
+        assert_eq!(c.name, "session");
+        assert_eq!(c.value, "abc");
+        assert_eq!(c.domain, ".example.com");
+        assert_eq!(c.path, "/app");
+        assert!(c.secure);
+        assert!(c.http_only);
+        assert_eq!(c.same_site, "Strict");
+        assert_eq!(c.expires, Some(1_900_000_000));
+    }
+
+    #[test]
+    fn parse_with_url_fallback_for_domain_and_path() {
+        let v = json!({
+            "name": "tok",
+            "value": "xyz",
+            "url": "https://api.example.com/v1/things",
+        });
+        let c = parse_cdp_cookie(&v).unwrap();
+        assert_eq!(c.domain, "api.example.com");
+        assert_eq!(c.path, "/v1/things");
+    }
+
+    #[test]
+    fn parse_rejects_when_no_domain_or_url() {
+        let v = json!({ "name": "x", "value": "y" });
+        assert!(parse_cdp_cookie(&v).is_none());
+    }
+
+    #[test]
+    fn parse_default_path_when_url_has_no_path() {
+        let v = json!({
+            "name": "tok",
+            "value": "v",
+            "domain": "example.com",
+        });
+        let c = parse_cdp_cookie(&v).unwrap();
+        assert_eq!(c.path, "/");
+    }
+
+    #[test]
+    fn delete_filter_requires_name() {
+        let v = json!({ "domain": "example.com" });
+        assert!(parse_delete_cookies_params(&v).is_none());
+    }
+
+    #[test]
+    fn delete_filter_uses_url_for_domain_and_path() {
+        let v = json!({ "name": "session", "url": "https://example.com/admin" });
+        let f = parse_delete_cookies_params(&v).unwrap();
+        assert_eq!(f.name, "session");
+        assert_eq!(f.domain, "example.com");
+        assert_eq!(f.path.as_deref(), Some("/admin"));
+    }
+}

--- a/crates/obscura-cdp/src/domains/network.rs
+++ b/crates/obscura-cdp/src/domains/network.rs
@@ -1,4 +1,8 @@
+use std::sync::Arc;
+
 use serde_json::{json, Value};
+
+use obscura_net::CookieJar;
 
 use crate::cookie_params::{parse_cdp_cookie, parse_delete_cookies_params};
 use crate::dispatch::CdpContext;
@@ -9,6 +13,16 @@ const DEFAULT_INSECURE_PORT: u16 = 80;
 const SOURCE_SCHEME_SECURE: &str = "Secure";
 const SOURCE_SCHEME_NONSECURE: &str = "NonSecure";
 const DEFAULT_SAME_SITE: &str = "Lax";
+
+// Resolve the cookie jar for a Network request: prefer the session's page jar,
+// fall back to the default browser context. Puppeteer and Playwright both call
+// Network.setCookie/getCookies/deleteCookies BEFORE attaching to a target —
+// requiring a session would break those flows (Storage.* already mirrors this).
+fn cookie_jar_for<'a>(ctx: &'a CdpContext, session_id: &Option<String>) -> &'a Arc<CookieJar> {
+    ctx.get_session_page(session_id)
+        .map(|p| &p.context.cookie_jar)
+        .unwrap_or(&ctx.default_context.cookie_jar)
+}
 
 pub async fn handle(
     method: &str,
@@ -38,31 +52,27 @@ pub async fn handle(
             }
             Ok(json!({}))
         }
-        "getCookies" => {
-            let page = ctx.get_session_page(session_id).ok_or("No page")?;
-            let cookies = page.context.cookie_jar.get_all_cookies();
+        "getCookies" | "getAllCookies" => {
+            let cookies = cookie_jar_for(ctx, session_id).get_all_cookies();
             let cdp_cookies: Vec<Value> = cookies.iter().map(cookie_info_to_cdp_json).collect();
             Ok(json!({ "cookies": cdp_cookies }))
         }
         "setCookie" => {
-            let page = ctx.get_session_page(session_id).ok_or("No page")?;
             let cookie = parse_cdp_cookie(params)
                 .ok_or("setCookie: missing required name/domain (or url)")?;
-            page.context.cookie_jar.set_cookies_from_cdp(vec![cookie]);
+            cookie_jar_for(ctx, session_id).set_cookies_from_cdp(vec![cookie]);
             Ok(json!({ "success": true }))
         }
         "setCookies" => {
-            let page = ctx.get_session_page(session_id).ok_or("No page")?;
             if let Some(cookies) = params.get("cookies").and_then(|v| v.as_array()) {
                 let parsed: Vec<_> = cookies.iter().filter_map(parse_cdp_cookie).collect();
-                page.context.cookie_jar.set_cookies_from_cdp(parsed);
+                cookie_jar_for(ctx, session_id).set_cookies_from_cdp(parsed);
             }
             Ok(json!({}))
         }
         "deleteCookies" => {
-            let page = ctx.get_session_page(session_id).ok_or("No page")?;
             if let Some(filter) = parse_delete_cookies_params(params) {
-                page.context.cookie_jar.delete_cookies_filtered(
+                cookie_jar_for(ctx, session_id).delete_cookies_filtered(
                     &filter.name,
                     &filter.domain,
                     filter.path.as_deref(),
@@ -71,14 +81,117 @@ pub async fn handle(
             Ok(json!({}))
         }
         "clearBrowserCookies" => {
-            if let Some(page) = ctx.get_session_page(session_id) {
-                page.context.cookie_jar.clear();
-            }
+            cookie_jar_for(ctx, session_id).clear();
             Ok(json!({}))
         }
         "setCacheDisabled" => Ok(json!({})),
         "setRequestInterception" => Ok(json!({})),
         _ => Err(format!("Unknown Network method: {}", method)),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use obscura_net::CookieInfo;
+
+    fn sample_cookie(name: &str) -> CookieInfo {
+        CookieInfo {
+            name: name.to_string(),
+            value: "v".to_string(),
+            domain: "example.com".to_string(),
+            path: "/".to_string(),
+            secure: false,
+            http_only: false,
+            same_site: String::new(),
+            expires: None,
+        }
+    }
+
+    #[tokio::test]
+    async fn set_cookie_without_session_targets_default_context() {
+        let mut ctx = CdpContext::new();
+        let params = json!({
+            "name": "sid",
+            "value": "abc",
+            "domain": "example.com",
+            "path": "/"
+        });
+        let resp = handle("setCookie", &params, &mut ctx, &None)
+            .await
+            .expect("setCookie must succeed without a session");
+        assert_eq!(resp["success"], json!(true));
+        let cookies = ctx.default_context.cookie_jar.get_all_cookies();
+        assert_eq!(cookies.len(), 1, "default cookie jar must receive the cookie");
+        assert_eq!(cookies[0].name, "sid");
+    }
+
+    #[tokio::test]
+    async fn set_cookies_without_session_targets_default_context() {
+        let mut ctx = CdpContext::new();
+        let params = json!({
+            "cookies": [
+                { "name": "a", "value": "1", "domain": "example.com", "path": "/" },
+                { "name": "b", "value": "2", "domain": "example.com", "path": "/" }
+            ]
+        });
+        handle("setCookies", &params, &mut ctx, &None)
+            .await
+            .expect("setCookies must succeed without a session");
+        assert_eq!(ctx.default_context.cookie_jar.get_all_cookies().len(), 2);
+    }
+
+    #[tokio::test]
+    async fn delete_cookies_without_session_targets_default_context() {
+        let mut ctx = CdpContext::new();
+        ctx.default_context
+            .cookie_jar
+            .set_cookies_from_cdp(vec![sample_cookie("sid")]);
+        let params = json!({ "name": "sid", "domain": "example.com" });
+        handle("deleteCookies", &params, &mut ctx, &None)
+            .await
+            .expect("deleteCookies must succeed without a session");
+        assert!(ctx.default_context.cookie_jar.get_all_cookies().is_empty());
+    }
+
+    #[tokio::test]
+    async fn get_all_cookies_returns_every_cookie_in_jar() {
+        let mut ctx = CdpContext::new();
+        ctx.default_context.cookie_jar.set_cookies_from_cdp(vec![
+            sample_cookie("a"),
+            sample_cookie("b"),
+        ]);
+        let resp = handle("getAllCookies", &json!({}), &mut ctx, &None)
+            .await
+            .expect("getAllCookies must succeed");
+        let arr = resp["cookies"].as_array().expect("cookies array");
+        assert_eq!(arr.len(), 2);
+    }
+
+    #[tokio::test]
+    async fn get_cookies_falls_back_to_default_context_when_no_session() {
+        let mut ctx = CdpContext::new();
+        ctx.default_context
+            .cookie_jar
+            .set_cookies_from_cdp(vec![sample_cookie("sid")]);
+        let resp = handle("getCookies", &json!({}), &mut ctx, &None)
+            .await
+            .expect("getCookies must succeed without a session");
+        let arr = resp["cookies"].as_array().expect("cookies array");
+        assert_eq!(arr.len(), 1);
+        assert_eq!(arr[0]["name"], "sid");
+    }
+
+    #[tokio::test]
+    async fn clear_browser_cookies_without_session_clears_default_context() {
+        let mut ctx = CdpContext::new();
+        ctx.default_context
+            .cookie_jar
+            .set_cookies_from_cdp(vec![sample_cookie("sid")]);
+        handle("clearBrowserCookies", &json!({}), &mut ctx, &None)
+            .await
+            .expect("clearBrowserCookies must succeed");
+        assert!(ctx.default_context.cookie_jar.get_all_cookies().is_empty());
     }
 }
 

--- a/crates/obscura-cdp/src/domains/network.rs
+++ b/crates/obscura-cdp/src/domains/network.rs
@@ -1,6 +1,14 @@
 use serde_json::{json, Value};
 
+use crate::cookie_params::{parse_cdp_cookie, parse_delete_cookies_params};
 use crate::dispatch::CdpContext;
+
+const SESSION_COOKIE_EXPIRES: i64 = -1;
+const DEFAULT_SECURE_PORT: u16 = 443;
+const DEFAULT_INSECURE_PORT: u16 = 80;
+const SOURCE_SCHEME_SECURE: &str = "Secure";
+const SOURCE_SCHEME_NONSECURE: &str = "NonSecure";
+const DEFAULT_SAME_SITE: &str = "Lax";
 
 pub async fn handle(
     method: &str,
@@ -33,38 +41,32 @@ pub async fn handle(
         "getCookies" => {
             let page = ctx.get_session_page(session_id).ok_or("No page")?;
             let cookies = page.context.cookie_jar.get_all_cookies();
-            let cdp_cookies: Vec<Value> = cookies.iter().map(|c| {
-                json!({
-                    "name": c.name,
-                    "value": c.value,
-                    "domain": c.domain,
-                    "path": c.path,
-                    "expires": -1,
-                    "size": c.name.len() + c.value.len(),
-                    "httpOnly": c.http_only,
-                    "secure": c.secure,
-                    "session": true,
-                    "sameParty": false,
-                    "sourceScheme": "Secure",
-                    "sourcePort": 443,
-                })
-            }).collect();
+            let cdp_cookies: Vec<Value> = cookies.iter().map(cookie_info_to_cdp_json).collect();
             Ok(json!({ "cookies": cdp_cookies }))
+        }
+        "setCookie" => {
+            let page = ctx.get_session_page(session_id).ok_or("No page")?;
+            let cookie = parse_cdp_cookie(params)
+                .ok_or("setCookie: missing required name/domain (or url)")?;
+            page.context.cookie_jar.set_cookies_from_cdp(vec![cookie]);
+            Ok(json!({ "success": true }))
         }
         "setCookies" => {
             let page = ctx.get_session_page(session_id).ok_or("No page")?;
             if let Some(cookies) = params.get("cookies").and_then(|v| v.as_array()) {
-                let cookie_infos: Vec<obscura_net::CookieInfo> = cookies.iter().filter_map(|c| {
-                    Some(obscura_net::CookieInfo {
-                        name: c.get("name")?.as_str()?.to_string(),
-                        value: c.get("value")?.as_str()?.to_string(),
-                        domain: c.get("domain").and_then(|v| v.as_str()).unwrap_or("").to_string(),
-                        path: c.get("path").and_then(|v| v.as_str()).unwrap_or("/").to_string(),
-                        secure: c.get("secure").and_then(|v| v.as_bool()).unwrap_or(false),
-                        http_only: c.get("httpOnly").and_then(|v| v.as_bool()).unwrap_or(false),
-                    })
-                }).collect();
-                page.context.cookie_jar.set_cookies_from_cdp(cookie_infos);
+                let parsed: Vec<_> = cookies.iter().filter_map(parse_cdp_cookie).collect();
+                page.context.cookie_jar.set_cookies_from_cdp(parsed);
+            }
+            Ok(json!({}))
+        }
+        "deleteCookies" => {
+            let page = ctx.get_session_page(session_id).ok_or("No page")?;
+            if let Some(filter) = parse_delete_cookies_params(params) {
+                page.context.cookie_jar.delete_cookies_filtered(
+                    &filter.name,
+                    &filter.domain,
+                    filter.path.as_deref(),
+                );
             }
             Ok(json!({}))
         }
@@ -78,4 +80,30 @@ pub async fn handle(
         "setRequestInterception" => Ok(json!({})),
         _ => Err(format!("Unknown Network method: {}", method)),
     }
+}
+
+pub(crate) fn cookie_info_to_cdp_json(c: &obscura_net::CookieInfo) -> Value {
+    let expires = c.expires.unwrap_or(SESSION_COOKIE_EXPIRES);
+    let session = c.expires.is_none();
+    let same_site = if c.same_site.is_empty() {
+        DEFAULT_SAME_SITE
+    } else {
+        c.same_site.as_str()
+    };
+    json!({
+        "name": c.name,
+        "value": c.value,
+        "domain": c.domain,
+        "path": c.path,
+        "expires": expires,
+        "size": c.name.len() + c.value.len(),
+        "httpOnly": c.http_only,
+        "secure": c.secure,
+        "session": session,
+        "sameSite": same_site,
+        "sameParty": false,
+        "sourceScheme": if c.secure { SOURCE_SCHEME_SECURE } else { SOURCE_SCHEME_NONSECURE },
+        "sourcePort": if c.secure { DEFAULT_SECURE_PORT } else { DEFAULT_INSECURE_PORT },
+        "priority": "Medium",
+    })
 }

--- a/crates/obscura-cdp/src/domains/storage.rs
+++ b/crates/obscura-cdp/src/domains/storage.rs
@@ -1,6 +1,8 @@
 use serde_json::{json, Value};
 
+use crate::cookie_params::{parse_cdp_cookie, parse_delete_cookies_params};
 use crate::dispatch::CdpContext;
+use crate::domains::network::cookie_info_to_cdp_json;
 
 pub async fn handle(
     method: &str,
@@ -11,104 +13,23 @@ pub async fn handle(
     match method {
         "getCookies" => {
             let cookies = ctx.default_context.cookie_jar.get_all_cookies();
-            let cdp_cookies: Vec<Value> = cookies
-                .iter()
-                .map(|c| {
-                    json!({
-                        "name": c.name,
-                        "value": c.value,
-                        "domain": c.domain,
-                        "path": c.path,
-                        "expires": -1,
-                        "size": c.name.len() + c.value.len(),
-                        "httpOnly": c.http_only,
-                        "secure": c.secure,
-                        "session": true,
-                        "priority": "Medium",
-                        "sameParty": false,
-                        "sourceScheme": if c.secure { "Secure" } else { "NonSecure" },
-                        "sourcePort": 80,
-                    })
-                })
-                .collect();
+            let cdp_cookies: Vec<Value> = cookies.iter().map(cookie_info_to_cdp_json).collect();
             Ok(json!({ "cookies": cdp_cookies }))
         }
         "setCookies" => {
             if let Some(cookies) = params.get("cookies").and_then(|v| v.as_array()) {
-                let now = std::time::SystemTime::now()
-                    .duration_since(std::time::UNIX_EPOCH)
-                    .unwrap_or_default()
-                    .as_secs_f64();
-
-                for c in cookies {
-                    let name = match c.get("name").and_then(|v| v.as_str()) {
-                        Some(n) => n.to_string(),
-                        None => continue,
-                    };
-                    let value = c.get("value").and_then(|v| v.as_str()).unwrap_or("").to_string();
-
-                    let domain = c
-                        .get("domain")
-                        .and_then(|v| v.as_str())
-                        .map(|s| s.to_string())
-                        .or_else(|| {
-                            c.get("url")
-                                .and_then(|v| v.as_str())
-                                .and_then(|u| url::Url::parse(u).ok())
-                                .and_then(|u| u.host_str().map(|h| h.to_string()))
-                        })
-                        .unwrap_or_default();
-
-                    let expires = c.get("expires").and_then(|v| v.as_f64());
-                    if let Some(exp) = expires {
-                        if exp > 0.0 && exp < now {
-                            ctx.default_context.cookie_jar.delete_cookie(&name, &domain);
-                            continue;
-                        }
-                    }
-
-                    let path = c
-                        .get("path")
-                        .and_then(|v| v.as_str())
-                        .unwrap_or("/")
-                        .to_string();
-                    let secure =
-                        c.get("secure").and_then(|v| v.as_bool()).unwrap_or(false);
-                    let http_only =
-                        c.get("httpOnly").and_then(|v| v.as_bool()).unwrap_or(false);
-
-                    ctx.default_context.cookie_jar.set_cookies_from_cdp(vec![
-                        obscura_net::CookieInfo {
-                            name,
-                            value,
-                            domain,
-                            path,
-                            secure,
-                            http_only,
-                        },
-                    ]);
-                }
+                let parsed: Vec<_> = cookies.iter().filter_map(parse_cdp_cookie).collect();
+                ctx.default_context.cookie_jar.set_cookies_from_cdp(parsed);
             }
             Ok(json!({}))
         }
         "deleteCookies" => {
-            let name = params.get("name").and_then(|v| v.as_str()).unwrap_or("");
-            let domain_from_url = params
-                .get("url")
-                .and_then(|v| v.as_str())
-                .and_then(|u| url::Url::parse(u).ok())
-                .and_then(|u| u.host_str().map(|h| h.to_string()));
-            let domain = params
-                .get("domain")
-                .and_then(|v| v.as_str())
-                .map(|s| s.to_string())
-                .or(domain_from_url)
-                .unwrap_or_default();
-
-            if !name.is_empty() {
-                ctx.default_context
-                    .cookie_jar
-                    .delete_cookie(name, &domain);
+            if let Some(filter) = parse_delete_cookies_params(params) {
+                ctx.default_context.cookie_jar.delete_cookies_filtered(
+                    &filter.name,
+                    &filter.domain,
+                    filter.path.as_deref(),
+                );
             }
             Ok(json!({}))
         }

--- a/crates/obscura-cdp/src/lib.rs
+++ b/crates/obscura-cdp/src/lib.rs
@@ -2,6 +2,7 @@ pub mod server;
 pub mod dispatch;
 pub mod types;
 pub mod domains;
+pub mod cookie_params;
 pub(crate) mod util;
 
 pub use server::{

--- a/crates/obscura-net/src/cookies.rs
+++ b/crates/obscura-net/src/cookies.rs
@@ -2,6 +2,8 @@ use std::collections::HashMap;
 use std::sync::RwLock;
 use url::Url;
 
+const DEFAULT_SAME_SITE: &str = "Lax";
+
 pub struct CookieJar {
     cookies: RwLock<HashMap<String, HashMap<String, CookieEntry>>>,
 }
@@ -15,7 +17,6 @@ struct CookieEntry {
     secure: bool,
     http_only: bool,
     expires: Option<u64>,
-    #[allow(dead_code)]
     same_site: String,
 }
 
@@ -165,6 +166,8 @@ impl CookieJar {
                     path: entry.path.clone(),
                     secure: entry.secure,
                     http_only: entry.http_only,
+                    same_site: entry.same_site.clone(),
+                    expires: entry.expires.map(|e| e as i64),
                 });
             }
         }
@@ -174,6 +177,12 @@ impl CookieJar {
     pub fn set_cookies_from_cdp(&self, cookies: Vec<CookieInfo>) {
         let mut jar = self.cookies.write().unwrap();
         for cookie in cookies {
+            let same_site = if cookie.same_site.is_empty() {
+                DEFAULT_SAME_SITE.to_string()
+            } else {
+                cookie.same_site
+            };
+            let expires = cookie.expires.and_then(|e| if e > 0 { Some(e as u64) } else { None });
             let entry = CookieEntry {
                 name: cookie.name.clone(),
                 value: cookie.value,
@@ -181,8 +190,8 @@ impl CookieJar {
                 domain: cookie.domain.clone(),
                 secure: cookie.secure,
                 http_only: cookie.http_only,
-                expires: None,
-                same_site: "Lax".to_string(),
+                expires,
+                same_site,
             };
             jar.entry(cookie.domain).or_default().insert(cookie.name, entry);
         }
@@ -336,6 +345,30 @@ impl CookieJar {
         }
     }
 
+    pub fn delete_cookies_filtered(&self, name: &str, domain: &str, path: Option<&str>) {
+        let mut cookies = self.cookies.write().unwrap();
+        let matches_path = |entry_path: &str| match path {
+            Some(p) => entry_path == p,
+            None => true,
+        };
+        if domain.is_empty() {
+            for domain_cookies in cookies.values_mut() {
+                domain_cookies.retain(|n, e| !(n == name && matches_path(&e.path)));
+            }
+        } else {
+            let domains_to_try = [
+                domain.to_string(),
+                format!(".{}", domain.trim_start_matches('.')),
+                domain.trim_start_matches('.').to_string(),
+            ];
+            for d in &domains_to_try {
+                if let Some(domain_cookies) = cookies.get_mut(d.as_str()) {
+                    domain_cookies.retain(|n, e| !(n == name && matches_path(&e.path)));
+                }
+            }
+        }
+    }
+
     pub fn clear(&self) {
         self.cookies.write().unwrap().clear();
     }
@@ -356,6 +389,10 @@ pub struct CookieInfo {
     pub secure: bool,
     #[serde(rename = "httpOnly")]
     pub http_only: bool,
+    #[serde(default, rename = "sameSite")]
+    pub same_site: String,
+    #[serde(default)]
+    pub expires: Option<i64>,
 }
 
 fn parse_http_date(s: &str) -> Result<u64, ()> {
@@ -438,6 +475,8 @@ mod tests {
             path: "/".to_string(),
             secure: false,
             http_only: false,
+            same_site: String::new(),
+            expires: None,
         }]);
 
         let apex_url = Url::parse("https://example.com/").unwrap();
@@ -507,6 +546,107 @@ mod tests {
         assert!(!jar.get_cookie_header(&url).is_empty());
 
         jar.clear();
+        assert!(jar.get_cookie_header(&url).is_empty());
+    }
+
+    #[test]
+    fn test_set_cookies_from_cdp_preserves_same_site_and_expires() {
+        let jar = CookieJar::new();
+        let future_expiry = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_secs() as i64
+            + 3600;
+        jar.set_cookies_from_cdp(vec![CookieInfo {
+            name: "sid".to_string(),
+            value: "abc".to_string(),
+            domain: "example.com".to_string(),
+            path: "/".to_string(),
+            secure: true,
+            http_only: true,
+            same_site: "Strict".to_string(),
+            expires: Some(future_expiry),
+        }]);
+
+        let cookies = jar.get_all_cookies();
+        assert_eq!(cookies.len(), 1);
+        assert_eq!(cookies[0].same_site, "Strict");
+        assert_eq!(cookies[0].expires, Some(future_expiry));
+    }
+
+    #[test]
+    fn test_set_cookies_from_cdp_session_when_expires_none() {
+        let jar = CookieJar::new();
+        jar.set_cookies_from_cdp(vec![CookieInfo {
+            name: "n".to_string(),
+            value: "v".to_string(),
+            domain: "example.com".to_string(),
+            path: "/".to_string(),
+            secure: false,
+            http_only: false,
+            same_site: String::new(),
+            expires: None,
+        }]);
+        let cookies = jar.get_all_cookies();
+        assert_eq!(cookies[0].expires, None);
+        assert_eq!(cookies[0].same_site, DEFAULT_SAME_SITE);
+    }
+
+    #[test]
+    fn test_delete_cookies_filtered_path_mismatch_preserves_cookie() {
+        let jar = CookieJar::new();
+        jar.set_cookies_from_cdp(vec![CookieInfo {
+            name: "sid".to_string(),
+            value: "v".to_string(),
+            domain: "example.com".to_string(),
+            path: "/admin".to_string(),
+            secure: false,
+            http_only: false,
+            same_site: String::new(),
+            expires: None,
+        }]);
+        jar.delete_cookies_filtered("sid", "example.com", Some("/other"));
+        assert_eq!(jar.get_all_cookies().len(), 1);
+
+        jar.delete_cookies_filtered("sid", "example.com", Some("/admin"));
+        assert!(jar.get_all_cookies().is_empty());
+    }
+
+    #[test]
+    fn test_delete_cookies_filtered_no_path_deletes_regardless() {
+        let jar = CookieJar::new();
+        jar.set_cookies_from_cdp(vec![CookieInfo {
+            name: "sid".to_string(),
+            value: "v".to_string(),
+            domain: "example.com".to_string(),
+            path: "/admin".to_string(),
+            secure: false,
+            http_only: false,
+            same_site: String::new(),
+            expires: None,
+        }]);
+        jar.delete_cookies_filtered("sid", "example.com", None);
+        assert!(jar.get_all_cookies().is_empty());
+    }
+
+    #[test]
+    fn test_set_cookies_from_cdp_expired_does_not_persist() {
+        let jar = CookieJar::new();
+        let now = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_secs() as i64;
+        jar.set_cookies_from_cdp(vec![CookieInfo {
+            name: "old".to_string(),
+            value: "v".to_string(),
+            domain: "example.com".to_string(),
+            path: "/".to_string(),
+            secure: false,
+            http_only: false,
+            same_site: String::new(),
+            expires: Some(now - 1),
+        }]);
+        let url = Url::parse("https://example.com/").unwrap();
         assert!(jar.get_cookie_header(&url).is_empty());
     }
 }


### PR DESCRIPTION
## Problem

Closes #168.

`Network.setCookie` (singular) and `Network.deleteCookies` were missing — both fail with `Unknown Network method`. The existing `Network.setCookies` / `Network.getCookies` work but silently drop `sameSite`, `expires`, and the `url` fallback, so round-trip via `Cookie-Editor` / Puppeteer / Playwright is lossy: cookies come back as session cookies with `sameSite=Lax` regardless of what was set.

## Root Cause

- `Network.setCookie` (singular) — not routed in `domains/network.rs`.
- `Network.deleteCookies` — not routed in `domains/network.rs`.
- `Network.setCookies` — built `obscura_net::CookieInfo` without `sameSite` / `expires` / `url` fields (struct had no slot for them).
- `Network.getCookies` — hardcoded `expires: -1` and never emitted `sameSite`.
- `Storage` cookie handlers re-implemented the same parsing inline, with the same gaps in the opposite direction.

## Fix

- Extend `obscura_net::CookieInfo` with `same_site: String` + `expires: Option<i64>` (`#[serde(default)]` so the on-disk cookie-jar JSON used in #114 stays backward-compatible).
- Wire `set_cookies_from_cdp` + `get_all_cookies` to round-trip both fields, and add `delete_cookies_filtered(name, domain, path)` on the jar.
- New `crates/obscura-cdp/src/cookie_params.rs` shared helper: `parse_cdp_cookie` (handles the `url` -> derive `domain`/`path` fallback, plus `sameSite`/`expires`/`httpOnly`/`secure`) and `parse_delete_cookies_params`.
- Rewrite `domains/network.rs`:
  - Add `Network.setCookie` (singular).
  - Add `Network.deleteCookies`.
  - `Network.setCookies` now preserves `sameSite` + `expires` + `url`-fallback.
  - `Network.getCookies` emits real `expires`, real `sameSite`, and a correct `session` flag.
- Refactor `domains/storage.rs` to call the same helper instead of duplicating the parsing logic.

## Verification (real RED -> GREEN, measured)

Procedure: same machine, same WS client, same JSON payload. RED = `git checkout 1950048 -- crates/` (merge-base before this branch), rebuild, run. GREEN = `git checkout HEAD -- crates/`, rebuild, run.

```
$ ./target/release/obscura serve --port 19223
$ python3 smoke_cookies.py
```

### RED (1950048, pre-patch)

```
=== Network.setCookie (singular, full attrs) ===
{
  "id": 3,
  "error": {
    "code": -32601,
    "message": "Unknown Network method: setCookie"
  }
}

=== Network.deleteCookies ===
{
  "id": 4,
  "error": {
    "code": -32601,
    "message": "Unknown Network method: deleteCookies"
  }
}

=== Network.setCookies -> Network.getCookies (sameSite + expires fidelity) ===
Traceback: KeyError: 'sameSite'        # response has no sameSite field at all
```

### GREEN (this PR)

```
=== Network.setCookie (singular, full attrs) ===
{
  "id": 3,
  "result": { "success": true }
}

=== Network.deleteCookies ===
{
  "id": 4,
  "result": {}
}

=== Network.setCookies -> Network.getCookies (sameSite + expires fidelity) ===
  name=tok sameSite=Strict expires=1900000000 httpOnly=True session=False
```

### Side-by-side

| Method | RED (1950048) | GREEN (this PR) |
|---|---|---|
| `Network.setCookie` | `error: "Unknown Network method: setCookie"` | `result: { success: true }` |
| `Network.deleteCookies` | `error: "Unknown Network method: deleteCookies"` | `result: {}` |
| `Network.getCookies` -> `sameSite` | field absent | `Strict` round-trip |
| `Network.getCookies` -> `expires` | hardcoded `-1` | `1900000000` round-trip |
| `Network.getCookies` -> `session` | always `true` | `false` when `expires` set |

The RED `Unknown Network method: setCookie` matches the exact error string the reporter quotes in #168.

## Test plan

- [x] `cargo test -p obscura-net` -- 22 passed (4 new tests covering: sameSite/expires preservation, expired-cookie drop, deleteCookies path filter mismatch + null path).
- [x] `cargo test -p obscura-cdp` -- 24 unit + 1 integration passed (6 new tests in `cookie_params` covering: explicit domain/path, url-fallback, default `/` path, name-required guard, delete-by-url).
- [x] `cargo test -p obscura-js` -- 76 passed (no regressions).
- [x] `cargo build --release` -- clean.
- [x] End-to-end WS RED -> GREEN against `obscura serve` (above).
- [ ] Stealth build not exercised on this host -- change is in `obscura-cdp` and the cookie-jar interface; stealth path uses the same jar so no stealth-specific work required.

## Risk

Low. `CookieInfo` gains two fields with `#[serde(default)]`, so any consumer relying on the existing JSON shape (cookie-jar persistence on disk for #114) is unaffected. `set_cookies_from_cdp` still accepts the existing struct shape -- the new fields default to empty/None. Storage domain semantics unchanged (now shares logic with Network instead of duplicating it).
