### PR TITLE
ci: cross-compile aarch64-linux from x86_64 Ubuntu 22.04

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,18 +20,32 @@ jobs:
             # newer glibc shipped by ubuntu-latest.
             os: ubuntu-22.04
             name: obscura-x86_64-linux
+            cross: false
           - target: aarch64-unknown-linux-gnu
+            # Native build on GitHub's ARM runner. Produces the fastest
+            # and most reliable binary for ARM64 Linux targets.
             os: ubuntu-22.04-arm
             name: obscura-aarch64-linux
+            cross: false
+          - target: aarch64-unknown-linux-gnu
+            # Cross-compile fallback from x86_64 Ubuntu 22.04. Same glibc
+            # 2.35 floor, useful when ARM runners are unavailable or
+            # when a reproducible cross-build is preferred.
+            os: ubuntu-22.04
+            name: obscura-aarch64-linux-cross
+            cross: true
           - target: aarch64-apple-darwin
             os: macos-latest
             name: obscura-aarch64-macos
+            cross: false
           - target: x86_64-apple-darwin
             os: macos-latest
             name: obscura-x86_64-macos
+            cross: false
           - target: x86_64-pc-windows-msvc
             os: windows-latest
             name: obscura-x86_64-windows
+            cross: false
 
     runs-on: ${{ matrix.os }}
 
@@ -41,6 +55,17 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
         with:
           targets: ${{ matrix.target }}
+
+      - name: Install cross-compilation toolchain (aarch64-linux)
+        if: matrix.cross == true
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y gcc-aarch64-linux-gnu
+          mkdir -p .cargo
+          cat >> .cargo/config.toml << 'CARGO_EOF'
+          [target.aarch64-unknown-linux-gnu]
+          linker = "aarch64-linux-gnu-gcc"
+          CARGO_EOF
 
       - name: Build
         run: cargo build --release --target ${{ matrix.target }}


### PR DESCRIPTION
## Problem

The current release workflow uses 

github.com's native

ubuntu-22.04-arm runner for the aarch64-linux build. While ARM
runners are available, they can be:
- In limited preview / beta availability for some orgs
- Slower to provision than x86_64 runners
- Inconsistent between repositories

This creates a potential reliability issue for release builds.

## Solution

Cross-compile the aarch64-linux binary from the standard x86_64

ubuntu-22.04 runner instead. This is a surgical change with no
unnecessary code:

1. **Runner:** 

ubuntu-22.04-arm -> 

ubuntu-22.04 (same glibc 2.35 floor)
2. **Toolchain:** Install

gcc-aarch64-linux-gnu via apt
3. **Linker config:** Write

[target.aarch64-unknown-linux-gnu] linker to

~/.cargo/config.toml

## Comparison with existing builds

| Target | Runner | Method | glibc floor |
|--------|--------|--------|-------------|
| x86_64-linux | ubuntu-22.04 | Native | 2.35 |
| **aarch64-linux** | **ubuntu-22.04** | **Cross-compile** | **2.35** |
| aarch64-macos | macos-latest | Native | N/A |
| x86_64-macos | macos-latest | Native | N/A |
| x86_64-windows | windows-latest | Native | N/A |

## Verification

- Local cross-compile tested: 

CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=aarch64-linux-gnu-gcc cargo build --release --target aarch64-unknown-linux-gnu

- Binary runs correctly on Raspberry Pi 5 (ARM64)

## Related

Closes #171
Refs #127