### PR TITLE
fix(mcp): add missing CORS headers for MCP Streamable HTTP transport

### DIFF
--- a/crates/obscura-mcp/src/http.rs
+++ b/crates/obscura-mcp/src/http.rs
@@ -86,7 +86,8 @@ async fn handle_connection(
                 let hdr = "HTTP/1.1 204 No Content\r\n\
                     Access-Control-Allow-Origin: *\r\n\
                     Access-Control-Allow-Methods: GET, POST, OPTIONS\r\n\
-                    Access-Control-Allow-Headers: Content-Type\r\n\
+                    Access-Control-Allow-Headers: Content-Type, Accept, mcp-protocol-version\r\n\
+                    Access-Control-Max-Age: 86400\r\n\
                     \r\n";
                 writer.write_all(hdr.as_bytes()).await?;
             }
@@ -196,6 +197,7 @@ async fn respond(writer: &mut (impl AsyncWriteExt + Unpin), status: u16, body: &
         "HTTP/1.1 {status} {status_text}\r\n\
          Content-Type: application/json\r\n\
          Content-Length: {}\r\n\
+         Access-Control-Allow-Origin: *\r\n\
          \r\n",
         body.len()
     );


### PR DESCRIPTION
## Problem

Browser-based MCP clients (e.g. llama.cpp-web) get CORS errors when connecting to Obscura's MCP endpoint. The OPTIONS preflight response only allows `Content-Type`, missing the `mcp-protocol-version` and `Accept` headers required by the MCP spec for Streamable HTTP transport.

Additionally, error responses (4xx, 5xx) lack CORS headers entirely, so browsers cannot read error bodies.

## Fix

1. Added `Accept` and `mcp-protocol-version` to `Access-Control-Allow-Headers` in the OPTIONS preflight handler
2. Added `Access-Control-Max-Age: 86400` to allow browsers to cache preflight results
3. Added `Access-Control-Allow-Origin: *` to error responses so browsers can read error details

## Testing

- `cargo check -p obscura-mcp` passes
- No new warnings introduced

Closes #175