### PR TITLE
fix(js): make createHTMLDocument return a detached document (147)

### DIFF
--- a/crates/obscura-js/js/bootstrap.js
+++ b/crates/obscura-js/js/bootstrap.js
@@ -1042,7 +1042,20 @@ class Document extends Node {
   get activeElement() { return globalThis.__obscura_focused || this.body; }
   get implementation() {
     return {
-      createHTMLDocument(title) { return globalThis.document; },
+      // Must return a NEW, DETACHED document. jQuery and others use this as a
+      // sandbox: `createHTMLDocument("").body.innerHTML = "<form></form>..."`
+      // for feature detection. Returning the live document made that wipe the
+      // real <body>, dropping all page content (see issue 147).
+      createHTMLDocument(title) {
+        const doc = new _IframeDocument('', 'about:blank', undefined);
+        if (title !== undefined) {
+          const titleEl = document.createElement('title');
+          titleEl.textContent = String(title);
+          doc._head.appendChild(titleEl);
+          doc._title = String(title);
+        }
+        return doc;
+      },
       createDocument() { return globalThis.document; },
       hasFeature() { return true; },
     };

--- a/crates/obscura-js/src/runtime.rs
+++ b/crates/obscura-js/src/runtime.rs
@@ -965,6 +965,64 @@ mod tests {
         assert_eq!(text, serde_json::json!("BODY_TEXT"));
     }
 
+    /// Regression test for #147: `document.implementation.createHTMLDocument`
+    /// must return a NEW, detached document. jQuery 3.7.x uses it as a
+    /// sandbox — `createHTMLDocument("").body.innerHTML = "<form></form>..."`
+    /// during feature detection. The previous implementation returned the
+    /// live `globalThis.document`, so that write wiped the real <body> down
+    /// to two `<form>` stubs — every page that loaded jQuery (e.g. WordPress
+    /// + GeneratePress + offside.js) collapsed to a 1-byte text dump because
+    /// `.slideout-navigation` no longer matched any element, then offside.js
+    /// dereferenced `undefined.classList`.
+    #[test]
+    fn create_html_document_returns_detached_document() {
+        let mut rt = setup_runtime(
+            "<html><body><nav id=keep>NAV_CONTENT</nav><p>PARA</p></body></html>",
+        );
+
+        let before_children = rt
+            .evaluate("document.body.children.length")
+            .unwrap()
+            .as_f64()
+            .unwrap();
+        assert_eq!(before_children, 2.0, "baseline: <body> has nav + p");
+
+        // Reproduce the exact jQuery 3.7.1 feature-detect snippet that used
+        // to wipe the live body.
+        rt.execute_script(
+            "jquery-support-detect",
+            r#"
+            var sandbox = document.implementation.createHTMLDocument("");
+            sandbox.body.innerHTML = "<form></form><form></form>";
+            globalThis.__sandboxFormCount = sandbox.body.children.length;
+            globalThis.__sandboxIsLive = (sandbox === document);
+            "#,
+        )
+        .unwrap();
+
+        // The sandbox must be a distinct document, not the live one.
+        let is_live = rt.evaluate("globalThis.__sandboxIsLive").unwrap();
+        assert_eq!(is_live, serde_json::json!(false),
+                   "createHTMLDocument must NOT return the live document");
+
+        // The sandbox itself received the two forms.
+        let sandbox_forms = rt.evaluate("globalThis.__sandboxFormCount").unwrap();
+        assert_eq!(sandbox_forms, serde_json::json!(2.0));
+
+        // Critical assertion: the real <body> still has its original content.
+        let after_children = rt
+            .evaluate("document.body.children.length")
+            .unwrap()
+            .as_f64()
+            .unwrap();
+        assert_eq!(after_children, 2.0,
+                   "live <body> must be untouched by sandbox writes");
+        let nav_text = rt
+            .evaluate("document.querySelector('#keep').textContent")
+            .unwrap();
+        assert_eq!(nav_text, serde_json::json!("NAV_CONTENT"));
+    }
+
     /// Regression for #105: `element.querySelector` and `querySelectorAll`
     /// must scope to the receiver's subtree, not the whole document.
     #[test]


### PR DESCRIPTION
## Summary

Fixes issue 147. `document.implementation.createHTMLDocument(title)` returned the live `globalThis.document`. jQuery 3.7.x feature-detects via that API and writes `<form></form><form></form>` into the returned document's body, so the live `<body>` was wiped down to two anonymous `<form>` stubs as soon as jQuery loaded. The classList `TypeError` from `offside.min.js` is a downstream symptom of the same root cause: with the body wiped, `.slideout-navigation` matched zero elements and offside.js's `OffsideInstance` constructor was called with `undefined` as the target.

## Root Cause

`crates/obscura-js/js/bootstrap.js`, line 1045:

```js
get implementation() {
  return {
    createHTMLDocument(title) { return globalThis.document; },  // <-- wrong
    ...
  };
}
```

Spec: createHTMLDocument must return a **new, detached** Document. jQuery's `src/selector.js` and `support` module rely on that detachment:

```js
// jquery-3.7.1.js : line 10131
var body = document.implementation.createHTMLDocument( "" ).body;
body.innerHTML = "<form></form><form></form>";
```

With Obscura returning the live document, that `innerHTML =` assignment cleared the real `<body>`. Snapshot taken at runtime before the patch:

```
[BODY-PRE-JQUERY]  51 children: NOSCRIPT, A.skip-link, NAV#site-navigation, DIV#ocs-site, ..., NAV#generate-slideout-menu.main-navigation slideout-navig, ..., SCRIPT, IFRAME
[BODY-POST-JQUERY]  2 children: FORM, FORM
```

After the wipe, every later script that queried the page (offside.js for `.slideout-navigation`, GP menu plugin for `.main-navigation`, WP-Rocket lazy-loader for image placeholders) saw an empty document and either crashed or no-op'd. `--dump text` collapsed to 1 byte.

## Fix

Return a fresh `_IframeDocument` (the same detached-document class already used for `<iframe srcdoc>` and similar). Create a `<title>` element in the new document's head when the caller passes a title argument.

```js
createHTMLDocument(title) {
  const doc = new _IframeDocument('', 'about:blank', undefined);
  if (title !== undefined) {
    const titleEl = document.createElement('title');
    titleEl.textContent = String(title);
    doc._head.appendChild(titleEl);
    doc._title = String(title);
  }
  return doc;
}
```

`_IframeDocument` already constructs an `<html><head></head><body></body></html>` tree via `document.createElement(...)` calls; the resulting nodes are real DOM nodes but they are **detached** from `document.body`, so `innerHTML` writes on the sandbox's body never reach the live tree.

`createDocument` (XML) is left untouched in this change — it has the same problem in principle but no caller in the reproducer exercised it; treating it the same way is a separate cleanup.

## Verification

Reporter's command, before the patch:

```
$ obscura fetch https://vacuumwars.com/best-march-2026-robot-vacuums/ --dump text --timeout 25 --quiet | wc -c
1
$ obscura fetch https://vacuumwars.com/best-march-2026-robot-vacuums/ --dump text --timeout 25
WARN obscura_browser::page: Script error (https://vacuumwars.com/wp-content/plugins/gp-premium/menu-plus/functions/js/offside.min.js?ver=2.5.5): JS error: TypeError: Cannot read properties of undefined (reading 'classList')
    at h (<script>:1:306)
    at new l (<script>:1:2592)
    at Object.getOffsideInstance (<script>:1:2901)
    at getInstance (<script>:1:133)
    at <script>:1:3089
```

After the patch:

```
$ obscura fetch https://vacuumwars.com/best-march-2026-robot-vacuums/ --dump text --timeout 25 --quiet | wc -c
57838
$ obscura fetch https://vacuumwars.com/best-march-2026-robot-vacuums/ --dump text --timeout 25 2>&1 >/dev/null | grep -c classList
0
```

No `classList` TypeError in stderr; full article body is dumped to stdout.

The 3 other reporter URLs (`/vacuum-wars-best-robot-vacuums/`, `/top-rated-robot-vacuums-and-three-to-never-get/`, `/roborock-reviews/`) all use the same GP-Premium + jQuery + offside.js stack and recover the same way.

## Test plan

- [x] `cargo build --release` clean (no new warnings)
- [x] `cargo check -p obscura-cli` clean
- [x] `cargo test -p obscura-js` — 86 pass (baseline 85, +1 new regression test)
- [x] `cargo test -p obscura-dom` — 31 pass (no change)
- [x] `cargo test -p obscura-browser` — 3 pass (no change)
- [x] New test `create_html_document_returns_detached_document` reproduces the bug — RED (test fails when the one-line fix is reverted) and GREEN (test passes with fix applied). Captured locally on this branch.
- [x] End-to-end test against the reporter's live URL: 1 byte → 57838 bytes, classList TypeError gone.
- [ ] Stealth build skipped (no macOS available; per repo rules I should not claim stealth verification I didn't run).

## Risk

Low.

- `createHTMLDocument` was previously aliasing the global document, which meant any code that relied on it returning a detached sandbox could not work at all. Switching to a detached `_IframeDocument` makes the API behave per spec; callers that were silently corrupting the live `<body>` (jQuery feature-detection) now operate on the sandbox as intended.
- No call site in the codebase reads from a `createHTMLDocument(...)` return value as if it were the live document; the only existing test for `implementation` was the surrounding `Document.implementation` shape.
- The new `_IframeDocument` instance is unreferenced as soon as the caller drops it; no listeners or timers are attached.
