### PR TITLE
fix(net): use bundled webpki roots in stealth client (#184)

### DIFF
--- a/crates/obscura-net/src/wreq_client.rs
+++ b/crates/obscura-net/src/wreq_client.rs
@@ -36,10 +36,12 @@ impl StealthHttpClient {
     }
 
     pub fn with_proxy(cookie_jar: Arc<CookieJar>, proxy_url: Option<&str>) -> Self {
-        let cert_store = wreq::tls::CertStore::builder()
-            .set_default_paths()
-            .build()
-            .expect("Failed to load system CA certificates");
+        // Issue #184: `set_default_paths()` reads OpenSSL's compile-time CA
+        // paths, which only resolve on Linux. On Windows the store ends up
+        // empty and every TLS handshake fails with CERTIFICATE_VERIFY_FAILED.
+        // `CertStore::default()` uses wreq's bundled Mozilla roots
+        // (`webpki-root-certs`), which works the same on every platform.
+        let cert_store = wreq::tls::CertStore::default();
 
         let emulation_opts = wreq_util::EmulationOption::builder()
             .emulation(wreq_util::Emulation::Chrome145)


### PR DESCRIPTION
  set_default_paths only resolves OpenSSL's compile-time CA dirs, which
  exist on Linux but are empty on Windows. The stealth client's cert store
  ended up empty there and every TLS handshake failed with
  CERTIFICATE_VERIFY_FAILED inside BoringSSL handshake.cc.

  CertStore::default() uses wreq's bundled webpki-root-certs (Mozilla's
  trust list), which behaves the same on every platform and removes the
  dependency on a system CA store.