### PR TITLE
Fix bounded full-load script execution

### DIFF
--- a/crates/obscura-browser/src/page.rs
+++ b/crates/obscura-browser/src/page.rs
@@ -471,7 +471,7 @@ impl Page {
         if let Some(js) = &mut self.js {
             // Spec order: readyState -> interactive, fire DOMContentLoaded on both
             // document and window, then readyState -> complete, fire load.
-            let _ = js.execute_script("<load-events>",
+            let _ = js.execute_script_guarded("<load-events>",
                 "globalThis.__documentReadyState__ = 'interactive';\n\
                  try { document.dispatchEvent(new Event('DOMContentLoaded', {bubbles:false,cancelable:false})); } catch(e) {}\n\
                  try { window.dispatchEvent(new Event('DOMContentLoaded', {bubbles:false,cancelable:false})); } catch(e) {}\n\
@@ -484,13 +484,12 @@ impl Page {
             let deadline = tokio::time::Instant::now() + tokio::time::Duration::from_millis(500);
             let mut idle_count = 0u32;
             loop {
-                let result = tokio::time::timeout(
-                    tokio::time::Duration::from_millis(10),
-                    js.run_event_loop(),
-                ).await;
+                let result = js
+                    .run_event_loop_with_timeout(tokio::time::Duration::from_millis(10))
+                    .await;
 
                 match result {
-                    Ok(Ok(())) => {
+                    Ok(()) => {
                         if self.http_client.active_requests() == 0 {
                             idle_count += 1;
                             if idle_count >= 2 {
@@ -502,10 +501,9 @@ impl Page {
                             tokio::time::sleep(tokio::time::Duration::from_millis(1)).await;
                         }
                     }
-                    Ok(Err(_)) => break,
-                    Err(_) => {
+                    Err(e) => {
                         idle_count = 0;
-                        if tokio::time::Instant::now() >= deadline {
+                        if !e.contains("timed out") || tokio::time::Instant::now() >= deadline {
                             break;
                         }
                     }
@@ -807,10 +805,9 @@ impl Page {
                 }
 
                 if let Some(js) = &mut self.js {
-                    let _ = tokio::time::timeout(
-                        tokio::time::Duration::from_millis(50),
-                        js.run_event_loop(),
-                    ).await;
+                    let _ = js
+                        .run_event_loop_with_timeout(tokio::time::Duration::from_millis(50))
+                        .await;
                 } else {
                     tokio::time::sleep(tokio::time::Duration::from_millis(100)).await;
                 }

--- a/crates/obscura-browser/tests/bounded_full_load_scripts.rs
+++ b/crates/obscura-browser/tests/bounded_full_load_scripts.rs
@@ -1,0 +1,96 @@
+use std::sync::Arc;
+use std::time::Duration;
+
+use obscura_browser::context::BrowserContext;
+use obscura_browser::lifecycle::WaitUntil;
+use obscura_browser::page::Page;
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::TcpListener;
+
+const INDEX: &str = include_str!("fixtures/js-heavy-page/index.html");
+const COMPACT_BUSY_LOOP: &str = include_str!("fixtures/js-heavy-page/assets/compact-busy-loop.js");
+const POST_BUSY_LOOP: &str = include_str!("fixtures/js-heavy-page/assets/post-busy-loop.js");
+const DEFERRED: &str = include_str!("fixtures/js-heavy-page/assets/deferred.js");
+const ASYNC: &str = include_str!("fixtures/js-heavy-page/assets/async.js");
+
+async fn serve_fixture() -> String {
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+
+    tokio::spawn(async move {
+        loop {
+            let Ok((mut socket, _)) = listener.accept().await else {
+                break;
+            };
+            tokio::spawn(async move {
+                let mut buf = [0_u8; 2048];
+                let Ok(n) = socket.read(&mut buf).await else {
+                    return;
+                };
+                let req = String::from_utf8_lossy(&buf[..n]);
+                let path = req
+                    .lines()
+                    .next()
+                    .and_then(|line| line.split_whitespace().nth(1))
+                    .unwrap_or("/");
+
+                let (status, content_type, body) = match path {
+                    "/" | "/fixture/js-heavy-page" => ("200 OK", "text/html; charset=utf-8", INDEX),
+                    "/assets/compact-busy-loop.js" => {
+                        ("200 OK", "application/javascript", COMPACT_BUSY_LOOP)
+                    }
+                    "/assets/post-busy-loop.js" => {
+                        ("200 OK", "application/javascript", POST_BUSY_LOOP)
+                    }
+                    "/assets/deferred.js" => ("200 OK", "application/javascript", DEFERRED),
+                    "/assets/async.js" => ("200 OK", "application/javascript", ASYNC),
+                    _ => ("404 Not Found", "text/plain", "not found"),
+                };
+
+                let response = format!(
+                    "HTTP/1.1 {status}\r\nContent-Type: {content_type}\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{body}",
+                    body.as_bytes().len()
+                );
+                let _ = socket.write_all(response.as_bytes()).await;
+            });
+        }
+    });
+
+    format!("http://{addr}/fixture/js-heavy-page")
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn full_load_invokes_all_js_heavy_fixture_scripts_without_hanging() {
+    std::env::set_var("OBSCURA_ALLOW_PRIVATE_NETWORK", "1");
+
+    let url = serve_fixture().await;
+    let context = Arc::new(BrowserContext::new("js-heavy-fixture".to_string()));
+    let mut page = Page::new("js-heavy-page".to_string(), context);
+
+    tokio::time::timeout(
+        Duration::from_secs(5),
+        page.navigate_with_wait(&url, WaitUntil::Load),
+    )
+    .await
+    .expect("full-load navigation should be bounded")
+    .expect("fixture navigation should succeed");
+
+    let invoked = page
+        .evaluate("window.__jsHeavyPageInvoked && window.__jsHeavyPageInvoked.join(',')")
+        .as_str()
+        .unwrap_or_default()
+        .to_string();
+
+    for expected in [
+        "inline-init",
+        "compact-busy-loop",
+        "post-busy-loop",
+        "deferred",
+        "async",
+    ] {
+        assert!(
+            invoked.split(',').any(|actual| actual == expected),
+            "missing script invocation {expected}; got {invoked:?}"
+        );
+    }
+}

--- a/crates/obscura-browser/tests/fixtures/js-heavy-page/assets/async.js
+++ b/crates/obscura-browser/tests/fixtures/js-heavy-page/assets/async.js
@@ -1,0 +1,1 @@
+window.__jsHeavyPageInvoked.push('async');

--- a/crates/obscura-browser/tests/fixtures/js-heavy-page/assets/compact-busy-loop.js
+++ b/crates/obscura-browser/tests/fixtures/js-heavy-page/assets/compact-busy-loop.js
@@ -1,0 +1,2 @@
+window.__jsHeavyPageInvoked.push('compact-busy-loop');
+while (true) {}

--- a/crates/obscura-browser/tests/fixtures/js-heavy-page/assets/deferred.js
+++ b/crates/obscura-browser/tests/fixtures/js-heavy-page/assets/deferred.js
@@ -1,0 +1,1 @@
+window.__jsHeavyPageInvoked.push('deferred');

--- a/crates/obscura-browser/tests/fixtures/js-heavy-page/assets/post-busy-loop.js
+++ b/crates/obscura-browser/tests/fixtures/js-heavy-page/assets/post-busy-loop.js
@@ -1,0 +1,4 @@
+window.__jsHeavyPageInvoked.push('post-busy-loop');
+setInterval(function jsHeavyPageTick() {
+  window.__jsHeavyPageTicks += 1;
+}, 0);

--- a/crates/obscura-browser/tests/fixtures/js-heavy-page/index.html
+++ b/crates/obscura-browser/tests/fixtures/js-heavy-page/index.html
@@ -1,0 +1,26 @@
+<!doctype html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>JS-heavy page load reproducer</title>
+  <!--
+    Minimized fixture for a JS-heavy document shape: parser scripts, deferred
+    scripts, and an async script are all discovered; one compact regular script
+    can monopolize V8, and a later script keeps the event loop non-idle with
+    zero-delay work.
+  -->
+  <script>
+    window.__jsHeavyPageInvoked = ['inline-init'];
+    window.__jsHeavyPageTicks = 0;
+  </script>
+  <script src="/assets/compact-busy-loop.js"></script>
+  <script src="/assets/post-busy-loop.js"></script>
+  <script defer src="/assets/deferred.js"></script>
+  <script async src="/assets/async.js"></script>
+</head>
+<body>
+  <main id="fixture">
+    <button type="button">Continue</button>
+  </main>
+</body>
+</html>

--- a/crates/obscura-js/src/runtime.rs
+++ b/crates/obscura-js/src/runtime.rs
@@ -1,6 +1,7 @@
 use std::cell::RefCell;
 use std::collections::HashMap;
 use std::rc::Rc;
+use std::time::Duration;
 
 use deno_core::{JsRuntime, RuntimeOptions};
 use obscura_dom::DomTree;
@@ -416,18 +417,13 @@ impl ObscuraJsRuntime {
 
         let result = self.runtime.mod_evaluate(module_id);
 
-        let timeout = tokio::time::timeout(
-            tokio::time::Duration::from_secs(10),
-            self.runtime.run_event_loop(deno_core::PollEventLoopOptions::default()),
-        ).await;
-
-        match timeout {
-            Ok(Ok(())) => {}
-            Ok(Err(e)) => return Err(format!("Module event loop error: {}", e)),
-            Err(_) => {
+        match self.run_event_loop_with_timeout(Duration::from_secs(10)).await {
+            Ok(()) => {}
+            Err(e) if e.contains("timed out") => {
                 tracing::warn!("Module evaluation timed out after 10s: {}", url);
                 return Ok(());
             }
+            Err(e) => return Err(format!("Module event loop error: {}", e)),
         }
 
         match result.await {
@@ -458,18 +454,13 @@ impl ObscuraJsRuntime {
 
         let result = self.runtime.mod_evaluate(module_id);
 
-        let timeout = tokio::time::timeout(
-            tokio::time::Duration::from_secs(10),
-            self.runtime.run_event_loop(deno_core::PollEventLoopOptions::default()),
-        ).await;
-
-        match timeout {
-            Ok(Ok(())) => {}
-            Ok(Err(e)) => return Err(format!("Module event loop error: {}", e)),
-            Err(_) => {
+        match self.run_event_loop_with_timeout(Duration::from_secs(10)).await {
+            Ok(()) => {}
+            Err(e) if e.contains("timed out") => {
                 tracing::warn!("Inline module timed out after 10s");
                 return Ok(());
             }
+            Err(e) => return Err(format!("Module event loop error: {}", e)),
         }
 
         match result.await {
@@ -489,17 +480,26 @@ impl ObscuraJsRuntime {
     }
 
     pub fn execute_script_guarded(&mut self, _name: &str, source: &str) -> Result<(), String> {
-        if source.len() < 10_000 {
-            self.execute_script(_name, source)
-        } else {
-            self.execute_script_with_timeout(source, std::time::Duration::from_secs(5))
-        }
+        // Every page script must be attempted, but no single script may pin the
+        // browser forever. Small scripts need the same watchdog as larger scripts
+        // because a compact busy loop can block full-load navigation before later
+        // defer/async scripts run.
+        self.execute_script_with_timeout(source, Self::script_execution_timeout())
+    }
+
+    fn script_execution_timeout() -> Duration {
+        std::env::var("OBSCURA_SCRIPT_TIMEOUT_MS")
+            .ok()
+            .and_then(|raw| raw.parse::<u64>().ok())
+            .filter(|ms| *ms > 0)
+            .map(Duration::from_millis)
+            .unwrap_or_else(|| Duration::from_secs(1))
     }
 
     pub fn execute_script_with_timeout(
         &mut self,
         source: &str,
-        timeout: std::time::Duration,
+        timeout: Duration,
     ) -> Result<(), String> {
         if timeout.is_zero() {
             self.runtime
@@ -553,12 +553,78 @@ impl ObscuraJsRuntime {
             Err(e) => {
                 let msg = e.to_string();
                 if msg.contains("Uncaught Error: execution terminated") {
-                    tracing::warn!("Script killed after {}s timeout", timeout.as_secs());
+                    tracing::warn!("Script killed after {}ms timeout", timeout.as_millis());
+                    let _ = self.runtime.v8_isolate().cancel_terminate_execution();
                     self.runtime.execute_script("<reset>", "undefined".to_string()).ok();
                     Ok(())
                 } else {
                     Err(format!("JS error: {}", msg))
                 }
+            }
+        }
+    }
+
+    pub async fn run_event_loop_with_timeout(&mut self, timeout: Duration) -> Result<(), String> {
+        if timeout.is_zero() {
+            return self.run_event_loop().await;
+        }
+
+        let isolate_handle = self.runtime.v8_isolate().thread_safe_handle();
+        let pair = std::sync::Arc::new((
+            std::sync::Mutex::new(false),
+            std::sync::Condvar::new(),
+        ));
+        let pair_clone = pair.clone();
+
+        let watchdog = std::thread::spawn(move || {
+            let (lock, cvar) = &*pair_clone;
+            let mut cancelled = lock.lock().unwrap();
+            let deadline = std::time::Instant::now() + timeout;
+
+            loop {
+                let remaining = deadline.saturating_duration_since(std::time::Instant::now());
+                if remaining.is_zero() {
+                    isolate_handle.terminate_execution();
+                    return;
+                }
+
+                let result = cvar.wait_timeout(cancelled, remaining).unwrap();
+                cancelled = result.0;
+                if *cancelled {
+                    return;
+                }
+            }
+        });
+
+        let result = tokio::select! {
+            result = self.runtime.run_event_loop(deno_core::PollEventLoopOptions::default()) => Some(result),
+            _ = tokio::time::sleep(timeout) => None,
+        };
+
+        {
+            let (lock, cvar) = &*pair;
+            let mut cancelled = lock.lock().unwrap();
+            *cancelled = true;
+            cvar.notify_one();
+        }
+        let _ = watchdog.join();
+
+        match result {
+            Some(Ok(())) => Ok(()),
+            Some(Err(e)) => {
+                let msg = e.to_string();
+                if msg.contains("execution terminated") {
+                    tracing::warn!("Event loop killed after {}ms timeout", timeout.as_millis());
+                    let _ = self.runtime.v8_isolate().cancel_terminate_execution();
+                    self.runtime.execute_script("<reset>", "undefined".to_string()).ok();
+                    Err(format!("Event loop timed out after {}ms", timeout.as_millis()))
+                } else {
+                    Err(format!("Event loop error: {}", msg))
+                }
+            }
+            None => {
+                let _ = self.runtime.v8_isolate().cancel_terminate_execution();
+                Err(format!("Event loop timed out after {}ms", timeout.as_millis()))
             }
         }
     }
@@ -932,6 +998,34 @@ mod tests {
         .unwrap();
         let result = rt.evaluate("globalThis.__result").unwrap();
         assert_eq!(result, serde_json::json!(["A", "B"]));
+    }
+
+    #[test]
+    fn guarded_small_busy_loop_times_out_and_runtime_recovers() {
+        let mut rt = setup_runtime("<html><body></body></html>");
+        let started = std::time::Instant::now();
+
+        rt.execute_script_guarded(
+            "busy",
+            "globalThis.__busyLoopStarted = true; while (true) {}",
+        )
+        .unwrap();
+
+        assert!(
+            started.elapsed() < std::time::Duration::from_secs(3),
+            "guarded small script was not bounded"
+        );
+        assert_eq!(
+            rt.evaluate("globalThis.__busyLoopStarted").unwrap(),
+            serde_json::json!(true)
+        );
+
+        rt.execute_script("after", "globalThis.__afterBusyLoop = 'still alive';")
+            .unwrap();
+        assert_eq!(
+            rt.evaluate("globalThis.__afterBusyLoop").unwrap(),
+            serde_json::json!("still alive")
+        );
     }
 
     /// Regression test for #147: a TypeError in one script must not poison


### PR DESCRIPTION
## Issue
Full-load navigation could hang when a compact page script monopolized V8 or when load/event-loop pumping waited on non-idle work.

## Generic reproducer case
Adds a local JS-heavy page fixture with parser, deferred, and async scripts. The parser path includes a compact busy-loop script and a follow-up zero-delay interval script to verify all scripts are attempted and navigation remains bounded.

## Tests
- `cargo test -p obscura-js guarded_small_busy_loop_times_out_and_runtime_recovers`
- `cargo test -p obscura-browser --test bounded_full_load_scripts`

## Solution
- Use guarded script execution for all page scripts.
- Add bounded event-loop pumping for module evaluation and load/network-idle waits.
- Reset V8 termination state after watchdog kills a script/event loop.

## Risk / timeout env var
Risk is that extremely slow scripts may now be cut off by the default 1s watchdog. Tune with `OBSCURA_SCRIPT_TIMEOUT_MS` (positive milliseconds).
