### PR TITLE
feat(js): adopt deno_url/web/crypto, enforce navigation deadline

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,6 +9,50 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
+name = "aead"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d122413f284cf2d62fb1b7db97e02edb8cda96d769b16e443a4f6195e35662b0"
+dependencies = [
+ "crypto-common",
+ "generic-array",
+]
+
+[[package]]
+name = "aes"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac1f845298e95f983ff1944b728ae08b8cebab80d684f0a832ed0fc74dfa27e2"
+dependencies = [
+ "cfg-if",
+ "cipher",
+ "cpufeatures",
+]
+
+[[package]]
+name = "aes-gcm"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "831010a0f742e1209b3bcea8fab6a8e149051ba6099432c8cb2cc117dec3ead1"
+dependencies = [
+ "aead",
+ "aes",
+ "cipher",
+ "ctr",
+ "ghash",
+ "subtle",
+]
+
+[[package]]
+name = "aes-kw"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69fa2b352dcefb5f7f3a5fb840e02665d311d878955380515e4fd50095dd3d8c"
+dependencies = [
+ "aes",
+]
+
+[[package]]
 name = "ahash"
 version = "0.8.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -142,6 +186,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be5eb007b7cacc6c660343e96f650fedf4b5a77512399eb952ca6642cf8d13f7"
 
 [[package]]
+name = "base16ct"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
+
+[[package]]
 name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -156,6 +206,12 @@ dependencies = [
  "outref",
  "vsimd",
 ]
+
+[[package]]
+name = "base64ct"
+version = "1.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 
 [[package]]
 name = "bincode"
@@ -247,6 +303,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "block-padding"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8894febbff9f758034a5b8e12d87918f56dfc64a8e1fe757d65e29041538d93"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "boring-sys2"
 version = "5.0.0-alpha.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -331,6 +396,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cbc"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26b52a9543ae338f279b96b0b9fed9c8093744685043739079ce85cd58f289a6"
+dependencies = [
+ "cipher",
+]
+
+[[package]]
 name = "cc"
 version = "1.2.59"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -356,6 +430,16 @@ name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "cipher"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
+dependencies = [
+ "crypto-common",
+ "inout",
+]
 
 [[package]]
 name = "clang-sys"
@@ -442,6 +526,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75984efb6ed102a0d42db99afb6c1948f0380d1d91808d5529916e6c08b49d8d"
 
 [[package]]
+name = "const-oid"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
+
+[[package]]
 name = "cooked-waker"
 version = "5.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -511,12 +601,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "crypto-bigint"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0dc92fb57ca44df6db8059111ab3af99a63d5d0f8375d9972e319a379c6bab76"
+dependencies = [
+ "generic-array",
+ "rand_core 0.6.4",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "crypto-common"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
 dependencies = [
  "generic-array",
+ "rand_core 0.6.4",
  "typenum",
 ]
 
@@ -539,6 +642,41 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13b588ba4ac1a99f7f2964d24b3d896ddc6bf847ee3855dbd4366f058cfcd331"
 dependencies = [
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "ctr"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0369ee1ad671834580515889b80f2ea915f23b8be8d0daa4bbaf2ac5c7590835"
+dependencies = [
+ "cipher",
+]
+
+[[package]]
+name = "curve25519-dalek"
+version = "4.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "curve25519-dalek-derive",
+ "fiat-crypto 0.2.9",
+ "rustc_version",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "curve25519-dalek-derive"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
+dependencies = [
+ "proc-macro2",
  "quote",
  "syn",
 ]
@@ -613,6 +751,46 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fe4dccb6147bb3f3ba0c7a48e993bfeb999d2c2e47a81badee80e2b370c8d695"
 
 [[package]]
+name = "deno_crypto"
+version = "0.221.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69bafb97386adfbee4761516c9a938d82dbf537b9d04b66415b32f5dd7013fc6"
+dependencies = [
+ "aes",
+ "aes-gcm",
+ "aes-kw",
+ "base64",
+ "cbc",
+ "const-oid",
+ "ctr",
+ "curve25519-dalek",
+ "deno_core",
+ "deno_error",
+ "deno_web",
+ "ecdsa",
+ "ed448-goldilocks",
+ "elliptic-curve",
+ "num-traits",
+ "once_cell",
+ "p256",
+ "p384",
+ "p521",
+ "rand 0.8.5",
+ "ring",
+ "rsa",
+ "serde",
+ "serde_bytes",
+ "sha1",
+ "sha2",
+ "signature",
+ "spki",
+ "thiserror",
+ "tokio",
+ "uuid",
+ "x25519-dalek",
+]
+
+[[package]]
 name = "deno_error"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -668,6 +846,44 @@ dependencies = [
 ]
 
 [[package]]
+name = "deno_permissions"
+version = "0.66.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b9256f64185bc173996367f64bb6c85dac6364fd85d60441470b06475d4c61a"
+dependencies = [
+ "capacity_builder",
+ "deno_error",
+ "deno_path_util",
+ "deno_terminal",
+ "deno_unsync",
+ "fqdn",
+ "libc",
+ "log",
+ "nix",
+ "once_cell",
+ "parking_lot",
+ "percent-encoding",
+ "serde",
+ "serde_json",
+ "sys_traits",
+ "temp_deno_which",
+ "thiserror",
+ "url",
+ "winapi",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "deno_terminal"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23f71c27009e0141dedd315f1dfa3ebb0a6ca4acce7c080fac576ea415a465f6"
+dependencies = [
+ "once_cell",
+ "termcolor",
+]
+
+[[package]]
 name = "deno_unsync"
 version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -690,12 +906,44 @@ dependencies = [
 ]
 
 [[package]]
+name = "deno_web"
+version = "0.238.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6788af5a6234e2287157f4a2c3aa083af0587548146c877c4062e20323f4f0b9"
+dependencies = [
+ "async-trait",
+ "base64-simd",
+ "bytes",
+ "deno_core",
+ "deno_error",
+ "deno_permissions",
+ "encoding_rs",
+ "flate2",
+ "futures",
+ "serde",
+ "thiserror",
+ "tokio",
+ "uuid",
+]
+
+[[package]]
 name = "deno_webidl"
 version = "0.207.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23f33442dc019ef045b0185def9603656efa61b3551df745d17218a75da5636c"
 dependencies = [
  "deno_core",
+]
+
+[[package]]
+name = "der"
+version = "0.7.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
+dependencies = [
+ "const-oid",
+ "pem-rfc7468",
+ "zeroize",
 ]
 
 [[package]]
@@ -725,7 +973,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer",
+ "const-oid",
  "crypto-common",
+ "subtle",
 ]
 
 [[package]]
@@ -764,10 +1014,60 @@ dependencies = [
 ]
 
 [[package]]
+name = "ecdsa"
+version = "0.16.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee27f32b5c5292967d2d4a9d7f1e0b0aed2c15daded5a60300e4abb9d8020bca"
+dependencies = [
+ "der",
+ "digest",
+ "elliptic-curve",
+ "rfc6979",
+ "signature",
+ "spki",
+]
+
+[[package]]
+name = "ed448-goldilocks"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06924531e9e90130842b012e447f85bdaf9161bc8a0f8092be8cb70b01ebe092"
+dependencies = [
+ "fiat-crypto 0.1.20",
+ "hex",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+
+[[package]]
+name = "elliptic-curve"
+version = "0.13.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5e6043086bf7973472e0c7dff2142ea0b680d30e18d9cc40f267efbf222bd47"
+dependencies = [
+ "base16ct",
+ "base64ct",
+ "crypto-bigint",
+ "digest",
+ "ff",
+ "generic-array",
+ "group",
+ "hkdf",
+ "pem-rfc7468",
+ "pkcs8",
+ "rand_core 0.6.4",
+ "sec1",
+ "serde_json",
+ "serdect",
+ "subtle",
+ "zeroize",
+]
 
 [[package]]
 name = "encoding_rs"
@@ -799,6 +1099,28 @@ name = "fastrand"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
+
+[[package]]
+name = "ff"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0b50bfb653653f9ca9095b427bed08ab8d75a137839d9ad64eb11810d5b6393"
+dependencies = [
+ "rand_core 0.6.4",
+ "subtle",
+]
+
+[[package]]
+name = "fiat-crypto"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e825f6987101665dea6ec934c09ec6d721de7bc1bf92248e1d5810c8cd636b77"
+
+[[package]]
+name = "fiat-crypto"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
 
 [[package]]
 name = "find-msvc-tools"
@@ -878,6 +1200,12 @@ checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
 ]
+
+[[package]]
+name = "fqdn"
+version = "0.3.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb540cf7bc4fe6df9d8f7f0c974cfd0dce8ed4e9e8884e73433b503ee78b4e7d"
 
 [[package]]
 name = "fs_extra"
@@ -1016,6 +1344,18 @@ checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
 dependencies = [
  "typenum",
  "version_check",
+ "zeroize",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi",
 ]
 
 [[package]]
@@ -1044,10 +1384,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "ghash"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0d8a4362ccb29cb0b265253fb0a2728f592895ee6854fd9bc13f2ffda266ff1"
+dependencies = [
+ "opaque-debug",
+ "polyval",
+]
+
+[[package]]
 name = "glob"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
+
+[[package]]
+name = "group"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0f9ef7462f7c099f518d754361858f86d8a07af53ba9af0fe635bbccb151a63"
+dependencies = [
+ "ff",
+ "rand_core 0.6.4",
+ "subtle",
+]
 
 [[package]]
 name = "gzip-header"
@@ -1084,6 +1445,30 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
+name = "hkdf"
+version = "0.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b5f8eb2ad728638ea2c7d47a21db23b7b58a72ed6a38256b8a1849f15fbbdf7"
+dependencies = [
+ "hmac",
+]
+
+[[package]]
+name = "hmac"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
+dependencies = [
+ "digest",
+]
 
 [[package]]
 name = "home"
@@ -1352,6 +1737,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "inout"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
+dependencies = [
+ "block-padding",
+ "generic-array",
+]
+
+[[package]]
 name = "ipnet"
 version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1415,6 +1810,9 @@ name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+dependencies = [
+ "spin",
+]
 
 [[package]]
 name = "leb128fmt"
@@ -1437,6 +1835,12 @@ dependencies = [
  "cfg-if",
  "windows-link",
 ]
+
+[[package]]
+name = "libm"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
 name = "linux-raw-sys"
@@ -1574,6 +1978,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
 
 [[package]]
+name = "nix"
+version = "0.27.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2eb04e9c688eff1c89d72b407f168cf79bb9e867a9d3323ed6c01519eb9cc053"
+dependencies = [
+ "bitflags",
+ "cfg-if",
+ "libc",
+]
+
+[[package]]
 name = "nom"
 version = "7.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1604,6 +2019,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-bigint-dig"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e661dda6640fad38e827a6d4a310ff4763082116fe217f279885c97f511bb0b7"
+dependencies = [
+ "lazy_static",
+ "libm",
+ "num-integer",
+ "num-iter",
+ "num-traits",
+ "rand 0.8.5",
+ "smallvec",
+ "zeroize",
+]
+
+[[package]]
 name = "num-conv"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1619,12 +2050,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-iter"
+version = "0.1.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1429034a0490724d0075ebb2bc9e875d6503c3cf69e235a8941aa757d83ef5bf"
+dependencies = [
+ "autocfg",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
 name = "num-traits"
 version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
+ "libm",
 ]
 
 [[package]]
@@ -1706,8 +2149,10 @@ dependencies = [
  "base64",
  "deno_console",
  "deno_core",
+ "deno_crypto",
  "deno_error",
  "deno_url",
+ "deno_web",
  "deno_webidl",
  "html5ever",
  "obscura-dom",
@@ -1766,6 +2211,12 @@ name = "once_cell_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
+
+[[package]]
+name = "opaque-debug"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
 name = "openssl"
@@ -1828,6 +2279,44 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a80800c0488c3a21695ea981a54918fbb37abf04f4d0720c453632255e2ff0e"
 
 [[package]]
+name = "p256"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9863ad85fa8f4460f9c48cb909d38a0d689dba1f6f6988a5e3e0d31071bcd4b"
+dependencies = [
+ "ecdsa",
+ "elliptic-curve",
+ "primeorder",
+ "sha2",
+]
+
+[[package]]
+name = "p384"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe42f1670a52a47d448f14b6a5c61dd78fce51856e68edaa38f7ae3a46b8d6b6"
+dependencies = [
+ "ecdsa",
+ "elliptic-curve",
+ "primeorder",
+ "sha2",
+]
+
+[[package]]
+name = "p521"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fc9e2161f1f215afdfce23677034ae137bbd45016a880c2eb3ba8eb95f085b2"
+dependencies = [
+ "base16ct",
+ "ecdsa",
+ "elliptic-curve",
+ "primeorder",
+ "rand_core 0.6.4",
+ "sha2",
+]
+
+[[package]]
 name = "parking_lot"
 version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1855,6 +2344,15 @@ name = "paste"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
+
+[[package]]
+name = "pem-rfc7468"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88b39c9bfcfc231068454382784bb460aae594343fb030d46e9f50a645418412"
+dependencies = [
+ "base64ct",
+]
 
 [[package]]
 name = "percent-encoding"
@@ -1941,10 +2439,43 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
+name = "pkcs1"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8ffb9f10fa047879315e6625af03c164b16962a5368d724ed16323b68ace47f"
+dependencies = [
+ "der",
+ "pkcs8",
+ "spki",
+]
+
+[[package]]
+name = "pkcs8"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
+dependencies = [
+ "der",
+ "spki",
+]
+
+[[package]]
 name = "pkg-config"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
+
+[[package]]
+name = "polyval"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d1fe60d06143b2430aa532c94cfe9e29783047f06c0d7fd359a9a51b729fa25"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "opaque-debug",
+ "universal-hash",
+]
 
 [[package]]
 name = "potential_utf"
@@ -1984,6 +2515,15 @@ checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
  "syn",
+]
+
+[[package]]
+name = "primeorder"
+version = "0.13.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "353e1ca18966c16d9deb1c69278edbc5f194139612772bd9537af60ac231e1e6"
+dependencies = [
+ "elliptic-curve",
 ]
 
 [[package]]
@@ -2067,6 +2607,8 @@ version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
+ "libc",
+ "rand_chacha 0.3.1",
  "rand_core 0.6.4",
 ]
 
@@ -2076,8 +2618,18 @@ version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
 dependencies = [
- "rand_chacha",
+ "rand_chacha 0.9.0",
  "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -2095,6 +2647,9 @@ name = "rand_core"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+dependencies = [
+ "getrandom 0.2.17",
+]
 
 [[package]]
 name = "rand_core"
@@ -2182,10 +2737,63 @@ dependencies = [
 ]
 
 [[package]]
+name = "rfc6979"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dd2a808d456c4a54e300a23e9f5a67e122c3024119acbfd73e3bf664491cb2"
+dependencies = [
+ "hmac",
+ "subtle",
+]
+
+[[package]]
+name = "ring"
+version = "0.17.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "getrandom 0.2.17",
+ "libc",
+ "untrusted",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rsa"
+version = "0.9.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8573f03f5883dcaebdfcf4725caa1ecb9c15b2ef50c43a07b816e06799bb12d"
+dependencies = [
+ "const-oid",
+ "digest",
+ "num-bigint-dig",
+ "num-integer",
+ "num-traits",
+ "pkcs1",
+ "pkcs8",
+ "rand_core 0.6.4",
+ "signature",
+ "spki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "rustc-hash"
 version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
+
+[[package]]
+name = "rustc_version"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
+dependencies = [
+ "semver",
+]
 
 [[package]]
 name = "rustix"
@@ -2261,6 +2869,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
+name = "sec1"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3e97a565f76233a6003f9f5c54be1d9c5bdfa3eccfb189469f11ec4901c47dc"
+dependencies = [
+ "base16ct",
+ "der",
+ "generic-array",
+ "pkcs8",
+ "serdect",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "security-framework"
 version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2316,6 +2939,16 @@ checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
 dependencies = [
  "serde_core",
  "serde_derive",
+]
+
+[[package]]
+name = "serde_bytes"
+version = "0.11.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5d440709e79d88e51ac01c4b72fc6cb7314017bb7da9eeff678aa94c10e3ea8"
+dependencies = [
+ "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -2379,6 +3012,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "serdect"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a84f14a19e9a014bb9f4512488d9829a68e04ecabffb0f9904cd1ace94598177"
+dependencies = [
+ "base16ct",
+ "serde",
+]
+
+[[package]]
 name = "servo_arc"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2435,6 +3078,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "signature"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
+dependencies = [
+ "digest",
+ "rand_core 0.6.4",
+]
+
+[[package]]
 name = "simd-adler32"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2484,6 +3137,22 @@ dependencies = [
  "serde_json",
  "unicode-id-start",
  "url",
+]
+
+[[package]]
+name = "spin"
+version = "0.9.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+
+[[package]]
+name = "spki"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
+dependencies = [
+ "base64ct",
+ "der",
 ]
 
 [[package]]
@@ -2557,6 +3226,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "subtle"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
+
+[[package]]
 name = "syn"
 version = "2.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2589,9 +3264,9 @@ dependencies = [
 
 [[package]]
 name = "sys_traits"
-version = "0.1.27"
+version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a79feaa49de4a6c8191bdbd5fb3eada50671e9367d874d1c12e3d36db131414"
+checksum = "dc4707edf3196e8037ee45018d1bb1bfb233b0e4fc440fa3d3f25bc69bfdaf26"
 dependencies = [
  "sys_traits_macros",
 ]
@@ -2612,6 +3287,15 @@ name = "tap"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
+
+[[package]]
+name = "temp_deno_which"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "366c5ccd670145885feb6efd6bbf2478ed236c4c3839046fcc8e2a1a84c51091"
+dependencies = [
+ "either",
+]
 
 [[package]]
 name = "tempfile"
@@ -2635,6 +3319,15 @@ dependencies = [
  "futf",
  "mac",
  "utf-8",
+]
+
+[[package]]
+name = "termcolor"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755"
+dependencies = [
+ "winapi-util",
 ]
 
 [[package]]
@@ -3000,6 +3693,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
+name = "universal-hash"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc1de2c688dc15305988b563c3854064043356019f97a4b46276fe734c4f07ea"
+dependencies = [
+ "crypto-common",
+ "subtle",
+]
+
+[[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
 name = "url"
 version = "2.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3050,6 +3759,7 @@ checksum = "5ac8b6f42ead25368cf5b098aeb3dc8a1a2c05a3eee8a9a1a68c640edbfc79d9"
 dependencies = [
  "getrandom 0.4.2",
  "js-sys",
+ "serde_core",
  "wasm-bindgen",
 ]
 
@@ -3273,6 +3983,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
 
 [[package]]
+name = "winapi-util"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3289,6 +4008,15 @@ name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.59.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
  "windows-targets",
 ]
@@ -3520,6 +4248,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "x25519-dalek"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7e468321c81fb07fa7f4c636c3972b9100f0346e5b6a9f2bd0603a52f7ed277"
+dependencies = [
+ "curve25519-dalek",
+ "rand_core 0.6.4",
+ "serde",
+ "zeroize",
+]
+
+[[package]]
 name = "yoke"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3588,6 +4328,20 @@ name = "zeroize"
 version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+dependencies = [
+ "zeroize_derive",
+]
+
+[[package]]
+name = "zeroize_derive"
+version = "1.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85a5b4158499876c763cb03bc4e49185d3cccbabb15b33c627f7884f43db852e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "zerotrie"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -560,6 +560,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "deno_console"
+version = "0.207.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b3a607e9d9a83083d3afcf2873003af96562cb7f405d01a43f682ae78d54820"
+dependencies = [
+ "deno_core",
+]
+
+[[package]]
 name = "deno_core"
 version = "0.350.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -667,6 +676,26 @@ dependencies = [
  "futures-util",
  "parking_lot",
  "tokio",
+]
+
+[[package]]
+name = "deno_url"
+version = "0.207.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64ab901dd2de18ad9ba6a31b6d591c517759254efedbc9424adbd0f9bc709946"
+dependencies = [
+ "deno_core",
+ "deno_error",
+ "urlpattern",
+]
+
+[[package]]
+name = "deno_webidl"
+version = "0.207.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23f33442dc019ef045b0185def9603656efa61b3551df745d17218a75da5636c"
+dependencies = [
+ "deno_core",
 ]
 
 [[package]]
@@ -1675,8 +1704,11 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "base64",
+ "deno_console",
  "deno_core",
  "deno_error",
+ "deno_url",
+ "deno_webidl",
  "html5ever",
  "obscura-dom",
  "obscura-net",
@@ -2909,6 +2941,47 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
 
 [[package]]
+name = "unic-char-property"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8c57a407d9b6fa02b4795eb81c5b6652060a15a7903ea981f3d723e6c0be221"
+dependencies = [
+ "unic-char-range",
+]
+
+[[package]]
+name = "unic-char-range"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0398022d5f700414f6b899e10b8348231abf9173fa93144cbc1a43b9793c1fbc"
+
+[[package]]
+name = "unic-common"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "80d7ff825a6a654ee85a63e80f92f054f904f21e7d12da4e22f9834a4aaa35bc"
+
+[[package]]
+name = "unic-ucd-ident"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e230a37c0381caa9219d67cf063aa3a375ffed5bf541a452db16e744bdab6987"
+dependencies = [
+ "unic-char-property",
+ "unic-char-range",
+ "unic-ucd-version",
+]
+
+[[package]]
+name = "unic-ucd-version"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96bd2f2237fe450fcd0a1d2f5f4e91711124f7857ba2e964247776ebeeb7b0c4"
+dependencies = [
+ "unic-common",
+]
+
+[[package]]
 name = "unicode-id-start"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2937,6 +3010,18 @@ dependencies = [
  "percent-encoding",
  "serde",
  "serde_derive",
+]
+
+[[package]]
+name = "urlpattern"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70acd30e3aa1450bc2eece896ce2ad0d178e9c079493819301573dae3c37ba6d"
+dependencies = [
+ "regex",
+ "serde",
+ "unic-ucd-ident",
+ "url",
 ]
 
 [[package]]

--- a/crates/obscura-browser/src/page.rs
+++ b/crates/obscura-browser/src/page.rs
@@ -149,6 +149,12 @@ pub struct Page {
     // contract. Includes `Runtime.addBinding` shims so puppeteer's
     // `exposeFunction` bindings exist before inline `<script>` tags execute.
     preload_scripts: Vec<String>,
+    /// Hard wall-clock deadline for the *current* navigation. Threaded
+    /// into the synchronous JS execution path so a single page-supplied
+    /// script can no longer hold the tokio executor past `--timeout` —
+    /// `tokio::time::timeout` only fires at await points, and inline
+    /// `<script>` evaluation has none.
+    navigation_deadline: Option<std::time::Instant>,
     #[cfg(feature = "stealth")]
     pub stealth_client: Option<Arc<StealthHttpClient>>,
 }
@@ -196,9 +202,27 @@ impl Page {
             intercept_block_patterns: Vec::new(),
             intercept_tx: None,
             preload_scripts: Vec::new(),
+            navigation_deadline: None,
             #[cfg(feature = "stealth")]
             stealth_client,
         }
+    }
+
+    /// Set a wall-clock deadline that bounds the next navigation. Pass
+    /// `None` to clear. The deadline is checked between scripts and is
+    /// also handed to the per-script V8 watchdog so synchronous JS work
+    /// is terminated when it overruns.
+    pub fn set_navigation_deadline(&mut self, deadline: Option<std::time::Instant>) {
+        self.navigation_deadline = deadline;
+    }
+
+    fn navigation_remaining(&self) -> Option<std::time::Duration> {
+        self.navigation_deadline
+            .map(|d| d.saturating_duration_since(std::time::Instant::now()))
+    }
+
+    fn navigation_expired(&self) -> bool {
+        matches!(self.navigation_remaining(), Some(r) if r.is_zero())
     }
 
     fn should_block_url(&self, url: &str) -> bool {
@@ -408,6 +432,7 @@ impl Page {
         }
 
         let client = self.http_client.clone();
+        let nav_deadline = self.navigation_deadline;
         let fetch_futures: Vec<_> = fetch_tasks.iter().map(|(idx, url)| {
             let client = client.clone();
             let url = url.clone();
@@ -438,10 +463,18 @@ impl Page {
                     };
                     return Some((idx, url, resp));
                 }
-                match client.fetch(&parsed).await {
-                    Ok(resp) => Some((idx, url, resp)),
-                    Err(e) => {
+                let fetch_budget = nav_deadline
+                    .map(|d| d.saturating_duration_since(std::time::Instant::now()))
+                    .filter(|d| !d.is_zero())
+                    .unwrap_or_else(|| std::time::Duration::from_secs(30));
+                match tokio::time::timeout(fetch_budget, client.fetch(&parsed)).await {
+                    Ok(Ok(resp)) => Some((idx, url, resp)),
+                    Ok(Err(e)) => {
                         tracing::warn!("Failed to fetch script {}: {}", url, e);
+                        None
+                    }
+                    Err(_) => {
+                        tracing::debug!("Script fetch deadline exceeded: {}", url);
                         None
                     }
                 }
@@ -500,13 +533,26 @@ impl Page {
                 );
                 break;
             }
+            // Hard cut-off when the caller's deadline has elapsed. Without
+            // this, `--timeout=1` on a script-heavy page would still run
+            // every remaining `<script>` to completion because the
+            // synchronous V8 calls below never yield to the tokio
+            // executor.
+            if self.navigation_expired() {
+                break;
+            }
+            let script_budget = self
+                .navigation_remaining()
+                .unwrap_or_else(|| std::time::Duration::from_secs(5));
+
+
             if script.src.is_some() {
                 if let Some((url, code, resp)) = fetched.remove(&i) {
                     tracing::info!("Executing script ({} bytes): {}", code.len(), url);
                     self.record_network_event(&url, "GET", "Script", resp.status, &resp.headers, resp.body.len());
                     if let Some(js) = &mut self.js {
                         let _ = js.execute_script("<current-script>", &format!("globalThis.__currentScriptNid={};", script.nid));
-                        if let Err(e) = js.execute_script_guarded(&url, &code) {
+                        if let Err(e) = js.execute_script_with_timeout(&code, script_budget) {
                             tracing::warn!("Script error ({}): {}", url, e);
                         }
                         let _ = js.execute_script("<current-script>", "globalThis.__currentScriptNid=0;");
@@ -515,7 +561,7 @@ impl Page {
             } else if !script.inline.is_empty() {
                 if let Some(js) = &mut self.js {
                     let _ = js.execute_script("<current-script>", &format!("globalThis.__currentScriptNid={};", script.nid));
-                    if let Err(e) = js.execute_script_guarded("<inline>", &script.inline) {
+                    if let Err(e) = js.execute_script_with_timeout(&script.inline, script_budget) {
                         tracing::warn!("Inline script error: {}", e);
                     }
                     let _ = js.execute_script("<current-script>", "globalThis.__currentScriptNid=0;");
@@ -523,9 +569,29 @@ impl Page {
             }
         }
 
-        for module_script in &module_scripts {
+        for module_script in module_scripts.iter() {
             if tokio::time::Instant::now() >= script_deadline {
                 tracing::warn!("execute_scripts: deadline reached, skipping remaining module scripts");
+                break;
+            }
+            if self.navigation_expired() {
+                break;
+            }
+            let module_budget = self
+                .navigation_remaining()
+                .unwrap_or_else(|| std::time::Duration::from_secs(10));
+
+            // V8 module evaluation cannot be reliably interrupted: JS try-catch
+            // absorbs terminate_execution(), so the module runs to natural
+            // completion regardless of the watchdog. Only start a module when
+            // there is enough budget to absorb its worst-case run time.
+            const MIN_MODULE_BUDGET: std::time::Duration = std::time::Duration::from_secs(15);
+            if self.navigation_deadline.is_some() && module_budget < MIN_MODULE_BUDGET {
+                tracing::info!(
+                    "skipping ES module: only {:.1}s remaining (need {}s min)",
+                    module_budget.as_secs_f64(),
+                    MIN_MODULE_BUDGET.as_secs()
+                );
                 break;
             }
             if let Some(ref src) = module_script.src {
@@ -539,7 +605,7 @@ impl Page {
 
                 tracing::info!("Loading ES module: {}", full_url);
                 if let Some(js) = &mut self.js {
-                    match js.load_module(&full_url).await {
+                    match js.load_module(&full_url, module_budget).await {
                         Ok(()) => {
                             tracing::info!("ES module loaded: {}", full_url);
                             self.record_network_event(&full_url, "GET", "Script", 200, &std::collections::HashMap::new(), 0);
@@ -552,38 +618,57 @@ impl Page {
             } else if !module_script.inline.is_empty() {
                 let base = self.url_string();
                 if let Some(js) = &mut self.js {
-                    if let Err(e) = js.load_inline_module(&module_script.inline, &base).await {
+                    if let Err(e) = js.load_inline_module(&module_script.inline, &base, module_budget).await {
                         tracing::warn!("Inline ES module error: {}", e);
                     }
                 }
             }
         }
 
+        // Compute budgets before mutably borrowing self.js.
+        let events_budget = self
+            .navigation_remaining()
+            .unwrap_or_else(|| std::time::Duration::from_secs(5))
+            .max(std::time::Duration::from_millis(50));
+        let event_loop_cap = std::time::Duration::from_millis(500);
+        let event_loop_budget = self
+            .navigation_remaining()
+            .map(|r| r.min(event_loop_cap))
+            .unwrap_or(event_loop_cap);
+
         if let Some(js) = &mut self.js {
             // Spec order: readyState -> interactive, fire DOMContentLoaded on both
             // document and window, then readyState -> complete, fire load.
-            let _ = js.execute_script("<load-events>",
+            // Allow at least 50 ms so basic event dispatch always completes, but cap
+            // at the remaining navigation budget so heavy onload handlers don't escape.
+            let _ = js.execute_script_with_timeout(
                 "globalThis.__documentReadyState__ = 'interactive';\n\
                  try { document.dispatchEvent(new Event('DOMContentLoaded', {bubbles:false,cancelable:false})); } catch(e) {}\n\
                  try { window.dispatchEvent(new Event('DOMContentLoaded', {bubbles:false,cancelable:false})); } catch(e) {}\n\
                  if (typeof window.onload === 'function') { try { window.onload(); } catch(e) {} }\n\
                  globalThis.__documentReadyState__ = 'complete';\n\
-                 try { window.dispatchEvent(new Event('load', {bubbles:false,cancelable:false})); } catch(e) {}");
+                 try { window.dispatchEvent(new Event('load', {bubbles:false,cancelable:false})); } catch(e) {}",
+                events_budget,
+            );
         }
 
         if let Some(js) = &mut self.js {
-            // Bound the post-script settle loop by wall clock, not just by the
-            // 10ms-tick branch. The old code only consulted `deadline` inside
-            // the `Err(_)` arm (when the inner tick timed out), so a steady
+            // Bound the post-script settle loop. `event_loop_budget` caps at
+            // 500ms (or the remaining navigation budget, whichever is
+            // smaller). The old code only consulted `deadline` inside the
+            // `Err(_)` arm (when the inner tick timed out), so a steady
             // stream of inflight XHR/fetch (active_requests() > 0) kept the
             // loop running indefinitely because it took the `Ok(Ok(()))` arm
             // and slept 1ms each iteration without ever checking the clock.
             // On busy sites this could keep the V8 lock held for tens of
-            // seconds, wedging the entire CDP dispatcher (see triage for
-            // issue series around the 40-site compat sweep).
-            let deadline = tokio::time::Instant::now() + tokio::time::Duration::from_millis(500);
+            // seconds, wedging the entire CDP dispatcher.
+            let deadline = tokio::time::Instant::now() + event_loop_budget;
             let mut idle_count = 0u32;
             loop {
+                // Check the deadline on every iteration, not only in the
+                // timeout branch — otherwise a page that keeps the event
+                // loop "busy" (microtask spirals, stuck XHRs) can loop here
+                // indefinitely because the deadline check is unreachable.
                 if tokio::time::Instant::now() >= deadline {
                     break;
                 }
@@ -942,6 +1027,16 @@ impl Page {
         // of waitUntil and DCL means "DOM parsed AND scripts executed".
         self.execute_scripts().await;
 
+        // execute_scripts honours the deadline internally and breaks
+        // early, but `Ok(())` from there is ambiguous: the caller still
+        // sees "navigation succeeded". Surface the timeout so the CLI
+        // produces the expected "Timed out navigating" error instead of
+        // silently returning a partially-rendered page.
+        if self.navigation_expired() {
+            self.lifecycle = LifecycleState::Failed;
+            return Err(PageError::NavigationTimedOut);
+        }
+
         self.lifecycle = LifecycleState::DomContentLoaded;
 
         if wait_until == crate::lifecycle::WaitUntil::DomContentLoaded {
@@ -1263,6 +1358,9 @@ pub enum PageError {
 
     #[error("Too many redirects (limit {0})")]
     TooManyRedirects(usize),
+
+    #[error("Navigation deadline exceeded")]
+    NavigationTimedOut,
 }
 
 impl From<ObscuraNetError> for PageError {

--- a/crates/obscura-cli/src/main.rs
+++ b/crates/obscura-cli/src/main.rs
@@ -525,8 +525,25 @@ async fn run_fetch(
         eprintln!("Fetching {}...", url_str);
     }
 
+    // tokio::time::timeout can only fire at await points, so synchronous
+    // V8 work (page-supplied `<script>` evaluation) used to hold the
+    // executor for the entire duration of every script regardless of
+    // `--timeout`. Plumb the deadline into the page itself so each
+    // script runs under a V8 watchdog with the remaining budget, and
+    // the navigation aborts cleanly between scripts once the deadline
+    // is past. The outer `timeout(...)` wrapper still guards async-only
+    // hangs (slow network, idle wait).
+    let deadline = std::time::Instant::now() + Duration::from_secs(timeout_secs);
+    page.set_navigation_deadline(Some(deadline));
+
     match timeout(Duration::from_secs(timeout_secs), page.navigate_with_wait(url_str, wait_condition)).await {
-        Ok(result) => result.map_err(|e| anyhow::anyhow!("Failed to navigate to {}: {}", url_str, e))?,
+        Ok(Ok(())) => {}
+        Ok(Err(obscura_browser::page::PageError::NavigationTimedOut)) => anyhow::bail!(
+            "Timed out navigating to {} after {}s",
+            url_str,
+            timeout_secs
+        ),
+        Ok(Err(e)) => return Err(anyhow::anyhow!("Failed to navigate to {}: {}", url_str, e)),
         Err(_) => anyhow::bail!(
             "Timed out navigating to {} after {}s",
             url_str,

--- a/crates/obscura-js/Cargo.toml
+++ b/crates/obscura-js/Cargo.toml
@@ -8,6 +8,8 @@ deno_core = "0.350"
 deno_url = "0.207"
 deno_webidl = "0.207"
 deno_console = "0.207"
+deno_web = "0.238"
+deno_crypto = "0.221"
 
 [dependencies]
 obscura-dom = { workspace = true }
@@ -16,6 +18,8 @@ deno_core = "0.350"
 deno_url = "0.207"
 deno_webidl = "0.207"
 deno_console = "0.207"
+deno_web = "0.238"
+deno_crypto = "0.221"
 tokio = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/crates/obscura-js/Cargo.toml
+++ b/crates/obscura-js/Cargo.toml
@@ -5,11 +5,17 @@ edition.workspace = true
 
 [build-dependencies]
 deno_core = "0.350"
+deno_url = "0.207"
+deno_webidl = "0.207"
+deno_console = "0.207"
 
 [dependencies]
 obscura-dom = { workspace = true }
 obscura-net = { workspace = true }
 deno_core = "0.350"
+deno_url = "0.207"
+deno_webidl = "0.207"
+deno_console = "0.207"
 tokio = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/crates/obscura-js/build.rs
+++ b/crates/obscura-js/build.rs
@@ -1,7 +1,11 @@
 use std::path::PathBuf;
 
+#[path = "src/deno_extensions.rs"]
+mod deno_extensions;
+
 fn main() {
     println!("cargo:rerun-if-changed=js/bootstrap.js");
+    println!("cargo:rerun-if-changed=src/deno_extensions.rs");
     println!("cargo:rerun-if-changed=build.rs");
 
     let out_dir = PathBuf::from(std::env::var("OUT_DIR").unwrap());
@@ -14,7 +18,7 @@ fn main() {
             cargo_manifest_dir: env!("CARGO_MANIFEST_DIR"),
             startup_snapshot: None,
             skip_op_registration: true,
-            extensions: vec![],
+            extensions: deno_extensions::build(),
             extension_transpiler: None,
             with_runtime_cb: Some(Box::new(move |runtime| {
                 runtime

--- a/crates/obscura-js/js/bootstrap.js
+++ b/crates/obscura-js/js/bootstrap.js
@@ -145,45 +145,12 @@ globalThis.console = {
   assert: (c, ...a) => { if (!c) _consoleFn("error", ["Assertion failed:", ...a]); },
 };
 
-let _tid = 0;
-const _clearedTimers = new Set();
-const _intervals = new Set();
-
-const _scheduleAfter = (delay, fn) => {
-  const d = Math.max(0, Number(delay) || 0);
-  if (d === 0) Promise.resolve().then(fn);
-  else Deno.core.ops.op_sleep(d).then(fn);
-};
-
-globalThis.setTimeout = (fn, delay = 0, ...args) => {
-  if (typeof fn !== "function") return ++_tid;
-  const id = ++_tid;
-  _scheduleAfter(delay, () => {
-    if (_clearedTimers.has(id)) return;
-    try { fn(...args); } catch(e) { console.error("Timer error:", e); }
-  });
-  return id;
-};
-
-globalThis.clearTimeout = (id) => { _clearedTimers.add(id); };
-
-globalThis.setInterval = (fn, delay = 0, ...args) => {
-  if (typeof fn !== "function") return ++_tid;
-  const id = ++_tid;
-  _intervals.add(id);
-  const tick = () => {
-    if (!_intervals.has(id)) return;
-    try { fn(...args); } catch(e) { console.error("Interval error:", e); }
-    if (!_intervals.has(id)) return;
-    _scheduleAfter(delay, tick);
-  };
-  _scheduleAfter(delay, tick);
-  return id;
-};
-
-globalThis.clearInterval = (id) => { _intervals.delete(id); _clearedTimers.add(id); };
+// setTimeout / setInterval / clearTimeout / clearInterval are provided by
+// deno_web (see deno_extensions.rs). requestAnimationFrame is not in
+// deno_web; we wire it to setTimeout(0) — close enough for a headless
+// scraping browser with no rendering pipeline.
 globalThis.requestAnimationFrame = (fn) => setTimeout(fn, 0);
-globalThis.cancelAnimationFrame = globalThis.clearTimeout;
+globalThis.cancelAnimationFrame = (id) => clearTimeout(id);
 globalThis.queueMicrotask = globalThis.queueMicrotask || ((fn) => Promise.resolve().then(fn));
 
 class CSSStyleDeclaration {
@@ -547,6 +514,71 @@ class Element extends Node {
   setAttributeNS(ns, n, v) { this.setAttribute(n, v); } // Simplified NS handling
   removeAttribute(n) { _dom("remove_attribute", this._nid, n); }
   removeAttributeNS(ns, n) { this.removeAttribute(n); }
+  // <slot> element API. Obscura has no slot-distribution pipeline; return
+  // empty so libraries (e.g. Swiper, Lit, lit-html) keep mounting.
+  assignedNodes() { return []; }
+  assignedElements() { return []; }
+  // HTMLMediaElement no-ops. Obscura doesn't run a video/audio pipeline,
+  // but bundles probe `<video>` capability with `el.play()` (e.g. WaPo's
+  // zeus/main.js iOS-Safari sniff plays a tiny MP4 to feature-detect
+  // playsinline support) and React components call play/pause on refs.
+  play() { return Promise.resolve(); }
+  pause() {}
+  load() {}
+  canPlayType() { return ""; }
+  // <style>.sheet and <link rel=stylesheet>.sheet. CSS-in-JS runtimes
+  // (Stitches, Emotion, styled-components, Goober) read `el.sheet.cssRules`
+  // to detect already-injected rules during hydration. We don't apply CSS,
+  // but giving them a CSSStyleSheet backed by the element's textContent
+  // lets them keep working.
+  get sheet() {
+    const tag = this.localName;
+    if (tag !== "style" && tag !== "link") return null;
+    if (!this._sheet) {
+      this._sheet = new CSSStyleSheet();
+      if (tag === "style") {
+        const text = this.textContent || "";
+        if (text) this._sheet.replaceSync(text);
+      }
+    }
+    return this._sheet;
+  }
+  removeAttributeNode(attr) {
+    if (attr && typeof attr.name === "string") this.removeAttribute(attr.name);
+    return attr;
+  }
+  getAttributeNode(n) {
+    const v = this.getAttribute(n);
+    return v === null ? null : { name: n, value: v, namespaceURI: null, ownerElement: this, specified: true };
+  }
+  setAttributeNode(attr) {
+    if (attr && typeof attr.name === "string") this.setAttribute(attr.name, attr.value ?? "");
+    return attr;
+  }
+  get attributes() {
+    const el = this;
+    return new Proxy({}, {
+      get(_t, p) {
+        const pairs = _domParse("element_attributes", el._nid) || [];
+        if (p === "length") return pairs.length;
+        if (p === Symbol.iterator) {
+          return function*() {
+            for (const [name, value] of pairs) yield { name, value, namespaceURI: null, ownerElement: el, specified: true };
+          };
+        }
+        if (p === "item") return (i) => {
+          const e = pairs[i];
+          return e ? { name: e[0], value: e[1], namespaceURI: null, ownerElement: el, specified: true } : null;
+        };
+        if (p === "getNamedItem") return (name) => el.getAttributeNode(name);
+        if (typeof p === "string" && /^\d+$/.test(p)) {
+          const e = pairs[+p];
+          return e ? { name: e[0], value: e[1], namespaceURI: null, ownerElement: el, specified: true } : undefined;
+        }
+        return undefined;
+      },
+    });
+  }
   hasAttribute(n) { return this.getAttribute(n) !== null; }
   hasAttributes() { return true; } // Simplified
   get attributes() {
@@ -761,8 +793,48 @@ class Element extends Node {
   set name(v) { this.setAttribute("name", v); }
   get placeholder() { return this.getAttribute("placeholder") || ""; }
   set placeholder(v) { this.setAttribute("placeholder", v); }
-  get href() { return this.getAttribute("href") || ""; }
+  get dir() { return this.getAttribute("dir") || ""; }
+  set dir(v) { this.setAttribute("dir", v); }
+  get lang() { return this.getAttribute("lang") || ""; }
+  set lang(v) { this.setAttribute("lang", v); }
+  get title() { return this.getAttribute("title") || ""; }
+  set title(v) { this.setAttribute("title", v); }
+  get hidden() { return this.hasAttribute("hidden"); }
+  set hidden(v) { if (v) this.setAttribute("hidden", ""); else this.removeAttribute("hidden"); }
+  get tabIndex() { const v = this.getAttribute("tabindex"); return v === null ? -1 : parseInt(v, 10) || 0; }
+  set tabIndex(v) { this.setAttribute("tabindex", String(v|0)); }
+  get isContentEditable() { return this.getAttribute("contenteditable") === "true"; }
+  get contentEditable() { return this.getAttribute("contenteditable") || "inherit"; }
+  set contentEditable(v) { this.setAttribute("contenteditable", String(v)); }
+  get draggable() { return this.getAttribute("draggable") === "true"; }
+  set draggable(v) { this.setAttribute("draggable", v ? "true" : "false"); }
+  get spellcheck() { return this.getAttribute("spellcheck") !== "false"; }
+  set spellcheck(v) { this.setAttribute("spellcheck", v ? "true" : "false"); }
+  get href() {
+    const raw = this.getAttribute("href");
+    if (raw === null) return "";
+    const tag = this.localName;
+    if (tag === "a" || tag === "area") {
+      try { return new URL(raw, _domParse("document_url") || "about:blank").href; } catch { return raw; }
+    }
+    return raw;
+  }
   set href(v) { this.setAttribute("href", v); }
+  get _hyperlinkURL() {
+    const tag = this.localName;
+    if (tag !== "a" && tag !== "area") return null;
+    const raw = this.getAttribute("href");
+    if (raw === null) return null;
+    try { return new URL(raw, _domParse("document_url") || "about:blank"); } catch { return null; }
+  }
+  get origin()   { const u = this._hyperlinkURL; return u ? u.origin   : ""; }
+  get protocol() { const u = this._hyperlinkURL; return u ? u.protocol : ""; }
+  get host()     { const u = this._hyperlinkURL; return u ? u.host     : ""; }
+  get hostname() { const u = this._hyperlinkURL; return u ? u.hostname : ""; }
+  get port()     { const u = this._hyperlinkURL; return u ? u.port     : ""; }
+  get pathname() { const u = this._hyperlinkURL; return u ? u.pathname : ""; }
+  get search()   { const u = this._hyperlinkURL; return u ? u.search   : ""; }
+  get hash()     { const u = this._hyperlinkURL; return u ? u.hash     : ""; }
   get src() { return this.getAttribute("src") || ""; }
   set src(v) {
     this.setAttribute("src", v);
@@ -1253,7 +1325,15 @@ class Document extends Node {
       hasFeature() { return true; },
     };
   }
-  get styleSheets() { return []; }
+  get styleSheets() {
+    const els = this.querySelectorAll("style, link[rel=stylesheet]");
+    const out = [];
+    for (let i = 0; i < els.length; i++) {
+      const s = els[i].sheet;
+      if (s) out.push(s);
+    }
+    return out;
+  }
   get forms() { return this.querySelectorAll("form"); }
   get images() { return this.querySelectorAll("img"); }
   get links() { return this.querySelectorAll("a[href], area[href]"); }
@@ -1461,7 +1541,12 @@ globalThis.navigator = {
   vendor: "Google Inc.", product: "Gecko", productSub: "20030107",
   doNotTrack: null,
   deviceMemory: 8,
-  connection: { effectiveType: "4g", rtt: 50, downlink: 10, saveData: false },
+  connection: (() => {
+    const c = new EventTarget();
+    c.effectiveType = "4g"; c.rtt = 50; c.downlink = 10; c.saveData = false;
+    c.type = "wifi"; c.onchange = null;
+    return c;
+  })(),
   get webdriver() { return undefined; },
   pdfViewerEnabled: true,
   get plugins() {
@@ -2120,37 +2205,132 @@ globalThis.getSelection = _markNative(function getSelection() {
   };
 });
 
+// Parse one CSS rule into a CSSRule-shaped object. Handles plain style rules
+// (`sel { decls }`), @media wrappers, @keyframes, and bare @-rules. Stitches /
+// Emotion / styled-components iterate `cssRules` and read `.selectorText`,
+// `.style.cssText`, `.type`, `.conditionText` — give them enough that those
+// reads return something sensible.
+function _parseCSSRule(text, sheet) {
+  const t = String(text ?? "").trim();
+  if (!t) return { cssText: "", type: 1, selectorText: "", style: _makeCSSStyleDecl(""), parentStyleSheet: sheet, parentRule: null };
+  if (t.startsWith("@")) {
+    const m = t.match(/^@([a-z-]+)\s*([^{]*)\{/i);
+    const kind = m ? m[1].toLowerCase() : "";
+    // 1=STYLE, 4=MEDIA, 7=KEYFRAMES, 5=FONT_FACE, 8=KEYFRAME, 12=SUPPORTS
+    const TYPES = { media: 4, keyframes: 7, "font-face": 5, supports: 12, import: 3, charset: 2, page: 6 };
+    const type = TYPES[kind] ?? 0;
+    return {
+      cssText: t, type,
+      cssRules: [], conditionText: m ? m[2].trim() : "",
+      name: kind === "keyframes" && m ? m[2].trim() : "",
+      parentStyleSheet: sheet, parentRule: null,
+    };
+  }
+  const brace = t.indexOf("{");
+  if (brace < 0) return { cssText: t, type: 1, selectorText: t, style: _makeCSSStyleDecl(""), parentStyleSheet: sheet, parentRule: null };
+  const selector = t.slice(0, brace).trim();
+  const body = t.slice(brace + 1).replace(/\}\s*$/, "");
+  return {
+    cssText: t,
+    type: 1,
+    selectorText: selector,
+    style: _makeCSSStyleDecl(body),
+    parentStyleSheet: sheet,
+    parentRule: null,
+  };
+}
+
+function _makeCSSStyleDecl(cssText) {
+  const props = new Map();
+  const text = String(cssText ?? "").trim();
+  if (text) {
+    for (const decl of text.split(";")) {
+      const colon = decl.indexOf(":");
+      if (colon < 0) continue;
+      const name = decl.slice(0, colon).trim();
+      const value = decl.slice(colon + 1).trim();
+      if (name) props.set(name, value);
+    }
+  }
+  const obj = {
+    get cssText() {
+      return Array.from(props).map(([k, v]) => `${k}: ${v}`).join("; ");
+    },
+    set cssText(v) {
+      props.clear();
+      for (const decl of String(v ?? "").split(";")) {
+        const colon = decl.indexOf(":");
+        if (colon < 0) continue;
+        const n = decl.slice(0, colon).trim();
+        const vv = decl.slice(colon + 1).trim();
+        if (n) props.set(n, vv);
+      }
+    },
+    get length() { return props.size; },
+    item(i) { return Array.from(props.keys())[i] ?? ""; },
+    getPropertyValue(name) { return props.get(String(name).toLowerCase()) ?? ""; },
+    getPropertyPriority() { return ""; },
+    setProperty(name, value) { props.set(String(name).toLowerCase(), String(value)); },
+    removeProperty(name) { const k = String(name).toLowerCase(); const v = props.get(k) ?? ""; props.delete(k); return v; },
+  };
+  return obj;
+}
+
 globalThis.CSSStyleSheet = class CSSStyleSheet {
   constructor(options) {
-    this.cssRules = [];
     this.ownerRule = null;
     this.disabled = false;
     this._rules = [];
   }
+  get cssRules() { return this._rules; }
+  get rules() { return this._rules; }
+  get type() { return "text/css"; }
+  get href() { return null; }
+  get media() { return { mediaText: "", length: 0, item() { return null; } }; }
+  get title() { return null; }
+  get ownerNode() { return this._ownerNode || null; }
   insertRule(rule, index) {
     const idx = index ?? this._rules.length;
-    this._rules.splice(idx, 0, { cssText: rule, type: 1 });
-    this.cssRules = this._rules;
+    this._rules.splice(idx, 0, _parseCSSRule(rule, this));
     return idx;
   }
-  deleteRule(index) {
-    this._rules.splice(index, 1);
-    this.cssRules = this._rules;
-  }
-  addRule(selector, style, index) {
-    return this.insertRule(selector + '{' + style + '}', index);
-  }
+  deleteRule(index) { this._rules.splice(index, 1); }
+  addRule(selector, style, index) { return this.insertRule(selector + "{" + (style ?? "") + "}", index); }
   removeRule(index) { this.deleteRule(index); }
   replace(text) {
-    this._rules = [{ cssText: text, type: 1 }];
-    this.cssRules = this._rules;
+    this._rules = _splitCSSRules(text).map((r) => _parseCSSRule(r, this));
     return Promise.resolve(this);
   }
   replaceSync(text) {
-    this._rules = [{ cssText: text, type: 1 }];
-    this.cssRules = this._rules;
+    this._rules = _splitCSSRules(text).map((r) => _parseCSSRule(r, this));
   }
 };
+
+// Naive top-level rule splitter. Tracks brace depth and string state so a
+// `{` inside a value or a quoted url() doesn't confuse the split. Good
+// enough for CSS-in-JS output, which is well-formed.
+function _splitCSSRules(text) {
+  const out = [];
+  const s = String(text ?? "");
+  let depth = 0, start = 0, q = "";
+  for (let i = 0; i < s.length; i++) {
+    const c = s[i];
+    if (q) { if (c === q && s[i-1] !== "\\") q = ""; continue; }
+    if (c === '"' || c === "'") { q = c; continue; }
+    if (c === "{") depth++;
+    else if (c === "}") {
+      depth--;
+      if (depth === 0) {
+        const r = s.slice(start, i + 1).trim();
+        if (r) out.push(r);
+        start = i + 1;
+      }
+    }
+  }
+  const tail = s.slice(start).trim();
+  if (tail) out.push(tail);
+  return out;
+}
 
 Object.defineProperty(Document.prototype, 'adoptedStyleSheets', {
   get() { return this._adoptedStyleSheets || []; },
@@ -2711,28 +2891,51 @@ globalThis.scrollX = 0; globalThis.scrollY = 0;
 globalThis.CSS = { supports(){return false;}, escape(s){return s;} };
 
 globalThis.HTMLElement = Element;
-globalThis.HTMLDivElement = Element;
-globalThis.HTMLSpanElement = Element;
-globalThis.HTMLParagraphElement = Element;
-globalThis.HTMLAnchorElement = Element;
-globalThis.HTMLImageElement = Element;
-globalThis.HTMLInputElement = Element;
-globalThis.HTMLButtonElement = Element;
-globalThis.HTMLFormElement = class HTMLFormElement extends Element {
-  get elements() { return this.querySelectorAll("input, select, textarea, button, fieldset, output, object"); }
-  get length() { return this.elements.length; }
-  // Inherit submit() from Element.prototype: it dispatches the cancelable
-  // 'submit' event and (if not prevented) builds form data and navigates.
-  reset() { for (const f of this.elements) { if ('value' in f) f.value = ''; } }
+function _tagElementClass(name, ...tags) {
+  const C = class extends Element {};
+  Object.defineProperty(C, 'name', { value: name });
+  Object.defineProperty(C, Symbol.hasInstance, {
+    value: function(inst) {
+      if (!(inst instanceof Element)) return false;
+      const t = (inst.localName || '').toLowerCase();
+      for (let i = 0; i < tags.length; i++) if (tags[i] === t) return true;
+      return false;
+    },
+  });
+  return C;
+}
+globalThis.HTMLDivElement       = _tagElementClass('HTMLDivElement', 'div');
+globalThis.HTMLSpanElement      = _tagElementClass('HTMLSpanElement', 'span');
+globalThis.HTMLParagraphElement = _tagElementClass('HTMLParagraphElement', 'p');
+globalThis.HTMLAnchorElement    = _tagElementClass('HTMLAnchorElement', 'a');
+globalThis.HTMLImageElement     = _tagElementClass('HTMLImageElement', 'img');
+globalThis.HTMLInputElement     = _tagElementClass('HTMLInputElement', 'input');
+globalThis.HTMLButtonElement    = _tagElementClass('HTMLButtonElement', 'button');
+globalThis.HTMLFormElement      = _tagElementClass('HTMLFormElement', 'form');
+globalThis.HTMLSelectElement    = _tagElementClass('HTMLSelectElement', 'select');
+globalThis.HTMLTextAreaElement  = _tagElementClass('HTMLTextAreaElement', 'textarea');
+globalThis.HTMLLabelElement     = _tagElementClass('HTMLLabelElement', 'label');
+globalThis.HTMLTableElement     = _tagElementClass('HTMLTableElement', 'table');
+globalThis.HTMLIFrameElement    = _tagElementClass('HTMLIFrameElement', 'iframe');
+globalThis.HTMLCanvasElement    = _tagElementClass('HTMLCanvasElement', 'canvas');
+globalThis.HTMLVideoElement     = _tagElementClass('HTMLVideoElement', 'video');
+globalThis.HTMLAudioElement     = _tagElementClass('HTMLAudioElement', 'audio');
+// HTMLFormElement's tag class above gates `instanceof`; the form-specific
+// methods (`.elements`, `.length`, `.reset()`) live on Element.prototype
+// gated by localName, so any `<form>` node — which is an Element instance,
+// not an HTMLFormElement instance — still gets them. submit() is inherited
+// from Element.prototype and dispatches the cancelable 'submit' event.
+Object.defineProperty(Element.prototype, 'elements', {
+  configurable: true,
+  get() {
+    if ((this.localName || '').toLowerCase() !== 'form') return undefined;
+    return this.querySelectorAll("input, select, textarea, button, fieldset, output, object");
+  },
+});
+Element.prototype.reset = function reset() {
+  if ((this.localName || '').toLowerCase() !== 'form') return;
+  for (const f of this.elements) { if ('value' in f) f.value = ''; }
 };
-globalThis.HTMLSelectElement = Element;
-globalThis.HTMLTextAreaElement = Element;
-globalThis.HTMLLabelElement = Element;
-globalThis.HTMLTableElement = Element;
-globalThis.HTMLIFrameElement = Element;
-globalThis.HTMLCanvasElement = Element;
-globalThis.HTMLVideoElement = Element;
-globalThis.HTMLAudioElement = Element;
 globalThis.HTMLScriptElement = Element;
 globalThis.HTMLStyleElement = Element;
 globalThis.HTMLLinkElement = Element;

--- a/crates/obscura-js/js/bootstrap.js
+++ b/crates/obscura-js/js/bootstrap.js
@@ -1873,52 +1873,6 @@ _markNative(XMLHttpRequest.prototype.setRequestHeader);
 _markNative(XMLHttpRequest.prototype.getResponseHeader);
 _markNative(XMLHttpRequest.prototype.getAllResponseHeaders);
 
-if (typeof URL === 'undefined' || !URL.prototype) {
-  globalThis.URL = class URL {
-    constructor(url, base) {
-      // Per WHATWG URL spec, both arguments are stringified — callers
-      // routinely pass `window.location` (Location object) or a URL
-      // instance as `base`. Coerce explicitly so the regex .match() calls
-      // below don't blow up on non-strings.
-      url = String(url);
-      if (base !== undefined && base !== null) base = String(base);
-      let full = url;
-      if (base && !url.includes('://')) {
-        var bm = base.match(/^(https?:\/\/[^\/\?#]+)(\/[^?#]*)?/);
-        if (bm) {
-          var bOrigin = bm[1];
-          var bPath = bm[2] || '/';
-          if (url.startsWith('/')) {
-            full = bOrigin + url;
-          } else if (url.startsWith('?') || url.startsWith('#')) {
-            full = bOrigin + bPath + url;
-          } else {
-            var dir = bPath.substring(0, bPath.lastIndexOf('/') + 1);
-            full = bOrigin + dir + url;
-          }
-        }
-      }
-      const m = full.match(/^(https?):\/\/([^\/\?#]+)(\/[^?#]*)?(\?[^#]*)?(#.*)?$/);
-      if (m) {
-        this.protocol = m[1] + ':';
-        this.host = m[2]; this.hostname = m[2].split(':')[0];
-        this.port = m[2].includes(':') ? m[2].split(':')[1] : '';
-        this.pathname = m[3] || '/';
-        this.search = m[4] || ''; this.hash = m[5] || '';
-      } else {
-        this.protocol = ''; this.host = ''; this.hostname = '';
-        this.port = ''; this.pathname = full; this.search = ''; this.hash = '';
-      }
-      this.href = full; this.origin = this.protocol + '//' + this.host;
-      this.searchParams = new URLSearchParams(this.search);
-    }
-    toString() { return this.href; }
-    toJSON() { return this.href; }
-    static createObjectURL() { return 'blob:null/fake-' + Math.random().toString(36).slice(2); }
-    static revokeObjectURL() {}
-  };
-}
-
 globalThis.requestIdleCallback = globalThis.requestIdleCallback || function requestIdleCallback(cb, opts) {
   const start = Date.now();
   return setTimeout(() => {
@@ -2560,25 +2514,6 @@ globalThis.AbortSignal = { timeout(ms){return {aborted:false,addEventListener(){
 if (typeof Blob === "undefined") globalThis.Blob = class Blob { constructor(parts=[],opts={}){this._data=parts.join("");this.size=this._data.length;this.type=opts.type||"";} async text(){return this._data;} };
 if (typeof File === "undefined") globalThis.File = class extends Blob { constructor(parts,name,opts){super(parts,opts);this.name=name;} };
 if (typeof FormData === "undefined") globalThis.FormData = class FormData { constructor(){this._d=[];} append(k,v){this._d.push([k,v]);} get(k){const e=this._d.find(([a])=>a===k);return e?e[1]:null;} getAll(k){return this._d.filter(([a])=>a===k).map(([,v])=>v);} has(k){return this._d.some(([a])=>a===k);} entries(){return this._d[Symbol.iterator]();} forEach(cb){this._d.forEach(([k,v])=>cb(v,k));} };
-if (typeof URLSearchParams === "undefined") globalThis.URLSearchParams = class {
-  constructor(init=""){
-    this._p=[];
-    if(typeof init==="string"){
-      init.replace(/^\?/,"").split("&").forEach(p=>{const[k,...v]=p.split("=");if(k)this.append(decodeURIComponent(k),decodeURIComponent(v.join("=")));});
-    } else if (init && typeof init[Symbol.iterator] === 'function') {
-      for (const pair of init) if (pair && pair.length >= 2) this.append(pair[0], pair[1]);
-    } else if (init && typeof init === 'object') {
-      Object.keys(init).forEach(k => this.append(k, init[k]));
-    }
-  }
-  append(k,v){this._p.push([String(k),String(v)]);}
-  get(k){const p=this._p.find(([key])=>key===String(k)); return p?p[1]:null;}
-  set(k,v){this.delete(k); this.append(k,v);}
-  delete(k){k=String(k); this._p=this._p.filter(([key])=>key!==k);}
-  has(k){k=String(k); return this._p.some(([key])=>key===k);}
-  toString(){return this._p.map(([k,v])=>`${encodeURIComponent(k)}=${encodeURIComponent(v)}`).join("&");}
-  forEach(cb){this._p.forEach(([k,v])=>cb(v,k,this));}
-};
 
 // Real-enough DOMParser. The previous one-liner returned `globalThis.document`,
 // so anything that did `new DOMParser().parseFromString(s, 'text/html')` and
@@ -4058,12 +3993,6 @@ if (typeof SharedWorker === 'undefined') {
 }
 if (typeof ServiceWorkerContainer === 'undefined') {
   globalThis.ServiceWorkerContainer = class { register(){return Promise.resolve();} getRegistrations(){return Promise.resolve([]);} };
-}
-
-if (typeof URLPattern === 'undefined') {
-  globalThis.URLPattern = class URLPattern {
-    constructor(pattern){this._pattern=pattern||{};} test(){return false;} exec(){return null;}
-  };
 }
 
 if (typeof Document !== 'undefined' && !Document.prototype.importNode) {

--- a/crates/obscura-js/js/bootstrap.js
+++ b/crates/obscura-js/js/bootstrap.js
@@ -186,21 +186,6 @@ globalThis.requestAnimationFrame = (fn) => setTimeout(fn, 0);
 globalThis.cancelAnimationFrame = globalThis.clearTimeout;
 globalThis.queueMicrotask = globalThis.queueMicrotask || ((fn) => Promise.resolve().then(fn));
 
-class MessageChannel {
-  constructor() {
-    this.port1 = { onmessage: null, postMessage: () => {}, close() {}, addEventListener() {}, removeEventListener() {} };
-    this.port2 = { onmessage: null, postMessage: () => {}, close() {}, addEventListener() {}, removeEventListener() {} };
-    this.port1.postMessage = (data) => {
-      Promise.resolve().then(() => { if (this.port2.onmessage) this.port2.onmessage({ data }); });
-    };
-    this.port2.postMessage = (data) => {
-      Promise.resolve().then(() => { if (this.port1.onmessage) this.port1.onmessage({ data }); });
-    };
-  }
-}
-globalThis.MessageChannel = MessageChannel;
-globalThis.MessagePort = class MessagePort { constructor(){} postMessage(){} close(){} addEventListener(){} removeEventListener(){} };
-
 class CSSStyleDeclaration {
   constructor() { this._props = {}; }
   setProperty(name, value) { this._props[name] = String(value); }
@@ -648,8 +633,13 @@ class Element extends Node {
   }
   dispatchEvent(event) {
     if (!event) return true;
-    if (!event.target) event.target = this;
-    event.currentTarget = this;
+    // deno_web's Event has getter-only `target` and `currentTarget`; use
+    // defineProperty so our DOM-side dispatch (which doesn't go through the
+    // native EventTarget machinery) can still set them.
+    if (!event.target) {
+      Object.defineProperty(event, 'target', { value: this, writable: true, configurable: true });
+    }
+    Object.defineProperty(event, 'currentTarget', { value: this, writable: true, configurable: true });
     // Spec: inline `onclick="..."` content attributes are event handlers
     // for the matching event type. Fire them alongside any
     // addEventListener handlers. Also honor the IDL property
@@ -2026,45 +2016,6 @@ globalThis.ResizeObserver = class ResizeObserver {
   disconnect() { this._connected = false; this._targets.clear(); }
 };
 
-if (typeof TextEncoder === 'undefined') {
-  globalThis.TextEncoder = class TextEncoder {
-    get encoding() { return 'utf-8'; }
-    encode(str) {
-      str = String(str);
-      const buf = [];
-      for (let i = 0; i < str.length; i++) {
-        let c = str.charCodeAt(i);
-        if (c < 0x80) buf.push(c);
-        else if (c < 0x800) { buf.push(0xC0|(c>>6), 0x80|(c&0x3F)); }
-        else if (c < 0xD800 || c >= 0xE000) { buf.push(0xE0|(c>>12), 0x80|((c>>6)&0x3F), 0x80|(c&0x3F)); }
-        else { c = 0x10000 + (((c & 0x3FF) << 10) | (str.charCodeAt(++i) & 0x3FF)); buf.push(0xF0|(c>>18), 0x80|((c>>12)&0x3F), 0x80|((c>>6)&0x3F), 0x80|(c&0x3F)); }
-      }
-      return new Uint8Array(buf);
-    }
-    encodeInto(str, dest) { const enc = this.encode(str); dest.set(enc.slice(0, dest.length)); return { read: str.length, written: Math.min(enc.length, dest.length) }; }
-  };
-}
-if (typeof TextDecoder === 'undefined') {
-  globalThis.TextDecoder = class TextDecoder {
-    constructor(label) { this.encoding = label || 'utf-8'; }
-    decode(buf) {
-      if (!buf) return '';
-      const bytes = ArrayBuffer.isView(buf)
-        ? new Uint8Array(buf.buffer, buf.byteOffset, buf.byteLength)
-        : new Uint8Array(buf);
-      let str = '', i = 0;
-      while (i < bytes.length) {
-        let c = bytes[i++];
-        if (c < 0x80) str += String.fromCharCode(c);
-        else if (c < 0xE0) str += String.fromCharCode(((c&0x1F)<<6)|(bytes[i++]&0x3F));
-        else if (c < 0xF0) { const b1=bytes[i++], b2=bytes[i++]; str += String.fromCharCode(((c&0x0F)<<12)|((b1&0x3F)<<6)|(b2&0x3F)); }
-        else { const b1=bytes[i++], b2=bytes[i++], b3=bytes[i++]; const cp=((c&0x07)<<18)|((b1&0x3F)<<12)|((b2&0x3F)<<6)|(b3&0x3F); if(cp>0xFFFF){const s=cp-0x10000;str+=String.fromCharCode(0xD800+(s>>10),0xDC00+(s&0x3FF));}else str+=String.fromCharCode(cp); }
-      }
-      return str;
-    }
-  };
-}
-
 globalThis.matchMedia = _markNative(function matchMedia(q) { return { matches: false, media: q, addListener(){}, removeListener(){}, addEventListener(){}, removeEventListener(){}, dispatchEvent(){return true;} }; });
 globalThis.getComputedStyle = (el) => {
   if (!el) el = document.body || {};
@@ -2466,29 +2417,29 @@ globalThis.IntersectionObserver = class IntersectionObserver {
 globalThis.IntersectionObserverEntry = class IntersectionObserverEntry {};
 globalThis.PerformanceObserver = class { constructor(){} observe(){} disconnect(){} };
 
-globalThis.Event = class Event {
-  constructor(t,o={}) { this.type=t;this.bubbles=!!o.bubbles;this.cancelable=!!o.cancelable;this.composed=!!o.composed;this.defaultPrevented=false;this.target=null;this.currentTarget=null;this.eventPhase=0;this.timeStamp=Date.now();this._propagationStopped=false;this._immediatePropagationStopped=false; }
-  get isTrusted() { return true; }
-  preventDefault() { if (this.cancelable) this.defaultPrevented=true; } stopPropagation(){ this._propagationStopped=true; } stopImmediatePropagation(){ this._propagationStopped=true; this._immediatePropagationStopped=true; }
-  initEvent(type,bubbles,cancelable) { this.type=type;this.bubbles=!!bubbles;this.cancelable=!!cancelable;this.defaultPrevented=false;this._propagationStopped=false;this._immediatePropagationStopped=false; }
-};
-globalThis.CustomEvent = class extends Event {
-  constructor(t,o={}) { super(t,o);this.detail=o.detail; }
-  // Legacy DOM Level 2 init; some libraries (Starbucks China bundle, older
-  // analytics shims) still call createEvent('CustomEvent') + initCustomEvent
-  // instead of new CustomEvent(...). See issue #41.
-  initCustomEvent(type,bubbles,cancelable,detail) {
-    this.type = type;
-    this.bubbles = !!bubbles;
-    this.cancelable = !!cancelable;
-    this.detail = detail;
-  }
-};
+// Event, CustomEvent, ErrorEvent, MessageEvent, ProgressEvent, CloseEvent,
+// PromiseRejectionEvent, EventTarget, AbortController, AbortSignal,
+// Blob, File, and FileReader are provided by `deno_web` (V8/ICU-native).
+// The DOM-specific Event subclasses below extend the native Event.
+
+// Legacy DOM Level 2 method some pages still rely on (see issue #41:
+// Starbucks China bundle, older analytics shims call createEvent +
+// initCustomEvent instead of `new CustomEvent`). deno_web only ships the
+// modern API, so we re-attach this on the prototype. Uses defineProperty
+// because deno_web's `type`/`bubbles`/`cancelable` are getter-only.
+if (!CustomEvent.prototype.initCustomEvent) {
+  CustomEvent.prototype.initCustomEvent = function(type, bubbles, cancelable, detail) {
+    Object.defineProperty(this, 'type', { value: type, writable: true, configurable: true });
+    Object.defineProperty(this, 'bubbles', { value: !!bubbles, writable: true, configurable: true });
+    Object.defineProperty(this, 'cancelable', { value: !!cancelable, writable: true, configurable: true });
+    Object.defineProperty(this, 'detail', { value: detail, writable: true, configurable: true });
+  };
+}
+
 globalThis.MouseEvent = class extends Event { constructor(t,o={}) { super(t,o);this.clientX=o.clientX||0;this.clientY=o.clientY||0; } };
 globalThis.KeyboardEvent = class extends Event { constructor(t,o={}) { super(t,o);this.key=o.key||"";this.code=o.code||""; } };
 globalThis.FocusEvent = class extends Event {};
 globalThis.InputEvent = class extends Event { constructor(t,o={}) { super(t,o);this.data=o.data||null;this.inputType=o.inputType||""; } };
-globalThis.ErrorEvent = class extends Event { constructor(t,o={}) { super(t,o);this.message=o.message||"";this.error=o.error||null; } };
 globalThis.PointerEvent = class extends Event { constructor(t,o={}) { super(t,o); } };
 globalThis.AnimationEvent = class extends Event {};
 globalThis.TransitionEvent = class extends Event {};
@@ -2505,14 +2456,12 @@ globalThis.PopStateEvent = class extends Event {
   }
 };
 globalThis.HashChangeEvent = class extends Event {};
-globalThis.MessageEvent = class extends Event { constructor(t,o={}) { super(t,o);this.data=o.data; } };
 globalThis.ClipboardEvent = class extends Event {};
 globalThis.SubmitEvent = class extends Event {};
 
-globalThis.AbortController = class AbortController { constructor(){this.signal={aborted:false,addEventListener(){},removeEventListener(){},onabort:null};} abort(){this.signal.aborted=true;} };
-globalThis.AbortSignal = { timeout(ms){return {aborted:false,addEventListener(){},removeEventListener(){}}; } };
-if (typeof Blob === "undefined") globalThis.Blob = class Blob { constructor(parts=[],opts={}){this._data=parts.join("");this.size=this._data.length;this.type=opts.type||"";} async text(){return this._data;} };
-if (typeof File === "undefined") globalThis.File = class extends Blob { constructor(parts,name,opts){super(parts,opts);this.name=name;} };
+// FormData is not in deno_web (it ships in deno_fetch, which we deliberately
+// avoid to keep our SSRF-policed fetch implementation). Keep a minimal stub
+// that now stores real Blobs since the native Blob is available.
 if (typeof FormData === "undefined") globalThis.FormData = class FormData { constructor(){this._d=[];} append(k,v){this._d.push([k,v]);} get(k){const e=this._d.find(([a])=>a===k);return e?e[1]:null;} getAll(k){return this._d.filter(([a])=>a===k).map(([,v])=>v);} has(k){return this._d.some(([a])=>a===k);} entries(){return this._d[Symbol.iterator]();} forEach(cb){this._d.forEach(([k,v])=>cb(v,k));} };
 
 // Real-enough DOMParser. The previous one-liner returned `globalThis.document`,
@@ -2618,21 +2567,30 @@ globalThis.XMLSerializer = class XMLSerializer {
     return "";
   }
 };
-globalThis.performance = globalThis.performance || {
-  now: () => Date.now(),
-  mark(){}, measure(){},
-  clearMarks(){}, clearMeasures(){}, clearResourceTimings(){},
-  getEntries(){return [];}, getEntriesByName(){return [];}, getEntriesByType(){return [];},
-  setResourceTimingBufferSize(){},
-  timeOrigin: 0,
-  timing: { navigationStart: 0, domContentLoadedEventEnd: 0, loadEventEnd: 0 },
-  navigation: { type: 0, redirectCount: 0 },
-  memory: {
+// `performance` (with sub-ms resolution and proper `mark`/`measure`) comes
+// from deno_web. We patch on the two non-standard properties that real Chrome
+// exposes (`performance.timing` legacy + `performance.memory`) for pages that
+// fingerprint or sniff them — `Performance.prototype` is shared, so this
+// assigns directly on the singleton.
+Object.defineProperty(performance, 'timing', {
+  value: { navigationStart: 0, domContentLoadedEventEnd: 0, loadEventEnd: 0 },
+  writable: true,
+  configurable: true,
+});
+Object.defineProperty(performance, 'navigation', {
+  value: { type: 0, redirectCount: 0 },
+  writable: true,
+  configurable: true,
+});
+Object.defineProperty(performance, 'memory', {
+  value: {
     jsHeapSizeLimit: 2172649472,
     totalJSHeapSize: 19321856,
     usedJSHeapSize: 16781520,
   },
-};
+  writable: true,
+  configurable: true,
+});
 
 Object.defineProperty(Document.prototype, 'fonts', {
   get() {
@@ -2653,9 +2611,9 @@ Object.defineProperty(Document.prototype, 'fonts', {
   },
   configurable: true,
 });
-globalThis.crypto = globalThis.crypto || { getRandomValues(arr) { for(let i=0;i<arr.length;i++) arr[i]=Math.floor(Math.random()*256); return arr; }, randomUUID(){ return "xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx".replace(/[xy]/g,c=>{const r=Math.random()*16|0;return(c==="x"?r:(r&3|8)).toString(16);}); } };
-globalThis.structuredClone = globalThis.structuredClone || ((v) => JSON.parse(JSON.stringify(v)));
-globalThis.reportError = globalThis.reportError || ((e) => console.error(e));
+// `crypto` (Web Crypto API, including secure `crypto.getRandomValues`,
+// `crypto.randomUUID`, and `crypto.subtle`) comes from deno_crypto.
+// `structuredClone` and `reportError` come from deno_web.
 
 globalThis.Storage = function Storage() {};
 Storage.prototype.getItem = function(k) { return (this._data && this._data[k]) ?? null; };
@@ -2669,8 +2627,7 @@ const _mkStore = () => { var s = Object.create(Storage.prototype); s._data = {};
 globalThis.localStorage = _mkStore();
 globalThis.sessionStorage = _mkStore();
 
-globalThis.btoa = globalThis.btoa || ((s) => { const b = new TextEncoder().encode(s); const c="ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/"; let r=""; for(let i=0;i<b.length;i+=3){const a=b[i],bb=b[i+1]??0,cc=b[i+2]??0; r+=c[a>>2]+c[((a&3)<<4)|(bb>>4)]+(i+1<b.length?c[((bb&15)<<2)|(cc>>6)]:"=")+(i+2<b.length?c[cc&63]:"=");} return r; });
-globalThis.atob = globalThis.atob || ((s) => { const c="ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/"; let r=[]; for(let i=0;i<s.length;i+=4){const a=c.indexOf(s[i]),b=c.indexOf(s[i+1]),cc=c.indexOf(s[i+2]),d=c.indexOf(s[i+3]); r.push((a<<2)|(b>>4)); if(cc>=0)r.push(((b&15)<<4)|(cc>>2)); if(d>=0)r.push(((cc&3)<<6)|d);} return String.fromCharCode(...r); });
+// atob / btoa come from deno_web.
 
 // Functional History API. The earlier stub returned constant state and was a
 // no-op on push/replace, so any SPA that tried to update its URL (Next.js
@@ -2809,7 +2766,10 @@ globalThis.DocumentType = DocumentType;
 globalThis.Node = Node;
 globalThis.Element = Element;
 globalThis.Document = Document;
-globalThis.EventTarget = Node;
+// Note: real `EventTarget` comes from deno_web. The DOM `Node` here does not
+// extend it (DOM-side event dispatch is handled in Rust via `_listeners`),
+// so `nodeInstance instanceof EventTarget` is false — matching no real
+// browser, but no observed pages rely on this check.
 globalThis.Range = class Range { setStart(){} setEnd(){} collapse(){} selectNodeContents(){} deleteContents(){} cloneContents(){ return document.createDocumentFragment(); } insertNode(){} getBoundingClientRect(){return {x:0,y:0,width:0,height:0,top:0,right:0,bottom:0,left:0};} };
 
 [
@@ -3666,97 +3626,11 @@ globalThis.stop = function() {};
 globalThis.postMessage = function() {};
 globalThis.requestIdleCallback = globalThis.requestIdleCallback || function(cb) { return setTimeout(cb, 0); };
 globalThis.cancelIdleCallback = globalThis.cancelIdleCallback || function(id) { clearTimeout(id); };
-if (typeof ReadableStream === 'undefined') {
-  globalThis.ReadableStream = class ReadableStream {
-    constructor(source = {}, strategy = {}) {
-      this._source = source; this._queue = []; this._closed = false;
-      this.locked = false;
-      if (source.start) source.start({ enqueue: (chunk) => this._queue.push(chunk), close: () => { this._closed = true; }, error: () => {} });
-    }
-    getReader() {
-      this.locked = true;
-      const stream = this;
-      return {
-        read() {
-          if (stream._queue.length > 0) return Promise.resolve({ value: stream._queue.shift(), done: false });
-          if (stream._closed) return Promise.resolve({ value: undefined, done: true });
-          return Promise.resolve({ value: undefined, done: true });
-        },
-        releaseLock() { stream.locked = false; },
-        cancel() { stream._closed = true; return Promise.resolve(); },
-        get closed() { return stream._closed ? Promise.resolve() : new Promise(() => {}); },
-      };
-    }
-    cancel() { this._closed = true; return Promise.resolve(); }
-    pipeTo(dest) { return Promise.resolve(); }
-    pipeThrough(transform) { return transform.readable || new ReadableStream(); }
-    tee() { return [new ReadableStream(), new ReadableStream()]; }
-    [Symbol.asyncIterator]() {
-      const reader = this.getReader();
-      return { next: () => reader.read(), return: () => { reader.releaseLock(); return Promise.resolve({done:true}); } };
-    }
-  };
-}
-if (typeof WritableStream === 'undefined') {
-  globalThis.WritableStream = class WritableStream {
-    constructor(sink = {}) { this._sink = sink; this.locked = false; }
-    getWriter() {
-      this.locked = true;
-      const stream = this;
-      return {
-        write(chunk) { if (stream._sink.write) stream._sink.write(chunk); return Promise.resolve(); },
-        close() { if (stream._sink.close) stream._sink.close(); return Promise.resolve(); },
-        abort() { return Promise.resolve(); },
-        releaseLock() { stream.locked = false; },
-        get ready() { return Promise.resolve(); },
-        get closed() { return Promise.resolve(); },
-        get desiredSize() { return 1; },
-      };
-    }
-    close() { return Promise.resolve(); }
-    abort() { return Promise.resolve(); }
-  };
-}
-if (typeof TransformStream === 'undefined') {
-  globalThis.TransformStream = class TransformStream {
-    constructor(transformer = {}) {
-      this.readable = new ReadableStream();
-      this.writable = new WritableStream();
-    }
-  };
-}
-
-if (!globalThis.crypto) globalThis.crypto = {};
-if (!globalThis.crypto.subtle) {
-  globalThis.crypto.subtle = {
-    async digest(algorithm, data) {
-      // Real WebCrypto digest. Delegates to `op_subtle_digest` which runs
-      // the actual SHA-1/256/384/512 via Rust's `sha1` and `sha2` crates.
-      // The previous JS implementation was a custom FNV variant that
-      // produced bytes shaped like the hash but with wrong contents, so
-      // SRI checks, JWS signature verification, and OAuth PKCE silently
-      // accepted invalid input.
-      const name = (typeof algorithm === 'string' ? algorithm : algorithm?.name) || 'SHA-256';
-      let bytes;
-      if (data instanceof ArrayBuffer) bytes = new Uint8Array(data);
-      else if (ArrayBuffer.isView(data)) bytes = new Uint8Array(data.buffer, data.byteOffset, data.byteLength);
-      else bytes = new Uint8Array(data || []);
-      const out = Deno.core.ops.op_subtle_digest(name, bytes);
-      return new Uint8Array(out).buffer;
-    },
-    async encrypt() { throw new DOMException('NotSupportedError'); },
-    async decrypt() { throw new DOMException('NotSupportedError'); },
-    async sign() { return new ArrayBuffer(32); },
-    async verify() { return true; },
-    async generateKey() { return { type: 'secret', algorithm: {}, extractable: false, usages: [] }; },
-    async importKey() { return { type: 'secret', algorithm: {}, extractable: false, usages: [] }; },
-    async exportKey() { return new ArrayBuffer(32); },
-    async deriveBits() { return new ArrayBuffer(32); },
-    async deriveKey() { return { type: 'secret', algorithm: {}, extractable: false, usages: [] }; },
-    async wrapKey() { return new ArrayBuffer(32); },
-    async unwrapKey() { return { type: 'secret', algorithm: {}, extractable: false, usages: [] }; },
-  };
-}
+// ReadableStream, WritableStream, TransformStream (plus controllers, readers,
+// writers, and queuing strategies) come from deno_web.
+// Web Crypto API (crypto.getRandomValues, randomUUID, crypto.subtle) comes
+// from deno_crypto — real implementations, not the previous Math.random()-
+// backed stubs that were a glaring stealth tell.
 
 if (typeof DOMRect === 'undefined') {
   globalThis.DOMRect = class DOMRect {
@@ -4065,8 +3939,11 @@ globalThis.__obscura_init = function() {
   globalThis.innerWidth = sw; globalThis.innerHeight = sh - 80;
   globalThis.outerWidth = sw; globalThis.outerHeight = sh;
 
+  // performance.timeOrigin is a getter-only accessor on deno_web's real
+  // Performance, populated from StartTime when the runtime initialises — no
+  // need to (and we can't) reassign it. We still patch `timing` because some
+  // pages read it through the legacy DOM Level 1 surface.
   const t0 = Date.now();
-  globalThis.performance.timeOrigin = t0;
   globalThis.performance.timing = { navigationStart: t0, domContentLoadedEventEnd: t0, loadEventEnd: t0 };
 
   const hide = (obj, props) => {

--- a/crates/obscura-js/src/deno_extensions.rs
+++ b/crates/obscura-js/src/deno_extensions.rs
@@ -1,0 +1,46 @@
+use std::sync::Arc;
+
+use deno_core::Extension;
+use deno_core::ExtensionFileSource;
+
+fn with_esm_entry(mut ext: Extension, entry: &'static str) -> Extension {
+    ext.esm_entry_point = Some(entry);
+    ext
+}
+
+/// deno_url ships two ESM files (`00_url.js`, `01_urlpattern.js`) that only
+/// `export` their classes — Deno's own runtime is responsible for exposing
+/// them on `globalThis`. We add a synthetic entry that imports both files and
+/// installs the global bindings, then point `esm_entry_point` at it.
+fn deno_url_with_globals() -> Extension {
+    let mut ext = deno_url::deno_url::init();
+    let mut files = ext.esm_files.into_owned();
+    files.push(ExtensionFileSource::new_computed(
+        "ext:obscura/deno_url_entry.js",
+        Arc::from(
+            r#"
+import { URL, URLSearchParams } from "ext:deno_url/00_url.js";
+import { URLPattern } from "ext:deno_url/01_urlpattern.js";
+Object.defineProperty(globalThis, "URL", { value: URL, writable: true, configurable: true });
+Object.defineProperty(globalThis, "URLSearchParams", { value: URLSearchParams, writable: true, configurable: true });
+Object.defineProperty(globalThis, "URLPattern", { value: URLPattern, writable: true, configurable: true });
+"#,
+        ),
+    ));
+    ext.esm_files = std::borrow::Cow::Owned(files);
+    ext.esm_entry_point = Some("ext:obscura/deno_url_entry.js");
+    ext
+}
+
+/// Returns the deno extensions required by both the snapshot build and the
+/// runtime: `deno_webidl`, `deno_console` (needed as a library dep by
+/// `deno_url`'s `customInspect` — does not replace `globalThis.console`), and
+/// `deno_url` wired to expose `URL` / `URLSearchParams` / `URLPattern`
+/// globally.
+pub fn build() -> Vec<Extension> {
+    vec![
+        with_esm_entry(deno_webidl::deno_webidl::init(), "ext:deno_webidl/00_webidl.js"),
+        with_esm_entry(deno_console::deno_console::init(), "ext:deno_console/01_console.js"),
+        deno_url_with_globals(),
+    ]
+}

--- a/crates/obscura-js/src/deno_extensions.rs
+++ b/crates/obscura-js/src/deno_extensions.rs
@@ -51,10 +51,8 @@ Object.defineProperty(globalThis, "URLPattern", { value: URLPattern, writable: t
 /// globals separately. We do the same here via a synthetic entry that
 /// imports every public class and exposes it on `globalThis`.
 fn deno_web_with_globals() -> Extension {
-    let ext = deno_web::deno_web::init::<ObscuraTimersPermission>(
-        Arc::new(BlobStore::default()),
-        None,
-    );
+    let ext =
+        deno_web::deno_web::init::<ObscuraTimersPermission>(Arc::new(BlobStore::default()), None);
     add_synthetic_entry(
         ext,
         "ext:obscura/deno_web_entry.js",
@@ -70,15 +68,17 @@ import {
   ProgressEvent,
   PromiseRejectionEvent,
   reportError,
+  saveGlobalThisReference,
 } from "ext:deno_web/02_event.js";
+saveGlobalThisReference(globalThis);
 import { AbortController, AbortSignal } from "ext:deno_web/03_abort_signal.js";
 import { structuredClone } from "ext:deno_web/02_structured_clone.js";
-// 02_timers.js is loaded transitively (deno_web internals - AbortSignal.timeout,
-// performance.now, FileReader event scheduling - depend on it). We deliberately
-// do NOT expose its setTimeout / setInterval / clearTimeout / clearInterval
-// here: bootstrap.js installs fast-fake versions that dispatch via microtask
-// regardless of delay, and that behavior is load-bearing for the scraper's
-// throughput target (the README's 51-85 ms page-load numbers).
+import {
+  setTimeout,
+  setInterval,
+  clearTimeout,
+  clearInterval,
+} from "ext:deno_web/02_timers.js";
 import { atob, btoa } from "ext:deno_web/05_base64.js";
 import {
   ByteLengthQueuingStrategy,
@@ -146,6 +146,10 @@ expose("reportError", reportError);
 expose("AbortController", AbortController);
 expose("AbortSignal", AbortSignal);
 expose("structuredClone", structuredClone);
+expose("setTimeout", setTimeout);
+expose("setInterval", setInterval);
+expose("clearTimeout", clearTimeout);
+expose("clearInterval", clearInterval);
 expose("atob", atob);
 expose("btoa", btoa);
 expose("ReadableStream", ReadableStream);
@@ -228,8 +232,14 @@ fn add_synthetic_entry(
 /// - `deno_crypto` (Web Crypto API + secure CSPRNG)
 pub fn build() -> Vec<Extension> {
     vec![
-        with_esm_entry(deno_webidl::deno_webidl::init(), "ext:deno_webidl/00_webidl.js"),
-        with_esm_entry(deno_console::deno_console::init(), "ext:deno_console/01_console.js"),
+        with_esm_entry(
+            deno_webidl::deno_webidl::init(),
+            "ext:deno_webidl/00_webidl.js",
+        ),
+        with_esm_entry(
+            deno_console::deno_console::init(),
+            "ext:deno_console/01_console.js",
+        ),
         deno_url_with_globals(),
         deno_web_with_globals(),
         deno_crypto_with_globals(),

--- a/crates/obscura-js/src/deno_extensions.rs
+++ b/crates/obscura-js/src/deno_extensions.rs
@@ -2,45 +2,236 @@ use std::sync::Arc;
 
 use deno_core::Extension;
 use deno_core::ExtensionFileSource;
+use deno_web::BlobStore;
+use deno_web::TimersPermission;
+
+/// Permission shim for `deno_web` timer / `performance.now()` ops.
+///
+/// Obscura is a single-tenant scraping browser, not a multi-origin runtime —
+/// there is no untrusted code we'd need to fuzz-protect against by clamping
+/// `performance.now()` resolution. Always grant high-resolution time so the
+/// JS surface matches real Chrome (Spectre mitigations don't apply to a
+/// headless single-isolate process anyway).
+pub struct ObscuraTimersPermission;
+
+impl TimersPermission for ObscuraTimersPermission {
+    #[inline(always)]
+    fn allow_hrtime(&mut self) -> bool {
+        true
+    }
+}
 
 fn with_esm_entry(mut ext: Extension, entry: &'static str) -> Extension {
     ext.esm_entry_point = Some(entry);
     ext
 }
 
-/// deno_url ships two ESM files (`00_url.js`, `01_urlpattern.js`) that only
+/// `deno_url` ships two ESM files (`00_url.js`, `01_urlpattern.js`) that only
 /// `export` their classes — Deno's own runtime is responsible for exposing
 /// them on `globalThis`. We add a synthetic entry that imports both files and
 /// installs the global bindings, then point `esm_entry_point` at it.
 fn deno_url_with_globals() -> Extension {
-    let mut ext = deno_url::deno_url::init();
-    let mut files = ext.esm_files.into_owned();
-    files.push(ExtensionFileSource::new_computed(
+    add_synthetic_entry(
+        deno_url::deno_url::init(),
         "ext:obscura/deno_url_entry.js",
-        Arc::from(
-            r#"
+        r#"
 import { URL, URLSearchParams } from "ext:deno_url/00_url.js";
 import { URLPattern } from "ext:deno_url/01_urlpattern.js";
 Object.defineProperty(globalThis, "URL", { value: URL, writable: true, configurable: true });
 Object.defineProperty(globalThis, "URLSearchParams", { value: URLSearchParams, writable: true, configurable: true });
 Object.defineProperty(globalThis, "URLPattern", { value: URLPattern, writable: true, configurable: true });
 "#,
-        ),
+    )
+}
+
+/// `deno_web` ships ~18 ESM modules covering Blob/File, FormData/streams,
+/// TextEncoder/Decoder, Event/EventTarget, AbortController, structuredClone,
+/// timers, atob/btoa, performance, MessageChannel/Port, and DOMException.
+/// None of them touch `globalThis` directly — Deno's runtime sets up the
+/// globals separately. We do the same here via a synthetic entry that
+/// imports every public class and exposes it on `globalThis`.
+fn deno_web_with_globals() -> Extension {
+    let ext = deno_web::deno_web::init::<ObscuraTimersPermission>(
+        Arc::new(BlobStore::default()),
+        None,
+    );
+    add_synthetic_entry(
+        ext,
+        "ext:obscura/deno_web_entry.js",
+        r#"
+import { DOMException } from "ext:deno_web/01_dom_exception.js";
+import {
+  CloseEvent,
+  CustomEvent,
+  ErrorEvent,
+  Event,
+  EventTarget,
+  MessageEvent,
+  ProgressEvent,
+  PromiseRejectionEvent,
+  reportError,
+} from "ext:deno_web/02_event.js";
+import { AbortController, AbortSignal } from "ext:deno_web/03_abort_signal.js";
+import { structuredClone } from "ext:deno_web/02_structured_clone.js";
+// 02_timers.js is loaded transitively (deno_web internals - AbortSignal.timeout,
+// performance.now, FileReader event scheduling - depend on it). We deliberately
+// do NOT expose its setTimeout / setInterval / clearTimeout / clearInterval
+// here: bootstrap.js installs fast-fake versions that dispatch via microtask
+// regardless of delay, and that behavior is load-bearing for the scraper's
+// throughput target (the README's 51-85 ms page-load numbers).
+import { atob, btoa } from "ext:deno_web/05_base64.js";
+import {
+  ByteLengthQueuingStrategy,
+  CountQueuingStrategy,
+  ReadableByteStreamController,
+  ReadableStream,
+  ReadableStreamBYOBReader,
+  ReadableStreamBYOBRequest,
+  ReadableStreamDefaultController,
+  ReadableStreamDefaultReader,
+  TransformStream,
+  TransformStreamDefaultController,
+  WritableStream,
+  WritableStreamDefaultController,
+  WritableStreamDefaultWriter,
+} from "ext:deno_web/06_streams.js";
+import {
+  TextDecoder,
+  TextDecoderStream,
+  TextEncoder,
+  TextEncoderStream,
+} from "ext:deno_web/08_text_encoding.js";
+import { Blob, File } from "ext:deno_web/09_file.js";
+import { FileReader } from "ext:deno_web/10_filereader.js";
+import { MessageChannel, MessagePort } from "ext:deno_web/13_message_port.js";
+import { CompressionStream, DecompressionStream } from "ext:deno_web/14_compression.js";
+import {
+  Performance,
+  performance,
+  PerformanceEntry,
+  PerformanceMark,
+  PerformanceMeasure,
+} from "ext:deno_web/15_performance.js";
+// Side-effect imports: deno_web ships these modules but our synthetic entry
+// only follows the import graph reachable from itself, so we load them
+// explicitly to satisfy the snapshot's "all modules evaluated" check.
+// We do not re-expose their exports globally:
+// - 12_location.js: bootstrap.js installs its own `location` object backed by
+//   the runtime navigation state, so we keep that.
+// - 04_global_interfaces.js: Window/WorkerGlobalScope descriptors, irrelevant
+//   to a single-page scraping context where `globalThis` is the only realm.
+// - 16_image_data.js: canvas ImageData, unused by obscura.
+import "ext:deno_web/12_location.js";
+import "ext:deno_web/04_global_interfaces.js";
+import "ext:deno_web/16_image_data.js";
+
+const expose = (name, value) => {
+  Object.defineProperty(globalThis, name, {
+    value,
+    writable: true,
+    configurable: true,
+  });
+};
+
+expose("DOMException", DOMException);
+expose("Event", Event);
+expose("EventTarget", EventTarget);
+expose("CustomEvent", CustomEvent);
+expose("ErrorEvent", ErrorEvent);
+expose("MessageEvent", MessageEvent);
+expose("ProgressEvent", ProgressEvent);
+expose("PromiseRejectionEvent", PromiseRejectionEvent);
+expose("CloseEvent", CloseEvent);
+expose("reportError", reportError);
+expose("AbortController", AbortController);
+expose("AbortSignal", AbortSignal);
+expose("structuredClone", structuredClone);
+expose("atob", atob);
+expose("btoa", btoa);
+expose("ReadableStream", ReadableStream);
+expose("ReadableStreamBYOBReader", ReadableStreamBYOBReader);
+expose("ReadableStreamBYOBRequest", ReadableStreamBYOBRequest);
+expose("ReadableStreamDefaultReader", ReadableStreamDefaultReader);
+expose("ReadableByteStreamController", ReadableByteStreamController);
+expose("ReadableStreamDefaultController", ReadableStreamDefaultController);
+expose("WritableStream", WritableStream);
+expose("WritableStreamDefaultController", WritableStreamDefaultController);
+expose("WritableStreamDefaultWriter", WritableStreamDefaultWriter);
+expose("TransformStream", TransformStream);
+expose("TransformStreamDefaultController", TransformStreamDefaultController);
+expose("ByteLengthQueuingStrategy", ByteLengthQueuingStrategy);
+expose("CountQueuingStrategy", CountQueuingStrategy);
+expose("TextEncoder", TextEncoder);
+expose("TextDecoder", TextDecoder);
+expose("TextEncoderStream", TextEncoderStream);
+expose("TextDecoderStream", TextDecoderStream);
+expose("Blob", Blob);
+expose("File", File);
+expose("FileReader", FileReader);
+expose("MessageChannel", MessageChannel);
+expose("MessagePort", MessagePort);
+expose("CompressionStream", CompressionStream);
+expose("DecompressionStream", DecompressionStream);
+expose("performance", performance);
+expose("Performance", Performance);
+expose("PerformanceEntry", PerformanceEntry);
+expose("PerformanceMark", PerformanceMark);
+expose("PerformanceMeasure", PerformanceMeasure);
+"#,
+    )
+}
+
+/// `deno_crypto` ships `00_crypto.js` exporting `Crypto`, `crypto`,
+/// `CryptoKey`, `SubtleCrypto`. Same export-only pattern — we re-expose
+/// `crypto` (the instance) and its constructors on `globalThis`.
+fn deno_crypto_with_globals() -> Extension {
+    let ext = deno_crypto::deno_crypto::init(None);
+    add_synthetic_entry(
+        ext,
+        "ext:obscura/deno_crypto_entry.js",
+        r#"
+import { Crypto, crypto, CryptoKey, SubtleCrypto } from "ext:deno_crypto/00_crypto.js";
+Object.defineProperty(globalThis, "crypto", { value: crypto, writable: true, configurable: true });
+Object.defineProperty(globalThis, "Crypto", { value: Crypto, writable: true, configurable: true });
+Object.defineProperty(globalThis, "CryptoKey", { value: CryptoKey, writable: true, configurable: true });
+Object.defineProperty(globalThis, "SubtleCrypto", { value: SubtleCrypto, writable: true, configurable: true });
+"#,
+    )
+}
+
+fn add_synthetic_entry(
+    mut ext: Extension,
+    specifier: &'static str,
+    source: &'static str,
+) -> Extension {
+    let mut files = ext.esm_files.into_owned();
+    files.push(ExtensionFileSource::new_computed(
+        specifier,
+        Arc::from(source),
     ));
     ext.esm_files = std::borrow::Cow::Owned(files);
-    ext.esm_entry_point = Some("ext:obscura/deno_url_entry.js");
+    ext.esm_entry_point = Some(specifier);
     ext
 }
 
 /// Returns the deno extensions required by both the snapshot build and the
-/// runtime: `deno_webidl`, `deno_console` (needed as a library dep by
-/// `deno_url`'s `customInspect` — does not replace `globalThis.console`), and
-/// `deno_url` wired to expose `URL` / `URLSearchParams` / `URLPattern`
-/// globally.
+/// runtime, in dependency order.
+///
+/// - `deno_webidl` (foundation)
+/// - `deno_console` (library dep of `deno_url`'s `customInspect`; does not
+///   replace `globalThis.console`)
+/// - `deno_url` (URL, URLSearchParams, URLPattern)
+/// - `deno_web` (Blob, FormData-adjacent classes, TextEncoder/Decoder, Event,
+///   EventTarget, AbortController, structuredClone, timers, atob/btoa,
+///   performance, MessageChannel, streams, DOMException, FileReader,
+///   CompressionStream)
+/// - `deno_crypto` (Web Crypto API + secure CSPRNG)
 pub fn build() -> Vec<Extension> {
     vec![
         with_esm_entry(deno_webidl::deno_webidl::init(), "ext:deno_webidl/00_webidl.js"),
         with_esm_entry(deno_console::deno_console::init(), "ext:deno_console/01_console.js"),
         deno_url_with_globals(),
+        deno_web_with_globals(),
+        deno_crypto_with_globals(),
     ]
 }

--- a/crates/obscura-js/src/lib.rs
+++ b/crates/obscura-js/src/lib.rs
@@ -1,6 +1,7 @@
 #[macro_use]
 extern crate html5ever;
 
+pub mod deno_extensions;
 pub mod module_loader;
 pub mod runtime;
 pub mod ops;

--- a/crates/obscura-js/src/ops.rs
+++ b/crates/obscura-js/src/ops.rs
@@ -286,6 +286,15 @@ fn op_dom(state: &OpState, #[string] cmd: String, #[string] arg1: String, #[stri
                 .map(|id| id.index() as i32).collect();
             serde_json::to_string(&ids).unwrap_or("[]".into())
         }
+        "element_attributes" => {
+            let nid = arg1.parse::<u32>().unwrap_or(0);
+            let pairs: Vec<(String, String)> = dom.get_node(NodeId::new(nid))
+                .and_then(|n| if let NodeData::Element { attrs, .. } = &n.data {
+                    Some(attrs.iter().map(|a| (a.name.local.as_ref().to_string(), a.value.to_string())).collect())
+                } else { None })
+                .unwrap_or_default();
+            serde_json::to_string(&pairs).unwrap_or("[]".into())
+        }
         "has_child_nodes" => {
             let nid = arg1.parse::<u32>().unwrap_or(0);
             dom.get_node(NodeId::new(nid)).map(|n| n.first_child.is_some()).unwrap_or(false).to_string()

--- a/crates/obscura-js/src/runtime.rs
+++ b/crates/obscura-js/src/runtime.rs
@@ -57,6 +57,7 @@ impl ObscuraJsRuntime {
         });
 
         runtime.op_state().borrow_mut().put(state_clone);
+        runtime.op_state().borrow_mut().put(deno_extensions::ObscuraTimersPermission);
 
         runtime
             .execute_script(
@@ -484,7 +485,7 @@ impl ObscuraJsRuntime {
         );
         self.object_store.clear();
     }
-    pub async fn load_module(&mut self, url: &str) -> Result<(), String> {
+    pub async fn load_module(&mut self, url: &str, timeout: std::time::Duration) -> Result<(), String> {
         let specifier = deno_core::ModuleSpecifier::parse(url)
             .map_err(|e| format!("Invalid module URL {}: {}", url, e))?;
 
@@ -512,32 +513,10 @@ impl ObscuraJsRuntime {
             .await
             .map_err(|e| format!("Module load error: {}", e))?;
 
-        let result = self.runtime.mod_evaluate(module_id);
-
-        let timeout = tokio::time::timeout(
-            tokio::time::Duration::from_secs(10),
-            self.runtime.run_event_loop(deno_core::PollEventLoopOptions::default()),
-        ).await;
-
-        match timeout {
-            Ok(Ok(())) => {}
-            Ok(Err(e)) => return Err(format!("Module event loop error: {}", e)),
-            Err(_) => {
-                tracing::warn!("Module evaluation timed out after 10s: {}", url);
-                return Ok(());
-            }
-        }
-
-        match result.await {
-            Ok(()) => Ok(()),
-            Err(e) => {
-                tracing::warn!("Module eval error: {}", e);
-                Ok(())
-            }
-        }
+        self.eval_module_with_timeout(module_id, timeout, url).await
     }
 
-    pub async fn load_inline_module(&mut self, code: &str, base_url: &str) -> Result<(), String> {
+    pub async fn load_inline_module(&mut self, code: &str, base_url: &str, timeout: std::time::Duration) -> Result<(), String> {
         let specifier = deno_core::ModuleSpecifier::parse(
             &format!("{}#inline-module-{}", base_url, self.object_counter),
         )
@@ -554,26 +533,51 @@ impl ObscuraJsRuntime {
             .await
             .map_err(|e| format!("Inline module load error: {}", e))?;
 
-        let result = self.runtime.mod_evaluate(module_id);
+        self.eval_module_with_timeout(module_id, timeout, base_url).await
+    }
 
-        let timeout = tokio::time::timeout(
-            tokio::time::Duration::from_secs(10),
-            self.runtime.run_event_loop(deno_core::PollEventLoopOptions::default()),
+    // Drive module evaluation with a deadline-aware tokio timeout.
+    // The tokio timeout fires when V8 yields (between ticks), bounding the
+    // overshoot to the module's natural completion time. A V8 watchdog thread
+    // (like execute_script_with_timeout) is intentionally NOT used here:
+    // terminate_execution is catchable by JS try-catch, and a single
+    // termination call on heavy module code with error-recovery paths ends up
+    // running the module LONGER than letting it complete naturally.
+    async fn eval_module_with_timeout(
+        &mut self,
+        module_id: deno_core::ModuleId,
+        timeout: std::time::Duration,
+        label: &str,
+    ) -> Result<(), String> {
+        let effective = if timeout.is_zero() {
+            std::time::Duration::from_secs(10)
+        } else {
+            timeout
+        };
+
+        let mod_eval = self.runtime.mod_evaluate(module_id);
+
+        // Drive the event loop concurrently with mod_evaluate, returning as
+        // soon as the module's top-level evaluation completes. Plain
+        // run_event_loop only resolves once ALL pending work in the runtime
+        // drains, so a page with a persistent setInterval would block here
+        // indefinitely.
+        let result = tokio::time::timeout(
+            effective,
+            self.runtime.with_event_loop_promise(
+                Box::pin(mod_eval),
+                deno_core::PollEventLoopOptions::default(),
+            ),
         ).await;
 
-        match timeout {
-            Ok(Ok(())) => {}
-            Ok(Err(e)) => return Err(format!("Module event loop error: {}", e)),
-            Err(_) => {
-                tracing::warn!("Inline module timed out after 10s");
-                return Ok(());
+        match result {
+            Ok(Ok(())) => Ok(()),
+            Ok(Err(e)) => {
+                tracing::warn!("Module eval error ({}): {}", label, e);
+                Ok(())
             }
-        }
-
-        match result.await {
-            Ok(()) => Ok(()),
-            Err(e) => {
-                tracing::warn!("Inline module eval error: {}", e);
+            Err(_) => {
+                tracing::warn!("Module eval timed out ({}s): {}", effective.as_secs_f64(), label);
                 Ok(())
             }
         }
@@ -600,9 +604,6 @@ impl ObscuraJsRuntime {
         timeout: std::time::Duration,
     ) -> Result<(), String> {
         if timeout.is_zero() {
-            self.runtime
-                .execute_script("<script>", source.to_string())
-                .map_err(|e| format!("JS error: {}", e))?;
             return Ok(());
         }
 
@@ -622,8 +623,20 @@ impl ObscuraJsRuntime {
             loop {
                 let remaining = deadline.saturating_duration_since(std::time::Instant::now());
                 if remaining.is_zero() {
-                    isolate_handle.terminate_execution();
-                    return;
+                    // Repeated firing: a single terminate_execution can be
+                    // swallowed by JS try-catch. Re-fire every 10 ms so that
+                    // scripts with catch-all handlers are eventually forced to
+                    // terminate.
+                    loop {
+                        isolate_handle.terminate_execution();
+                        let (c2, _) = cvar
+                            .wait_timeout(cancelled, std::time::Duration::from_millis(10))
+                            .unwrap();
+                        cancelled = c2;
+                        if *cancelled {
+                            return;
+                        }
+                    }
                 }
 
                 let result = cvar.wait_timeout(cancelled, remaining).unwrap();

--- a/crates/obscura-js/src/runtime.rs
+++ b/crates/obscura-js/src/runtime.rs
@@ -5,6 +5,7 @@ use std::rc::Rc;
 use deno_core::{JsRuntime, RuntimeOptions};
 use obscura_dom::DomTree;
 
+use crate::deno_extensions;
 use crate::module_loader::ObscuraModuleLoader;
 use crate::ops::{build_extension, ObscuraState};
 
@@ -45,8 +46,11 @@ impl ObscuraJsRuntime {
 
         let module_loader = Rc::new(ObscuraModuleLoader::with_proxy(base_url, proxy_url));
 
+        let mut extensions = deno_extensions::build();
+        extensions.push(build_extension());
+
         let mut runtime = JsRuntime::new(RuntimeOptions {
-            extensions: vec![build_extension()],
+            extensions,
             module_loader: Some(module_loader),
             startup_snapshot: Some(SNAPSHOT),
             ..Default::default()

--- a/crates/obscura-js/src/runtime.rs
+++ b/crates/obscura-js/src/runtime.rs
@@ -2123,4 +2123,193 @@ mod tests {
             .unwrap();
         assert_eq!(result, serde_json::json!(["menu", "true"]));
     }
+
+    // ---------------------------------------------------------------
+    // deno_web / deno_crypto regression tests.
+    //
+    // These pin the behavioral contract that the hand-rolled polyfills
+    // in bootstrap.js previously *broke* (see ISSUE_deno_web.md). If any
+    // of these start failing after a dep bump, the deno extension wiring
+    // in `deno_extensions.rs` has regressed.
+    // ---------------------------------------------------------------
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn test_blob_preserves_binary_data() {
+        // The old hand-rolled Blob `join("")`-ed its parts as strings, so
+        // `new Blob([Uint8Array]).text()` returned "[object Object]". The
+        // real Blob from deno_web must round-trip bytes intact.
+        let mut rt = setup_runtime("<html><body></body></html>");
+        let result = rt
+            .call_function_on_for_cdp(
+                r#"async () => {
+                    const bytes = new Uint8Array([0xE2, 0x9C, 0x93]); // UTF-8 for U+2713 ✓
+                    const blob = new Blob([bytes]);
+                    return {
+                        size: blob.size,
+                        text: await blob.text(),
+                        buffer: Array.from(new Uint8Array(await blob.arrayBuffer())),
+                    };
+                }"#,
+                None,
+                &[],
+                true,
+                true,
+            )
+            .await
+            .unwrap();
+        let v = result.value.unwrap();
+        assert_eq!(v["size"].as_u64().unwrap(), 3);
+        assert_eq!(v["text"].as_str().unwrap(), "\u{2713}");
+        assert_eq!(v["buffer"], serde_json::json!([0xE2, 0x9C, 0x93]));
+    }
+
+    #[test]
+    fn test_text_encoder_handles_surrogate_pair() {
+        // A code point above U+FFFF requires a UTF-16 surrogate pair on input
+        // and four UTF-8 bytes on output. The old hand-rolled TextEncoder
+        // mishandled lone-surrogate edge cases; deno_web's ICU-backed
+        // encoder matches V8/Chrome exactly.
+        let mut rt = setup_runtime("<html><body></body></html>");
+        let result = rt
+            .evaluate(
+                // U+1F600 GRINNING FACE — UTF-8: F0 9F 98 80
+                "Array.from(new TextEncoder().encode('\\uD83D\\uDE00'))",
+            )
+            .unwrap();
+        assert_eq!(result, serde_json::json!([0xF0, 0x9F, 0x98, 0x80]));
+    }
+
+    #[test]
+    fn test_structured_clone_preserves_date_and_typed_array() {
+        // Old polyfill was `JSON.parse(JSON.stringify(v))` — silently
+        // turned Date into a string, Uint8Array into an object with
+        // numeric keys, lost circular refs entirely.
+        let mut rt = setup_runtime("<html><body></body></html>");
+        let result = rt
+            .evaluate(
+                r#"(() => {
+                    const src = { d: new Date(1700000000000), bytes: new Uint8Array([1, 2, 3]) };
+                    const cloned = structuredClone(src);
+                    return {
+                        dateIsDate: cloned.d instanceof Date,
+                        dateMs: cloned.d.getTime(),
+                        bytesIsUint8: cloned.bytes instanceof Uint8Array,
+                        bytesLen: cloned.bytes.length,
+                        firstByte: cloned.bytes[0],
+                    };
+                })()"#,
+            )
+            .unwrap();
+        assert_eq!(result["dateIsDate"], serde_json::json!(true));
+        assert_eq!(result["dateMs"].as_i64().unwrap(), 1700000000000);
+        assert_eq!(result["bytesIsUint8"], serde_json::json!(true));
+        assert_eq!(result["bytesLen"].as_u64().unwrap(), 3);
+        assert_eq!(result["firstByte"].as_u64().unwrap(), 1);
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn test_abort_controller_fires_abort_event() {
+        // Old stub set `.aborted = true` on `abort()` but never invoked
+        // the listener. Real AbortSignal must actually fire `'abort'`.
+        let mut rt = setup_runtime("<html><body></body></html>");
+        let result = rt
+            .call_function_on_for_cdp(
+                r#"async () => {
+                    const ctrl = new AbortController();
+                    let fired = 0;
+                    ctrl.signal.addEventListener('abort', () => { fired++; });
+                    ctrl.abort();
+                    // Allow microtask draining.
+                    await Promise.resolve();
+                    return { fired, aborted: ctrl.signal.aborted };
+                }"#,
+                None,
+                &[],
+                true,
+                true,
+            )
+            .await
+            .unwrap();
+        let v = result.value.unwrap();
+        assert_eq!(v["fired"].as_u64().unwrap(), 1);
+        assert_eq!(v["aborted"], serde_json::json!(true));
+    }
+
+    #[test]
+    fn test_crypto_get_random_values_has_entropy() {
+        // Old crypto.getRandomValues used Math.random() — a fingerprinting
+        // tell and not actually random across calls in some patterns. The
+        // real CSPRNG from deno_crypto must produce different outputs on
+        // sequential calls (probability of collision over 32 bytes is
+        // negligible).
+        let mut rt = setup_runtime("<html><body></body></html>");
+        let result = rt
+            .evaluate(
+                r#"(() => {
+                    const a = new Uint8Array(32); crypto.getRandomValues(a);
+                    const b = new Uint8Array(32); crypto.getRandomValues(b);
+                    let equal = true;
+                    for (let i = 0; i < 32; i++) if (a[i] !== b[i]) { equal = false; break; }
+                    return { equal, allZeroA: a.every(x => x === 0) };
+                })()"#,
+            )
+            .unwrap();
+        assert_eq!(
+            result["equal"],
+            serde_json::json!(false),
+            "two 32-byte CSPRNG draws were identical"
+        );
+        assert_eq!(
+            result["allZeroA"],
+            serde_json::json!(false),
+            "CSPRNG returned all-zero buffer"
+        );
+    }
+
+    #[test]
+    fn test_crypto_random_uuid_is_v4_format() {
+        // Old stub used Math.random() with a `4xxx`/`yxxx` template — looked
+        // right but wasn't CSPRNG-backed. Real `randomUUID` must match the
+        // RFC 4122 v4 shape: xxxxxxxx-xxxx-4xxx-Yxxx-xxxxxxxxxxxxx where
+        // Y is one of 8/9/a/b.
+        let mut rt = setup_runtime("<html><body></body></html>");
+        let result = rt.evaluate("crypto.randomUUID()").unwrap();
+        let uuid = result.as_str().unwrap();
+        assert_eq!(uuid.len(), 36, "uuid wrong length: {}", uuid);
+        let parts: Vec<&str> = uuid.split('-').collect();
+        assert_eq!(parts.len(), 5);
+        assert_eq!(parts[0].len(), 8);
+        assert_eq!(parts[1].len(), 4);
+        assert_eq!(parts[2].len(), 4);
+        assert_eq!(parts[3].len(), 4);
+        assert_eq!(parts[4].len(), 12);
+        assert!(
+            parts[2].starts_with('4'),
+            "v4 UUID must start its 3rd group with '4': {}",
+            uuid
+        );
+        let variant = parts[3].chars().next().unwrap();
+        assert!(
+            matches!(variant, '8' | '9' | 'a' | 'b'),
+            "RFC 4122 variant bits wrong (got {}): {}",
+            variant,
+            uuid
+        );
+    }
+
+    #[test]
+    fn test_btoa_handles_non_ascii_via_textencoder() {
+        // The old hand-rolled btoa depended on the broken hand-rolled
+        // TextEncoder, so multi-byte input produced wrong output. With
+        // both backed by deno_web/V8 ICU, base64 of UTF-8 is correct.
+        let mut rt = setup_runtime("<html><body></body></html>");
+        // btoa expects a binary string (latin-1). For UTF-8, pages typically
+        // do `btoa(String.fromCharCode(...new TextEncoder().encode(s)))`.
+        let result = rt
+            .evaluate(
+                "btoa(String.fromCharCode(...new TextEncoder().encode('\u{2713}')))",
+            )
+            .unwrap();
+        assert_eq!(result.as_str().unwrap(), "4pyT");
+    }
 }


### PR DESCRIPTION
This branch replaces several broken / fingerprintable hand-rolled web API polyfills with their Deno counterparts, and adds hard deadline enforcement so a single page-supplied script can no longer hold the tokio executor past `--timeout`.

Three independent commits, each landable on its own.

## Why

Obscura is intentionally lean — 30 MB memory, 70 MB binary, scoped to scraping and agent automation. That's a feature.

But several `crates/obscura-js/js/bootstrap.js` globals aren't lean — they're broken or fingerprintable:

| API | Problem |
|---|---|
| `URL` | Regex-based; `new URL('/foo', window.location)` threw `TypeError: base.match is not a function` for any non-string `base`. Only handled `http(s)`. |
| `Blob`/`File`/`FormData` | `Blob` joined parts as strings — `new Blob([uint8Array]).text()` returned `"[object Object]"`. `fetch` file uploads silently corrupted. |
| `TextEncoder`/`TextDecoder` | JS-only, no ICU. Wrong on non-UTF-8 encodings, surrogate halves, fatal mode, BOM. |
| `AbortController`/`AbortSignal` | Stubs. `abort()` set a flag but never fired the `'abort'` event. `AbortSignal.timeout()` didn't time out. |
| `structuredClone` | `JSON.parse(JSON.stringify(v))`. Silently corrupted `Date`, `Map`, `Set`, `RegExp`, `Uint8Array`, circular refs. |
| `ReadableStream`/`WritableStream` | Stubs. Streaming `fetch().body`, `pipeTo` all failed. |
| `Event`/`EventTarget` | `globalThis.EventTarget = Node` collapsed two unrelated prototype chains. |
| `atob`/`btoa` | Depended on the broken `TextEncoder`; wrong on multi-byte. |
| `performance` | `Date.now()`-based, no sub-millisecond resolution. |
| `crypto.getRandomValues` | Backed by `Math.random()` — detectable bias, no real entropy. |
| `crypto.randomUUID` | Template-string stub, not CSPRNG-backed. |

Each broken implementation is also a fingerprinting tell. Any bot-detection service that probes `new Blob([new Uint8Array([1,2,3])]).text()` or checks `structuredClone(new Date()) instanceof Date` flags us as non-Chrome. `deno_web` / `deno_url` / `deno_crypto` are V8/ICU-native and match Chrome's behavior byte-for-byte — same direction as the existing stealth features.

## What changes

### 1. `feat(js): adopt deno_url for WHATWG-compliant URL implementation`

Drops the regex-based `URL` polyfill. The deno_url implementation handles every scheme correctly, accepts non-string `base` arguments per spec, and is what real Chrome uses.

### 2. `feat(js): adopt deno_web + deno_crypto, drop remaining broken polyfills`

All-or-nothing — `Blob` ↔ `FormData` ↔ `Response` and `EventTarget` ↔ `AbortSignal` import each other internally, so they cannot be cherry-picked. `deno_crypto` is folded into this commit because it's standalone (~150 KB) and shares the same V8/extension wiring path.

Includes regression tests (`mod tests` in `runtime.rs`) pinning the behavioral contract that the polyfills broke — `Blob.text()` round-trips bytes, `TextEncoder` handles surrogate pairs, `structuredClone` preserves `Date`/`Uint8Array`, `AbortSignal` actually fires `'abort'`, `crypto.getRandomValues` produces real entropy.

### 3. `fix(browser,js): enforce navigation deadline through synchronous V8 execution`

`tokio::time::timeout` only fires at `.await` points. Any synchronous V8 work — script evaluation, module top-level code — holds the tokio executor thread for its entire duration, so pages with heavy synchronous scripts could run arbitrarily past `--timeout` with no way to stop them.

Adds `navigation_deadline: Option<Instant>` to `Page` and threads it through every execution phase:

- **Script execution** — each call receives the remaining budget as a hard ceiling. A watchdog thread fires `terminate_execution()` in a 10 ms loop once the budget is exhausted so that scripts with `try-catch` error-recovery handlers (which absorb a single termination) are still forced to stop.
- **Network fetches** — each parallel script fetch is wrapped in `tokio::time::timeout(remaining_budget, ...)`. A slow CDN response can no longer exhaust the deadline by itself.
- **ES modules** — `terminate_execution` is catchable by JavaScript `try-catch`. A threshold guard skips any module whose remaining budget is too small to reliably stop, rather than starting work that cannot be terminated.
- **Load-events / event-loop drain** — capped at the remaining budget, checking the deadline on every iteration.
- **Error surface** — new `PageError::NavigationTimedOut` variant. The CLI's outer `tokio::time::timeout` could only fire once V8 yielded; the deadline is now enforced at the point of each V8 call.

Also switches `eval_module_with_timeout` from `run_event_loop` to `with_event_loop_promise`: the former waits for *all* pending work in the runtime to drain (blocking indefinitely on a page with a live `setInterval`), while the latter resolves as soon as the module's top-level evaluation completes.

## Out of scope (intentional)

- **`fetch` and `XMLHttpRequest` stay hand-rolled.** They route through `op_fetch_url`, which enforces SSRF policy, blocked-URL patterns, the cookie jar, and the CDP Fetch domain's request interception. Replacing with `deno_fetch` would bypass the security model.
- **`setTimeout` / `setInterval`** now come from `deno_web`. The hand-rolled timers in `bootstrap.js` are removed.
- The existing `URL.createObjectURL` override is unchanged in shape — it still routes through the embedder-side `BlobUrlStore`.

## Cost

- Snapshot grows by roughly +500–900 KB. Binary still well under the 70 MB target.
- ~30 LoC of Rust glue in `crates/obscura-js/src/deno_extensions.rs` (BlobUrlStore + TimersPermission).
- Version pin matches the current `deno_core 0.350`.

## Verification

- `cargo test --features stealth --workspace`: 253 passed, 0 failed.
- `cargo build --release --features stealth`: clean (only the pre-existing `RpcResponse` visibility warning in `obscura-mcp`, unrelated).
- Regression tests for each replaced polyfill in `crates/obscura-js/src/runtime.rs::tests` lock the contract in place.