### PR TITLE
fix(js): HTMLMetaElement.content is read/write (#210)

### DIFF
--- a/crates/obscura-js/js/bootstrap.js
+++ b/crates/obscura-js/js/bootstrap.js
@@ -491,9 +491,23 @@ class Element extends Node {
     return ids.map(_wrapEl).filter(Boolean);
   }
   get content() {
-    if (this.localName !== 'template') return undefined;
-    if (!this._templateContent) this._templateContent = document.createDocumentFragment();
-    return this._templateContent;
+    // <template>.content is a DocumentFragment; <meta>.content reflects
+    // the content attribute (read/write per spec). Next.js' next/head
+    // iterates <meta> tags and sets .content during hydration, which
+    // threw with the previous getter-only stub and put React into an
+    // infinite retry loop (issue #210).
+    const tag = this.localName;
+    if (tag === 'template') {
+      if (!this._templateContent) this._templateContent = document.createDocumentFragment();
+      return this._templateContent;
+    }
+    if (tag === 'meta') return this.getAttribute('content') || '';
+    return undefined;
+  }
+  set content(v) {
+    if (this.localName === 'meta') {
+      this.setAttribute('content', v == null ? '' : String(v));
+    }
   }
   get childElementCount() { return this.children.length; }
   get firstElementChild() { return this.children[0] || null; }


### PR DESCRIPTION
Per spec, <meta>.content reflects the content attribute with both get and set. We only handled <template>.content (which is a DocumentFragment) and left .content as a getter-only stub for everything else.

next/head and next/document iterate <meta> tags and assign .content during hydration. With the old stub the assignment threw 'Cannot set property content', React caught and retried in a tight loop, the page never mounted, and the error spammed the console thousands of times. Traveloka and any Next.js site doing meta management was unusable.

Repro from the issue now works:
  document.querySelector('meta[name=x]').content = 'new';
  // before: TypeError. after: "new".