### PR TITLE
fix(js): load_module actually fetches the module source (#205)

### DIFF
--- a/crates/obscura-js/src/runtime.rs
+++ b/crates/obscura-js/src/runtime.rs
@@ -412,9 +412,27 @@ impl ObscuraJsRuntime {
         let specifier = deno_core::ModuleSpecifier::parse(url)
             .map_err(|e| format!("Invalid module URL {}: {}", url, e))?;
 
+        // Fetch the module source. The old impl registered an empty string
+        // and called it loaded, so every Vite / Next module bundle "loaded"
+        // in 1ms with zero code and the SPA never mounted (issue #205).
+        let client = self.state.borrow().http_client.clone();
+        let source_code = match client {
+            Some(c) => match c.fetch(&specifier).await {
+                Ok(resp) => obscura_net::decode_non_html(&resp.body, resp.content_type()),
+                Err(e) => {
+                    tracing::warn!("Module fetch failed ({}): {}", url, e);
+                    String::new()
+                }
+            },
+            None => {
+                tracing::warn!("No http_client wired to runtime; module {} will be empty", url);
+                String::new()
+            }
+        };
+
         let module_id = self
             .runtime
-            .load_side_es_module_from_code(&specifier, deno_core::ModuleCodeString::from_static(""))
+            .load_side_es_module_from_code(&specifier, deno_core::ModuleCodeString::from(source_code))
             .await
             .map_err(|e| format!("Module load error: {}", e))?;
 


### PR DESCRIPTION
load_module registered an empty string as the module body and called it loaded. Every Vite / Next / SvelteKit external module bundle 'loaded' in 1ms with zero code, so the framework never executed and the SPA shell sat empty (#root.children.length == 0).

Now fetches the URL through the page's http_client and passes the real source. getvix.dev/docs (Vite + React) goes from rootChildren=0 / bodyTextLength=10 (SSR shell only) to rootChildren=4 / bodyTextLength=3708 (React app mounted).

Closes #205.