### PR TITLE
fix(js): implement DocumentFragment getElementById

### DIFF
--- a/crates/obscura-js/js/bootstrap.js
+++ b/crates/obscura-js/js/bootstrap.js
@@ -1542,7 +1542,18 @@ class DocumentFragment extends Node {
   }
   get firstElementChild() { return this.children[0] || null; }
   get lastElementChild() { const ch = this.children; return ch[ch.length - 1] || null; }
-  getElementById(id) { return null; }
+  getElementById(id) {
+    const needle = String(id);
+    const stack = Array.from(this.childNodes || []).reverse();
+    while (stack.length) {
+      const node = stack.pop();
+      if (!node) continue;
+      if (node.nodeType === 1 && node.id === needle) return node;
+      const children = node.childNodes || [];
+      for (let i = children.length - 1; i >= 0; i--) stack.push(children[i]);
+    }
+    return null;
+  }
   cloneNode(deep) {
     const frag = document.createDocumentFragment();
     if (deep) frag.innerHTML = this.innerHTML;

--- a/crates/obscura-js/src/runtime.rs
+++ b/crates/obscura-js/src/runtime.rs
@@ -1046,6 +1046,44 @@ mod tests {
     }
 
     #[test]
+    fn document_fragment_get_element_by_id_searches_descendants() {
+        let mut rt = setup_runtime(r#"<div id="target">document</div>"#);
+        let result = rt
+            .evaluate(
+                r#"
+                (() => {
+                    const frag = document.createDocumentFragment();
+                    const section = document.createElement('section');
+                    section.innerHTML = '<div><span id="target">fragment</span></div><p id="a.b">literal</p>';
+                    frag.appendChild(section);
+
+                    const dup = document.createDocumentFragment();
+                    const deepParent = document.createElement('div');
+                    deepParent.innerHTML = '<span id="dup">deep</span>';
+                    const shallow = document.createElement('p');
+                    shallow.id = 'dup';
+                    shallow.textContent = 'shallow';
+                    dup.appendChild(deepParent);
+                    dup.appendChild(shallow);
+
+                    return [
+                        frag.getElementById('target').textContent,
+                        frag.getElementById('missing') === null,
+                        frag.getElementById('a.b').textContent,
+                        frag.getElementById(123) === null,
+                        dup.getElementById('dup').textContent,
+                    ];
+                })()
+                "#,
+            )
+            .unwrap();
+        assert_eq!(
+            result,
+            serde_json::json!(["fragment", true, "literal", true, "deep"])
+        );
+    }
+
+    #[test]
     fn test_inner_html() {
         let mut rt = setup_runtime(r#"<div id="x"><p>Hello</p></div>"#);
         let html = rt.evaluate("document.getElementById('x').innerHTML").unwrap();


### PR DESCRIPTION
## Summary

Implements `DocumentFragment.prototype.getElementById()` so it searches descendant elements inside the fragment instead of always returning `null`.

The implementation performs a scoped descendant traversal and compares literal element IDs, avoiding selector pitfalls for IDs like `a.b`.

Related to #167.

## Tests

- `cargo test -p obscura-js document_fragment_get_element_by_id_searches_descendants -- --nocapture`
- `cargo test -p obscura-js get_element_by_id -- --nocapture`
- `cargo test -p obscura-js`
- `cargo test --workspace`

## Real binary smoke tests

Built and tested with the real debug binary:

- `cargo build -p obscura-cli`
- `./target/debug/obscura fetch https://example.com --dump text --quiet`
- `./target/debug/obscura fetch https://example.com --quiet --eval "...DocumentFragment.getElementById..."`
- `./target/debug/obscura fetch https://example.org --quiet --timeout 30 --wait 1 --eval "...DocumentFragment.getElementById..."`
- `./target/debug/obscura fetch https://www.iana.org/help/example-domains --quiet --timeout 30 --wait 1 --eval "...DocumentFragment.getElementById..."`
- `./target/debug/obscura fetch https://httpbin.org/html --quiet --timeout 30 --wait 1 --eval "...DocumentFragment.getElementById..."`

Observed live-site eval output included:

```text
fragment|true|literal
```
