### PR TITLE
ci: build and push multi-arch Docker images (amd64 + arm64)

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -14,6 +14,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
@@ -35,5 +38,6 @@ jobs:
           tags: |
             ${{ secrets.DOCKERHUB_USERNAME }}/obscura:${{ steps.version.outputs.version }}
             ${{ secrets.DOCKERHUB_USERNAME }}/obscura:latest
+          platforms: linux/amd64,linux/arm64
           cache-from: type=gha
           cache-to: type=gha,mode=max


### PR DESCRIPTION
Add QEMU emulation and multi-platform build to the Docker workflow so the published image includes both `linux/amd64` and `linux/arm64` manifests.

This allows the image to run natively on Apple Silicon and other ARM64 hosts without `--platform linux/amd64` emulation.

The `rust:1-slim-bookworm` and `gcr.io/distroless/cc-debian12` base images already support arm64, so no Dockerfile changes are needed.