### PR TITLE
ci: derive release binary version from tag

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -32,6 +32,8 @@ jobs:
         with:
           context: .
           push: true
+          build-args: |
+            OBSCURA_VERSION=${{ steps.version.outputs.version }}
           tags: |
             ${{ secrets.DOCKERHUB_USERNAME }}/obscura:${{ steps.version.outputs.version }}
             ${{ secrets.DOCKERHUB_USERNAME }}/obscura:latest

--- a/Dockerfile
+++ b/Dockerfile
@@ -29,9 +29,12 @@ RUN for crate in obscura-dom obscura-net obscura-browser obscura-cdp obscura-js 
 
 RUN cargo build --release --bin obscura --bin obscura-worker 2>/dev/null || true
 
+ARG OBSCURA_VERSION
+
 # Copy real sources and build
 COPY crates/ crates/
-RUN touch crates/*/src/*.rs && cargo build --release --bin obscura --bin obscura-worker
+RUN echo "Building Obscura version ${OBSCURA_VERSION:-from Cargo.toml}" && \
+    touch crates/*/src/*.rs && cargo build --release --bin obscura --bin obscura-worker
 
 # ---
 

--- a/crates/obscura-cli/build.rs
+++ b/crates/obscura-cli/build.rs
@@ -1,0 +1,36 @@
+use std::env;
+
+fn env_value(name: &str) -> Option<String> {
+    env::var(name)
+        .ok()
+        .map(|value| value.trim().to_string())
+        .filter(|value| !value.is_empty())
+}
+
+fn normalize_version(version: String) -> String {
+    version.strip_prefix('v').unwrap_or(&version).to_string()
+}
+
+fn github_tag_version() -> Option<String> {
+    if env_value("GITHUB_REF_TYPE").as_deref() == Some("tag") {
+        return env_value("GITHUB_REF_NAME").map(normalize_version);
+    }
+
+    env_value("GITHUB_REF")
+        .and_then(|value| value.strip_prefix("refs/tags/").map(str::to_owned))
+        .map(normalize_version)
+}
+
+fn main() {
+    println!("cargo:rerun-if-env-changed=OBSCURA_VERSION");
+    println!("cargo:rerun-if-env-changed=GITHUB_REF_TYPE");
+    println!("cargo:rerun-if-env-changed=GITHUB_REF_NAME");
+    println!("cargo:rerun-if-env-changed=GITHUB_REF");
+
+    let version = env_value("OBSCURA_VERSION")
+        .map(normalize_version)
+        .or_else(github_tag_version)
+        .unwrap_or_else(|| env::var("CARGO_PKG_VERSION").expect("Cargo sets CARGO_PKG_VERSION"));
+
+    println!("cargo:rustc-env=OBSCURA_BUILD_VERSION={version}");
+}

--- a/crates/obscura-cli/src/main.rs
+++ b/crates/obscura-cli/src/main.rs
@@ -10,7 +10,7 @@ use tokio::time::{timeout, Duration};
 #[derive(Parser)]
 #[command(
     name = "obscura",
-    version = env!("CARGO_PKG_VERSION"),
+    version = env!("OBSCURA_BUILD_VERSION"),
     about = "Obscura - A lightweight headless browser for web scraping and automation",
 )]
 struct Args {
@@ -189,9 +189,9 @@ fn print_banner(port: u16) {
  | |__| | |_) \__ \ (__| |_| | | | (_| |
   \____/|_.__/|___/\___|\__,_|_|  \__,_|
                    
-  Headless Browser v0.1.6
+  Headless Browser v{}
   CDP server: ws://127.0.0.1:{}/devtools/browser
-"#, port);
+"#, env!("OBSCURA_BUILD_VERSION"), port);
 }
 
 fn select_log_filter(verbose: bool, quiet: bool) -> &'static str {


### PR DESCRIPTION
## Summary

Release artifacts and Docker images are currently tagged from Git tags, but the binary version still comes from `Cargo.toml`, which has remained at `0.1.0`. This makes published artifacts report `obscura 0.1.0` via `--version`, while the startup banner is maintained separately.

This PR keeps the current tag-driven release flow and makes the compiled binary version follow it:

- derive `OBSCURA_BUILD_VERSION` from:
  1. explicit `OBSCURA_VERSION`,
  2. GitHub tag env such as `GITHUB_REF_NAME=v0.1.7`,
  3. fallback `CARGO_PKG_VERSION` for normal local/dev builds;
- use the same value for both `--version` and the startup banner;
- pass the existing Docker tag-derived version into Docker builds as `OBSCURA_VERSION`.

No release-time mutation of `Cargo.toml` is needed, and normal local builds still fall back to the Cargo version.

## Behavior

- GitHub tag release `v0.1.7` builds binaries reporting `obscura 0.1.7`.
- Docker workflow builds images whose binary reports the same version as the image tag.
- Local dev builds without release env still report the Cargo fallback, currently `obscura 0.1.0`.
- If the project later adopts Cargo.toml/crates.io-style versioning, the fallback path already supports that.

## Validation

```bash
rustfmt --check crates/obscura-cli/build.rs
OBSCURA_VERSION=9.9.9 cargo check -p obscura-cli --bin obscura
OBSCURA_VERSION=9.9.9 cargo run -q -p obscura-cli --bin obscura -- --version
# obscura 9.9.9

GITHUB_REF_TYPE=tag GITHUB_REF_NAME=v1.2.3 cargo run -q -p obscura-cli --bin obscura -- --version
# obscura 1.2.3

env -u OBSCURA_VERSION -u GITHUB_REF_TYPE -u GITHUB_REF_NAME -u GITHUB_REF \
  cargo run -q -p obscura-cli --bin obscura -- --version
# obscura 0.1.0
```

The existing `private_interfaces` warning in `obscura-mcp` still appears during cargo checks and is unrelated to this change.