### PR TITLE
Fix/rescue 227 regressions

### DIFF
--- a/crates/obscura-cli/build.rs
+++ b/crates/obscura-cli/build.rs
@@ -1,0 +1,36 @@
+use std::env;
+
+fn env_value(name: &str) -> Option<String> {
+    env::var(name)
+        .ok()
+        .map(|value| value.trim().to_string())
+        .filter(|value| !value.is_empty())
+}
+
+fn normalize_version(version: String) -> String {
+    version.strip_prefix('v').unwrap_or(&version).to_string()
+}
+
+fn github_tag_version() -> Option<String> {
+    if env_value("GITHUB_REF_TYPE").as_deref() == Some("tag") {
+        return env_value("GITHUB_REF_NAME").map(normalize_version);
+    }
+
+    env_value("GITHUB_REF")
+        .and_then(|value| value.strip_prefix("refs/tags/").map(str::to_owned))
+        .map(normalize_version)
+}
+
+fn main() {
+    println!("cargo:rerun-if-env-changed=OBSCURA_VERSION");
+    println!("cargo:rerun-if-env-changed=GITHUB_REF_TYPE");
+    println!("cargo:rerun-if-env-changed=GITHUB_REF_NAME");
+    println!("cargo:rerun-if-env-changed=GITHUB_REF");
+
+    let version = env_value("OBSCURA_VERSION")
+        .map(normalize_version)
+        .or_else(github_tag_version)
+        .unwrap_or_else(|| env::var("CARGO_PKG_VERSION").expect("Cargo sets CARGO_PKG_VERSION"));
+
+    println!("cargo:rustc-env=OBSCURA_BUILD_VERSION={version}");
+}

--- a/crates/obscura-cli/src/main.rs
+++ b/crates/obscura-cli/src/main.rs
@@ -10,7 +10,7 @@ use tokio::time::{timeout, Duration};
 #[derive(Parser)]
 #[command(
     name = "obscura",
-    version = env!("CARGO_PKG_VERSION"),
+    version = env!("OBSCURA_BUILD_VERSION"),
     about = "Obscura - A lightweight headless browser for web scraping and automation",
 )]
 struct Args {
@@ -189,9 +189,9 @@ fn print_banner(port: u16) {
  | |__| | |_) \__ \ (__| |_| | | | (_| |
   \____/|_.__/|___/\___|\__,_|_|  \__,_|
                    
-  Headless Browser v0.1.6
+  Headless Browser v{}
   CDP server: ws://127.0.0.1:{}/devtools/browser
-"#, port);
+"#, env!("OBSCURA_BUILD_VERSION"), port);
 }
 
 fn select_log_filter(verbose: bool, quiet: bool) -> &'static str {
@@ -262,6 +262,17 @@ async fn main() -> anyhow::Result<()> {
     let v8_flags = effective_v8_flags(args.v8_flags.as_deref());
     tracing::debug!("V8 flags: {}", v8_flags);
     obscura_js::set_v8_flags(&v8_flags);
+
+    // The js-side fetch path (op_fetch_url) reads OBSCURA_ALLOW_PRIVATE_NETWORK
+    // directly for its SSRF gate. Mirror the CLI flag into the env var so
+    // iframe loads and JS fetch() see the same policy the http_client layer
+    // already uses (issue #33).
+    if args.allow_private_network {
+        // SAFETY: set_var is unsafe in newer rustc; this runs before any
+        // spawned thread inspects the env, so it's effectively single
+        // threaded at this point.
+        unsafe { std::env::set_var("OBSCURA_ALLOW_PRIVATE_NETWORK", "1"); }
+    }
 
     let global_proxy = args.proxy.clone();
 

--- a/crates/obscura-dom/src/tree.rs
+++ b/crates/obscura-dom/src/tree.rs
@@ -223,6 +223,14 @@ impl DomTree {
     }
 
     pub fn append_child(&self, parent_id: NodeId, child_id: NodeId) {
+        // Per DOM spec, appending a node to itself is a HierarchyRequestError;
+        // here we treat it as a no-op rather than panic. Without this the
+        // sibling-pointer fixup below sets the node's prev_sibling to itself
+        // and every later child-walk loops forever (same failure mode that
+        // insert_before's self-cycle guard was added to prevent).
+        if parent_id == child_id {
+            return;
+        }
         self.detach(child_id);
 
         let mut inner = self.inner.borrow_mut();
@@ -252,6 +260,15 @@ impl DomTree {
     }
 
     pub fn insert_before(&self, existing_id: NodeId, new_sibling_id: NodeId) {
+        // Per DOM spec: if the node being inserted IS the reference node,
+        // the operation is a no-op (the node is already in its target
+        // position). Without this, the linked-list fixup below sets the
+        // node's prev_sibling and next_sibling to itself, creating a cycle
+        // -- every later traversal (childNodes, querySelectorAll, etc) then
+        // loops forever and the test page hangs while obscura burns RAM.
+        if existing_id == new_sibling_id {
+            return;
+        }
         let (parent_id, prev_id) = {
             let inner = self.inner.borrow();
             let node = match inner.nodes.get(existing_id.index()).and_then(|n| n.as_ref()) {
@@ -463,6 +480,20 @@ impl DomTree {
 
     pub fn text_content(&self, node_id: NodeId) -> String {
         let inner = self.inner.borrow();
+        // Per DOM spec, calling textContent ON a CharacterData node
+        // (Text, Comment, ProcessingInstruction) returns its .data.
+        // Calling textContent on an Element walks descendants and
+        // concatenates Text node content only (Comment + PI are
+        // skipped). Handle the direct-CharacterData case here so the
+        // descent helper can keep its element-centric behavior.
+        if let Some(Some(node)) = inner.nodes.get(node_id.index()) {
+            match &node.data {
+                NodeData::Text { contents } => return contents.clone(),
+                NodeData::Comment { contents } => return contents.clone(),
+                NodeData::ProcessingInstruction { data, .. } => return data.clone(),
+                _ => {}
+            }
+        }
         let mut result = String::new();
         collect_text_inner(&inner, node_id, &mut result);
         result
@@ -570,6 +601,10 @@ fn collect_text_inner(inner: &DomTreeInner, node_id: NodeId, buf: &mut String) {
     if let Some(Some(node)) = inner.nodes.get(node_id.index()) {
         match &node.data {
             NodeData::Text { contents } => buf.push_str(contents),
+            // Comment and ProcessingInstruction are intentionally NOT
+            // appended when traversing descendants: per spec, textContent
+            // on an Element only includes Text descendants. Direct
+            // textContent on a Comment/PI is handled by the caller.
             _ => {
                 let mut child = node.first_child;
                 while let Some(child_id) = child {

--- a/crates/obscura-js/js/bootstrap.js
+++ b/crates/obscura-js/js/bootstrap.js
@@ -1842,7 +1842,7 @@ globalThis.navigator = {
     p.item = (i) => p[i] || null;
     p.namedItem = (name) => p.find(x => x.name === name) || null;
     p.refresh = () => {};
-    p[Symbol.iterator] = function() { return this[Symbol.iterator](); };
+    p[Symbol.iterator] = Array.prototype[Symbol.iterator].bind(p);
     return p;
   },
   get mimeTypes() {
@@ -4312,7 +4312,7 @@ _markNative(MediaStream); _markNative(MediaStreamTrack);
 _markNative(RTCPeerConnection); _markNative(RTCSessionDescription); _markNative(RTCIceCandidate);
 
 const _OrigDateTimeFormat = Intl.DateTimeFormat;
-const _defaultTZ = 'Europe/Germany';
+const _defaultTZ = 'Europe/Berlin';
 Intl.DateTimeFormat = function(locales, options) {
   if (!options) options = {};
   if (!options.timeZone) options.timeZone = _defaultTZ;

--- a/crates/obscura-js/src/ops.rs
+++ b/crates/obscura-js/src/ops.rs
@@ -259,6 +259,7 @@ fn op_dom(state: &OpState, #[string] cmd: String, #[string] arg1: String, #[stri
                 match &mut n.data {
                     NodeData::Text { contents } => { *contents = arg2.clone(); }
                     NodeData::Comment { contents } => { *contents = arg2.clone(); }
+                    NodeData::ProcessingInstruction { data, .. } => { *data = arg2.clone(); }
                     _ => {}
                 }
             });
@@ -278,6 +279,47 @@ fn op_dom(state: &OpState, #[string] cmd: String, #[string] arg1: String, #[stri
         }
         "create_comment_node" => {
             dom.new_node(NodeData::Comment { contents: arg1.clone() }).index().to_string()
+        }
+        "create_processing_instruction" => {
+            // arg1 = target, arg2 = data
+            dom.new_node(NodeData::ProcessingInstruction {
+                target: arg1.clone(),
+                data: arg2.clone(),
+            }).index().to_string()
+        }
+        "create_doctype" => {
+            // arg1 = name, arg2 = public_id. system_id stored only in the
+            // JS wrapper since neither current WPT test reads it back from
+            // the underlying tree.
+            dom.new_node(NodeData::Doctype {
+                name: arg1.clone(),
+                public_id: arg2.clone(),
+                system_id: String::new(),
+            }).index().to_string()
+        }
+        "pi_target" => {
+            let nid = arg1.parse::<u32>().unwrap_or(0);
+            let val = dom.get_node(NodeId::new(nid)).and_then(|n| match &n.data {
+                NodeData::ProcessingInstruction { target, .. } => Some(target.clone()),
+                _ => None,
+            }).unwrap_or_default();
+            serde_json::to_string(&val).unwrap_or("\"\"".into())
+        }
+        "doctype_name" => {
+            let nid = arg1.parse::<u32>().unwrap_or(0);
+            let val = dom.get_node(NodeId::new(nid)).and_then(|n| match &n.data {
+                NodeData::Doctype { name, .. } => Some(name.clone()),
+                _ => None,
+            }).unwrap_or_default();
+            serde_json::to_string(&val).unwrap_or("\"\"".into())
+        }
+        "doctype_public_id" => {
+            let nid = arg1.parse::<u32>().unwrap_or(0);
+            let val = dom.get_node(NodeId::new(nid)).and_then(|n| match &n.data {
+                NodeData::Doctype { public_id, .. } => Some(public_id.clone()),
+                _ => None,
+            }).unwrap_or_default();
+            serde_json::to_string(&val).unwrap_or("\"\"".into())
         }
         "element_children" => {
             let nid = arg1.parse::<u32>().unwrap_or(0);
@@ -726,7 +768,7 @@ fn validate_fetch_url(url: &url::Url) -> Result<(), String> {
         ));
     }
 
-    if scheme == "file" {
+    if scheme == "file" || obscura_net::env_allows_private_network() {
         return Ok(());
     }
 


### PR DESCRIPTION


  ## Regressions from #227

  **build.rs deleted** (#224 reverted)
  #227 removed the build script that derives OBSCURA_BUILD_VERSION from the
  git tag. Restored build.rs and the two references to OBSCURA_BUILD_VERSION
  in main.rs (--version string and startup banner).

  **--allow-private-network broken**
  The block that mirrors the CLI flag into OBSCURA_ALLOW_PRIVATE_NETWORK was
  removed from main.rs, and the env_allows_private_network() check was removed
  from validate_fetch_url in ops.rs. Together these made --allow-private-network
  a no-op for JS-side fetch calls. Both restored.

  **DOM cycle guards removed**
  append_child and insert_before lost their self-reference no-ops. Without
  them, passing a node as both parent and child (or as both reference and
  new sibling) corrupts the linked list and causes infinite traversal loops.
  Both guards restored in tree.rs.

  **textContent CharacterData fast-path removed**
  Calling .textContent on a Text, Comment, or ProcessingInstruction node
  fell through to the descendant walker instead of returning the node's own
  data. Fast-path restored in tree.rs.

  **PI/Doctype Rust ops removed**
  create_processing_instruction, create_doctype, pi_target, doctype_name,
  doctype_public_id, and the ProcessingInstruction branch in set_text_content
  were all deleted from ops.rs. These back the JS DOM APIs added in #230/#231.
  All restored.

  ## Bugs in #227's stealth code

  **Europe/Germany is not a valid IANA timezone**
  Intl.DateTimeFormat silently fell back to UTC. Changed to Europe/Berlin,
  which is consistent with the Frankfurt geolocation coordinates.

  **navigator.plugins[Symbol.iterator] infinite recursion**
  The implementation was `function() { return this[Symbol.iterator](); }`,
  which recurses forever and blows the stack on Array.from(navigator.plugins).
  Fixed to bind Array.prototype[Symbol.iterator] directly to the array.