### PR TITLE
  fix(net): pin exact wreq and wreq-util versions for stealth build

### DIFF
--- a/crates/obscura-net/Cargo.toml
+++ b/crates/obscura-net/Cargo.toml
@@ -18,14 +18,19 @@ thiserror = { workspace = true }
 async-trait = "0.1"
 encoding_rs = "0.8"
 tempfile = "3"
-wreq-util = { version = "3.0.0-rc.10", optional = true }
+# wreq and wreq-util are pre-release crates whose API changes between rc builds
+# (CertStore moved out of `tls`, `cert_store` renamed to `tls_cert_store`, the
+# Emulation builder reshuffled). A caret requirement let a fresh resolve pull a
+# newer, incompatible rc and broke `cargo build --features stealth` (issue #234).
+# Pin exact versions so the build always resolves to the API wreq_client.rs targets.
+wreq-util = { version = "=3.0.0-rc.10", optional = true }
 
 # `prefix-symbols` renames BoringSSL exports to avoid clashes with system OpenSSL,
 # but the renaming is only correct on Linux and Android (per wreq's README).
 # Enabling it on other platforms produces unresolved `build_script_main_*`
 # symbols at link time (see issue #39).
 [target.'cfg(any(target_os = "linux", target_os = "android"))'.dependencies]
-wreq = { version = "6.0.0-rc.28", optional = true, features = ["prefix-symbols"] }
+wreq = { version = "=6.0.0-rc.28", optional = true, features = ["prefix-symbols"] }
 
 [target.'cfg(not(any(target_os = "linux", target_os = "android")))'.dependencies]
-wreq = { version = "6.0.0-rc.28", optional = true }
+wreq = { version = "=6.0.0-rc.28", optional = true }


### PR DESCRIPTION
Closes #234.

  cargo build --features stealth fails on a fresh checkout with four errors in wreq_client.rs (CertStore not in tls, missing EmulationOption/EmulationOS, cert_store should be tls_cert_store).

  Cause

  wreq and wreq-util are release candidates whose public API changes between rc numbers. The manifest required them with caret ranges (6.0.0-rc.28, 3.0.0-rc.10), so a fresh resolve or cargo update is free to pull a newer
  6.0.0-rc.N. A later rc moved CertStore out of tls, renamed cert_store to tls_cert_store, and reshuffled the Emulation builder, so the stealth client no longer compiles against it. The committed lockfile pins the good
  versions, which is why CI and lockfile-based builds were fine, but building from source off the manifest drifts and breaks.

  Fix

  Pin both crates to exact versions so the manifest itself cannot drift off the API the code targets:

  wreq-util = "=3.0.0-rc.10"
  wreq      = "=6.0.0-rc.28"   # both target blocks, socks/prefix-symbols features unchanged

  No source changes. wreq_client.rs already targets this API.