### PR TITLE
fix(api/js): Browser cookie jar + base href + Node.baseURI + XHR EventTarget + Page::settle (closes #241,#242,#244,#245,#247)

### DIFF
--- a/crates/obscura-browser/src/page.rs
+++ b/crates/obscura-browser/src/page.rs
@@ -282,8 +282,31 @@ impl Page {
         self.js = Some(rt);
     }
 
+    /// Resolve the document base URL per HTML spec:
+    /// https://html.spec.whatwg.org/multipage/urls-and-fetching.html#document-base-url
+    /// Falls back to self.url when no <base href> exists.
+    fn resolve_base_url(&self) -> Option<url::Url> {
+        let doc_url = self.url.as_ref()?;
+        let base_href: Option<String> = self.js.as_ref().and_then(|js| {
+            js.with_dom(|dom| {
+                match dom.query_selector("base[href]") {
+                    Ok(Some(nid)) => {
+                        dom.get_node(nid).and_then(|n| n.get_attribute("href").map(|s| s.to_string()))
+                    }
+                    _ => None,
+                }
+            }).flatten()
+        });
+        match base_href {
+            Some(href) => doc_url.join(&href).ok(),
+            None => Some(doc_url.clone()),
+        }
+    }
+
     async fn execute_scripts(&mut self) {
         tracing::info!("execute_scripts called, js runtime exists: {}", self.js.is_some());
+        // Compute document base URL, respecting <base href>.
+        let document_base = self.resolve_base_url();
         // Soft deadline on the entire script-execution phase. Heavy SPAs
         // (GitHub, Linear, CodeSandbox) ship 50+ scripts and our serial
         // fetch + execute loop can blow past a 25s Puppeteer goto timeout.
@@ -397,7 +420,7 @@ impl Page {
             if let Some(src_url) = &script.src {
                 let full_url = if src_url.starts_with("http://") || src_url.starts_with("https://") {
                     src_url.clone()
-                } else if let Some(base) = &self.url {
+                } else if let Some(base) = &document_base {
                     base.join(src_url).map(|u| u.to_string()).unwrap_or_else(|_| src_url.clone())
                 } else {
                     src_url.clone()
@@ -557,7 +580,7 @@ impl Page {
             if let Some(ref src) = module_script.src {
                 let full_url = if src.starts_with("http://") || src.starts_with("https://") {
                     src.clone()
-                } else if let Some(base) = &self.url {
+                } else if let Some(base) = &document_base {
                     base.join(src).map(|u| u.to_string()).unwrap_or_else(|_| src.clone())
                 } else {
                     src.clone()

--- a/crates/obscura-js/js/bootstrap.js
+++ b/crates/obscura-js/js/bootstrap.js
@@ -2645,6 +2645,7 @@ globalThis.XMLHttpRequest = class XMLHttpRequest extends XMLHttpRequestEventTarg
   UNSENT = 0; OPENED = 1; HEADERS_RECEIVED = 2; LOADING = 3; DONE = 4;
 
   constructor() {
+    super();
     this.readyState = 0;
     this.status = 0;
     this.statusText = "";
@@ -2796,7 +2797,33 @@ globalThis.XMLHttpRequest = class XMLHttpRequest extends XMLHttpRequestEventTarg
     this.readyState = 0;
   }
 
-  // addEventListener/removeEventListener/dispatchEvent inherited from XMLHttpRequestEventTarget
+  addEventListener(type, handler) {
+    if (!this._listeners[type]) this._listeners[type] = [];
+    this._listeners[type].push(handler);
+  }
+
+  removeEventListener(type, handler) {
+    if (this._listeners[type]) {
+      this._listeners[type] = this._listeners[type].filter(h => h !== handler);
+    }
+  }
+
+  // Per WHATWG DOM spec — required by zone.js which patches XHR via
+  // Object.getOwnPropertyDescriptor on XMLHttpRequestEventTarget.prototype.
+  dispatchEvent(event) {
+    if (!event || !event.type) return false;
+    const ev = (typeof event === 'object') ? event : { type: event };
+    ev.target = ev.target || this;
+    ev.currentTarget = ev.currentTarget || this;
+    const type = ev.type;
+    const handlers = (this._listeners && this._listeners[type]) || [];
+    for (const h of handlers) { try { h.call(this, ev); } catch (e) {} }
+    const prop = 'on' + type;
+    if (typeof this[prop] === 'function') {
+      try { this[prop](ev); } catch (e) {}
+    }
+    return true;
+  }
 
   _setReadyState(state) {
     this.readyState = state;
@@ -2821,6 +2848,9 @@ _markNative(XMLHttpRequest.prototype.open);
 _markNative(XMLHttpRequest.prototype.send);
 _markNative(XMLHttpRequest.prototype.abort);
 _markNative(XMLHttpRequest.prototype.setRequestHeader);
+_markNative(XMLHttpRequest.prototype.addEventListener);
+_markNative(XMLHttpRequest.prototype.removeEventListener);
+_markNative(XMLHttpRequest.prototype.dispatchEvent);
 _markNative(XMLHttpRequest.prototype.getResponseHeader);
 _markNative(XMLHttpRequest.prototype.getAllResponseHeaders);
 

--- a/crates/obscura-js/js/bootstrap.js
+++ b/crates/obscura-js/js/bootstrap.js
@@ -351,22 +351,9 @@ class Node {
       const src = c.getAttribute('src');
       const prevNid = globalThis.__currentScriptNid;
       if (src) {
-        // Resolve relative to document base URL, respecting <base href>.
-        // Dynamic imports (Angular lazy chunks) need this because the Rust
-        // execute_scripts base-href fix only covers initial <script> tags.
-        const baseUrl = (() => {
-          try {
-            const baseEl = document.querySelector('base[href]');
-            if (baseEl) {
-              const href = baseEl.getAttribute('href');
-              if (href) return new URL(href, globalThis.location?.href || 'http://localhost/').href;
-            }
-          } catch(e) {}
-          return globalThis.location?.href || 'http://localhost/';
-        })();
         const fullUrl = src.startsWith('http') || src.startsWith('data:')
           ? src
-          : new URL(src, baseUrl).href;
+          : new URL(src, globalThis.location?.href || 'http://localhost/').href;
         const pageOrigin = (function() { try { return new URL(globalThis.location?.href || "about:blank").origin; } catch(e) { return ""; } })();
         (async () => {
           try {

--- a/crates/obscura-js/js/bootstrap.js
+++ b/crates/obscura-js/js/bootstrap.js
@@ -283,6 +283,23 @@ class Node {
   get nodeType() { return +_dom("node_type", this._nid); }
   get nodeName() { return _domParse("node_name", this._nid) || ""; }
   get ownerDocument() { return globalThis.document; }
+  // https://dom.spec.whatwg.org/#dom-node-baseuri
+  get baseURI() {
+    try {
+      const doc = globalThis.document;
+      const docUrl = (doc && doc.URL) || "";
+      const baseEl = (doc && doc.querySelector) ? doc.querySelector("base[href]") : null;
+      if (baseEl) {
+        const href = baseEl.getAttribute("href");
+        if (href) {
+          return docUrl ? new URL(href, docUrl).href : href;
+        }
+      }
+      return docUrl;
+    } catch (e) {
+      return "";
+    }
+  }
   get textContent() { return _domParse("text_content", this._nid) ?? ""; }
   set textContent(v) {
     const oldChildren = _domParse("child_nodes", this._nid) || [];

--- a/crates/obscura-js/js/bootstrap.js
+++ b/crates/obscura-js/js/bootstrap.js
@@ -351,9 +351,22 @@ class Node {
       const src = c.getAttribute('src');
       const prevNid = globalThis.__currentScriptNid;
       if (src) {
+        // Resolve relative to document base URL, respecting <base href>.
+        // Dynamic imports (Angular lazy chunks) need this because the Rust
+        // execute_scripts base-href fix only covers initial <script> tags.
+        const baseUrl = (() => {
+          try {
+            const baseEl = document.querySelector('base[href]');
+            if (baseEl) {
+              const href = baseEl.getAttribute('href');
+              if (href) return new URL(href, globalThis.location?.href || 'http://localhost/').href;
+            }
+          } catch(e) {}
+          return globalThis.location?.href || 'http://localhost/';
+        })();
         const fullUrl = src.startsWith('http') || src.startsWith('data:')
           ? src
-          : new URL(src, globalThis.location?.href || 'http://localhost/').href;
+          : new URL(src, baseUrl).href;
         const pageOrigin = (function() { try { return new URL(globalThis.location?.href || "about:blank").origin; } catch(e) { return ""; } })();
         (async () => {
           try {

--- a/crates/obscura-js/js/bootstrap.js
+++ b/crates/obscura-js/js/bootstrap.js
@@ -2601,7 +2601,42 @@ if (typeof Headers === "undefined") {
   };
 }
 
-globalThis.XMLHttpRequest = class XMLHttpRequest {
+// XMLHttpRequestEventTarget — spec-required ancestor for XHR EventTarget methods.
+// zone.js prefers to walk XMLHttpRequestEventTarget.prototype for addEventListener/
+// removeEventListener/dispatchEvent descriptors before falling back to XHR.prototype.
+class XMLHttpRequestEventTarget {
+  addEventListener(type, handler) {
+    if (!this._listeners) this._listeners = {};
+    if (!this._listeners[type]) this._listeners[type] = [];
+    this._listeners[type].push(handler);
+  }
+  removeEventListener(type, handler) {
+    if (this._listeners && this._listeners[type]) {
+      this._listeners[type] = this._listeners[type].filter(h => h !== handler);
+    }
+  }
+  dispatchEvent(event) {
+    if (!event || !event.type) return false;
+    const ev = (typeof event === 'object') ? event : { type: event };
+    ev.target = ev.target || this;
+    ev.currentTarget = ev.currentTarget || this;
+    const type = ev.type;
+    const handlers = (this._listeners && this._listeners[type]) || [];
+    for (const h of handlers) { try { h.call(this, ev); } catch (e) {} }
+    const prop = 'on' + type;
+    if (typeof this[prop] === 'function') {
+      try { this[prop](ev); } catch (e) {}
+    }
+    return true;
+  }
+}
+globalThis.XMLHttpRequestEventTarget = XMLHttpRequestEventTarget;
+_markNative(XMLHttpRequestEventTarget);
+_markNative(XMLHttpRequestEventTarget.prototype.addEventListener);
+_markNative(XMLHttpRequestEventTarget.prototype.removeEventListener);
+_markNative(XMLHttpRequestEventTarget.prototype.dispatchEvent);
+
+globalThis.XMLHttpRequest = class XMLHttpRequest extends XMLHttpRequestEventTarget {
   static UNSENT = 0;
   static OPENED = 1;
   static HEADERS_RECEIVED = 2;
@@ -2761,16 +2796,7 @@ globalThis.XMLHttpRequest = class XMLHttpRequest {
     this.readyState = 0;
   }
 
-  addEventListener(type, handler) {
-    if (!this._listeners[type]) this._listeners[type] = [];
-    this._listeners[type].push(handler);
-  }
-
-  removeEventListener(type, handler) {
-    if (this._listeners[type]) {
-      this._listeners[type] = this._listeners[type].filter(h => h !== handler);
-    }
-  }
+  // addEventListener/removeEventListener/dispatchEvent inherited from XMLHttpRequestEventTarget
 
   _setReadyState(state) {
     this.readyState = state;

--- a/crates/obscura/src/browser.rs
+++ b/crates/obscura/src/browser.rs
@@ -22,15 +22,6 @@ impl Browser {
     }
 
     pub fn build(config: BrowserConfig) -> Result<Self, Error> {
-        let cookie_jar = Arc::new(CookieJar::new());
-
-        if let Some(ref dir) = config.storage_dir {
-            let cookie_path = dir.join("cookies.json");
-            if cookie_path.exists() {
-                let _ = cookie_jar.load_from_file(&cookie_path);
-            }
-        }
-
         let context = if let Some(ref dir) = config.storage_dir {
             BrowserContext::with_storage_full(
                 "api".to_string(),
@@ -48,10 +39,10 @@ impl Browser {
             )
         };
 
-        Ok(Browser {
-            context: Arc::new(context),
-            cookie_jar,
-        })
+        let context = Arc::new(context);
+        let cookie_jar = context.cookie_jar.clone();
+
+        Ok(Browser { context, cookie_jar })
     }
 
     pub fn builder() -> BrowserBuilder {

--- a/crates/obscura/src/page.rs
+++ b/crates/obscura/src/page.rs
@@ -84,6 +84,15 @@ impl Page {
             tokio::time::sleep(Duration::from_millis(100)).await;
         }
     }
+
+    /// Drive the page's JS event loop for up to `max_ms` milliseconds.
+    ///
+    /// Call this after `evaluate()` kicks off async work (Promises, fetch,
+    /// setTimeout, RxJS subscribers) to let the V8 event loop pump and
+    /// resolve scheduled microtasks/macrotasks before the next `evaluate()`.
+    pub async fn settle(&mut self, max_ms: u64) {
+        self.inner.settle(max_ms).await
+    }
 }
 
 /// Handle to a DOM element.


### PR DESCRIPTION
## Changes

### 1. Cookie jar disconnect (closes #241)
`crates/obscura/src/browser.rs` — 4 insertions, 13 deletions.

`Browser::cookies()` returned an empty `CookieStore` after navigation because `Browser::build()` created its own empty `CookieJar`, while `BrowserContext` internally uses a *separate* jar for HTTP `Set-Cookie` handling.

**Fix**: Use `context.cookie_jar.clone()` instead of `Arc::new(CookieJar::new())`. Also removes redundant cookie-loading in `Browser::build()` since `BrowserContext::_new_inner` already handles `storage_dir` cookie loading.

### 2. Script src <base href> resolution (closes #242)
`crates/obscura-browser/src/page.rs` — 25 insertions, 2 deletions.

Relative `<script src>` URLs were resolved against the document URL instead of `<base href>`. This broke all SPAs served from sub-paths (Angular/Vite/Next.js with `BASE_URL != "/"`).

**Fix**: Added `resolve_base_url()` that queries DOM for `<base href>` and uses it as the URL base per [HTML spec](https://html.spec.whatwg.org/multipage/urls-and-fetching.html#document-base-url). Applied to both regular script loading and ES module loading.

## Verification
- `cargo check -p obscura` passes
- `cargo check -p obscura-browser` passes

@kakserpom thanks for the detailed analysis!