### PR TITLE
 fix: resolve element .src to an absolute URL (#255)

### DIFF
--- a/crates/obscura-js/js/bootstrap.js
+++ b/crates/obscura-js/js/bootstrap.js
@@ -1433,7 +1433,16 @@ class Element extends Node {
   get hash() { const u = (this.localName === 'a' || this.localName === 'area') ? _elemHrefURL(this) : null; return u ? u.hash : ''; }
   set hash(v) { if (this.localName === 'a' || this.localName === 'area') _setElemHrefPart(this, 'hash', v); }
   get origin() { const u = (this.localName === 'a' || this.localName === 'area') ? _elemHrefURL(this) : null; return u ? u.origin : ''; }
-  get src() { return this.getAttribute("src") || ""; }
+  get src() {
+    // IDL reflection: HTMLScriptElement/HTMLImageElement/etc. `.src` returns the
+    // resolved absolute URL, not the literal attribute. Loaders that compute their
+    // base via `new URL(document.currentScript.src).origin` break on a relative
+    // value (issue #255). getAttribute("src") still returns the literal.
+    const v = this.getAttribute("src");
+    if (!v) return "";
+    try { return new URL(v, globalThis.location?.href || "about:blank").href; }
+    catch (e) { return v; }
+  }
   set src(v) {
     this.setAttribute("src", v);
     if (this.localName === 'iframe' && v && v !== 'about:blank') {


### PR DESCRIPTION
### Description:
  Fixes the live half of #255.

  `document.currentScript` already works on main, so the actual blocker for the
  reported SPAs is that `HTMLScriptElement.src` (the shared element `.src` getter)
  returned the literal attribute instead of the resolved absolute URL. Loaders
  that compute their base with `new URL(document.currentScript.src).origin` get a
  relative value, `new URL` throws "Invalid URL", the loader aborts, and the page
  bundle never loads (empty body).
  
  ### Change
  `.src` now resolves against the document base URL, matching the IDL reflection
  spec and what the iframe loader and dynamic-script handler already do.
  `getAttribute("src")` still returns the literal.
  
  ### Testing
  Reproduced a galicia-style loader (relative `<script src>` +
  `new URL(currentScript.src).origin`): empty before, renders the form after.
  `.src` is absolute for classic scripts, dynamically injected scripts and
  `<img>`; obstacle course 33/33; WPT dom/nodes unchanged.

  Note: #255 also reports a separate "a0do is not a constructor" error (an
  unimplemented Web API surfaced only by that page's obfuscated bundle). That is
  not addressed here and needs a trace against the live page.