### PR TITLE
Fix/issues 257 258

### DIFF
--- a/crates/obscura-js/js/bootstrap.js
+++ b/crates/obscura-js/js/bootstrap.js
@@ -4997,6 +4997,15 @@ class _Canvas2D {
   createPattern() { return {}; }
   isPointInPath() { return false; }
   isPointInStroke() { return false; }
+  // Line-dash plus a few path/style methods that charting libraries (Highcharts,
+  // ECharts) call on every animation frame. A missing setLineDash threw
+  // "is not a function" from a timer each tick, spamming errors (#258).
+  setLineDash() {}
+  getLineDash() { return []; }
+  ellipse() {}
+  roundRect() {}
+  createConicGradient() { return { addColorStop(){} }; }
+  getContextAttributes() { return { alpha: true, desynchronized: false, colorSpace: "srgb", willReadFrequently: false }; }
 }
 
 Element.prototype.getContext = function getContext(type) {

--- a/crates/obscura-mcp/src/lib.rs
+++ b/crates/obscura-mcp/src/lib.rs
@@ -1608,14 +1608,20 @@ fn tool_search(args: &Value, state: &mut BrowserState) -> Result<String, String>
     let mut idx = 0;
     while let Some(pos) = haystack[idx..].find(&needle) {
         let abs = idx + pos;
-        let start = abs.saturating_sub(context);
-        let end = (abs + needle.len() + context).min(body.len());
-        // body and haystack share byte offsets even when lowercased (only ASCII fold).
-        // For safety on non-ASCII, fall back to char-boundary trimming.
-        let start = body[..start].rfind(|c: char| c.is_whitespace())
-            .map(|i| i + 1).unwrap_or(start);
-        let end = body[end..].find(|c: char| c.is_whitespace())
-            .map(|i| end + i).unwrap_or(end);
+        let mut start = abs.saturating_sub(context);
+        let mut end = (abs + needle.len() + context).min(body.len());
+        // start/end are byte offsets derived from char counts and needle.len(),
+        // so they can land inside a multi-byte (CJK) character. Snap to char
+        // boundaries before slicing or body[..start] panics (#257).
+        while start > 0 && !body.is_char_boundary(start) { start -= 1; }
+        while end < body.len() && !body.is_char_boundary(end) { end += 1; }
+        // Trim inward to the nearest whitespace so snippets start/end on words.
+        if let Some(i) = body[..start].rfind(|c: char| c.is_whitespace()) {
+            start = i + body[i..].chars().next().map_or(1, char::len_utf8);
+        }
+        if let Some(i) = body[end..].find(|c: char| c.is_whitespace()) {
+            end += i;
+        }
         let snippet = body.get(start..end).unwrap_or("").trim().replace('\n', " ");
         out.push(json!({
             "offset": abs,

--- a/crates/obscura-mcp/src/lib.rs
+++ b/crates/obscura-mcp/src/lib.rs
@@ -102,6 +102,7 @@ impl BrowserState {
             self.active_tab = Some(id);
         }
         let id = self.active_tab.as_ref().unwrap().clone();
+        self.activate(&id);
         self.tabs.get_mut(&id).expect("active tab must exist")
     }
 
@@ -112,6 +113,34 @@ impl BrowserState {
         self.active_tab = Some(id.clone());
         self.interactive_refs.clear();
         id
+    }
+
+    /// Enforce the single-live-isolate invariant. rusty_v8 enters each V8
+    /// isolate on creation and requires isolates be dropped in reverse order of
+    /// creation, so keeping more than one tab's isolate live at once and then
+    /// dropping a non-newest one aborts the whole process (#258). Suspend every
+    /// other tab (drops its isolate, keeps its DOM in self.dom) and make the
+    /// active tab the only live isolate, mirroring the CDP server's
+    /// Dispatcher::get_session_page_mut.
+    fn activate(&mut self, tab_id: &str) {
+        for (id, page) in self.tabs.iter_mut() {
+            if id.as_str() != tab_id && page.has_js() {
+                page.suspend_js();
+            }
+        }
+        if let Some(page) = self.tabs.get_mut(tab_id) {
+            page.resume_js();
+        }
+    }
+
+    /// Close a tab without breaking the LIFO isolate-drop rule. suspend_js drops
+    /// this tab's isolate (if it is the live one) while it is still the only
+    /// entered isolate, so the following remove disposes no isolate (#258).
+    fn close_tab(&mut self, tab_id: &str) -> bool {
+        if let Some(page) = self.tabs.get_mut(tab_id) {
+            page.suspend_js();
+        }
+        self.tabs.remove(tab_id).is_some()
     }
 
     /// Resolve `ref=eN` to a CSS selector that uniquely targets the
@@ -903,6 +932,12 @@ fn tool_console_messages(state: &BrowserState) -> Result<String, String> {
 }
 
 fn tool_close(state: &mut BrowserState) -> Result<String, String> {
+    // Drop the one live isolate (if any) via suspend_js before clearing, so the
+    // map drop disposes no isolate and the LIFO rule holds regardless of the
+    // BTreeMap's ascending drop order (#258).
+    for page in state.tabs.values_mut() {
+        page.suspend_js();
+    }
     state.tabs.clear();
     state.active_tab = None;
     state.console_messages.clear();
@@ -1513,7 +1548,7 @@ fn tool_tab_close(args: &Value, state: &mut BrowserState) -> Result<String, Stri
         .map(String::from)
         .or_else(|| state.active_tab.clone())
         .ok_or("No tab to close")?;
-    if state.tabs.remove(&tab_id).is_none() {
+    if !state.close_tab(&tab_id) {
         return Err(format!("No such tab: {tab_id}"));
     }
     if state.active_tab.as_deref() == Some(&tab_id) {


### PR DESCRIPTION
 ### Description:
Closes #257, #258.

  ### #257 - browser_search panics on CJK pages
  The snippet window sliced `body[..start]` / `body[end..]` at byte offsets
  derived from char counts and `needle.len()`, which land inside multi-byte
  characters and panic ("byte index N is not a char boundary"), killing the MCP
  stdio transport. Snap start/end to char boundaries before slicing and advance
  past whitespace by the actual char width.
  Repro: search "沪银" on a CJK page panics on main (exit 101), returns correct
  snippets after.
  
  ### #258 - tab_close aborts the process (multi-tab)
  Root cause: rusty_v8 enters each V8 isolate on creation and requires isolates be
  dropped in reverse order of creation (it asserts `self == GetCurrent()` in
  `OwnedIsolate::Drop`). The MCP gave each tab its own isolate and dropped them in
  whatever order tabs were closed, so closing a non-newest tab aborted with
  `Check failed: heap->isolate() == Isolate::TryGetCurrent()`. Pages with active
  timers (Highcharts/ECharts) made it easy to hit, and a missing `setLineDash` in
  the canvas mock spammed timer errors on the way in.
  
  Two commits:
  - Add `setLineDash`/`getLineDash`/`ellipse`/`roundRect`/`createConicGradient`/
    `getContextAttributes` to the canvas 2D mock (stops the "is not a function"
    spam; the documented trigger).
  - Enforce the CDP server's single-live-isolate discipline in the MCP: at most
    one tab's isolate is ever live. `page_mut` calls `activate()`, which suspends
    every other tab (drops its isolate, keeps its DOM) and resumes the active one.
    `close_tab` drops the closing tab's isolate via `suspend_js` while it is still
    the only entered isolate, and `tool_close` suspends all tabs before clearing.
    Confined to obscura-mcp; the engine and CDP server are untouched, and peak
    memory drops to one isolate instead of N.