### PR TITLE
Drop unused context field from obscura::Page

### DIFF
--- a/crates/obscura/src/browser.rs
+++ b/crates/obscura/src/browser.rs
@@ -57,7 +57,6 @@ impl Browser {
         );
         Ok(Page {
             inner: page,
-            context: self.context.clone(),
         })
     }
 

--- a/crates/obscura/src/page.rs
+++ b/crates/obscura/src/page.rs
@@ -1,8 +1,7 @@
-use std::sync::Arc;
 use std::time::Duration;
 
 use obscura_browser::lifecycle::WaitUntil;
-use obscura_browser::{BrowserContext, Page as InnerPage};
+use obscura_browser::Page as InnerPage;
 use serde_json::Value;
 
 use crate::error::Error;
@@ -18,7 +17,6 @@ fn nid_from_value(v: &Value) -> Option<u64> {
 /// A browser tab/page.
 pub struct Page {
     pub(crate) inner: InnerPage,
-    pub(crate) context: Arc<BrowserContext>,
 }
 
 impl Page {


### PR DESCRIPTION
The wrapper Page cloned a second Arc<BrowserContext> the struct never read. The inner obscura_browser::Page already holds the context and keeps it alive, so the field was dead weight. Removes the dead_code warning reported on aarch64 (#273).