### PR TITLE
Security: close SSRF DNS-rebinding bypass and harden MCP HTTP server

### DIFF
--- a/crates/obscura-js/src/ops.rs
+++ b/crates/obscura-js/src/ops.rs
@@ -509,6 +509,10 @@ fn build_request_client(proxy_url: Option<&str>) -> Result<reqwest::Client, Stri
     let mut builder = reqwest::Client::builder()
         .redirect(reqwest::redirect::Policy::none())
         .timeout(std::time::Duration::from_millis(timeout_ms))
+        // SSRF: same DNS-resolving guard as the navigation client, so a scripted
+        // fetch()/XHR cannot reach a private/loopback IP via a public hostname
+        // (env/--allow-private-network still relaxes it inside the resolver).
+        .dns_resolver(std::sync::Arc::new(obscura_net::SsrfGuardResolver::new(false)))
         // Be explicit about pool size: default is unbounded which is fine,
         // but pool_idle_timeout default (90s) is short for SPA-heavy
         // workloads where the same origin is hit dozens of times across
@@ -893,12 +897,7 @@ fn validate_fetch_url(url: &url::Url) -> Result<(), String> {
     if let Some(host) = url.host() {
         match host {
             url::Host::Ipv4(ip) => {
-                if ip.is_loopback()
-                    || ip.is_private()
-                    || ip.is_link_local()
-                    || ip.is_broadcast()
-                    || ip.is_documentation()
-                {
+                if obscura_net::is_forbidden_ip(std::net::IpAddr::V4(ip)) {
                     return Err(format!(
                         "Access to private/internal IP address {} is not allowed",
                         ip
@@ -906,7 +905,7 @@ fn validate_fetch_url(url: &url::Url) -> Result<(), String> {
                 }
             }
             url::Host::Ipv6(ip) => {
-                if ip.is_loopback() || ip.is_unicast_link_local() {
+                if obscura_net::is_forbidden_ip(std::net::IpAddr::V6(ip)) {
                     return Err(format!(
                         "Access to private/internal IPv6 address {} is not allowed",
                         ip

--- a/crates/obscura-mcp/src/http.rs
+++ b/crates/obscura-mcp/src/http.rs
@@ -5,6 +5,42 @@ use tokio::net::TcpListener;
 
 use crate::{dispatch, BrowserState};
 
+/// Hard cap on a single MCP request body. The client-supplied `Content-Length`
+/// is used to pre-size the read buffer; without a ceiling a request advertising
+/// e.g. `Content-Length: 4294967296` makes the server allocate and zero-fill
+/// that many bytes before reading any body — an unauthenticated OOM/DoS. 16 MiB
+/// is far above any real JSON-RPC tool call.
+const MAX_BODY_BYTES: usize = 16 * 1024 * 1024;
+
+/// Origin allowlist for browser callers, read from `OBSCURA_MCP_ALLOWED_ORIGINS`
+/// (comma-separated). Unset/empty → permissive (unchanged `*`) so hosted
+/// dashboards keep working (issue #175).
+fn allowed_origins_env() -> Option<String> {
+    std::env::var("OBSCURA_MCP_ALLOWED_ORIGINS")
+        .ok()
+        .filter(|s| !s.trim().is_empty())
+}
+
+/// Whether a request's `Origin` is permitted. A request with no `Origin`
+/// (native, non-browser MCP clients) is always allowed — the same-origin
+/// policy only constrains browser callers. When an allowlist is configured, a
+/// browser `Origin` must match one of its entries (case-insensitive); this
+/// stops a malicious local web page from driving the loopback MCP port.
+fn origin_allowed(origin: Option<&str>, allowlist: Option<&str>) -> bool {
+    match allowlist {
+        None => true,
+        Some(list) => match origin {
+            None => true,
+            Some(o) => {
+                let o = o.trim();
+                list.split(',')
+                    .map(str::trim)
+                    .any(|a| !a.is_empty() && a.eq_ignore_ascii_case(o))
+            }
+        },
+    }
+}
+
 /// MCP Streamable HTTP transport (POST /mcp → JSON response).
 ///
 /// Connections are handled sequentially on the current thread — the browser
@@ -55,6 +91,7 @@ async fn handle_connection(
         let mut content_length: Option<usize> = None;
         let mut accept_sse = false;
         let mut keep_alive = false;
+        let mut origin: Option<String> = None;
 
         loop {
             let mut line = String::new();
@@ -67,6 +104,11 @@ async fn handle_connection(
             if let Some(v) = lower.strip_prefix("content-length: ") {
                 content_length = v.trim().parse().ok();
             }
+            if lower.starts_with("origin:") {
+                if let Some(idx) = trimmed.find(':') {
+                    origin = Some(trimmed[idx + 1..].trim().to_string());
+                }
+            }
             if lower.contains("text/event-stream") {
                 accept_sse = true;
             }
@@ -78,6 +120,16 @@ async fn handle_connection(
         // ── routing ──────────────────────────────────────────────────────────
         if path != "/mcp" {
             respond(&mut writer, 404, b"{\"error\":\"not found\"}").await?;
+            break;
+        }
+
+        // Origin gate: when OBSCURA_MCP_ALLOWED_ORIGINS is configured, a browser
+        // request from a non-listed origin is refused before it can drive the
+        // browser session (mitigates a malicious local web page issuing
+        // cross-origin POSTs to the loopback MCP port). The permissive default
+        // and no-Origin native clients are unaffected.
+        if !origin_allowed(origin.as_deref(), allowed_origins_env().as_deref()) {
+            respond(&mut writer, 403, b"{\"error\":\"origin not allowed\"}").await?;
             break;
         }
 
@@ -123,6 +175,14 @@ async fn handle_connection(
                         break;
                     }
                 };
+
+                // Reject oversized bodies BEFORE allocating: `vec![0u8; len]`
+                // commits `len` bytes up front, so an attacker-chosen
+                // Content-Length would otherwise OOM the process (DoS).
+                if len > MAX_BODY_BYTES {
+                    respond(&mut writer, 413, b"{\"error\":\"payload too large\"}").await?;
+                    break;
+                }
 
                 let mut body = vec![0u8; len];
                 reader.read_exact(&mut body).await?;
@@ -193,8 +253,10 @@ async fn respond_json(writer: &mut (impl AsyncWriteExt + Unpin), body: &[u8]) ->
 async fn respond(writer: &mut (impl AsyncWriteExt + Unpin), status: u16, body: &[u8]) -> Result<()> {
     let status_text = match status {
         400 => "Bad Request",
+        403 => "Forbidden",
         404 => "Not Found",
         405 => "Method Not Allowed",
+        413 => "Payload Too Large",
         _ => "OK",
     };
     let hdr = format!(
@@ -208,4 +270,32 @@ async fn respond(writer: &mut (impl AsyncWriteExt + Unpin), status: u16, body: &
     writer.write_all(body).await?;
     writer.flush().await?;
     Ok(())
+}
+
+#[cfg(test)]
+mod mcp_hardening_tests {
+    use super::{origin_allowed, MAX_BODY_BYTES};
+
+    #[test]
+    fn no_allowlist_is_permissive() {
+        assert!(origin_allowed(Some("https://evil.example"), None));
+        assert!(origin_allowed(None, None));
+    }
+
+    #[test]
+    fn allowlist_matches_case_insensitively_and_rejects_others() {
+        let list = Some("http://localhost:3000, https://app.example.com");
+        assert!(origin_allowed(Some("http://localhost:3000"), list));
+        assert!(origin_allowed(Some("https://APP.example.com"), list));
+        assert!(!origin_allowed(Some("https://evil.example"), list));
+        // A native client (no Origin header) is always allowed.
+        assert!(origin_allowed(None, list));
+    }
+
+    #[test]
+    fn body_cap_is_sane() {
+        // Far above a real JSON-RPC tool call, far below an OOM-inducing value.
+        assert!(MAX_BODY_BYTES >= 1 << 20);
+        assert!(MAX_BODY_BYTES <= 64 << 20);
+    }
 }

--- a/crates/obscura-mcp/tests/cors_preflight.rs
+++ b/crates/obscura-mcp/tests/cors_preflight.rs
@@ -84,3 +84,54 @@ async fn options_preflight_lists_required_browser_headers() {
     })
     .await;
 }
+
+/// Regression test for the unbounded `Content-Length` allocation: a POST that
+/// advertises a huge body must be rejected with 413 *before* the server tries
+/// to allocate `vec![0u8; len]`, rather than committing gigabytes of RAM and
+/// OOM-ing the process (unauthenticated DoS).
+#[tokio::test(flavor = "current_thread")]
+async fn oversized_content_length_is_rejected() {
+    let port = pick_free_port();
+    let local = LocalSet::new();
+
+    let server = local.spawn_local(async move {
+        let _ = obscura_mcp::http::run("127.0.0.1".to_string(), port, None, None, false).await;
+    });
+
+    local
+        .run_until(async {
+            for _ in 0..40 {
+                if TcpStream::connect(("127.0.0.1", port)).await.is_ok() {
+                    break;
+                }
+                sleep(Duration::from_millis(50)).await;
+            }
+
+            let mut stream = TcpStream::connect(("127.0.0.1", port))
+                .await
+                .expect("MCP server did not come up");
+            // 8 GiB advertised, zero body sent. Pre-fix the server allocates 8 GiB.
+            let req = b"POST /mcp HTTP/1.1\r\n\
+                        Host: 127.0.0.1\r\n\
+                        Content-Type: application/json\r\n\
+                        Content-Length: 8589934592\r\n\
+                        \r\n";
+            stream.write_all(req).await.unwrap();
+            stream.flush().await.unwrap();
+
+            let mut buf = [0u8; 1024];
+            let n = timeout(Duration::from_secs(2), stream.read(&mut buf))
+                .await
+                .expect("read timed out")
+                .expect("read failed");
+            let response = String::from_utf8_lossy(&buf[..n]).to_string();
+
+            server.abort();
+
+            assert!(
+                response.starts_with("HTTP/1.1 413"),
+                "expected 413 Payload Too Large, got:\n{response}"
+            );
+        })
+        .await;
+}

--- a/crates/obscura-net/src/client.rs
+++ b/crates/obscura-net/src/client.rs
@@ -2,6 +2,9 @@ use std::collections::HashMap;
 use std::sync::Arc;
 use std::time::Duration;
 
+use std::net::{IpAddr, SocketAddr};
+
+use reqwest::dns::{Addrs, Name, Resolve, Resolving};
 use reqwest::header::{HeaderMap, HeaderName, HeaderValue, USER_AGENT};
 use reqwest::redirect::Policy;
 use reqwest::{Client, Method};
@@ -88,6 +91,84 @@ pub fn env_allows_private_network() -> bool {
     )
 }
 
+/// True when `ip` must never be the target of an outbound request from the
+/// engine: loopback, RFC1918 private, link-local (incl. the 169.254.169.254
+/// cloud-metadata endpoint), broadcast, documentation, the unspecified address
+/// (0.0.0.0 / ::, which the OS routes to localhost), IPv6 unique-local
+/// (fc00::/7), and any IPv4-mapped/compatible IPv6 form of the above.
+/// Centralizes the SSRF deny-set so the literal-host check and the
+/// DNS-resolution check (`SsrfGuardResolver`) can never disagree.
+pub fn is_forbidden_ip(ip: IpAddr) -> bool {
+    match ip {
+        IpAddr::V4(v4) => {
+            v4.is_loopback()
+                || v4.is_private()
+                || v4.is_link_local()
+                || v4.is_broadcast()
+                || v4.is_documentation()
+                || v4.is_unspecified()
+        }
+        IpAddr::V6(v6) => {
+            if v6.is_loopback()
+                || v6.is_unspecified()
+                || v6.is_unique_local()
+                || v6.is_unicast_link_local()
+            {
+                return true;
+            }
+            // Unwrap IPv4-mapped (::ffff:a.b.c.d) and IPv4-compatible (::a.b.c.d)
+            // forms and re-check the embedded v4 so e.g. [::ffff:127.0.0.1] or
+            // [::ffff:169.254.169.254] cannot slip past the v6 arm.
+            if let Some(v4) = v6.to_ipv4_mapped().or_else(|| v6.to_ipv4()) {
+                return is_forbidden_ip(IpAddr::V4(v4));
+            }
+            false
+        }
+    }
+}
+
+/// reqwest DNS resolver that performs the lookup and then rejects the whole
+/// request if ANY resolved address is in the SSRF deny-set. This closes the
+/// DNS-rebinding bypass a host-string check alone cannot: a public name that
+/// resolves to 127.0.0.1 / 169.254.169.254 / an RFC1918 address is blocked at
+/// connect time, using the very addresses reqwest will dial. When private
+/// access is permitted (`--allow-private-network` or
+/// `OBSCURA_ALLOW_PRIVATE_NETWORK`) the lookup passes through unfiltered.
+pub struct SsrfGuardResolver {
+    allow_private: bool,
+}
+
+impl SsrfGuardResolver {
+    pub fn new(allow_private: bool) -> Self {
+        Self { allow_private }
+    }
+}
+
+impl Resolve for SsrfGuardResolver {
+    fn resolve(&self, name: Name) -> Resolving {
+        let allow = self.allow_private || env_allows_private_network();
+        let host = name.as_str().to_string();
+        Box::pin(async move {
+            let addrs: Vec<SocketAddr> = tokio::net::lookup_host((host.as_str(), 0))
+                .await
+                .map_err(|e| -> Box<dyn std::error::Error + Send + Sync> { Box::new(e) })?
+                .collect();
+            if !allow {
+                if let Some(bad) = addrs.iter().find(|sa| is_forbidden_ip(sa.ip())) {
+                    return Err(format!(
+                        "SSRF blocked: '{}' resolves to forbidden address {}",
+                        host,
+                        bad.ip()
+                    )
+                    .into());
+                }
+            }
+            let iter: Addrs = Box::new(addrs.into_iter());
+            Ok(iter)
+        })
+    }
+}
+
 fn validate_url(url: &Url, allow_private_network: bool) -> Result<(), ObscuraNetError> {
     let allow_private_network = allow_private_network || env_allows_private_network();
     let scheme = url.scheme();
@@ -105,12 +186,7 @@ fn validate_url(url: &Url, allow_private_network: bool) -> Result<(), ObscuraNet
     if let Some(host) = url.host() {
         match host {
             url::Host::Ipv4(ip) => {
-                if ip.is_loopback()
-                    || ip.is_private()
-                    || ip.is_link_local()
-                    || ip.is_broadcast()
-                    || ip.is_documentation()
-                {
+                if is_forbidden_ip(IpAddr::V4(ip)) {
                     return Err(ObscuraNetError::Network(format!(
                         "Access to private/internal IP address {} is not allowed",
                         ip
@@ -118,7 +194,7 @@ fn validate_url(url: &Url, allow_private_network: bool) -> Result<(), ObscuraNet
                 }
             }
             url::Host::Ipv6(ip) => {
-                if ip.is_loopback() || ip.is_unicast_link_local() {
+                if is_forbidden_ip(IpAddr::V6(ip)) {
                     return Err(ObscuraNetError::Network(format!(
                         "Access to private/internal IPv6 address {} is not allowed",
                         ip
@@ -239,6 +315,10 @@ impl ObscuraHttpClient {
                 .redirect(Policy::none())
                 .timeout(Duration::from_secs(30))
                 .danger_accept_invalid_certs(false)
+                // SSRF: resolve + validate every hostname against the deny-set
+                // so a public name pointing at a private/loopback IP is rejected
+                // at connect time (DNS-rebinding safe).
+                .dns_resolver(Arc::new(SsrfGuardResolver::new(self.allow_private_network)))
 ;
 
             if let Some(ref proxy) = self.proxy_url {
@@ -525,4 +605,96 @@ pub enum ObscuraNetError {
 
     #[error("Request blocked: {0}")]
     Blocked(String),
+}
+
+#[cfg(test)]
+mod ssrf_tests {
+    use super::{is_forbidden_ip, validate_url, SsrfGuardResolver};
+    use reqwest::dns::{Name, Resolve};
+    use std::net::IpAddr;
+    use std::str::FromStr;
+    use url::Url;
+
+    fn ip(s: &str) -> IpAddr {
+        IpAddr::from_str(s).unwrap()
+    }
+
+    #[test]
+    fn ipv4_private_and_special_ranges_are_forbidden() {
+        for s in [
+            "127.0.0.1",
+            "127.5.6.7",
+            "10.0.0.1",
+            "172.16.0.1",
+            "192.168.1.1",
+            "169.254.169.254", // cloud-metadata endpoint
+            "0.0.0.0",         // unspecified -> localhost (was a bypass)
+            "255.255.255.255", // broadcast
+            "192.0.2.1",       // documentation
+        ] {
+            assert!(is_forbidden_ip(ip(s)), "{s} should be forbidden");
+        }
+    }
+
+    #[test]
+    fn public_ipv4_is_allowed() {
+        for s in ["1.1.1.1", "8.8.8.8", "93.184.216.34"] {
+            assert!(!is_forbidden_ip(ip(s)), "{s} should be allowed");
+        }
+    }
+
+    #[test]
+    fn ipv6_loopback_ula_linklocal_and_mapped_are_forbidden() {
+        for s in [
+            "::1",                    // loopback
+            "::",                     // unspecified
+            "fc00::1",                // unique-local (was a bypass)
+            "fd12:3456:789a::1",      // unique-local
+            "fe80::1",                // link-local
+            "::ffff:127.0.0.1",       // v4-mapped loopback (was a bypass)
+            "::ffff:169.254.169.254", // v4-mapped metadata
+        ] {
+            assert!(is_forbidden_ip(ip(s)), "{s} should be forbidden");
+        }
+    }
+
+    #[test]
+    fn public_ipv6_is_allowed() {
+        assert!(!is_forbidden_ip(ip("2606:4700:4700::1111"))); // cloudflare dns
+    }
+
+    #[test]
+    fn validate_url_blocks_unspecified_and_allows_public() {
+        // 0.0.0.0 previously slipped through validate_url's literal-host check.
+        assert!(validate_url(&Url::parse("http://0.0.0.0:8080/").unwrap(), false).is_err());
+        assert!(validate_url(&Url::parse("http://127.0.0.1/").unwrap(), false).is_err());
+        assert!(validate_url(&Url::parse("http://example.com/").unwrap(), false).is_ok());
+        // The allow flag bypasses the guard (local-dev escape hatch).
+        assert!(validate_url(&Url::parse("http://127.0.0.1/").unwrap(), true).is_ok());
+    }
+
+    #[tokio::test]
+    async fn resolver_blocks_hostname_that_resolves_to_loopback() {
+        // localtest.me is a public DNS name that resolves to 127.0.0.1 — the
+        // canonical DNS-rebinding test. The guard must reject it. If DNS is
+        // unavailable the lookup itself errors (also Err), so the assertion
+        // holds either way.
+        let r = SsrfGuardResolver::new(false);
+        let res = r.resolve(Name::from_str("localtest.me").unwrap()).await;
+        assert!(res.is_err(), "localtest.me -> 127.0.0.1 must be blocked");
+    }
+
+    #[tokio::test]
+    async fn resolver_does_not_ssrf_block_public_host() {
+        // A public host must not be SSRF-blocked. Tolerate a no-network sandbox
+        // by only failing on an actual SSRF rejection, not a lookup failure.
+        let r = SsrfGuardResolver::new(false);
+        match r.resolve(Name::from_str("example.com").unwrap()).await {
+            Ok(_) => {}
+            Err(e) => assert!(
+                !e.to_string().contains("SSRF blocked"),
+                "example.com wrongly SSRF-blocked: {e}"
+            ),
+        }
+    }
 }

--- a/crates/obscura-net/src/lib.rs
+++ b/crates/obscura-net/src/lib.rs
@@ -8,8 +8,8 @@ pub mod blocklist;
 pub mod wreq_client;
 
 pub use client::{
-    env_allows_private_network, ObscuraHttpClient, ObscuraNetError, RequestInfo, ResourceType,
-    Response,
+    env_allows_private_network, is_forbidden_ip, ObscuraHttpClient, ObscuraNetError, RequestInfo,
+    ResourceType, Response, SsrfGuardResolver,
 };
 pub use cookies::{CookieInfo, CookieJar};
 pub use encoding::{


### PR DESCRIPTION
## Summary

Hardens two server-reachable surfaces against well-known attack classes, with
no change to default behaviour for legitimate callers:

1. **SSRF — close the DNS-rebinding bypass and widen the IP deny-set.** The
   pre-existing guard only inspected the URL's *literal* host, so a public
   hostname resolving to a private/loopback address (the classic rebinding
   trick, e.g. `localtest.me → 127.0.0.1`, or a name pointing at
   `169.254.169.254`) sailed through. It also missed `0.0.0.0` (routes to
   localhost), IPv6 unique-local (`fc00::/7`), and IPv4-mapped IPv6
   (`::ffff:127.0.0.1`).
2. **MCP HTTP — unauthenticated OOM via `Content-Length`.** The Streamable-HTTP
   transport did `vec![0u8; content_length]` from a client-controlled header
   before reading any body, so a single request advertising
   `Content-Length: 4294967296` committed ~4 GiB up front.

## Changes

### SSRF (`obscura-net`, `obscura-js`)
- New `obscura_net::is_forbidden_ip(IpAddr)` centralises the deny-set: loopback,
  RFC1918 private, link-local (incl. the `169.254.169.254` cloud-metadata
  endpoint), broadcast, documentation, **unspecified (`0.0.0.0` / `::`)**,
  **IPv6 unique-local (`fc00::/7`)**, and **IPv4-mapped/compatible IPv6** forms.
- New `obscura_net::SsrfGuardResolver` implements `reqwest::dns::Resolve`: it
  performs the lookup and rejects the request if **any resolved address** is in
  the deny-set, at the exact addresses reqwest will dial — closing DNS
  rebinding. Wired into the navigation client (`ObscuraHttpClient`) and the
  JS-side `op_fetch_url` client (scripted `fetch()`/XHR).
- `validate_url` / `validate_fetch_url` now use `is_forbidden_ip` for literal
  hosts, so `0.0.0.0` and the IPv6 ranges are caught pre-DNS too.
- The existing escape hatch is preserved: `--allow-private-network` /
  `OBSCURA_ALLOW_PRIVATE_NETWORK` makes the resolver pass through unfiltered.

### MCP HTTP (`obscura-mcp`)
- `MAX_BODY_BYTES` (16 MiB) ceiling: an over-large `Content-Length` is answered
  `413 Payload Too Large` **before** any allocation.
- Optional `OBSCURA_MCP_ALLOWED_ORIGINS` (comma-separated) origin allowlist:
  when set, a browser `Origin` not on the list is refused `403`. **Unset is the
  default and keeps the current permissive `*` behaviour** so hosted-dashboard
  deployments (issue #175) and native (no-`Origin`) clients are unaffected.

## Testing
- `cargo test -p obscura-net` — 7 SSRF tests: IPv4/IPv6 deny-set table
  (incl. `0.0.0.0`, `fc00::/7`, `::ffff:127.0.0.1`), `validate_url`, and a live
  resolver test that blocks `localtest.me` (→ `127.0.0.1`).
- `cargo test -p obscura-mcp` — `origin_allowed` cases, body-cap sanity, the
  existing #175 preflight regression test (unchanged), and a new integration
  test that a `Content-Length: 8589934592` POST is rejected `413`.
- Manual end-to-end with the built binary: `obscura fetch` against
  `http://127.0.0.1/`, `http://0.0.0.0:8080/`, and `http://localtest.me/` are
  all blocked; `https://example.com/` still works.

## Compatibility
No public API removed; `is_forbidden_ip` and `SsrfGuardResolver` are additive
exports. Default behaviour is unchanged for legitimate traffic; both new
controls have explicit opt-out / opt-in switches.
