### PR TITLE
fix(js): add insertAdjacentText/insertAdjacentElement polyfills (#285)

### DIFF
--- a/crates/obscura-js/js/bootstrap.js
+++ b/crates/obscura-js/js/bootstrap.js
@@ -1111,6 +1111,51 @@ class Element extends Node {
         break;
     }
   }
+  // Same insertion semantics as insertAdjacentHTML but inserts a Text node
+  // instead of parsing markup — that distinction is the whole point of the API
+  // (DDoS-Guard, reCAPTCHA, and others use it precisely because it does NOT
+  // parse HTML). Position string is case-insensitive per spec. See issue #285.
+  insertAdjacentText(position, text) {
+    const parent = this.parentNode;
+    const node = document.createTextNode(String(text));
+    switch (String(position).toLowerCase()) {
+      case 'beforebegin':
+        if (parent) parent.insertBefore(node, this);
+        break;
+      case 'afterbegin':
+        this.insertBefore(node, this.firstChild);
+        break;
+      case 'beforeend':
+        this.appendChild(node);
+        break;
+      case 'afterend':
+        if (parent) parent.insertBefore(node, this.nextSibling);
+        break;
+    }
+  }
+  // Per spec, returns the inserted element, or null when position is
+  // beforebegin/afterend and this element has no parent (so the node could
+  // not be placed). See issue #285.
+  insertAdjacentElement(position, element) {
+    const parent = this.parentNode;
+    switch (String(position).toLowerCase()) {
+      case 'beforebegin':
+        if (!parent) return null;
+        parent.insertBefore(element, this);
+        return element;
+      case 'afterbegin':
+        this.insertBefore(element, this.firstChild);
+        return element;
+      case 'beforeend':
+        this.appendChild(element);
+        return element;
+      case 'afterend':
+        if (!parent) return null;
+        parent.insertBefore(element, this.nextSibling);
+        return element;
+    }
+    return null;
+  }
   addEventListener(type, handler, opts) {
     const key = this._nid;
     if (!_eventRegistry[key]) _eventRegistry[key] = {};
@@ -4823,7 +4868,8 @@ _markNative(globalThis.Selection);
   Element.prototype.focus, Element.prototype.blur,
   Element.prototype.showPopover, Element.prototype.hidePopover, Element.prototype.togglePopover,
   Element.prototype.cloneNode, Element.prototype.attachShadow,
-  Element.prototype.insertAdjacentHTML, Element.prototype.scrollIntoView,
+  Element.prototype.insertAdjacentHTML, Element.prototype.insertAdjacentText,
+  Element.prototype.insertAdjacentElement, Element.prototype.scrollIntoView,
   Element.prototype.append, Element.prototype.prepend, Element.prototype.remove,
   Element.prototype.before, Element.prototype.after, Element.prototype.replaceWith,
   HTMLFormElement.prototype.reset,

--- a/crates/obscura-js/src/runtime.rs
+++ b/crates/obscura-js/src/runtime.rs
@@ -2357,6 +2357,80 @@ mod tests {
     /// Setting an ARIA reflection property must write through to the
     /// underlying attribute so frameworks that toggle state via
     /// `el.ariaExpanded = 'true'` actually update the DOM.
+    /// Regression test for #285: DDoS-Guard's challenge calls
+    /// `t.insertAdjacentText(...)` and dies with `TypeError: ... is not a
+    /// function` because `Element.prototype.insertAdjacentText` was missing.
+    /// Verify all four positions place a Text node (NOT parsed HTML) at the
+    /// right spot. Tests `insertAdjacentText` exists, is callable, and that
+    /// inserted content remains literal text — angle brackets must not be
+    /// parsed as markup, which is the whole point of the API.
+    #[test]
+    fn element_insert_adjacent_text_polyfill() {
+        let mut rt = setup_runtime(r#"<div id="p"><span id="t">X</span></div>"#);
+        let result = rt
+            .evaluate(
+                r#"
+                const t = document.getElementById('t');
+                t.insertAdjacentText('afterbegin', 'AB');
+                t.insertAdjacentText('beforeend', 'BE');
+                t.insertAdjacentText('beforebegin', 'BB');
+                t.insertAdjacentText('afterend', 'AE');
+                t.insertAdjacentText('beforeend', '<b>raw</b>');
+                return [
+                    typeof Element.prototype.insertAdjacentText,
+                    document.getElementById('p').textContent,
+                    t.getElementsByTagName('b').length,
+                ];
+                "#,
+            )
+            .unwrap();
+        assert_eq!(
+            result,
+            serde_json::json!(["function", "BBABXBE<b>raw</b>AE", 0])
+        );
+    }
+
+    /// Regression test for #285: `Element.prototype.insertAdjacentElement`
+    /// was missing alongside `insertAdjacentText`. Verify all four positions
+    /// place the given element correctly and that the inserted element is
+    /// returned (per spec — that's the contract callers rely on for chaining).
+    #[test]
+    fn element_insert_adjacent_element_polyfill() {
+        let mut rt = setup_runtime(r#"<div id="p"><span id="t">X</span></div>"#);
+        let result = rt
+            .evaluate(
+                r#"
+                const t = document.getElementById('t');
+                const before = document.createElement('b');  before.id = 'before';
+                const after  = document.createElement('i');  after.id  = 'after';
+                const inside = document.createElement('em'); inside.id = 'inside';
+                const last   = document.createElement('u');  last.id   = 'last';
+                const r1 = t.insertAdjacentElement('beforebegin', before);
+                const r2 = t.insertAdjacentElement('afterend',    after);
+                const r3 = t.insertAdjacentElement('afterbegin',  inside);
+                const r4 = t.insertAdjacentElement('beforeend',   last);
+                const siblings = Array.from(document.getElementById('p').children).map(c => c.id);
+                const inT = Array.from(t.children).map(c => c.id);
+                return [
+                    typeof Element.prototype.insertAdjacentElement,
+                    r1 === before && r2 === after && r3 === inside && r4 === last,
+                    siblings,
+                    inT,
+                ];
+                "#,
+            )
+            .unwrap();
+        assert_eq!(
+            result,
+            serde_json::json!([
+                "function",
+                true,
+                ["before", "t", "after"],
+                ["inside", "last"]
+            ])
+        );
+    }
+
     #[test]
     fn element_aria_reflection_setters_write_through() {
         let mut rt = setup_runtime(r#"<div id="d"></div>"#);


### PR DESCRIPTION
## Summary

Fix #285 — `DDoS-Guard`'s JS challenge calls `Element.prototype.insertAdjacentText` and dies with `TypeError: ... is not a function`, blocking every DDoS-Guard-protected site (pikabu.ru is the reproducer in the issue). `insertAdjacentElement` was missing too. `insertAdjacentHTML` was already implemented, so this lifts the same insertion pattern for Text-node and Element insertion semantics — small, self-contained polyfill in `crates/obscura-js/js/bootstrap.js`.

## Root Cause

`crates/obscura-js/js/bootstrap.js` defines `Element` (line 879) with a polyfill for `insertAdjacentHTML` (line 1097) but never added the sibling APIs. Result:

```
> typeof Element.prototype.insertAdjacentText
'undefined'
> typeof Element.prototype.insertAdjacentElement
'undefined'
```

## Fix

`crates/obscura-js/js/bootstrap.js`:

- `Element.prototype.insertAdjacentText(position, text)` — creates a Text node via `document.createTextNode(String(text))` and inserts at the requested position. **Text node, not parsed HTML** — that distinction is the whole point of the API (challenge scripts use it precisely because it does NOT parse markup).
- `Element.prototype.insertAdjacentElement(position, element)` — inserts the element at the requested position and returns it. Returns `null` for `beforebegin`/`afterend` when this element has no parent (per spec — "If element is not actually inserted, return null").
- Both methods accept `position` case-insensitively (spec).
- Both registered with `_markNative` alongside `insertAdjacentHTML` so `Function.prototype.toString` keeps reporting `[native code]` — consistent with the existing stealth registration for every other `Element.prototype.*` method.

Diff is +48/-1 in `bootstrap.js` and +73 in tests; no other crate touched.

## Verification

Local repro and RED→GREEN proof on `main` @ 4a00a6a (issue base):

```bash
cargo test -p obscura-js --lib element_insert_adjacent
```

**RED (with `crates/obscura-js/js/bootstrap.js` reverted to main via `git stash push -- crates/obscura-js/js/bootstrap.js`):**

```
running 2 tests
test runtime::tests::element_insert_adjacent_element_polyfill ... FAILED
test runtime::tests::element_insert_adjacent_text_polyfill ... FAILED

---- runtime::tests::element_insert_adjacent_text_polyfill stdout ----
assertion `left == right` failed
  left: Null
 right: Array [String("function"), String("BBABXBE<b>raw</b>AE"), Number(0)]

test result: FAILED. 0 passed; 2 failed; 0 ignored; 0 measured; 86 filtered out
```

The IIFE wrapper of `evaluate()` catches the JS-thrown `TypeError: t.insertAdjacentText is not a function` in its try/catch and yields `Null` — exactly the symptom the issue reports.

**GREEN (polyfill restored):**

```
running 2 tests
test runtime::tests::element_insert_adjacent_element_polyfill ... ok
test runtime::tests::element_insert_adjacent_text_polyfill ... ok

test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured; 86 filtered out
```

Tests cover all four positions for both methods, the spec-mandated return value of `insertAdjacentElement`, AND that `insertAdjacentText` does NOT parse HTML (inserts `<b>raw</b>` literally; `getElementsByTagName('b').length === 0`) — that last assertion is what makes the test catch the bug instead of being a tautology.

## Test plan

- [x] Two new tests added in `crates/obscura-js/src/runtime.rs` (`element_insert_adjacent_text_polyfill`, `element_insert_adjacent_element_polyfill`)
- [x] `cargo test -p obscura-js --lib` — 88 pass / 0 fail / 0 skip (baseline was 86 pass / 0 fail; +2 from this PR, no regression)
- [x] `cargo build --release -p obscura-js` — clean
- [x] `cargo check -p obscura-cli` — clean (cross-crate sanity)
- [ ] Stealth build (`--features stealth`) skipped on this Linux env — non-stealth build covers the polyfill code path; new methods registered with `_markNative` so stealth toString-trap stays consistent

## Risk

**Low.** Pure additive change to `bootstrap.js`:
- Two new methods on `Element.prototype` (previously `undefined` — nothing to collide with).
- No existing tests touched; no existing methods touched.
- No crate boundary, no dependency change, no public Rust API change.
- `_markNative` is the existing stealth hook; the two new entries match the pattern used for every other DOM method (no behavioral side-effect, marks the function as native for `Function.prototype.toString`).
