### PR TITLE
fix(js): console.log(Error) must not trigger Error.prepareStackTrace

### DIFF
--- a/crates/obscura-js/js/bootstrap.js
+++ b/crates/obscura-js/js/bootstrap.js
@@ -212,7 +212,13 @@ const _consoleFn = (level, args) => {
   try { Deno.core.ops.op_console_msg(level, args.map(a => {
     if (a === null) return "null";
     if (a === undefined) return "undefined";
-    if (a instanceof Error) return a.stack || a.message || String(a);
+    if (a instanceof Error) {
+      const _pst = Error.prepareStackTrace;
+      if (_pst !== undefined) Error.prepareStackTrace = undefined;
+      const _s = a.stack || a.message || String(a);
+      if (_pst !== undefined) Error.prepareStackTrace = _pst;
+      return _s;
+    }
     if (typeof a === "object") {
       try {
         const s = JSON.stringify(a);

--- a/crates/obscura-js/src/runtime.rs
+++ b/crates/obscura-js/src/runtime.rs
@@ -2453,6 +2453,21 @@ mod tests {
     }
 
     #[test]
+    fn console_log_error_does_not_trigger_prepare_stack_trace() {
+        let mut rt = setup_runtime("<div></div>");
+        let result = rt.evaluate(r#"
+            let called = false;
+            const saved = Error.prepareStackTrace;
+            Error.prepareStackTrace = function() { called = true; return saved; };
+            const e = new Error("test");
+            console.log(e);
+            Error.prepareStackTrace = saved;
+            return called;
+        "#).unwrap();
+        assert_eq!(result, serde_json::json!(false));
+    }
+
+    #[test]
     fn element_aria_reflection_setters_write_through() {
         let mut rt = setup_runtime(r#"<div id="d"></div>"#);
         let result = rt


### PR DESCRIPTION
Closes #198

  ## Root cause

  deviceandbrowserinfo.com/are_you_a_bot detects CDP automation with this snippet:

  ```js
  let called = false;
  const orig = Error.prepareStackTrace;
  Error.prepareStackTrace = function() { return called = true, orig };
  console.log(new Error(""));
  // isAutomatedWithCDP = called
  ```
  A native Chrome console formats errors in C++ and never calls
  Error.prepareStackTrace. Obscura's console.log is JavaScript and
  accessed a.stack directly on Error objects. In V8, accessing .stack
  calls Error.prepareStackTrace if it is set — so the spy fired and the
  session was flagged.

  Save and clear Error.prepareStackTrace before accessing .stack in
  _consoleFn, then restore it. V8 formats the stack with its default
  formatter, the spy never fires, and console output is unchanged.
