### PR TITLE
release: build x86_64-macos on a native Intel runner

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,30 +20,26 @@ jobs:
             # newer glibc shipped by ubuntu-latest.
             os: ubuntu-22.04
             name: obscura-x86_64-linux
-            cross: false
           - target: aarch64-unknown-linux-gnu
             # Native build on GitHub's ARM runner.
             os: ubuntu-22.04-arm
             name: obscura-aarch64-linux
-            cross: false
-          - target: aarch64-unknown-linux-gnu
-            # Cross-compile fallback from x86_64 Ubuntu 22.04. Same glibc
-            # 2.35 floor, useful when ARM runners are unavailable.
-            os: ubuntu-22.04
-            name: obscura-aarch64-linux-cross
-            cross: true
           - target: aarch64-apple-darwin
             os: macos-latest
             name: obscura-aarch64-macos
-            cross: false
           - target: x86_64-apple-darwin
-            os: macos-latest
+            # Must run on a native Intel runner. obscura-js bakes a V8 startup
+            # snapshot at build time, and that snapshot is architecture specific.
+            # macos-latest is Apple Silicon, so building x86_64 there embeds an
+            # arm64 snapshot into the Intel binary and V8 crashes deserializing
+            # it at isolate init (issue #290). macos-15-intel is the last x86_64
+            # image (available until Aug 2027); there is no cross-build that
+            # produces a correct snapshot.
+            os: macos-15-intel
             name: obscura-x86_64-macos
-            cross: false
           - target: x86_64-pc-windows-msvc
             os: windows-latest
             name: obscura-x86_64-windows
-            cross: false
 
     runs-on: ${{ matrix.os }}
 
@@ -54,23 +50,23 @@ jobs:
         with:
           targets: ${{ matrix.target }}
 
-      - name: Install cross-compilation toolchain (aarch64-linux)
-        if: matrix.cross == true
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y gcc-aarch64-linux-gnu
-          mkdir -p .cargo
-          cat >> .cargo/config.toml << 'CARGO_EOF'
-          [target.aarch64-unknown-linux-gnu]
-          linker = "aarch64-linux-gnu-gcc"
-          CARGO_EOF
-
       - name: Build
         run: cargo build --release --target ${{ matrix.target }}
 
       - name: Build stealth
         run: cargo build --release --target ${{ matrix.target }} --features stealth
         continue-on-error: true
+
+      - name: Smoke test (V8 snapshot)
+        # Run the V8 path once so a release never ships a binary that crashes at
+        # isolate init from a mismatched snapshot (issue #290). The data: URL
+        # keeps it offline. Every target here is native, so the runner can
+        # execute what it just built.
+        shell: bash
+        run: |
+          BIN=target/${{ matrix.target }}/release/obscura
+          [ -f "$BIN.exe" ] && BIN="$BIN.exe"
+          "$BIN" fetch "data:text/html,<title>ok</title>" --eval "1+1"
 
       - name: Package (Unix)
         if: runner.os != 'Windows'


### PR DESCRIPTION
The x86_64-apple-darwin release crashed at V8 isolate init with SIGSEGV in ReadOnly snapshot deserialization (issue #290). obscura-js bakes a V8 startup snapshot at build time via a build script, which runs on the host arch. The job built x86_64 on macos-latest (Apple Silicon), so an arm64 snapshot got embedded into the Intel binary and V8 crashed deserializing it. Build on macos-15-intel so the snapshot matches the target.

Drop the aarch64-linux-cross artifact: it has the same defect (x86_64-host snapshot in an arm64 binary) and the native ARM runner already covers it.

Add a post-build smoke test that runs the V8 path on a data: URL so a release can never ship a binary that crashes at isolate init again.