### PR TITLE
js: implement Element.getAttributeNames()

### DIFF
--- a/crates/obscura-js/js/bootstrap.js
+++ b/crates/obscura-js/js/bootstrap.js
@@ -1072,6 +1072,7 @@ class Element extends Node {
   removeAttributeNS(ns, n) { _dom("remove_attribute", this._nid, String(n)); }
   hasAttribute(n) { return this.getAttribute(n) !== null; }
   hasAttributes() { return true; } // Simplified
+  getAttributeNames() { return _domParse("attribute_names", this._nid) || []; }
   get attributes() {
     const el = this;
     const names = _domParse("attribute_names", el._nid) || [];


### PR DESCRIPTION
The method was missing, so calling it threw TypeError: ... is not a function, which broke Vue 3/Nuxt client hydration (issue #297). Back it with the existing attribute_names op, the same source as the attributes getter, so the order matches attributes and outerHTML.