### PR TITLE
js: mark Event constructor as native for stealth compatibility

### DIFF
--- a/crates/obscura-js/js/bootstrap.js
+++ b/crates/obscura-js/js/bootstrap.js
@@ -4016,6 +4016,7 @@ globalThis.Event = class Event {
     return path;
   }
 };
+_markNative(Event);
 globalThis.CustomEvent = class extends Event {
   constructor(t,o={}) { super(t,o);this.detail=o.detail; }
   // Legacy DOM Level 2 init; some libraries (Starbucks China bundle, older


### PR DESCRIPTION
Mark the Event constructor as native so that Event.toString() returns "[native code]" instead of leaking the JavaScript implementation. This closes a stealth fingerprinting vector.