### PR TITLE
fix(cdp): pass clickCount to MouseEvent.detail + pump event loop after char input (#316)

### DIFF
--- a/crates/obscura-cdp/src/domains/input.rs
+++ b/crates/obscura-cdp/src/domains/input.rs
@@ -14,7 +14,7 @@ pub async fn handle(
             let x = params.get("x").and_then(|v| v.as_f64()).unwrap_or(0.0);
             let y = params.get("y").and_then(|v| v.as_f64()).unwrap_or(0.0);
             let _button = params.get("button").and_then(|v| v.as_str()).unwrap_or("left");
-            let _click_count = params.get("clickCount").and_then(|v| v.as_u64()).unwrap_or(1);
+            let click_count = params.get("clickCount").and_then(|v| v.as_u64()).unwrap_or(1);
 
             if event_type == "mousePressed" {
                 if let Some(page) = ctx.get_session_page_mut(session_id) {
@@ -23,9 +23,9 @@ pub async fn handle(
                             var target = (document.elementFromPoint && document.elementFromPoint({x},{y})) || globalThis.__obscura_click_target || document.activeElement || document.body;\
                             if (!target) return;\
                             globalThis.__obscura_click_target = target;\
-                            var evt = globalThis.__obscura_markTrusted(new MouseEvent('mousedown', {{bubbles:true,cancelable:true,clientX:{x},clientY:{y},button:0}}));\
+                            var evt = globalThis.__obscura_markTrusted(new MouseEvent('mousedown', {{bubbles:true,cancelable:true,clientX:{x},clientY:{y},button:0,detail:{click_count}}}));\
                             target.dispatchEvent(evt);\
-                            var click = globalThis.__obscura_markTrusted(new MouseEvent('click', {{bubbles:true,cancelable:true,clientX:{x},clientY:{y},button:0}}));\
+                            var click = globalThis.__obscura_markTrusted(new MouseEvent('click', {{bubbles:true,cancelable:true,clientX:{x},clientY:{y},button:0,detail:{click_count}}}));\
                             var cancelled = !target.dispatchEvent(click);\
                             if (!cancelled) {{\
                                 var link = target.closest ? target.closest('a[href]') : null;\
@@ -51,7 +51,7 @@ pub async fn handle(
                                 }}\
                             }}\
                         }})()",
-                        x = x, y = y,
+                        x = x, y = y, click_count = click_count,
                     );
                     page.evaluate(&code);
                     page.process_pending_navigation().await.map_err(|e| e.to_string())?;
@@ -155,6 +155,7 @@ pub async fn handle(
                     }
                     "char" => {
                         if !text.is_empty() {
+                            let escaped_text = text.replace('\\', "\\\\").replace('\'', "\\'");
                             let js = format!(
                                 "(function() {{\
                                     var target = document.activeElement;\
@@ -163,9 +164,11 @@ pub async fn handle(
                                         target.dispatchEvent(globalThis.__obscura_markTrusted(new Event('input', {{bubbles:true}})));\
                                     }}\
                                 }})()",
-                                text = text.replace('\'', "\\'").replace('\\', "\\\\"),
+                                text = escaped_text,
                             );
                             page.evaluate(&js);
+                            // Pump event loop so Angular change detection picks up the input
+                            page.settle(50).await;
                         }
                     }
                     _ => {}


### PR DESCRIPTION
Fixes two CDP Input bugs reported in #316.

## Bug 1: clickCount:3 doesn't select text

`clickCount` from CDP `Input.dispatchMouseEvent` was read with an underscore prefix (`_click_count`) and silently discarded. Neither `mousedown` nor `click` `MouseEvent` constructors received a `detail` field, so the browser always treated them as single clicks regardless of clickCount. Text inputs never selected their full content on triple-click.

**Fix:** Pass `click_count` as `detail` in both MouseEvent constructors.

## Bug 2: page.type() intermittently drops last character

Two issues in the `char` handler of `Input.dispatchKeyEvent`:
1. Quote-escaping order was wrong — escaped single-quotes first, then backslashes, which double-escaped the backslash from the quote escape.
2. After dispatching `new Event('input')`, the V8 event loop wasn't pumped, so Angular's change detection didn't process the last character before puppeteer read the field value.

**Fix:** Correct escaping order (backslash then single-quote) and add `page.settle(50)` after each `char` handler's evaluate to pump the event loop.