### PR TITLE
fix: protocol-relative URL (//host/path) resolved incorrectly in dynamic script loading

### DIFF
--- a/crates/obscura-js/js/bootstrap.js
+++ b/crates/obscura-js/js/bootstrap.js
@@ -481,7 +481,9 @@ class Node {
         try {
           fullUrl = src.startsWith('http') || src.startsWith('data:')
             ? src
-            : new URL(src, baseUrl).href;
+            : src.startsWith('//')
+              ? (new URL(baseUrl).protocol || 'https:') + src
+              : new URL(src, baseUrl).href;
         } catch(e) {
           console.error('Dynamic script URL resolve failed (' + src + '):', e.message);
           fullUrl = src;


### PR DESCRIPTION
## Summary

Fixes incorrect resolution of protocol-relative URLs (`//host/path`) in dynamic `<script>` loading. This causes `Dynamic script error` and `Unexpected token '<'` on pages loading CDN scripts via `//` URLs (common on Chinese websites like bilibili).

## Root Cause

In `crates/obscura-js/js/bootstrap.js`, the `appendChild` method uses `new URL(src, baseUrl)` to resolve script URLs. The V8 URL implementation incorrectly handles protocol-relative URLs, concatenating the full base origin instead of inheriting just the scheme.

## Fix

Detect `//` prefix and manually prepend the base URL protocol:

```js
: src.startsWith('//')
    ? (new URL(baseUrl).protocol || 'https:') + src
    : new URL(src, baseUrl).href;
```

## Verification

```bash
obscura fetch https://www.bilibili.com/ --eval 'new URL("//s1.hdslb.com/path", location.href).href'
# Before: https://www.bilibili.com//s1.hdslb.com/path (wrong)
# After:  https://s1.hdslb.com/path (correct)
```

Closes #345