### PR TITLE
fix: harden comment serialization and DOMSnapshot recursion depth

### DIFF
--- a/crates/obscura-cdp/src/domains/domsnapshot.rs
+++ b/crates/obscura-cdp/src/domains/domsnapshot.rs
@@ -84,21 +84,32 @@ impl Interner {
 }
 
 /// Pre-order DFS from the document, recording each node and its parent's index.
+/// Iterative with an explicit stack: the MAX_NODES cap bounds the node count,
+/// but recursion depth is a separate axis. A deeply nested linear chain (script
+/// can build thousands of nested elements) would recurse that many frames deep
+/// and could overflow the stack before the count guard triggers. An explicit
+/// stack keeps the depth on the heap (issue #341).
 fn walk(
     dom: &DomTree,
-    id: NodeId,
-    parent: i64,
+    root: NodeId,
+    root_parent: i64,
     order: &mut Vec<NodeId>,
     parent_idx: &mut Vec<i64>,
 ) {
-    if order.len() >= MAX_NODES {
-        return;
-    }
-    let my = order.len() as i64;
-    order.push(id);
-    parent_idx.push(parent);
-    for child in dom.children(id) {
-        walk(dom, child, my, order, parent_idx);
+    // (node, parent_index). Children are pushed in reverse so they pop in
+    // document order, preserving the original pre-order traversal.
+    let mut stack: Vec<(NodeId, i64)> = vec![(root, root_parent)];
+    while let Some((id, parent)) = stack.pop() {
+        if order.len() >= MAX_NODES {
+            break;
+        }
+        let my = order.len() as i64;
+        order.push(id);
+        parent_idx.push(parent);
+        let children: Vec<NodeId> = dom.children(id);
+        for child in children.into_iter().rev() {
+            stack.push((child, my));
+        }
     }
 }
 

--- a/crates/obscura-dom/src/serialize.rs
+++ b/crates/obscura-dom/src/serialize.rs
@@ -72,7 +72,17 @@ impl DomTree {
             }
             NodeData::Comment { contents } => {
                 buf.push_str("<!--");
-                buf.push_str(contents);
+                // The HTML parser can never produce a comment whose data contains
+                // "-->" (that ends the comment), but script can via
+                // document.createComment("a-->b"). Emitting it verbatim would close
+                // the comment early and let the trailing text escape into markup.
+                // Neutralize the terminator so the serialized output round-trips as
+                // a single comment.
+                if contents.contains("-->") {
+                    buf.push_str(&contents.replace("-->", "--&gt;"));
+                } else {
+                    buf.push_str(contents);
+                }
                 buf.push_str("-->");
             }
             NodeData::ProcessingInstruction { target, data } => {


### PR DESCRIPTION
## Comment serialization break-out (#342)

The comment serializer wrote its contents verbatim. The HTML parser can never produce a comment whose data contains "-->" (that ends the comment), but script can via document.createComment("a-->b"). Serializing that verbatim closed the comment early and let the trailing text escape into markup. Now "-->" is replaced with "--&gt;" so the output round-trips as a single comment.

## DOMSnapshot recursion depth (#341)

The DOMSnapshot walk recursed one stack frame per nesting level. The existing MAX_NODES cap bounds the node count but not the depth, so a deeply nested linear chain (script can build thousands of nested elements) could overflow the stack before the count guard triggered. Rewrote it with an explicit heap stack. Pre-order traversal and the MAX_NODES cap are unchanged.

## Testing

• #342: createComment with an embedded "-->" serializes without the trailing markup escaping the comment.
• #341: a 5000-deep nested chain builds and DOMSnapshot returns; captureSnapshot output is byte-identical pre-order to the recursive version (verified over CDP).
• Obstacle course 33/33; obscura-dom + obscura-cdp nextest 82/82.

Closes #341, #342.