### PR TITLE
fix(cdp): apply Fetch.continueRequest overrides

### DIFF
--- a/crates/obscura-cdp/src/server.rs
+++ b/crates/obscura-cdp/src/server.rs
@@ -457,6 +457,24 @@ async fn cdp_processor(
     ctx.default_context.save_cookies();
 }
 
+// Parse a CDP header list (`[{"name":..,"value":..}, ..]`, as used by
+// Fetch.continueRequest / fulfillRequest) into a map. Returns None when the
+// `headers` field is absent, so the caller can leave the request's headers
+// untouched rather than clearing them.
+fn parse_cdp_headers(params: &serde_json::Value) -> Option<HashMap<String, String>> {
+    let arr = params.get("headers")?.as_array()?;
+    Some(
+        arr.iter()
+            .filter_map(|h| {
+                Some((
+                    h.get("name")?.as_str()?.to_string(),
+                    h.get("value")?.as_str()?.to_string(),
+                ))
+            })
+            .collect(),
+    )
+}
+
 fn handle_fetch_resolution(
     text: &str,
     _ctx: &mut CdpContext,
@@ -472,7 +490,14 @@ fn handle_fetch_resolution(
             tracing::info!("INTERCEPTION resolved: {}", request_id);
             let resolution = match method {
                 "Fetch.continueRequest" => obscura_js::ops::InterceptResolution::Continue {
-                    url: None, method: None, headers: None, body: None,
+                    // Honor the client's overrides (Playwright route.continue,
+                    // Puppeteer request.continue). op_fetch_url applies each and
+                    // re-validates a rewritten URL through the SSRF gate. Leaving
+                    // these None silently sent the request unmodified (issue #365).
+                    url: req.params.get("url").and_then(|v| v.as_str()).map(|s| s.to_string()),
+                    method: req.params.get("method").and_then(|v| v.as_str()).map(|s| s.to_string()),
+                    headers: parse_cdp_headers(&req.params),
+                    body: req.params.get("postData").and_then(|v| v.as_str()).map(|s| s.to_string()),
                 },
                 "Fetch.fulfillRequest" => {
                     let status = req.params.get("responseCode").and_then(|v| v.as_u64()).unwrap_or(200) as u16;
@@ -993,4 +1018,32 @@ async fn handle_connection_ws(
 
     send_task.abort();
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::parse_cdp_headers;
+    use serde_json::json;
+
+    // Issue #365: Fetch.continueRequest header overrides must be parsed from the
+    // CDP `[{name, value}]` list so they can be applied to the outgoing request.
+    #[test]
+    fn parse_cdp_headers_reads_name_value_pairs() {
+        let params = json!({
+            "headers": [
+                {"name": "X-A", "value": "1"},
+                {"name": "X-B", "value": "2"},
+            ]
+        });
+        let headers = parse_cdp_headers(&params).expect("headers present");
+        assert_eq!(headers.get("X-A").map(String::as_str), Some("1"));
+        assert_eq!(headers.get("X-B").map(String::as_str), Some("2"));
+    }
+
+    // No `headers` field means "leave the request's headers untouched", which is
+    // None, not an empty map that would clear them.
+    #[test]
+    fn parse_cdp_headers_absent_is_none() {
+        assert!(parse_cdp_headers(&json!({"url": "https://example.com"})).is_none());
+    }
 }


### PR DESCRIPTION
Fixes #365.

## Problem

`handle_fetch_resolution` (the live `Fetch` interception path in
`crates/obscura-cdp/src/server.rs`) built the continue resolution with every
field hardcoded to `None`:

```rust
"Fetch.continueRequest" => InterceptResolution::Continue {
    url: None, method: None, headers: None, body: None,
},
```

So `Fetch.continueRequest` reported success while sending the request
unmodified. Playwright's `route.continue({ headers, url, postData })` and
Puppeteer's `request.continue({ ... })` — adding an auth header, rewriting the
URL, changing the method/body — were silently ignored.

The downstream `op_fetch_url` (obscura-js) already applies all four overrides
(`override_url` with SSRF re-validation, `override_method`, `override_headers`,
`override_body`); only the CDP layer was discarding them.

## Fix

Read `url`, `method`, `headers`, and `postData` from the `continueRequest`
params and pass them through. A small `parse_cdp_headers` helper turns the CDP
`[{name, value}]` header list into a map, returning `None` when `headers` is
absent so the request's headers are left untouched rather than cleared.

## Testing

- Unit: `parse_cdp_headers_reads_name_value_pairs`, `parse_cdp_headers_absent_is_none`.
- Full `obscura-cdp` suite: 49/49 (incl. the fetch-interception concurrency test).
- End to end: intercept a JS `fetch('/echo')`, `continueRequest` with an added
  `X-Test-Override: 1` header, and inspect the origin server — before the fix
  the header was absent; after, the origin receives `x-test-override: 1`.
- `obscura-benchmark` obstacle course: 33/33.
