### PR TITLE
fix(js): fire trusted input/change from setFileInputFiles

### DIFF
--- a/crates/obscura-js/js/bootstrap.js
+++ b/crates/obscura-js/js/bootstrap.js
@@ -4478,8 +4478,13 @@ globalThis.__obscura_setInputFiles = function(el, specs) {
     return new File([bytes], s.name || "", { type: s.type || "" });
   });
   el._files = _makeFileList(files);
-  try { el.dispatchEvent(new Event("input", { bubbles: true })); } catch (_e) {}
-  try { el.dispatchEvent(new Event("change", { bubbles: true })); } catch (_e) {}
+  // Mark the events trusted (isTrusted === true), like the Input domain does
+  // for synthesized clicks/keys. A real <input type=file> selection fires
+  // trusted events; upload flows that gate their change handler on
+  // event.isTrusted (common in frameworks and anti-bot code) ignore untrusted
+  // ones, which would silently break the exact case this feature targets.
+  try { el.dispatchEvent(globalThis.__obscura_markTrusted(new Event("input", { bubbles: true }))); } catch (_e) {}
+  try { el.dispatchEvent(globalThis.__obscura_markTrusted(new Event("change", { bubbles: true }))); } catch (_e) {}
 };
 globalThis.Event = class Event {
   constructor(t,o={}) { this.type=t;this.bubbles=!!o.bubbles;this.cancelable=!!o.cancelable;this.composed=!!o.composed;this.defaultPrevented=false;this.target=null;this.currentTarget=null;this.eventPhase=0;this.timeStamp=Date.now();this._propagationStopped=false;this._immediatePropagationStopped=false; }


### PR DESCRIPTION
Fixes #384.

## Problem

`DOM.setFileInputFiles` (Puppeteer `uploadFile` / Playwright `setInputFiles`)
fires `input` and `change` on the `<input type=file>`, but the events were
untrusted (`event.isTrusted === false`). Upload flows and anti-bot code that
gate their change handler on `isTrusted` — a common pattern, and exactly the
kind of page this feature exists to automate — ignored them.

The page-side helper `__obscura_setInputFiles` dispatched plain events, while
the Input domain (synthesized clicks/keys) already wraps every event in
`__obscura_markTrusted(...)`.

## Fix

Mark the dispatched `input`/`change` events trusted via the existing
`__obscura_markTrusted` helper, matching the Input domain.

## Testing

- End to end via CDP: create an `<input type=file>`, register a `change`
  handler that records `event.isTrusted`, then set files. Before: the handler
  sees `{fired:true, trusted:false}`; after: `{fired:true, trusted:true,
  count:1}`.
- `obscura-benchmark` obstacle course: 33/33.

(No Rust unit test: the change is in the bootstrap JS shim and the
`setup_runtime` test harness is unrelated to it; the behavior is verified
end-to-end through the CDP path clients actually use.)
