### PR TITLE
fix(js): move navigator fingerprint props onto Navigator.prototype

### DIFF
--- a/crates/obscura-js/js/bootstrap.js
+++ b/crates/obscura-js/js/bootstrap.js
@@ -3020,13 +3020,8 @@ function _uaBrands() {
   return [ordered[p[0]], ordered[p[1]], ordered[p[2]]];
 }
 
-// Navigator fingerprint surfaces (userAgent, appVersion, platform, language,
-// languages, plugins, mimeTypes, hardwareConcurrency, deviceMemory, webdriver,
-// share, canShare) are intentionally NOT defined here. Defining them as own
-// instance accessors/data props is the textbook "navigator was patched" tell
-// that pixelscan's Navigator group flags. They are installed on a prototype
-// one hop above Navigator.prototype in the IIFE below, so
-// navigator.hasOwnProperty('platform') === false, exactly like real Chrome.
+// Fingerprint surfaces (UA, plugins, webdriver, etc.) live on the prototype
+// hop below, not as own props here: own accessors are a bot tell.
 globalThis.navigator = {
   onLine: true, cookieEnabled: true,
   maxTouchPoints: 0,
@@ -3120,16 +3115,9 @@ globalThis.navigator = {
   },
 };
 
-// Move spoofed navigator properties off the instance and onto a thin
-// prototype above Navigator.prototype, matching Chrome where they live on
-// Navigator.prototype. pixelscan's Navigator group flags any spoofed prop
-// that survives as an own-instance accessor/data property (hasOwnProperty /
-// getOwnPropertyDescriptor). Keep Navigator.prototype as the chain base so
-// navigator instanceof Navigator === true. Getters read the __obscura_*
-// globals lazily at call time: bootstrap.js is baked into the V8 snapshot at
-// build time, while those globals are set per page at runtime by set_user_agent
-// / set_platform / __obscura_init (runtime.rs:219-238). _markNative each getter
-// so its toString() reports [native code].
+// Put spoofed navigator props on a thin prototype above Navigator.prototype
+// so hasOwnProperty/getOwnPropertyDescriptor on the instance match Chrome.
+// Getters read __obscura_* lazily (snapshot vs per-page) and are _markNative'd.
 (function() {
   var _navProto = Object.create(Navigator.prototype);
 
@@ -3140,13 +3128,7 @@ globalThis.navigator = {
     });
   }
 
-  // webdriver (unchanged behavior, moved here from the old single-prop block).
   defGetter('webdriver', function() { return false; });
-
-  // UA surfaces read the same globals set_user_agent / set_platform write
-  // (runtime.rs:219, runtime.rs:227), so those Rust methods keep working
-  // with no change. appVersion reads the global directly rather than via
-  // this.userAgent so the getter is this-independent.
   defGetter('userAgent', function() {
     return globalThis.__obscura_ua ||
       "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 " +
@@ -3163,10 +3145,7 @@ globalThis.navigator = {
   defGetter('language', function() { return "en-US"; });
   defGetter('languages', function() { return ["en-US", "en"]; });
 
-  // plugins / mimeTypes: build once and cache, so navigator.plugins ===
-  // navigator.plugins (real Chrome returns a stable singleton). The
-  // PluginArray / Plugin / MimeType / MimeTypeArray constructors above
-  // already set Symbol.toStringTag and _markNative the item/namedItem methods.
+  // Cache plugins/mimeTypes so navigator.plugins === navigator.plugins.
   var _plugins = new PluginArray([
     new Plugin("PDF Viewer", "internal-pdf-viewer", "Portable Document Format", []),
     new Plugin("Chrome PDF Viewer", "internal-pdf-viewer", "Portable Document Format", []),
@@ -3181,14 +3160,10 @@ globalThis.navigator = {
   defGetter('plugins', function() { return _plugins; });
   defGetter('mimeTypes', function() { return _mimeTypes; });
 
-  // hardwareConcurrency / deviceMemory: randomized per-page in __obscura_init
-  // via backing globals, so no own data prop is created on the instance.
+  // Values set per-page by __obscura_init (avoids own data props on navigator).
   defGetter('hardwareConcurrency', function() { return globalThis.__obscura_hw || 8; });
   defGetter('deviceMemory', function() { return globalThis.__obscura_mem || 8; });
 
-  // share / canShare: own methods on the instance in real Chrome are also
-  // inherited from Navigator.prototype. DOMException resolves lazily at call
-  // time (its constructor is defined later in this file).
   _navProto.share = _markNative(function share(data) {
     return Promise.reject(new DOMException('Not allowed', 'NotAllowedError'));
   });

--- a/crates/obscura-js/js/bootstrap.js
+++ b/crates/obscura-js/js/bootstrap.js
@@ -15,6 +15,7 @@
     '__obscura_objects', '__obscura_oid', '__obscura_ua',
     '__obscura_platform', '__obscura_ua_platform', '__obscura_ua_platform_version',
     '__obscura_stealth', '__obscura_markTrusted',
+    '__obscura_hw', '__obscura_mem',
     '__documentReadyState__', '__currentUrl',
     // internal helpers (var-declared throughout the file)
     '__processDynScriptQueue', '_markNative', '_fpRand', '_fpNoise',
@@ -3019,32 +3020,20 @@ function _uaBrands() {
   return [ordered[p[0]], ordered[p[1]], ordered[p[2]]];
 }
 
+// Navigator fingerprint surfaces (userAgent, appVersion, platform, language,
+// languages, plugins, mimeTypes, hardwareConcurrency, deviceMemory, webdriver,
+// share, canShare) are intentionally NOT defined here. Defining them as own
+// instance accessors/data props is the textbook "navigator was patched" tell
+// that pixelscan's Navigator group flags. They are installed on a prototype
+// one hop above Navigator.prototype in the IIFE below, so
+// navigator.hasOwnProperty('platform') === false, exactly like real Chrome.
 globalThis.navigator = {
-  get userAgent() { return globalThis.__obscura_ua || "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/145.0.0.0 Safari/537.36"; },
-  get appVersion() { return this.userAgent.replace('Mozilla/', ''); },
-  language: "en-US", languages: ["en-US","en"], get platform() { return globalThis.__obscura_platform || "Win32"; },
-  onLine: true, cookieEnabled: true, hardwareConcurrency: 8,
+  onLine: true, cookieEnabled: true,
   maxTouchPoints: 0,
   vendor: "Google Inc.", product: "Gecko", productSub: "20030107",
   doNotTrack: null,
-  deviceMemory: 8,
   connection: new NetworkInformation(),
   pdfViewerEnabled: true,
-  get plugins() {
-    return new PluginArray([
-      new Plugin("PDF Viewer", "internal-pdf-viewer", "Portable Document Format", []),
-      new Plugin("Chrome PDF Viewer", "internal-pdf-viewer", "Portable Document Format", []),
-      new Plugin("Chromium PDF Viewer", "internal-pdf-viewer", "Portable Document Format", []),
-      new Plugin("Microsoft Edge PDF Viewer", "internal-pdf-viewer", "Portable Document Format", []),
-      new Plugin("WebKit built-in PDF", "internal-pdf-viewer", "Portable Document Format", []),
-    ]);
-  },
-  get mimeTypes() {
-    return new MimeTypeArray([
-      new MimeType("application/pdf", "Portable Document Format", "pdf", null),
-      new MimeType("text/pdf", "Portable Document Format", "pdf", null),
-    ]);
-  },
   userAgentData: {
     mobile: false,
     get brands() { return _uaBrands(); },
@@ -3131,16 +3120,81 @@ globalThis.navigator = {
   },
 };
 
-// Move navigator.webdriver off the instance and onto a thin prototype so that
-// Object.getOwnPropertyDescriptor(navigator, 'webdriver') returns undefined,
-// matching Chrome where the property lives on Navigator.prototype.
-// Use Navigator.prototype as the chain base so navigator instanceof Navigator === true.
+// Move spoofed navigator properties off the instance and onto a thin
+// prototype above Navigator.prototype, matching Chrome where they live on
+// Navigator.prototype. pixelscan's Navigator group flags any spoofed prop
+// that survives as an own-instance accessor/data property (hasOwnProperty /
+// getOwnPropertyDescriptor). Keep Navigator.prototype as the chain base so
+// navigator instanceof Navigator === true. Getters read the __obscura_*
+// globals lazily at call time: bootstrap.js is baked into the V8 snapshot at
+// build time, while those globals are set per page at runtime by set_user_agent
+// / set_platform / __obscura_init (runtime.rs:219-238). _markNative each getter
+// so its toString() reports [native code].
 (function() {
-  var _wdGetter = function() { return false; };
-  _markNative(_wdGetter);
-  var _wdProto = Object.create(Navigator.prototype);
-  Object.defineProperty(_wdProto, 'webdriver', {get: _wdGetter, set: undefined, enumerable: true, configurable: true});
-  Object.setPrototypeOf(globalThis.navigator, _wdProto);
+  var _navProto = Object.create(Navigator.prototype);
+
+  function defGetter(key, fn) {
+    _markNative(fn);
+    Object.defineProperty(_navProto, key, {
+      get: fn, set: undefined, enumerable: true, configurable: true,
+    });
+  }
+
+  // webdriver (unchanged behavior, moved here from the old single-prop block).
+  defGetter('webdriver', function() { return false; });
+
+  // UA surfaces read the same globals set_user_agent / set_platform write
+  // (runtime.rs:219, runtime.rs:227), so those Rust methods keep working
+  // with no change. appVersion reads the global directly rather than via
+  // this.userAgent so the getter is this-independent.
+  defGetter('userAgent', function() {
+    return globalThis.__obscura_ua ||
+      "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 " +
+      "(KHTML, like Gecko) Chrome/145.0.0.0 Safari/537.36";
+  });
+  defGetter('appVersion', function() {
+    return (globalThis.__obscura_ua ||
+      "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 " +
+      "(KHTML, like Gecko) Chrome/145.0.0.0 Safari/537.36").replace('Mozilla/', '');
+  });
+  defGetter('platform', function() {
+    return globalThis.__obscura_platform || "Win32";
+  });
+  defGetter('language', function() { return "en-US"; });
+  defGetter('languages', function() { return ["en-US", "en"]; });
+
+  // plugins / mimeTypes: build once and cache, so navigator.plugins ===
+  // navigator.plugins (real Chrome returns a stable singleton). The
+  // PluginArray / Plugin / MimeType / MimeTypeArray constructors above
+  // already set Symbol.toStringTag and _markNative the item/namedItem methods.
+  var _plugins = new PluginArray([
+    new Plugin("PDF Viewer", "internal-pdf-viewer", "Portable Document Format", []),
+    new Plugin("Chrome PDF Viewer", "internal-pdf-viewer", "Portable Document Format", []),
+    new Plugin("Chromium PDF Viewer", "internal-pdf-viewer", "Portable Document Format", []),
+    new Plugin("Microsoft Edge PDF Viewer", "internal-pdf-viewer", "Portable Document Format", []),
+    new Plugin("WebKit built-in PDF", "internal-pdf-viewer", "Portable Document Format", []),
+  ]);
+  var _mimeTypes = new MimeTypeArray([
+    new MimeType("application/pdf", "Portable Document Format", "pdf", null),
+    new MimeType("text/pdf", "Portable Document Format", "pdf", null),
+  ]);
+  defGetter('plugins', function() { return _plugins; });
+  defGetter('mimeTypes', function() { return _mimeTypes; });
+
+  // hardwareConcurrency / deviceMemory: randomized per-page in __obscura_init
+  // via backing globals, so no own data prop is created on the instance.
+  defGetter('hardwareConcurrency', function() { return globalThis.__obscura_hw || 8; });
+  defGetter('deviceMemory', function() { return globalThis.__obscura_mem || 8; });
+
+  // share / canShare: own methods on the instance in real Chrome are also
+  // inherited from Navigator.prototype. DOMException resolves lazily at call
+  // time (its constructor is defined later in this file).
+  _navProto.share = _markNative(function share(data) {
+    return Promise.reject(new DOMException('Not allowed', 'NotAllowedError'));
+  });
+  _navProto.canShare = _markNative(function canShare() { return false; });
+
+  Object.setPrototypeOf(globalThis.navigator, _navProto);
 })();
 
 globalThis.chrome = {
@@ -6672,8 +6726,6 @@ navigator.keyboard = {
 };
 navigator.gpu = { requestAdapter() { return Promise.resolve(null); } };
 navigator.wakeLock = { request() { return Promise.reject(new DOMException('Not allowed', 'NotAllowedError')); } };
-navigator.share = function(data) { return Promise.reject(new DOMException('Not allowed', 'NotAllowedError')); };
-navigator.canShare = function() { return false; };
 
 globalThis.opener = null;
 
@@ -7597,9 +7649,9 @@ globalThis.__obscura_init = function() {
   globalThis.outerWidth = sw; globalThis.outerHeight = sh - 40;
 
   var hwValues = globalThis.__obscura_stealth ? [4, 6, 8, 12, 16] : [2, 4, 6, 8, 12, 16];
-  globalThis.navigator.hardwareConcurrency = hwValues[Math.floor(_fpRand(400) * hwValues.length)];
+  globalThis.__obscura_hw = hwValues[Math.floor(_fpRand(400) * hwValues.length)];
   var memValues = globalThis.__obscura_stealth ? [4, 8] : [0.25, 0.5, 1, 2, 4, 8];
-  globalThis.navigator.deviceMemory = memValues[Math.floor(_fpRand(401) * memValues.length)];
+  globalThis.__obscura_mem = memValues[Math.floor(_fpRand(401) * memValues.length)];
 
   const t0 = Date.now() + Math.floor(_fpRand(641) * 100) - 50;
   globalThis.performance.timeOrigin = t0;


### PR DESCRIPTION
## Summary

pixelscan (and similar detectors) flag Obscura's Navigator group because
spoofed properties lived as own-instance accessors/data props on the
`navigator` object literal. Real Chrome keeps them on
`Navigator.prototype`, so `hasOwnProperty` / `getOwnPropertyDescriptor`
on the instance return false/undefined.

This moves every fingerprinted surface onto a thin prototype one hop
above `Navigator.prototype`, generalizing the existing `webdriver`
IIFE. One file changes (`bootstrap.js`); every consumer benefits
(fetch, serve, scrape, mcp, --stealth, CDP clients) with no init script.

## Changes

- Remove own props from the navigator literal: `userAgent`, `appVersion`,
  `platform`, `language`, `languages`, `plugins`, `mimeTypes`,
  `hardwareConcurrency`, `deviceMemory`
- Define them as `_markNative`'d getters on `_navProto`
  (`Object.create(Navigator.prototype)`), then
  `Object.setPrototypeOf(navigator, _navProto)`
- Move `share` / `canShare` off the instance onto the same proto
- Back `hardwareConcurrency` / `deviceMemory` with
  `__obscura_hw` / `__obscura_mem` written by `__obscura_init`
  (per-page randomization preserved; stealth/non-stealth pools intact)
- Pre-declare those globals in `_preHideInternals` so reflection APIs
  never expose them
- Cache `PluginArray` / `MimeTypeArray` so
  `navigator.plugins === navigator.plugins`
- Getters read `__obscura_*` lazily (V8 snapshot vs per-page timing);
  `set_user_agent` / `set_platform` need no Rust changes

## Test plan

- [x] In-page probe: all fingerprinted props fail `hasOwnProperty`;
      instance `getOwnPropertyDescriptor` is undefined; proto descriptor
      present; plugins stable singleton; getter `toString` is `[native code]`
- [x] pixelscan bot-check via `obscura serve` + Playwright, **no**
      `addInitScript`: Navigator / Webdriver / CDP / User Agent all Clear,
      flagged parameters NONE
- [x] `--stealth` parity: same ownership checks; UA/platform reflect
      stealth profile
- [x] `cargo nextest run -p obscura-js -- test_navigator`