### PR TITLE
fix(cdp): allow large WebSocket response frames (<64Mb)

### DIFF
--- a/crates/obscura-cdp/src/server.rs
+++ b/crates/obscura-cdp/src/server.rs
@@ -965,7 +965,7 @@ async fn handle_connection_ws(
     use tokio_tungstenite::tungstenite::protocol::WebSocketConfig;
     let mut cfg = WebSocketConfig::default();
     cfg.write_buffer_size = 0;
-    cfg.max_write_buffer_size = 1 << 20;
+    cfg.max_write_buffer_size = 64 << 20;
     let ws_stream = tokio_tungstenite::accept_async_with_config(stream, Some(cfg)).await?;
     info!("WebSocket connected");
     let (mut ws_sender, mut ws_receiver) = ws_stream.split();


### PR DESCRIPTION
## Summary
Raise the CDP WebSocket write-buffer limit from 1 MiB to 64 MiB.

## Problem solved
Some CDP commands, particularly `Runtime.evaluate`, can produce multi-megabyte responses such as rendered DOM snapshots. The previous 1 MiB limit caused these WebSocket responses to be dropped.
The new 64 MiB limit supports larger responses while keeping the write buffer bounded.