### PR TITLE
fix(js): load dynamically inserted stylesheets

### DIFF
--- a/crates/obscura-js/js/bootstrap.js
+++ b/crates/obscura-js/js/bootstrap.js
@@ -198,6 +198,59 @@ async function __processDynScriptQueue() {
     __dynScriptBusy = false;
   }
 }
+
+// Dynamic stylesheet loading. Vite's production preload helper appends
+// <link rel="stylesheet"> elements and waits for load/error before resolving a
+// lazy route import. Merely adding the node to the DOM leaves that promise
+// pending forever, so fetch the resource through the same guarded/proxied op as
+// fetch/XHR and deliver the element lifecycle event. Track the URL per element
+// so setting rel/href before insertion does not double-fetch, while changing
+// href after insertion still starts a new request.
+const __dynamicStylesheetLoads = new WeakMap();
+function __maybeLoadDynamicStylesheet(link) {
+  if (!link || link.tagName !== 'LINK' || !link.isConnected) return;
+  const rel = (link.getAttribute('rel') || '').toLowerCase().split(/\s+/);
+  const href = link.getAttribute('href');
+  if (!rel.includes('stylesheet') || !href) {
+    __dynamicStylesheetLoads.delete(link);
+    return;
+  }
+
+  let baseHref;
+  try {
+    const baseEl = globalThis.document?.querySelector('base[href]');
+    baseHref = baseEl ? baseEl.getAttribute('href') : null;
+  } catch(e) { baseHref = null; }
+  const docUrl = globalThis.location?.href || 'http://localhost/';
+  let baseUrl;
+  try { baseUrl = baseHref ? new URL(baseHref, docUrl).href : docUrl; }
+  catch(e) { baseUrl = docUrl; }
+  let fullUrl;
+  try { fullUrl = new URL(href, baseUrl).href; }
+  catch(e) {
+    Promise.resolve().then(() => link.dispatchEvent(new Event('error')));
+    return;
+  }
+  if (__dynamicStylesheetLoads.get(link) === fullUrl) return;
+  __dynamicStylesheetLoads.set(link, fullUrl);
+
+  const pageOrigin = (() => { try { return new URL(docUrl).origin; } catch(e) { return ''; } })();
+  Promise.resolve(Deno.core.ops.op_fetch_url(
+    fullUrl, 'GET', '{"accept":"text/css,*/*;q=0.1"}', '', pageOrigin, 'no-cors'
+  )).then(raw => {
+    if (__dynamicStylesheetLoads.get(link) !== fullUrl) return;
+    let response;
+    try { response = typeof raw === 'string' ? JSON.parse(raw) : raw; }
+    catch(e) { response = null; }
+    const loaded = response && response.status >= 200 && response.status < 400 && !response.blocked;
+    link.dispatchEvent(new Event(loaded ? 'load' : 'error'));
+  }).catch(() => {
+    if (__dynamicStylesheetLoads.get(link) === fullUrl) {
+      link.dispatchEvent(new Event('error'));
+    }
+  });
+}
+
 function _fpRand(salt) {
   let h = (_fpSeed ^ (salt || 0)) | 0;
   h = Math.imul(h ^ (h >>> 16), 0x45d9f3b);
@@ -687,6 +740,7 @@ class Node {
         }
       }
     }
+    __maybeLoadDynamicStylesheet(c);
     return c;
   }
   removeChild(c) {
@@ -705,6 +759,7 @@ class Node {
     if (!n) return n;
     if (!ref) { this.appendChild(n); return n; }
     _dom("insert_before", n._nid, ref._nid);
+    __maybeLoadDynamicStylesheet(n);
     return n;
   }
   contains(o) { return o ? _dom("contains", this._nid, o._nid) === "true" : false; }
@@ -1252,9 +1307,10 @@ class Element extends Node {
     _dom("set_attribute", this._nid, n + "\0" + String(v));
     if (popoverPrev !== undefined) this._popoverTypeMaybeChanged(popoverPrev);
     if (globalThis.__mutationObservers?.length) globalThis.__notifyMutation('attributes', this._nid, [], [], n);
+    if (this.tagName === 'LINK' && (n === 'rel' || n === 'href')) __maybeLoadDynamicStylesheet(this);
   }
   setAttributeNS(ns, n, v) { _dom("set_attribute", this._nid, String(n) + "\0" + String(v)); } // exact name, no HTML folding
-  removeAttribute(n) { n = _htmlAttrName(this, n); const popoverPrev = (n === "popover") ? this.popover : undefined; _dom("remove_attribute", this._nid, n); if (popoverPrev !== undefined) this._popoverTypeMaybeChanged(popoverPrev); }
+  removeAttribute(n) { n = _htmlAttrName(this, n); const popoverPrev = (n === "popover") ? this.popover : undefined; _dom("remove_attribute", this._nid, n); if (popoverPrev !== undefined) this._popoverTypeMaybeChanged(popoverPrev); if (this.tagName === 'LINK' && (n === 'rel' || n === 'href')) __maybeLoadDynamicStylesheet(this); }
   removeAttributeNS(ns, n) { _dom("remove_attribute", this._nid, String(n)); }
   hasAttribute(n) { return this.getAttribute(n) !== null; }
   hasAttributes() { return true; } // Simplified
@@ -1772,6 +1828,8 @@ class Element extends Node {
   set name(v) { this.setAttribute("name", v); }
   get placeholder() { return this.getAttribute("placeholder") || ""; }
   set placeholder(v) { this.setAttribute("placeholder", v); }
+  get rel() { return this.getAttribute("rel") || ""; }
+  set rel(v) { this.setAttribute("rel", v); }
   // For <a>/<area>, href returns the resolved absolute URL (the spec behavior,
   // and what scrapers want). It uses op_url_resolve, which returns just the
   // resolved string, rather than the full-component op the decomposition

--- a/crates/obscura-js/src/runtime.rs
+++ b/crates/obscura-js/src/runtime.rs
@@ -2176,6 +2176,120 @@ mod tests {
     }
 
     #[tokio::test(flavor = "current_thread")]
+    async fn test_dynamic_stylesheet_fetches_and_fires_load_or_error() {
+        let mut rt =
+            setup_runtime("<html><head><meta charset=\"utf-8\"></head><body></body></html>");
+        rt.run_page_init();
+        let result = rt
+            .call_function_on_for_cdp(
+                r#"async () => {
+                const originalFetchOp = Deno.core.ops.op_fetch_url;
+                const calls = [];
+                try {
+                    Deno.core.ops.op_fetch_url = (url, method, headers, body, origin, mode) => {
+                        calls.push({ url, method, headers: JSON.parse(headers), body, origin, mode });
+                        return JSON.stringify({
+                            status: url.endsWith('/missing.css') ? 404 : 200,
+                            headers: { 'content-type': 'text/css' },
+                            body: 'body { color: green; }',
+                            url,
+                        });
+                    };
+
+                    const loaded = document.createElement('link');
+                    loaded.rel = 'stylesheet';
+                    loaded.href = '/app.css';
+                    const loadEvent = new Promise(resolve => loaded.onload = () => resolve('load'));
+                    document.head.appendChild(loaded);
+
+                    const missing = document.createElement('link');
+                    missing.rel = 'stylesheet';
+                    missing.href = '/missing.css';
+                    const errorEvent = new Promise(resolve => missing.addEventListener('error', () => resolve('error')));
+                    document.head.insertBefore(missing, document.head.firstChild);
+
+                    const late = document.createElement('link');
+                    const lateEvent = new Promise(resolve => late.addEventListener('load', () => resolve('load')));
+                    document.head.appendChild(late);
+                    late.rel = 'stylesheet';
+                    late.href = 'late.css';
+
+                    const base = document.createElement('base');
+                    base.href = 'https://cdn.example/assets/';
+                    document.head.appendChild(base);
+                    const based = document.createElement('link');
+                    based.rel = 'stylesheet';
+                    based.href = 'theme.css';
+                    const basedEvent = new Promise(resolve => based.onload = () => resolve('load'));
+                    document.head.appendChild(based);
+
+                    return JSON.stringify({
+                        events: await Promise.all([loadEvent, errorEvent, lateEvent, basedEvent]),
+                        reflectedRel: loaded.getAttribute('rel'),
+                        calls,
+                    });
+                } catch (error) {
+                    return 'ERROR:' + String(error && (error.stack || error));
+                } finally {
+                    Deno.core.ops.op_fetch_url = originalFetchOp;
+                }
+            }"#,
+                None,
+                &[],
+                true,
+                true,
+            )
+            .await
+            .unwrap();
+
+        let raw = result.value.unwrap();
+        let raw = raw.as_str().unwrap();
+        assert!(!raw.starts_with("ERROR:"), "{}", raw);
+        let value: serde_json::Value = serde_json::from_str(raw).unwrap();
+        assert_eq!(
+            value,
+            serde_json::json!({
+                "events": ["load", "error", "load", "load"],
+                "reflectedRel": "stylesheet",
+                "calls": [
+                    {
+                        "url": "http://example.com/app.css",
+                        "method": "GET",
+                        "headers": { "accept": "text/css,*/*;q=0.1" },
+                        "body": "",
+                        "origin": "http://example.com",
+                        "mode": "no-cors",
+                    },
+                    {
+                        "url": "http://example.com/missing.css",
+                        "method": "GET",
+                        "headers": { "accept": "text/css,*/*;q=0.1" },
+                        "body": "",
+                        "origin": "http://example.com",
+                        "mode": "no-cors",
+                    },
+                    {
+                        "url": "http://example.com/late.css",
+                        "method": "GET",
+                        "headers": { "accept": "text/css,*/*;q=0.1" },
+                        "body": "",
+                        "origin": "http://example.com",
+                        "mode": "no-cors",
+                    },
+                    {
+                        "url": "https://cdn.example/assets/theme.css",
+                        "method": "GET",
+                        "headers": { "accept": "text/css,*/*;q=0.1" },
+                        "body": "",
+                        "origin": "http://example.com",
+                        "mode": "no-cors",
+                    },
+                ],
+            })
+        );
+    }
+
+    #[tokio::test(flavor = "current_thread")]
     async fn test_response_array_buffer_preserves_typed_array_view() {
         let mut rt = setup_runtime("<html><body></body></html>");
         let result = rt.call_function_on_for_cdp(

--- a/crates/obscura/tests/dynamic_stylesheet.rs
+++ b/crates/obscura/tests/dynamic_stylesheet.rs
@@ -1,0 +1,74 @@
+use std::io::{Read, Write};
+use std::sync::atomic::{AtomicU32, Ordering};
+use std::sync::Arc;
+
+use obscura::Browser;
+
+fn spawn_stylesheet_server() -> (String, Arc<AtomicU32>) {
+    let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+    let addr = listener.local_addr().unwrap();
+    let stylesheet_requests = Arc::new(AtomicU32::new(0));
+    let request_count = stylesheet_requests.clone();
+
+    std::thread::spawn(move || {
+        for incoming in listener.incoming() {
+            let mut stream = match incoming {
+                Ok(stream) => stream,
+                Err(_) => continue,
+            };
+            let mut buffer = [0u8; 4096];
+            let bytes_read = stream.read(&mut buffer).unwrap_or(0);
+            let request = std::str::from_utf8(&buffer[..bytes_read]).unwrap_or("");
+            let path = request.split_whitespace().nth(1).unwrap_or("/");
+            let (content_type, body) = if path == "/dynamic.css" {
+                request_count.fetch_add(1, Ordering::SeqCst);
+                ("text/css", "body { color: green; }")
+            } else {
+                (
+                    "text/html",
+                    r#"<script>
+                        globalThis.stylesheetEvent = "pending";
+                        const link = document.createElement("link");
+                        link.rel = "stylesheet";
+                        link.href = "/dynamic.css";
+                        link.onload = () => globalThis.stylesheetEvent = "load";
+                        link.addEventListener("error", () => globalThis.stylesheetEvent = "error");
+                        document.head.appendChild(link);
+                    </script>"#,
+                )
+            };
+            let response = format!(
+                "HTTP/1.1 200 OK\r\nContent-Type: {}\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+                content_type,
+                body.len(),
+                body
+            );
+            let _ = stream.write_all(response.as_bytes());
+            let _ = stream.shutdown(std::net::Shutdown::Both);
+        }
+    });
+
+    (format!("http://{}", addr), stylesheet_requests)
+}
+
+#[tokio::test]
+async fn dynamically_inserted_stylesheet_fetches_and_fires_load() {
+    std::env::set_var("OBSCURA_ALLOW_PRIVATE_NETWORK", "1");
+    let (base_url, stylesheet_requests) = spawn_stylesheet_server();
+    let browser = Browser::new().unwrap();
+    let mut page = browser.new_page().await.unwrap();
+
+    page.goto(&base_url).await.unwrap();
+    for _ in 0..20 {
+        page.settle(100).await;
+        if page.evaluate("globalThis.stylesheetEvent") == serde_json::json!("load") {
+            break;
+        }
+    }
+
+    assert_eq!(
+        page.evaluate("globalThis.stylesheetEvent"),
+        serde_json::json!("load")
+    );
+    assert_eq!(stylesheet_requests.load(Ordering::SeqCst), 1);
+}


### PR DESCRIPTION
fixes #409.

loads dynamically inserted stylesheet links and fires their load/error events. adds unit and end-to-end regression coverage.

validated with the release build, nextest, and the 33/33 obstacle course.