### PR TITLE
feat(css): add lightweight native style computation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1707,6 +1707,7 @@ dependencies = [
  "markup5ever",
  "precomputed-hash",
  "selectors",
+ "serde",
  "servo_arc",
  "thiserror 2.0.18",
  "tracing",

--- a/crates/obscura-browser/src/context.rs
+++ b/crates/obscura-browser/src/context.rs
@@ -3,6 +3,71 @@ use std::sync::Arc;
 
 use obscura_net::{CookieJar, ObscuraHttpClient, RobotsCache};
 
+/// Controls how stylesheet responses are handled.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub enum CssMode {
+    /// Parse stylesheets and expose a lightweight, non-rendering cascade.
+    #[default]
+    Compute,
+    /// Fetch top-level stylesheets for lifecycle fidelity, then discard them.
+    Drop,
+}
+
+impl std::str::FromStr for CssMode {
+    type Err = String;
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        match value.to_ascii_lowercase().as_str() {
+            "compute" => Ok(Self::Compute),
+            "drop" => Ok(Self::Drop),
+            _ => Err(format!(
+                "invalid CSS mode '{value}' (expected compute or drop)"
+            )),
+        }
+    }
+}
+
+impl std::fmt::Display for CssMode {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(match self {
+            Self::Compute => "compute",
+            Self::Drop => "drop",
+        })
+    }
+}
+
+impl CssMode {
+    pub fn process_default() -> Self {
+        std::env::var("OBSCURA_CSS_MODE")
+            .ok()
+            .and_then(|value| value.parse().ok())
+            .unwrap_or(Self::Compute)
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct BrowserContextOptions {
+    pub proxy_url: Option<String>,
+    pub stealth: bool,
+    pub user_agent: Option<String>,
+    pub storage_dir: Option<PathBuf>,
+    pub allow_private_network: bool,
+    pub css_mode: CssMode,
+}
+
+impl Default for BrowserContextOptions {
+    fn default() -> Self {
+        Self {
+            proxy_url: None,
+            stealth: false,
+            user_agent: None,
+            storage_dir: None,
+            allow_private_network: false,
+            css_mode: CssMode::process_default(),
+        }
+    }
+}
+
 pub struct BrowserContext {
     pub id: String,
     pub cookie_jar: Arc<CookieJar>,
@@ -30,21 +95,25 @@ pub struct BrowserContext {
     /// models: file:// is a local file-system read, while private-network is
     /// the broader SSRF gate from issue #4.
     pub allow_private_network: bool,
+    pub css_mode: CssMode,
 }
 
 impl BrowserContext {
     pub fn new(id: String) -> Self {
-        Self::_new_inner(id, None, false, None, None, false)
+        Self::with_config(id, BrowserContextOptions::default())
     }
 
     /// Create a BrowserContext with an optional storage directory.
     /// When `storage_dir` is set, cookies are automatically loaded from
     /// `{storage_dir}/cookies.json` on creation.
-    pub fn with_storage(
-        id: String,
-        storage_dir: Option<PathBuf>,
-    ) -> Self {
-        Self::_new_inner(id, None, false, None, storage_dir, false)
+    pub fn with_storage(id: String, storage_dir: Option<PathBuf>) -> Self {
+        Self::with_config(
+            id,
+            BrowserContextOptions {
+                storage_dir,
+                ..Default::default()
+            },
+        )
     }
 
     /// Create a BrowserContext with full options including storage_dir.
@@ -55,7 +124,16 @@ impl BrowserContext {
         user_agent: Option<String>,
         storage_dir: Option<PathBuf>,
     ) -> Self {
-        Self::_new_inner(id, proxy_url, stealth, user_agent, storage_dir, false)
+        Self::with_config(
+            id,
+            BrowserContextOptions {
+                proxy_url,
+                stealth,
+                user_agent,
+                storage_dir,
+                ..Default::default()
+            },
+        )
     }
 
     /// Variant that also accepts the `allow_private_network` opt-in. All
@@ -69,7 +147,29 @@ impl BrowserContext {
         storage_dir: Option<PathBuf>,
         allow_private_network: bool,
     ) -> Self {
-        Self::_new_inner(id, proxy_url, stealth, user_agent, storage_dir, allow_private_network)
+        Self::with_config(
+            id,
+            BrowserContextOptions {
+                proxy_url,
+                stealth,
+                user_agent,
+                storage_dir,
+                allow_private_network,
+                css_mode: CssMode::process_default(),
+            },
+        )
+    }
+
+    pub fn with_config(id: String, options: BrowserContextOptions) -> Self {
+        Self::_new_inner(
+            id,
+            options.proxy_url,
+            options.stealth,
+            options.user_agent,
+            options.storage_dir,
+            options.allow_private_network,
+            options.css_mode,
+        )
     }
 
     fn _new_inner(
@@ -79,6 +179,7 @@ impl BrowserContext {
         user_agent: Option<String>,
         storage_dir: Option<PathBuf>,
         allow_private_network: bool,
+        css_mode: CssMode,
     ) -> Self {
         let cookie_jar = Arc::new(CookieJar::new());
 
@@ -133,6 +234,7 @@ impl BrowserContext {
             allow_file_access: false,
             storage_dir,
             allow_private_network,
+            css_mode,
         }
     }
 
@@ -146,7 +248,15 @@ impl BrowserContext {
         stealth: bool,
         user_agent: Option<String>,
     ) -> Self {
-        Self::_new_inner(id, proxy_url, stealth, user_agent, None, false)
+        Self::with_config(
+            id,
+            BrowserContextOptions {
+                proxy_url,
+                stealth,
+                user_agent,
+                ..Default::default()
+            },
+        )
     }
 
     pub fn with_proxy(id: String, proxy_url: Option<String>) -> Self {

--- a/crates/obscura-browser/src/lib.rs
+++ b/crates/obscura-browser/src/lib.rs
@@ -1,12 +1,12 @@
-pub mod page;
 pub mod context;
 pub mod lifecycle;
+pub mod page;
 pub mod profiles;
 
-pub use page::{NetworkEvent, Page, PageError};
-pub use context::BrowserContext;
+pub use context::{BrowserContext, BrowserContextOptions, CssMode};
 pub use lifecycle::{LifecycleState, WaitUntil};
 pub use obscura_js::HTML_TO_MARKDOWN_JS;
+pub use page::{NetworkEvent, Page, PageError};
 // Re-exported so the embeddable `obscura` crate (which depends on obscura-browser,
 // not obscura-js) can surface the interception channel types.
 pub use obscura_js::ops::{InterceptResolution, InterceptedRequest};

--- a/crates/obscura-browser/src/page.rs
+++ b/crates/obscura-browser/src/page.rs
@@ -3,10 +3,12 @@ use std::sync::Arc;
 use base64::{engine::general_purpose::STANDARD as BASE64, Engine as _};
 use obscura_dom::{parse_html, DomTree};
 use obscura_js::runtime::ObscuraJsRuntime;
-use obscura_net::{ObscuraHttpClient, ObscuraNetError, RequestCallback, Response, ResponseCallback};
+use obscura_net::{
+    ObscuraHttpClient, ObscuraNetError, RequestCallback, Response, ResponseCallback,
+};
 use url::Url;
 
-use crate::context::BrowserContext;
+use crate::context::{BrowserContext, CssMode};
 use crate::lifecycle::LifecycleState;
 
 /// Parse `OBSCURA_GEOLOCATION="lat,lon"` for the navigator.geolocation shim.
@@ -108,38 +110,17 @@ fn cross_scheme_to_file(from: &str, to: &str) -> bool {
 /// Real Chrome allows data: subresources by default; Instagram and most
 /// Meta properties depend on this for their inline bootstrap scripts.
 fn subresource_allowed(page_url: Option<&Url>, resource: &str) -> bool {
-    let Ok(target) = Url::parse(resource) else { return false };
+    let Ok(target) = Url::parse(resource) else {
+        return false;
+    };
     let scheme = target.scheme().to_ascii_lowercase();
     match scheme.as_str() {
         "http" | "https" | "data" => true,
-        "file" => page_url.map(|u| u.scheme().eq_ignore_ascii_case("file")).unwrap_or(false),
+        "file" => page_url
+            .map(|u| u.scheme().eq_ignore_ascii_case("file"))
+            .unwrap_or(false),
         _ => false,
     }
-}
-
-/// Escape a value for safe inclusion inside a JavaScript template
-/// literal. The previous implementation only escaped `\`, `` ` `` and
-/// `${`; that left U+2028 / U+2029 (the JS-specific line terminators)
-/// and other control characters as breakout vectors. Done at the
-/// callsite means future tweaks come back to one function.
-fn escape_for_js_template_literal(input: &str) -> String {
-    let mut out = String::with_capacity(input.len());
-    for ch in input.chars() {
-        match ch {
-            '\\' => out.push_str("\\\\"),
-            '`' => out.push_str("\\`"),
-            '$' => out.push_str("\\$"),
-            '\u{2028}' => out.push_str("\\u2028"),
-            '\u{2029}' => out.push_str("\\u2029"),
-            '\u{0000}' => out.push_str("\\0"),
-            '\r' => out.push_str("\\r"),
-            c if (c as u32) < 0x20 => {
-                out.push_str(&format!("\\u{:04x}", c as u32));
-            }
-            c => out.push(c),
-        }
-    }
-    out
 }
 
 #[derive(Debug, Clone)]
@@ -273,6 +254,83 @@ impl Page {
         }
         self.http_client.fetch(url).await
     }
+
+    fn fetch_css_import_tree<'a>(
+        &'a mut self,
+        base_url: Url,
+        css: String,
+        inherited_media: String,
+        depth: usize,
+        visited: &'a mut std::collections::HashSet<String>,
+    ) -> std::pin::Pin<
+        Box<dyn std::future::Future<Output = Vec<(String, String, bool, String)>> + 'a>,
+    > {
+        Box::pin(async move {
+            if depth >= obscura_dom::style::MAX_IMPORT_DEPTH {
+                tracing::warn!(
+                    limit = obscura_dom::style::MAX_IMPORT_DEPTH,
+                    "CSS import depth limit reached"
+                );
+                return Vec::new();
+            }
+            let mut output = Vec::new();
+            for (href, import_media) in obscura_dom::extract_imports(&css) {
+                let Ok(import_url) = base_url.join(&href) else {
+                    continue;
+                };
+                let url_string = import_url.to_string();
+                if !visited.insert(url_string.clone())
+                    || !subresource_allowed(self.url.as_ref(), &url_string)
+                    || self.should_block_url(&url_string)
+                {
+                    continue;
+                }
+                let Ok(response) = self.do_fetch(&import_url).await else {
+                    continue;
+                };
+                self.record_network_event_with_body(
+                    &url_string,
+                    "GET",
+                    "Stylesheet",
+                    response.status,
+                    &response.headers,
+                    &response.body,
+                    false,
+                );
+                if !(200..400).contains(&response.status) {
+                    continue;
+                }
+                let child_css =
+                    obscura_net::decode_non_html(&response.body, response.content_type());
+                let media = match (
+                    inherited_media.trim().is_empty(),
+                    import_media.trim().is_empty(),
+                ) {
+                    (true, true) => String::new(),
+                    (true, false) => import_media,
+                    (false, true) => inherited_media.clone(),
+                    (false, false) => format!("{} and {}", inherited_media, import_media),
+                };
+                let nested = self
+                    .fetch_css_import_tree(
+                        import_url.clone(),
+                        child_css.clone(),
+                        media.clone(),
+                        depth + 1,
+                        visited,
+                    )
+                    .await;
+                output.extend(nested);
+                let same_origin = self
+                    .url
+                    .as_ref()
+                    .map(|page| page.origin() == import_url.origin())
+                    .unwrap_or(true);
+                output.push((url_string, media, same_origin, child_css));
+            }
+            output
+        })
+    }
     fn init_js(&mut self) {
         // Drop any existing runtime so the JS realm starts clean on
         // every navigation. The old code reused the V8 isolate and
@@ -296,6 +354,7 @@ impl Page {
         rt.set_url(&self.url_string());
         rt.set_encoding(&self.encoding);
         rt.set_title(&self.title);
+        rt.set_css_enabled(self.context.css_mode == CssMode::Compute);
 
         #[cfg(feature = "stealth")]
         if self.stealth_client.is_some() {
@@ -363,14 +422,13 @@ impl Page {
     fn resolve_base_url(&self) -> Option<url::Url> {
         let doc_url = self.url.as_ref()?;
         let base_href: Option<String> = self.js.as_ref().and_then(|js| {
-            js.with_dom(|dom| {
-                match dom.query_selector("base[href]") {
-                    Ok(Some(nid)) => {
-                        dom.get_node(nid).and_then(|n| n.get_attribute("href").map(|s| s.to_string()))
-                    }
-                    _ => None,
-                }
-            }).flatten()
+            js.with_dom(|dom| match dom.query_selector("base[href]") {
+                Ok(Some(nid)) => dom
+                    .get_node(nid)
+                    .and_then(|n| n.get_attribute("href").map(|s| s.to_string())),
+                _ => None,
+            })
+            .flatten()
         });
         match base_href {
             Some(href) => doc_url.join(&href).ok(),
@@ -424,8 +482,8 @@ impl Page {
         }
 
         let all_scripts = match &self.js {
-            Some(js) => {
-                js.with_dom(|dom| {
+            Some(js) => js
+                .with_dom(|dom| {
                     let script_ids = dom.query_selector_all("script").unwrap_or_default();
                     let mut scripts = Vec::new();
 
@@ -464,8 +522,8 @@ impl Page {
                         }
                     }
                     scripts
-                }).unwrap_or_default()
-            }
+                })
+                .unwrap_or_default(),
             None => return,
         };
 
@@ -1042,7 +1100,33 @@ impl Page {
             .map(|title_id| dom.text_content(title_id))
             .unwrap_or_default();
 
-        let stylesheet_urls: Vec<String> = dom
+        let stylesheet_nodes = dom.query_selector_all("link, style").unwrap_or_default();
+        let stylesheet_order: std::collections::HashMap<_, _> = stylesheet_nodes
+            .iter()
+            .enumerate()
+            .map(|(order, node)| (*node, order))
+            .collect();
+        let inline_css_sources: Vec<_> = stylesheet_nodes
+            .iter()
+            .filter_map(|&nid| {
+                dom.with_node(nid, |node| {
+                    (node
+                        .as_element()
+                        .map(|name| name.local.as_ref() == "style")
+                        .unwrap_or(false))
+                    .then(|| {
+                        (
+                            *stylesheet_order.get(&nid).unwrap_or(&usize::MAX),
+                            nid,
+                            node.get_attribute("media").unwrap_or("").to_string(),
+                            dom.text_content(nid),
+                        )
+                    })
+                })
+                .flatten()
+            })
+            .collect();
+        let stylesheet_links: Vec<(usize, obscura_dom::NodeId, String, String)> = dom
             .query_selector_all("link")
             .unwrap_or_default()
             .iter()
@@ -1055,18 +1139,27 @@ impl Page {
                     if !rel.eq_ignore_ascii_case("stylesheet") {
                         return None;
                     }
-                    node.get_attribute("href").map(|s| s.to_string())
+                    node.get_attribute("href").map(|href| {
+                        (
+                            *stylesheet_order.get(&nid).unwrap_or(&usize::MAX),
+                            nid,
+                            href.to_string(),
+                            node.get_attribute("media").unwrap_or("").to_string(),
+                        )
+                    })
                 })
                 .flatten()
             })
             .collect();
 
-        let mut css_fetch_urls: Vec<String> = Vec::new();
-        for href in &stylesheet_urls {
+        let mut css_fetches: Vec<(usize, obscura_dom::NodeId, String, String, bool)> = Vec::new();
+        for (order, owner, href, media) in &stylesheet_links {
             let full_url = if href.starts_with("http://") || href.starts_with("https://") {
                 href.clone()
             } else if let Some(base) = &self.url {
-                base.join(href).map(|u| u.to_string()).unwrap_or_else(|_| href.clone())
+                base.join(href)
+                    .map(|u| u.to_string())
+                    .unwrap_or_else(|_| href.clone())
             } else {
                 href.clone()
             };
@@ -1082,60 +1175,147 @@ impl Page {
                 tracing::info!("Blocked stylesheet by interception: {}", full_url);
                 continue;
             }
-            css_fetch_urls.push(full_url);
+            let same_origin = self
+                .url
+                .as_ref()
+                .and_then(|page| {
+                    Url::parse(&full_url)
+                        .ok()
+                        .map(|sheet| page.origin() == sheet.origin())
+                })
+                .unwrap_or(true);
+            css_fetches.push((*order, *owner, full_url, media.clone(), same_origin));
         }
 
         let client = self.http_client.clone();
-        let css_futures: Vec<_> = css_fetch_urls.iter().map(|full_url| {
-            let client = client.clone();
-            let url_str = full_url.clone();
-            async move {
-                let parsed = Url::parse(&url_str).unwrap_or_else(|_| Url::parse("about:blank").unwrap());
-                match client.fetch(&parsed).await {
-                    Ok(resp) => Some((url_str, resp)),
-                    Err(e) => {
-                        tracing::debug!("Failed to fetch stylesheet {}: {}", url_str, e);
-                        None
+        let css_futures: Vec<_> = css_fetches
+            .iter()
+            .map(|(order, owner, full_url, media, same_origin)| {
+                let client = client.clone();
+                let order = *order;
+                let owner = *owner;
+                let url_str = full_url.clone();
+                let media = media.clone();
+                let same_origin = *same_origin;
+                async move {
+                    let parsed =
+                        Url::parse(&url_str).unwrap_or_else(|_| Url::parse("about:blank").unwrap());
+                    match client.fetch(&parsed).await {
+                        Ok(resp) => Some((order, owner, url_str, media, same_origin, resp)),
+                        Err(e) => {
+                            tracing::debug!("Failed to fetch stylesheet {}: {}", url_str, e);
+                            None
+                        }
                     }
                 }
-            }
-        }).collect();
+            })
+            .collect();
 
         // Same concurrency cap as script fetches.
         use futures::StreamExt as _;
-        let css_results: Vec<_> = futures::stream::iter(css_futures)
+        let mut css_results: Vec<_> = futures::stream::iter(css_futures)
             .buffer_unordered(16)
             .collect()
             .await;
+        css_results
+            .sort_by_key(|result| result.as_ref().map(|entry| entry.0).unwrap_or(usize::MAX));
         let mut css_sources = Vec::new();
         for result in css_results {
-            if let Some((url_str, resp)) = result {
-                // CSS bodies: honor the Content-Type charset; CSS @charset is
-                // out of scope for the current scrape-focused pipeline.
-                let css = obscura_net::decode_non_html(&resp.body, resp.content_type());
-                self.record_network_event_with_body(&url_str, "GET", "Stylesheet", resp.status, &resp.headers, &resp.body, false);
-                css_sources.push(css);
+            if let Some((_order, owner, url_str, media, same_origin, resp)) = result {
+                if self.context.css_mode == CssMode::Compute {
+                    // CSS bodies: honor the Content-Type charset; CSS @charset is
+                    // out of scope for the current scrape-focused pipeline.
+                    let css = obscura_net::decode_non_html(&resp.body, resp.content_type());
+                    self.record_network_event_with_body(
+                        &url_str,
+                        "GET",
+                        "Stylesheet",
+                        resp.status,
+                        &resp.headers,
+                        &resp.body,
+                        false,
+                    );
+                    css_sources.push((owner, url_str, media, same_origin, css));
+                } else {
+                    // Explicit drop mode preserves the request/event metadata but
+                    // avoids UTF-8 conversion and response-body retention.
+                    self.record_network_event(
+                        &url_str,
+                        "GET",
+                        "Stylesheet",
+                        resp.status,
+                        &resp.headers,
+                        resp.body.len(),
+                    );
+                }
             }
+        }
+
+        let mut css_registrations: Vec<(
+            usize,
+            usize,
+            Option<obscura_dom::NodeId>,
+            Option<obscura_dom::NodeId>,
+            Option<String>,
+            String,
+            bool,
+            String,
+        )> = inline_css_sources
+            .into_iter()
+            .map(|(order, owner, media, css)| {
+                (order, 0, Some(owner), None, None, media, true, css)
+            })
+            .collect();
+        if self.context.css_mode == CssMode::Compute {
+            let mut visited = std::collections::HashSet::new();
+            for (owner, href, media, same_origin, css) in css_sources {
+                let order = *stylesheet_order.get(&owner).unwrap_or(&usize::MAX);
+                visited.insert(href.clone());
+                if let Ok(base) = Url::parse(&href) {
+                    for (sequence, (import_href, import_media, import_same_origin, import_css)) in self
+                        .fetch_css_import_tree(base, css.clone(), media.clone(), 0, &mut visited)
+                        .await
+                        .into_iter()
+                        .enumerate()
+                    {
+                        css_registrations.push((
+                            order,
+                            sequence,
+                            None,
+                            Some(owner),
+                            Some(import_href),
+                            import_media,
+                            import_same_origin,
+                            import_css,
+                        ));
+                    }
+                }
+                css_registrations.push((
+                    order,
+                    usize::MAX,
+                    Some(owner),
+                    None,
+                    Some(href),
+                    media,
+                    same_origin,
+                    css,
+                ));
+            }
+            css_registrations.sort_by_key(|entry| (entry.0, entry.1));
         }
 
         self.dom = Some(dom);
         self.init_js();
 
-        // Inject CSS as a global so getComputedStyle and any CSS-aware shim
-        // can read it. Has to happen before scripts run, regardless of
-        // waitUntil, so handlers that read window.__obscura_css see it.
-        if !css_sources.is_empty() {
-            if let Some(js) = &mut self.js {
-                let combined_css = css_sources.join("\n");
-                // Use the thorough template-literal escape that
-                // covers U+2028 / U+2029 and other control chars.
-                // The previous escaper only handled `, \, and ${,
-                // letting attacker-controlled CSS containing a raw
-                // U+2028 break out of the template literal and run
-                // arbitrary JS in the page's V8 realm.
-                let escaped = escape_for_js_template_literal(&combined_css);
-                let code = format!("globalThis.__obscura_css = `{}`;", escaped);
-                let _ = js.execute_script("<css>", &code);
+        if let Some(js) = &self.js {
+            if self.context.css_mode == CssMode::Compute {
+                for (_order, _sequence, owner, import_owner, href, media, same_origin, css) in css_registrations {
+                    if let (Some(import_owner), Some(href)) = (import_owner, href.clone()) {
+                        js.register_import_stylesheet(import_owner, href, media, same_origin, &css);
+                    } else {
+                        js.register_stylesheet(owner, href, media, same_origin, &css);
+                    }
+                }
             }
         }
         if let Some(js) = &mut self.js {
@@ -1488,12 +1668,13 @@ impl Page {
 
     pub fn get_response_body(&self, request_id: &str) -> Option<StoredResponseBody> {
         self.response_bodies.get(request_id).cloned().or_else(|| {
-            self.js.as_ref()?.get_network_response_body(request_id).map(|body| {
-                StoredResponseBody {
+            self.js
+                .as_ref()?
+                .get_network_response_body(request_id)
+                .map(|body| StoredResponseBody {
                     body: body.body,
                     base64_encoded: body.base64_encoded,
-                }
-            })
+                })
         })
     }
 

--- a/crates/obscura-cli/src/main.rs
+++ b/crates/obscura-cli/src/main.rs
@@ -2,7 +2,7 @@ use std::sync::Arc;
 use std::time::Instant;
 
 use clap::{Parser, Subcommand};
-use obscura_browser::{BrowserContext, Page};
+use obscura_browser::{BrowserContext, CssMode, Page};
 use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
 use tokio::process::Command as TokioCommand;
 use tokio::time::{timeout, Duration};
@@ -31,6 +31,11 @@ struct Args {
     /// Global: applies to fetch, serve, scrape, and mcp.
     #[arg(long, global = true)]
     stealth: bool,
+
+    /// Stylesheet handling: compute a lightweight cascade (default), or fetch
+    /// and discard stylesheet bodies for minimum overhead.
+    #[arg(long, global = true, default_value_t = CssMode::Compute)]
+    css_mode: CssMode,
 
     #[arg(long)]
     obey_robots: bool,
@@ -182,9 +187,7 @@ enum Command {
         #[arg(long)]
         user_agent: Option<String>,
     },
-
 }
-
 
 #[derive(Clone, Debug, clap::ValueEnum, PartialEq, Eq)]
 enum DumpFormat {
@@ -321,19 +324,38 @@ async fn main() -> anyhow::Result<()> {
         // SAFETY: set_var is unsafe in newer rustc; this runs before any
         // spawned thread inspects the env, so it's effectively single
         // threaded at this point.
-        unsafe { std::env::set_var("OBSCURA_ALLOW_PRIVATE_NETWORK", "1"); }
+        unsafe {
+            std::env::set_var("OBSCURA_ALLOW_PRIVATE_NETWORK", "1");
+        }
+    }
+    // All command surfaces, including worker and CDP child contexts, inherit
+    // the selected per-process CSS policy.
+    unsafe {
+        std::env::set_var("OBSCURA_CSS_MODE", args.css_mode.to_string());
     }
 
     let global_proxy = args.proxy.clone();
     let stealth = args.stealth;
 
     match args.command {
-        Some(Command::Serve { port, host, proxy, user_agent, workers, allow_file_access, storage_dir, quiet: _ }) => {
+        Some(Command::Serve {
+            port,
+            host,
+            proxy,
+            user_agent,
+            workers,
+            allow_file_access,
+            storage_dir,
+            quiet: _,
+        }) => {
             // Fall back to OBSCURA_PROXY so a proxy can be supplied without
             // putting credentials on the command line. The multi-worker load
             // balancer passes the proxy to each worker this way (issue #366).
-            let proxy = merge_proxy(global_proxy.clone(), proxy)
-                .or_else(|| std::env::var("OBSCURA_PROXY").ok().filter(|s| !s.is_empty()));
+            let proxy = merge_proxy(global_proxy.clone(), proxy).or_else(|| {
+                std::env::var("OBSCURA_PROXY")
+                    .ok()
+                    .filter(|s| !s.is_empty())
+            });
             print_banner(port);
             if let Some(ref dir) = storage_dir {
                 tracing::info!("Storage dir: {}", dir.display());
@@ -613,13 +635,23 @@ async fn run_fetch(
         let hard = Duration::from_secs(timeout_secs.saturating_add(wait_secs).saturating_add(10));
         std::thread::spawn(move || {
             std::thread::sleep(hard);
-            eprintln!("obscura: hard timeout exceeded ({}s); forcing exit", hard.as_secs());
+            eprintln!(
+                "obscura: hard timeout exceeded ({}s); forcing exit",
+                hard.as_secs()
+            );
             std::process::exit(124);
         });
     }
 
-    match timeout(Duration::from_secs(timeout_secs), page.navigate_with_wait(url_str, wait_condition)).await {
-        Ok(result) => result.map_err(|e| anyhow::anyhow!("Failed to navigate to {}: {}", url_str, e))?,
+    match timeout(
+        Duration::from_secs(timeout_secs),
+        page.navigate_with_wait(url_str, wait_condition),
+    )
+    .await
+    {
+        Ok(result) => {
+            result.map_err(|e| anyhow::anyhow!("Failed to navigate to {}: {}", url_str, e))?
+        }
         Err(_) => anyhow::bail!(
             "Timed out navigating to {} after {}s",
             url_str,
@@ -896,9 +928,9 @@ async fn write_or_print_bytes(
 async fn wait_for_selector(page: &mut Page, selector: &str, timeout_secs: u64) -> bool {
     let deadline = tokio::time::Instant::now() + tokio::time::Duration::from_secs(timeout_secs);
     loop {
-        let found = page.with_dom(|dom| {
-            dom.query_selector(selector).ok().flatten().is_some()
-        }).unwrap_or(false);
+        let found = page
+            .with_dom(|dom| dom.query_selector(selector).ok().flatten().is_some())
+            .unwrap_or(false);
 
         if found {
             return true;
@@ -1132,44 +1164,10 @@ async fn run_parallel_scrape(
             };
             let mut reader = BufReader::new(stdout);
 
-            let worker_result: Result<serde_json::Value, String> = match timeout(worker_timeout, async {
-                let nav_cmd = serde_json::json!({"cmd": "navigate", "url": url});
-                let mut line = serde_json::to_string(&nav_cmd).unwrap();
-                line.push('\n');
-                if stdin.write_all(line.as_bytes()).await.is_err() {
-                    return Err("Write failed".to_string());
-                }
-                if stdin.flush().await.is_err() {
-                    return Err("Write failed".to_string());
-                }
-
-                let mut resp_line = String::new();
-                match timeout(read_timeout, reader.read_line(&mut resp_line)).await {
-                    Ok(Ok(bytes)) if bytes > 0 => {}
-                    Ok(Ok(_)) | Ok(Err(_)) => return Err("Read failed".to_string()),
-                    Err(_) => return Err("timeout".to_string()),
-                };
-
-                let nav_resp: serde_json::Value =
-                    serde_json::from_str(resp_line.trim()).unwrap_or(serde_json::json!({"ok": false}));
-
-                if !nav_resp["ok"].as_bool().unwrap_or(false) {
-                    return Err(
-                        nav_resp["error"]
-                            .as_str()
-                            .unwrap_or("navigate failed")
-                            .to_string(),
-                    );
-                }
-
-                let title = nav_resp["result"]["title"]
-                    .as_str()
-                    .unwrap_or("")
-                    .to_string();
-
-                let eval_result = if let Some(ref expr) = *eval {
-                    let eval_cmd = serde_json::json!({"cmd": "evaluate", "expression": expr});
-                    let mut line = serde_json::to_string(&eval_cmd).unwrap();
+            let worker_result: Result<serde_json::Value, String> =
+                match timeout(worker_timeout, async {
+                    let nav_cmd = serde_json::json!({"cmd": "navigate", "url": url});
+                    let mut line = serde_json::to_string(&nav_cmd).unwrap();
                     line.push('\n');
                     if stdin.write_all(line.as_bytes()).await.is_err() {
                         return Err("Write failed".to_string());
@@ -1180,38 +1178,72 @@ async fn run_parallel_scrape(
 
                     let mut resp_line = String::new();
                     match timeout(read_timeout, reader.read_line(&mut resp_line)).await {
-                        Ok(Ok(bytes)) if bytes > 0 => {
-                            let resp: serde_json::Value = serde_json::from_str(resp_line.trim())
-                                .unwrap_or(serde_json::json!({"ok": false}));
-                            resp["result"].clone()
-                        }
+                        Ok(Ok(bytes)) if bytes > 0 => {}
                         Ok(Ok(_)) | Ok(Err(_)) => return Err("Read failed".to_string()),
                         Err(_) => return Err("timeout".to_string()),
+                    };
+
+                    let nav_resp: serde_json::Value = serde_json::from_str(resp_line.trim())
+                        .unwrap_or(serde_json::json!({"ok": false}));
+
+                    if !nav_resp["ok"].as_bool().unwrap_or(false) {
+                        return Err(nav_resp["error"]
+                            .as_str()
+                            .unwrap_or("navigate failed")
+                            .to_string());
                     }
-                } else {
-                    serde_json::Value::Null
+
+                    let title = nav_resp["result"]["title"]
+                        .as_str()
+                        .unwrap_or("")
+                        .to_string();
+
+                    let eval_result = if let Some(ref expr) = *eval {
+                        let eval_cmd = serde_json::json!({"cmd": "evaluate", "expression": expr});
+                        let mut line = serde_json::to_string(&eval_cmd).unwrap();
+                        line.push('\n');
+                        if stdin.write_all(line.as_bytes()).await.is_err() {
+                            return Err("Write failed".to_string());
+                        }
+                        if stdin.flush().await.is_err() {
+                            return Err("Write failed".to_string());
+                        }
+
+                        let mut resp_line = String::new();
+                        match timeout(read_timeout, reader.read_line(&mut resp_line)).await {
+                            Ok(Ok(bytes)) if bytes > 0 => {
+                                let resp: serde_json::Value =
+                                    serde_json::from_str(resp_line.trim())
+                                        .unwrap_or(serde_json::json!({"ok": false}));
+                                resp["result"].clone()
+                            }
+                            Ok(Ok(_)) | Ok(Err(_)) => return Err("Read failed".to_string()),
+                            Err(_) => return Err("timeout".to_string()),
+                        }
+                    } else {
+                        serde_json::Value::Null
+                    };
+
+                    let shutdown_cmd = serde_json::json!({"cmd": "shutdown"});
+                    let mut line = serde_json::to_string(&shutdown_cmd).unwrap();
+                    line.push('\n');
+                    let _ = stdin.write_all(line.as_bytes()).await;
+                    let _ = stdin.flush().await;
+                    let _ = timeout(shutdown_timeout, child.wait()).await;
+
+                    Ok(serde_json::json!({
+                        "url": url,
+                        "title": title,
+                        "eval": eval_result,
+                        "time_ms": task_start.elapsed().as_millis(),
+                        "worker": i,
+                    }))
+                })
+                .await
+                {
+                    Ok(result) => result,
+                    Err(_) => Err("timeout".to_string()),
                 };
-
-                let shutdown_cmd = serde_json::json!({"cmd": "shutdown"});
-                let mut line = serde_json::to_string(&shutdown_cmd).unwrap();
-                line.push('\n');
-                let _ = stdin.write_all(line.as_bytes()).await;
-                let _ = stdin.flush().await;
-                let _ = timeout(shutdown_timeout, child.wait()).await;
-
-                Ok(serde_json::json!({
-                    "url": url,
-                    "title": title,
-                    "eval": eval_result,
-                    "time_ms": task_start.elapsed().as_millis(),
-                    "worker": i,
-                }))
-            })
-            .await
-            {
-                Ok(result) => result,
-                Err(_) => Err("timeout".to_string()),
-            };
 
             match worker_result {
                 Ok(result) => result,
@@ -1366,9 +1398,13 @@ fn extract_assets(dom: &obscura_dom::DomTree, base_url: Option<&url::Url>) -> St
     for (selector, attr, default_kind) in ASSET_SELECTORS {
         let nodes = dom.query_selector_all(selector).unwrap_or_default();
         for node_id in nodes {
-            let Some(node) = dom.get_node(node_id) else { continue };
+            let Some(node) = dom.get_node(node_id) else {
+                continue;
+            };
             let raw = node.get_attribute(attr).unwrap_or_default().to_string();
-            let Some(url) = resolve_asset_url(&raw, base_url) else { continue };
+            let Some(url) = resolve_asset_url(&raw, base_url) else {
+                continue;
+            };
 
             let kind = if *default_kind == "link" {
                 let rel = node.get_attribute("rel").unwrap_or_default().to_string();
@@ -1424,7 +1460,27 @@ mod tests {
         write_or_print_bytes, Args, Command, DumpFormat, DEFAULT_V8_FLAGS,
     };
     use clap::Parser;
+    use obscura_browser::CssMode;
     use obscura_dom::parse_html;
+
+    #[test]
+    fn css_mode_is_global_and_defaults_to_compute() {
+        let default = Args::try_parse_from(["obscura", "fetch", "https://example.com"])
+            .expect("default CSS mode should parse");
+        assert_eq!(default.css_mode, CssMode::Compute);
+
+        let before = Args::try_parse_from([
+            "obscura", "--css-mode", "drop", "serve",
+        ])
+        .expect("global CSS mode should parse before a subcommand");
+        assert_eq!(before.css_mode, CssMode::Drop);
+
+        let after = Args::try_parse_from([
+            "obscura", "mcp", "--css-mode", "drop",
+        ])
+        .expect("global CSS mode should parse after a subcommand");
+        assert_eq!(after.css_mode, CssMode::Drop);
+    }
 
     // Issue #117 — `--dump original` short-circuits the browser stack and
     // streams the raw response body verbatim, including for binary payloads.
@@ -2016,5 +2072,4 @@ mod tests {
         assert!(lines[0].contains("\"https://example.test/ok.html\""));
         assert!(lines[0].contains("\"iframe\""));
     }
-
 }

--- a/crates/obscura-dom/Cargo.toml
+++ b/crates/obscura-dom/Cargo.toml
@@ -11,6 +11,7 @@ servo_arc = { workspace = true }
 cssparser = { workspace = true }
 thiserror = { workspace = true }
 tracing = { workspace = true }
+serde = { workspace = true }
 precomputed-hash = "0.1"
 
 [dev-dependencies]

--- a/crates/obscura-dom/src/lib.rs
+++ b/crates/obscura-dom/src/lib.rs
@@ -1,10 +1,12 @@
 #[macro_use]
 extern crate html5ever;
 
-pub mod tree;
-pub mod tree_sink;
 pub mod selector;
 pub mod serialize;
+pub mod style;
+pub mod tree;
+pub mod tree_sink;
 
+pub use style::{extract_imports, CssRuleInfo, MediaEnvironment, StyleEngine, StyleSheetInfo};
 pub use tree::{Attribute, DomTree, Node, NodeData, NodeId};
-pub use tree_sink::{parse_html, parse_fragment};
+pub use tree_sink::{parse_fragment, parse_html};

--- a/crates/obscura-dom/src/selector.rs
+++ b/crates/obscura-dom/src/selector.rs
@@ -382,10 +382,9 @@ impl<'a> Element for DomElement<'a> {
             .with_node(self.node_id, |node| {
                 node.attrs()
                     .map(|attrs| {
-                        attrs.iter().any(|a| {
-                            a.name.ns == html5ever::ns!()
-                                && a.name.local == local_name.0
-                        })
+                        attrs
+                            .iter()
+                            .any(|a| a.name.ns == html5ever::ns!() && a.name.local == local_name.0)
                     })
                     .unwrap_or(false)
             })
@@ -549,6 +548,40 @@ pub fn parse_selector(selector: &str) -> Result<SelectorList<ObscuraSelector>, S
         cache.insert(selector.to_string(), cached);
     });
     Ok(parsed)
+}
+
+/// Match a previously parsed selector list against one element.
+///
+/// Stylesheets parse selectors once and reuse the compiled representation for
+/// every `getComputedStyle()` query. Keeping this helper here ensures CSS and
+/// the DOM query APIs use exactly the same selector implementation without
+/// making the style engine reach into selectors' matching internals.
+pub fn matches_parsed_selector(
+    tree: &DomTree,
+    node_id: NodeId,
+    selector_list: &SelectorList<ObscuraSelector>,
+) -> bool {
+    let is_element = tree
+        .with_node(node_id, |node| node.is_element())
+        .unwrap_or(false);
+    if !is_element {
+        return false;
+    }
+
+    let mut caches = selectors::context::SelectorCaches::default();
+    let mut context = MatchingContext::new(
+        MatchingMode::Normal,
+        None,
+        &mut caches,
+        QuirksMode::NoQuirks,
+        NeedsSelectorFlags::No,
+        MatchingForInvalidation::No,
+    );
+    selectors::matching::matches_selector_list(
+        selector_list,
+        &DomElement::new(tree, node_id),
+        &mut context,
+    )
 }
 
 /// If `selector` is a bare ASCII id selector like `#main`, return the id (without

--- a/crates/obscura-dom/src/style.rs
+++ b/crates/obscura-dom/src/style.rs
@@ -1,0 +1,1606 @@
+//! Lightweight author-style cascade for Obscura's non-rendering DOM.
+//!
+//! This deliberately stops before layout and paint. It parses real-world CSS,
+//! matches selectors, applies the author cascade, resolves custom properties,
+//! and exposes enough retained rule metadata for CSSOM. Unknown declarations
+//! and unsupported selectors are isolated to that declaration/selector rather
+//! than invalidating the rest of a production stylesheet.
+
+use std::collections::{HashMap, HashSet};
+
+use cssparser::{
+    AtRuleParser, BasicParseErrorKind, CowRcStr, DeclarationParser, ParseError, Parser,
+    ParserInput, ParserState, QualifiedRuleParser, RuleBodyItemParser, RuleBodyParser,
+    StyleSheetParser, Token,
+};
+use selectors::context::QuirksMode;
+use selectors::matching::{
+    MatchingContext, MatchingForInvalidation, MatchingMode, NeedsSelectorFlags,
+};
+use selectors::SelectorList;
+
+use crate::selector::{parse_selector, DomElement, ObscuraSelector};
+use crate::{DomTree, NodeId};
+
+pub const MAX_CSS_BYTES: usize = 16 * 1024 * 1024;
+pub const MAX_RULES: usize = 50_000;
+pub const MAX_SHEETS: usize = 256;
+pub const MAX_IMPORT_DEPTH: usize = 8;
+const MAX_COMPUTED_CACHE: usize = 1_024;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct MediaEnvironment {
+    pub width: u32,
+    pub height: u32,
+    pub dark: bool,
+    pub reduced_motion: bool,
+    pub hover: bool,
+    pub pointer_fine: bool,
+}
+
+impl Default for MediaEnvironment {
+    fn default() -> Self {
+        Self {
+            width: 1920,
+            height: 1000,
+            dark: true,
+            reduced_motion: false,
+            hover: true,
+            pointer_fine: true,
+        }
+    }
+}
+
+#[derive(Debug, Clone, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CssRuleInfo {
+    pub css_text: String,
+    pub rule_type: u16,
+}
+
+#[derive(Debug, Clone, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct StyleSheetInfo {
+    pub id: u32,
+    pub owner_node: Option<u32>,
+    pub href: Option<String>,
+    pub media: String,
+    pub disabled: bool,
+    pub same_origin: bool,
+    pub rule_count: usize,
+}
+
+#[derive(Debug, Clone)]
+struct Declaration {
+    name: String,
+    value: String,
+    important: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+enum RuleKey {
+    Id(String),
+    Class(String),
+    Tag(String),
+    Universal,
+}
+
+struct CompiledRule {
+    selector: SelectorList<ObscuraSelector>,
+    key: RuleKey,
+    specificity: u32,
+    declarations: Vec<Declaration>,
+    media: Vec<String>,
+    sheet_id: u32,
+    source_order: u64,
+}
+
+struct StyleSheet {
+    info: StyleSheetInfo,
+    rules: Vec<CssRuleInfo>,
+    active: bool,
+    decoded_bytes: usize,
+}
+
+#[derive(Debug, Clone)]
+struct Winner {
+    value: String,
+    important: bool,
+    specificity: u32,
+    order: u64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+struct CacheKey {
+    node: NodeId,
+    environment: MediaEnvironment,
+}
+
+/// Per-document stylesheet registry and lazy cascade cache.
+pub struct StyleEngine {
+    sheets: Vec<StyleSheet>,
+    rules: Vec<CompiledRule>,
+    by_id: HashMap<String, Vec<usize>>,
+    by_class: HashMap<String, Vec<usize>>,
+    by_tag: HashMap<String, Vec<usize>>,
+    universal: Vec<usize>,
+    next_sheet_id: u32,
+    next_order: u64,
+    decoded_bytes: usize,
+    truncated: bool,
+    epoch: u64,
+    cache: HashMap<CacheKey, (u64, HashMap<String, String>)>,
+    imports_by_owner: HashMap<NodeId, Vec<u32>>,
+}
+
+impl Default for StyleEngine {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl StyleEngine {
+    pub fn new() -> Self {
+        Self {
+            sheets: Vec::new(),
+            rules: Vec::new(),
+            by_id: HashMap::new(),
+            by_class: HashMap::new(),
+            by_tag: HashMap::new(),
+            universal: Vec::new(),
+            next_sheet_id: 1,
+            next_order: 0,
+            decoded_bytes: 0,
+            truncated: false,
+            epoch: 0,
+            cache: HashMap::new(),
+            imports_by_owner: HashMap::new(),
+        }
+    }
+
+    pub fn clear(&mut self) {
+        *self = Self::new();
+    }
+
+    pub fn register_stylesheet(
+        &mut self,
+        owner_node: Option<NodeId>,
+        href: Option<String>,
+        media: String,
+        same_origin: bool,
+        css: &str,
+    ) -> Option<u32> {
+        if self.sheets.len() >= MAX_SHEETS {
+            tracing::warn!(
+                limit = MAX_SHEETS,
+                "CSS stylesheet limit reached; ignoring sheet"
+            );
+            self.truncated = true;
+            return None;
+        }
+        let remaining = MAX_CSS_BYTES.saturating_sub(self.decoded_bytes);
+        let css = if css.len() > remaining {
+            tracing::warn!(
+                limit = MAX_CSS_BYTES,
+                "CSS byte limit reached; stylesheet truncated"
+            );
+            self.truncated = true;
+            let mut end = remaining;
+            while end > 0 && !css.is_char_boundary(end) {
+                end -= 1;
+            }
+            &css[..end]
+        } else {
+            css
+        };
+
+        let id = self.next_sheet_id;
+        self.next_sheet_id += 1;
+        self.decoded_bytes += css.len();
+
+        let mut parser = SheetParser::new(id, self.next_order, self.rules.len());
+        let conditions = if media.trim().is_empty() {
+            Vec::new()
+        } else {
+            vec![media.clone()]
+        };
+        parser.parse(css, conditions);
+        self.next_order = parser.next_order;
+        if parser.hit_rule_limit {
+            tracing::warn!(
+                limit = MAX_RULES,
+                "CSS rule limit reached; stylesheet truncated"
+            );
+            self.truncated = true;
+        }
+
+        for rule in parser.compiled {
+            if self.rules.len() >= MAX_RULES {
+                break;
+            }
+            let index = self.rules.len();
+            match &rule.key {
+                RuleKey::Id(value) => self.by_id.entry(value.clone()).or_default().push(index),
+                RuleKey::Class(value) => {
+                    self.by_class.entry(value.clone()).or_default().push(index)
+                }
+                RuleKey::Tag(value) => self.by_tag.entry(value.clone()).or_default().push(index),
+                RuleKey::Universal => self.universal.push(index),
+            }
+            self.rules.push(rule);
+        }
+
+        let rule_count = parser.css_rules.len();
+        self.sheets.push(StyleSheet {
+            info: StyleSheetInfo {
+                id,
+                owner_node: owner_node.map(|node| node.raw()),
+                href,
+                media,
+                disabled: false,
+                same_origin,
+                rule_count,
+            },
+            rules: parser.css_rules,
+            active: true,
+            decoded_bytes: css.len(),
+        });
+        self.invalidate();
+        Some(id)
+    }
+
+    pub fn register_constructed(&mut self, css: &str) -> Option<u32> {
+        let id = self.register_stylesheet(None, None, String::new(), true, css)?;
+        if let Some(sheet) = self.sheets.iter_mut().find(|sheet| sheet.info.id == id) {
+            sheet.active = false;
+        }
+        self.invalidate();
+        Some(id)
+    }
+
+    pub fn register_import_stylesheet(
+        &mut self,
+        owner_node: NodeId,
+        href: String,
+        media: String,
+        same_origin: bool,
+        css: &str,
+    ) -> Option<u32> {
+        let id = self.register_stylesheet(None, Some(href), media, same_origin, css)?;
+        self.imports_by_owner.entry(owner_node).or_default().push(id);
+        Some(id)
+    }
+
+    pub fn set_adopted(&mut self, ids: &[u32]) {
+        let adopted: HashSet<u32> = ids.iter().copied().collect();
+        for sheet in &mut self.sheets {
+            if sheet.info.owner_node.is_none() && sheet.info.href.is_none() {
+                sheet.active = adopted.contains(&sheet.info.id);
+            }
+        }
+        self.invalidate();
+    }
+
+    pub fn replace_owner_stylesheet(
+        &mut self,
+        owner_node: NodeId,
+        href: Option<String>,
+        media: String,
+        same_origin: bool,
+        css: &str,
+    ) -> Option<u32> {
+        self.remove_owner(owner_node);
+        self.register_stylesheet(Some(owner_node), href, media, same_origin, css)
+    }
+
+    pub fn remove_owner(&mut self, owner_node: NodeId) {
+        let before = self.sheets.len();
+        let imported = self.imports_by_owner.remove(&owner_node).unwrap_or_default();
+        self.sheets
+            .retain(|sheet| {
+                sheet.info.owner_node != Some(owner_node.raw())
+                    && !imported.contains(&sheet.info.id)
+            });
+        if before != self.sheets.len() {
+            self.decoded_bytes = self.sheets.iter().map(|sheet| sheet.decoded_bytes).sum();
+            self.rebuild_rule_indexes();
+        }
+    }
+
+    pub fn set_disabled(&mut self, sheet_id: u32, disabled: bool) -> bool {
+        if let Some(sheet) = self
+            .sheets
+            .iter_mut()
+            .find(|sheet| sheet.info.id == sheet_id)
+        {
+            if sheet.info.disabled != disabled {
+                sheet.info.disabled = disabled;
+                self.invalidate();
+            }
+            true
+        } else {
+            false
+        }
+    }
+
+    pub fn sheet_infos(&self) -> Vec<StyleSheetInfo> {
+        self.sheets.iter().map(|sheet| sheet.info.clone()).collect()
+    }
+
+    pub fn sheet_rules(&self, sheet_id: u32) -> Option<Vec<CssRuleInfo>> {
+        self.sheets
+            .iter()
+            .find(|sheet| sheet.info.id == sheet_id)
+            .map(|sheet| sheet.rules.clone())
+    }
+
+    pub fn insert_rule(
+        &mut self,
+        sheet_id: u32,
+        css: &str,
+        index: usize,
+    ) -> Result<(usize, u32), String> {
+        let other_rule_count = self
+            .rules
+            .iter()
+            .filter(|rule| rule.sheet_id != sheet_id)
+            .count();
+        let sheet = self
+            .sheets
+            .iter_mut()
+            .find(|sheet| sheet.info.id == sheet_id)
+            .ok_or_else(|| "stylesheet not found".to_string())?;
+        if index > sheet.rules.len() {
+            return Err("IndexSizeError".to_string());
+        }
+        let mut parser = SheetParser::new(sheet_id, self.next_order, other_rule_count);
+        parser.parse(css, Vec::new());
+        let Some(info) = parser.css_rules.into_iter().next() else {
+            return Err("SyntaxError".to_string());
+        };
+        sheet.rules.insert(index, info);
+        sheet.info.rule_count = sheet.rules.len();
+        let combined = sheet
+            .rules
+            .iter()
+            .map(|rule| rule.css_text.as_str())
+            .collect::<Vec<_>>()
+            .join("\n");
+        let owner = sheet.info.owner_node.map(NodeId::new);
+        let href = sheet.info.href.clone();
+        let media = sheet.info.media.clone();
+        let same_origin = sheet.info.same_origin;
+        let constructed = owner.is_none() && href.is_none();
+        let was_active = sheet.active;
+        self.remove_sheet(sheet_id);
+        let new_id = (if constructed {
+            self.register_constructed(&combined)
+        } else {
+            self.register_stylesheet(owner, href, media, same_origin, &combined)
+        })
+        .ok_or_else(|| "stylesheet limit reached".to_string())?;
+        if constructed && was_active {
+            self.set_sheet_active(new_id, true);
+        }
+        Ok((index, new_id))
+    }
+
+    pub fn delete_rule(&mut self, sheet_id: u32, index: usize) -> Result<u32, String> {
+        let sheet = self
+            .sheets
+            .iter_mut()
+            .find(|sheet| sheet.info.id == sheet_id)
+            .ok_or_else(|| "stylesheet not found".to_string())?;
+        if index >= sheet.rules.len() {
+            return Err("IndexSizeError".to_string());
+        }
+        sheet.rules.remove(index);
+        sheet.info.rule_count = sheet.rules.len();
+        // CSSOM mutations are rare. Reparse the retained text to keep the
+        // matching representation and source order exactly aligned.
+        let css = sheet
+            .rules
+            .iter()
+            .map(|rule| rule.css_text.as_str())
+            .collect::<Vec<_>>()
+            .join("\n");
+        let owner = sheet.info.owner_node.map(NodeId::new);
+        let href = sheet.info.href.clone();
+        let media = sheet.info.media.clone();
+        let same_origin = sheet.info.same_origin;
+        let constructed = owner.is_none() && href.is_none();
+        let was_active = sheet.active;
+        self.remove_sheet(sheet_id);
+        let new_id = (if constructed {
+            self.register_constructed(&css)
+        } else {
+            self.register_stylesheet(owner, href, media, same_origin, &css)
+        })
+        .ok_or_else(|| "stylesheet limit reached".to_string())?;
+        if constructed && was_active {
+            self.set_sheet_active(new_id, true);
+        }
+        Ok(new_id)
+    }
+
+    pub fn replace_sheet(&mut self, sheet_id: u32, css: &str) -> Result<u32, String> {
+        let (info, was_active) = self
+            .sheets
+            .iter()
+            .find(|sheet| sheet.info.id == sheet_id)
+            .map(|sheet| (sheet.info.clone(), sheet.active))
+            .ok_or_else(|| "stylesheet not found".to_string())?;
+        self.remove_sheet(sheet_id);
+        let constructed = info.owner_node.is_none() && info.href.is_none();
+        let new_id = (if constructed {
+            self.register_constructed(css)
+        } else {
+            self.register_stylesheet(
+                info.owner_node.map(NodeId::new),
+                info.href,
+                info.media,
+                info.same_origin,
+                css,
+            )
+        })
+        .ok_or_else(|| "stylesheet limit reached".to_string())?;
+        if constructed && was_active {
+            self.set_sheet_active(new_id, true);
+        }
+        Ok(new_id)
+    }
+
+    pub fn compute_style(
+        &mut self,
+        dom: &DomTree,
+        node: NodeId,
+        environment: MediaEnvironment,
+    ) -> HashMap<String, String> {
+        let key = CacheKey { node, environment };
+        if let Some((epoch, cached)) = self.cache.get(&key) {
+            if *epoch == self.epoch {
+                return cached.clone();
+            }
+        }
+        let computed = self.compute_uncached(dom, node, environment, 0);
+        if self.cache.len() >= MAX_COMPUTED_CACHE {
+            self.cache.clear();
+        }
+        self.cache.insert(key, (self.epoch, computed.clone()));
+        computed
+    }
+
+    fn compute_uncached(
+        &self,
+        dom: &DomTree,
+        node: NodeId,
+        environment: MediaEnvironment,
+        depth: usize,
+    ) -> HashMap<String, String> {
+        if depth > 64 {
+            return HashMap::new();
+        }
+
+        let mut winners: HashMap<String, Winner> = HashMap::new();
+        let mut candidate_indexes = self.candidates(dom, node);
+        candidate_indexes.sort_unstable();
+        candidate_indexes.dedup();
+        // Reuse selector caches across every candidate for this element. A
+        // production bundle can contribute thousands of candidates; creating
+        // fresh relative-selector caches for each one dominated style queries.
+        let mut selector_caches = selectors::context::SelectorCaches::default();
+        let mut matching_context = MatchingContext::new(
+            MatchingMode::Normal,
+            None,
+            &mut selector_caches,
+            QuirksMode::NoQuirks,
+            NeedsSelectorFlags::No,
+            MatchingForInvalidation::No,
+        );
+
+        for index in candidate_indexes {
+            let Some(rule) = self.rules.get(index) else {
+                continue;
+            };
+            if !self.sheet_active(rule.sheet_id)
+                || !rule
+                    .media
+                    .iter()
+                    .all(|query| media_matches(query, environment))
+                || !selectors::matching::matches_selector_list(
+                    &rule.selector,
+                    &DomElement::new(dom, node),
+                    &mut matching_context,
+                )
+            {
+                continue;
+            }
+            for declaration in &rule.declarations {
+                apply_winner(
+                    &mut winners,
+                    declaration,
+                    rule.specificity,
+                    rule.source_order,
+                );
+            }
+        }
+        if let Some(style) = dom
+            .with_node(node, |element| {
+                element.get_attribute("style").map(str::to_string)
+            })
+            .flatten()
+        {
+            for declaration in parse_declarations(&style) {
+                apply_winner(&mut winners, &declaration, u32::MAX - 1, u64::MAX - 1);
+            }
+        }
+
+        let mut values: HashMap<String, String> = winners
+            .into_iter()
+            .map(|(name, winner)| (name, winner.value))
+            .collect();
+
+        if let Some(parent) = dom.with_node(node, |entry| entry.parent).flatten() {
+            let parent_is_element = dom
+                .with_node(parent, |entry| entry.is_element())
+                .unwrap_or(false);
+            if parent_is_element {
+                let inherited = self.compute_uncached(dom, parent, environment, depth + 1);
+                for (name, value) in inherited {
+                    if (name.starts_with("--") || is_inherited_property(&name))
+                        && !values.contains_key(&name)
+                    {
+                        values.insert(name, value);
+                    }
+                }
+            }
+        }
+        let variables: HashMap<String, String> = values
+            .iter()
+            .filter(|(name, _)| name.starts_with("--"))
+            .map(|(name, value)| (name.clone(), value.clone()))
+            .collect();
+        let mut resolved_variables: HashMap<String, Option<String>> = HashMap::new();
+        for (name, value) in values.iter_mut() {
+            // Custom properties are a token stream and are resolved when a
+            // normal declaration references them. Eagerly expanding every
+            // root variable makes design-system bundles quadratic while doing
+            // work no caller requested.
+            if !name.starts_with("--") {
+                let resolved = resolve_vars(
+                    value,
+                    &variables,
+                    &mut HashSet::new(),
+                    &mut resolved_variables,
+                    0,
+                );
+                *value = normalize_value(name, &resolved);
+            }
+        }
+        values
+    }
+
+    fn candidates(&self, dom: &DomTree, node: NodeId) -> Vec<usize> {
+        let mut out = self.universal.clone();
+        dom.with_node(node, |element| {
+            if let Some(id) = element.get_attribute("id") {
+                if let Some(indexes) = self.by_id.get(id) {
+                    out.extend(indexes.iter().copied());
+                }
+            }
+            if let Some(classes) = element.get_attribute("class") {
+                for class_name in classes.split_whitespace() {
+                    if let Some(indexes) = self.by_class.get(class_name) {
+                        out.extend(indexes.iter().copied());
+                    }
+                }
+            }
+            if let Some(name) = element.as_element() {
+                if let Some(indexes) = self.by_tag.get(name.local.as_ref()) {
+                    out.extend(indexes.iter().copied());
+                }
+            }
+        });
+        out
+    }
+
+    fn sheet_active(&self, sheet_id: u32) -> bool {
+        self.sheets
+            .iter()
+            .find(|sheet| sheet.info.id == sheet_id)
+            .map(|sheet| sheet.active && !sheet.info.disabled)
+            .unwrap_or(false)
+    }
+
+    fn remove_sheet(&mut self, sheet_id: u32) {
+        self.sheets.retain(|sheet| sheet.info.id != sheet_id);
+        for imports in self.imports_by_owner.values_mut() {
+            imports.retain(|id| *id != sheet_id);
+        }
+        self.decoded_bytes = self.sheets.iter().map(|sheet| sheet.decoded_bytes).sum();
+        self.rebuild_rule_indexes();
+    }
+
+    fn set_sheet_active(&mut self, sheet_id: u32, active: bool) {
+        if let Some(sheet) = self
+            .sheets
+            .iter_mut()
+            .find(|sheet| sheet.info.id == sheet_id)
+        {
+            sheet.active = active;
+            self.invalidate();
+        }
+    }
+
+    fn rebuild_rule_indexes(&mut self) {
+        let active_ids: HashSet<u32> = self.sheets.iter().map(|sheet| sheet.info.id).collect();
+        self.rules
+            .retain(|rule| active_ids.contains(&rule.sheet_id));
+        self.by_id.clear();
+        self.by_class.clear();
+        self.by_tag.clear();
+        self.universal.clear();
+        for (index, rule) in self.rules.iter().enumerate() {
+            match &rule.key {
+                RuleKey::Id(value) => self.by_id.entry(value.clone()).or_default().push(index),
+                RuleKey::Class(value) => {
+                    self.by_class.entry(value.clone()).or_default().push(index)
+                }
+                RuleKey::Tag(value) => self.by_tag.entry(value.clone()).or_default().push(index),
+                RuleKey::Universal => self.universal.push(index),
+            }
+        }
+        self.invalidate();
+    }
+
+    pub fn invalidate(&mut self) {
+        self.epoch = self.epoch.wrapping_add(1);
+        self.cache.clear();
+    }
+}
+
+fn apply_winner(
+    winners: &mut HashMap<String, Winner>,
+    declaration: &Declaration,
+    specificity: u32,
+    order: u64,
+) {
+    for expanded in expand_declaration(declaration) {
+        let candidate = Winner {
+            value: expanded.value,
+            important: expanded.important,
+            specificity,
+            order,
+        };
+        let replace = winners
+            .get(&expanded.name)
+            .map(|current| {
+                (candidate.important, candidate.specificity, candidate.order)
+                    >= (current.important, current.specificity, current.order)
+            })
+            .unwrap_or(true);
+        if replace {
+            winners.insert(expanded.name, candidate);
+        }
+    }
+}
+
+struct SheetParser {
+    sheet_id: u32,
+    next_order: u64,
+    initial_rule_count: usize,
+    compiled: Vec<CompiledRule>,
+    css_rules: Vec<CssRuleInfo>,
+    hit_rule_limit: bool,
+}
+
+impl SheetParser {
+    fn new(sheet_id: u32, next_order: u64, initial_rule_count: usize) -> Self {
+        Self {
+            sheet_id,
+            next_order,
+            initial_rule_count,
+            compiled: Vec::new(),
+            css_rules: Vec::new(),
+            hit_rule_limit: false,
+        }
+    }
+
+    fn parse(&mut self, css: &str, conditions: Vec<String>) {
+        if self.initial_rule_count + self.compiled.len() >= MAX_RULES {
+            self.hit_rule_limit = true;
+            return;
+        }
+        let mut input = ParserInput::new(css);
+        let mut input = Parser::new(&mut input);
+        let mut capture = CaptureRuleParser;
+        for result in StyleSheetParser::new(&mut input, &mut capture) {
+            if self.initial_rule_count + self.compiled.len() >= MAX_RULES {
+                self.hit_rule_limit = true;
+                break;
+            }
+            let Ok(rule) = result else { continue };
+            match rule {
+                CapturedRule::Style { selector, body } => {
+                    let css_text = format!("{} {{{}}}", selector.trim(), body.trim());
+                    self.css_rules.push(CssRuleInfo {
+                        css_text,
+                        rule_type: 1,
+                    });
+                    let declarations = parse_declarations(&body);
+                    for selector_text in split_selector_list(&selector) {
+                        let Ok(parsed) = parse_selector(selector_text) else {
+                            continue;
+                        };
+                        let Some(selector) = parsed.slice().first() else {
+                            continue;
+                        };
+                        self.next_order += 1;
+                        self.compiled.push(CompiledRule {
+                            specificity: selector.specificity(),
+                            selector: parsed,
+                            key: selector_key(selector_text),
+                            declarations: declarations.clone(),
+                            media: conditions.clone(),
+                            sheet_id: self.sheet_id,
+                            source_order: self.next_order,
+                        });
+                    }
+                }
+                CapturedRule::At {
+                    name,
+                    prelude,
+                    body,
+                } => {
+                    let lower = name.to_ascii_lowercase();
+                    let css_text = if let Some(body) = &body {
+                        format!("@{} {} {{{}}}", name, prelude.trim(), body.trim())
+                    } else {
+                        format!("@{} {};", name, prelude.trim())
+                    };
+                    let rule_type = match lower.as_str() {
+                        "import" => 3,
+                        "media" => 4,
+                        "font-face" => 5,
+                        "keyframes" | "-webkit-keyframes" => 7,
+                        "supports" => 12,
+                        "layer" => 0,
+                        _ => 0,
+                    };
+                    self.css_rules.push(CssRuleInfo {
+                        css_text,
+                        rule_type,
+                    });
+                    if let Some(body) = body {
+                        match lower.as_str() {
+                            "media" => {
+                                let mut nested = conditions.clone();
+                                nested.push(prelude);
+                                self.parse(&body, nested);
+                            }
+                            "supports" if supports_condition(&prelude) => {
+                                self.parse(&body, conditions.clone());
+                            }
+                            "layer" | "scope" => self.parse(&body, conditions.clone()),
+                            _ => {}
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+enum CapturedRule {
+    Style {
+        selector: String,
+        body: String,
+    },
+    At {
+        name: String,
+        prelude: String,
+        body: Option<String>,
+    },
+}
+
+struct CaptureRuleParser;
+
+impl<'i> QualifiedRuleParser<'i> for CaptureRuleParser {
+    type Prelude = String;
+    type QualifiedRule = CapturedRule;
+    type Error = ();
+
+    fn parse_prelude<'t>(
+        &mut self,
+        input: &mut Parser<'i, 't>,
+    ) -> Result<String, ParseError<'i, ()>> {
+        let start = input.position();
+        while input.next_including_whitespace().is_ok() {}
+        Ok(input.slice_from(start).to_string())
+    }
+
+    fn parse_block<'t>(
+        &mut self,
+        selector: String,
+        _start: &ParserState,
+        input: &mut Parser<'i, 't>,
+    ) -> Result<CapturedRule, ParseError<'i, ()>> {
+        let start = input.position();
+        while input.next_including_whitespace().is_ok() {}
+        Ok(CapturedRule::Style {
+            selector,
+            body: input.slice_from(start).to_string(),
+        })
+    }
+}
+
+impl<'i> AtRuleParser<'i> for CaptureRuleParser {
+    type Prelude = (String, String);
+    type AtRule = CapturedRule;
+    type Error = ();
+
+    fn parse_prelude<'t>(
+        &mut self,
+        name: CowRcStr<'i>,
+        input: &mut Parser<'i, 't>,
+    ) -> Result<Self::Prelude, ParseError<'i, ()>> {
+        let start = input.position();
+        while input.next_including_whitespace().is_ok() {}
+        Ok((name.to_string(), input.slice_from(start).to_string()))
+    }
+
+    fn rule_without_block(
+        &mut self,
+        (name, prelude): Self::Prelude,
+        _start: &ParserState,
+    ) -> Result<Self::AtRule, ()> {
+        Ok(CapturedRule::At {
+            name,
+            prelude,
+            body: None,
+        })
+    }
+
+    fn parse_block<'t>(
+        &mut self,
+        (name, prelude): Self::Prelude,
+        _start: &ParserState,
+        input: &mut Parser<'i, 't>,
+    ) -> Result<Self::AtRule, ParseError<'i, ()>> {
+        let start = input.position();
+        while input.next_including_whitespace().is_ok() {}
+        Ok(CapturedRule::At {
+            name,
+            prelude,
+            body: Some(input.slice_from(start).to_string()),
+        })
+    }
+}
+
+struct DeclarationCapture;
+
+impl<'i> DeclarationParser<'i> for DeclarationCapture {
+    type Declaration = Declaration;
+    type Error = ();
+
+    fn parse_value<'t>(
+        &mut self,
+        name: CowRcStr<'i>,
+        input: &mut Parser<'i, 't>,
+    ) -> Result<Declaration, ParseError<'i, ()>> {
+        let start = input.position();
+        while input.next_including_whitespace().is_ok() {}
+        let mut value = input.slice_from(start).trim().to_string();
+        let important = strip_important(&mut value);
+        if value.is_empty() {
+            return Err(input.new_error(BasicParseErrorKind::UnexpectedToken(Token::Ident(name))));
+        }
+        Ok(Declaration {
+            // CSS property names are ASCII case-insensitive, but custom
+            // property names are case-sensitive (CSS Variables section 2).
+            name: if name.starts_with("--") {
+                name.to_string()
+            } else {
+                name.to_ascii_lowercase()
+            },
+            value,
+            important,
+        })
+    }
+}
+
+impl<'i> AtRuleParser<'i> for DeclarationCapture {
+    type Prelude = ();
+    type AtRule = Declaration;
+    type Error = ();
+}
+
+impl<'i> QualifiedRuleParser<'i> for DeclarationCapture {
+    type Prelude = ();
+    type QualifiedRule = Declaration;
+    type Error = ();
+}
+
+impl<'i> RuleBodyItemParser<'i, Declaration, ()> for DeclarationCapture {
+    fn parse_declarations(&self) -> bool {
+        true
+    }
+    fn parse_qualified(&self) -> bool {
+        false
+    }
+}
+
+fn parse_declarations(input: &str) -> Vec<Declaration> {
+    let mut parser_input = ParserInput::new(input);
+    let mut parser = Parser::new(&mut parser_input);
+    let mut capture = DeclarationCapture;
+    RuleBodyParser::new(&mut parser, &mut capture)
+        .filter_map(Result::ok)
+        .collect()
+}
+
+fn strip_important(value: &mut String) -> bool {
+    let trimmed = value.trim_end();
+    let Some(bang) = trimmed.rfind('!') else {
+        return false;
+    };
+    if trimmed[bang + 1..].trim().eq_ignore_ascii_case("important") {
+        value.truncate(bang);
+        *value = value.trim_end().to_string();
+        true
+    } else {
+        false
+    }
+}
+
+fn split_selector_list(input: &str) -> Vec<&str> {
+    let mut out = Vec::new();
+    let mut start = 0;
+    let mut round = 0u32;
+    let mut square = 0u32;
+    let mut quote = None;
+    let mut escaped = false;
+    for (index, ch) in input.char_indices() {
+        if escaped {
+            escaped = false;
+            continue;
+        }
+        if ch == '\\' {
+            escaped = true;
+            continue;
+        }
+        if let Some(q) = quote {
+            if ch == q {
+                quote = None;
+            }
+            continue;
+        }
+        match ch {
+            '\'' | '"' => quote = Some(ch),
+            '(' => round += 1,
+            ')' => round = round.saturating_sub(1),
+            '[' => square += 1,
+            ']' => square = square.saturating_sub(1),
+            ',' if round == 0 && square == 0 => {
+                let selector = input[start..index].trim();
+                if !selector.is_empty() {
+                    out.push(selector);
+                }
+                start = index + ch.len_utf8();
+            }
+            _ => {}
+        }
+    }
+    let selector = input[start..].trim();
+    if !selector.is_empty() {
+        out.push(selector);
+    }
+    out
+}
+
+fn selector_key(selector: &str) -> RuleKey {
+    let tail = selector
+        .rsplit(|ch: char| ch == '>' || ch == '+' || ch == '~' || ch.is_whitespace())
+        .find(|part| !part.is_empty())
+        .unwrap_or(selector);
+    if let Some(index) = tail.rfind('#') {
+        let value = identifier_prefix(&tail[index + 1..]);
+        if !value.is_empty() {
+            return RuleKey::Id(value.to_string());
+        }
+    }
+    if let Some(index) = tail.rfind('.') {
+        let value = identifier_prefix(&tail[index + 1..]);
+        if !value.is_empty() {
+            return RuleKey::Class(value.to_string());
+        }
+    }
+    let tag = identifier_prefix(tail.trim_start_matches('*'));
+    if !tag.is_empty()
+        && tail
+            .chars()
+            .next()
+            .is_some_and(|ch| ch.is_ascii_alphabetic())
+    {
+        RuleKey::Tag(tag.to_ascii_lowercase())
+    } else {
+        RuleKey::Universal
+    }
+}
+
+fn identifier_prefix(input: &str) -> &str {
+    let end = input
+        .char_indices()
+        .find(|(_, ch)| !(ch.is_ascii_alphanumeric() || *ch == '-' || *ch == '_'))
+        .map(|(index, _)| index)
+        .unwrap_or(input.len());
+    &input[..end]
+}
+
+fn expand_declaration(declaration: &Declaration) -> Vec<Declaration> {
+    if declaration.name == "border" {
+        let values = split_component_whitespace(&declaration.value);
+        let mut width = "medium".to_string();
+        let mut style = "none".to_string();
+        let mut color = "currentcolor".to_string();
+        for value in values {
+            if matches!(
+                value.to_ascii_lowercase().as_str(),
+                "none" | "hidden" | "dotted" | "dashed" | "solid" | "double" | "groove"
+                    | "ridge" | "inset" | "outset"
+            ) {
+                style = value;
+            } else if matches!(value.as_str(), "thin" | "medium" | "thick")
+                || value == "0"
+                || value.chars().next().is_some_and(|ch| ch.is_ascii_digit() || ch == '.')
+            {
+                width = value;
+            } else {
+                color = value;
+            }
+        }
+        let mut out = vec![declaration.clone()];
+        for side in ["top", "right", "bottom", "left"] {
+            for (kind, value) in [
+                ("width", width.as_str()),
+                ("style", style.as_str()),
+                ("color", color.as_str()),
+            ] {
+                out.push(Declaration {
+                    name: format!("border-{side}-{kind}"),
+                    value: value.to_string(),
+                    important: declaration.important,
+                });
+            }
+        }
+        return out;
+    }
+    let names: &[&str] = match declaration.name.as_str() {
+        "margin" => &["margin-top", "margin-right", "margin-bottom", "margin-left"],
+        "padding" => &[
+            "padding-top",
+            "padding-right",
+            "padding-bottom",
+            "padding-left",
+        ],
+        "inset" => &["top", "right", "bottom", "left"],
+        "border-width" => &[
+            "border-top-width",
+            "border-right-width",
+            "border-bottom-width",
+            "border-left-width",
+        ],
+        "border-style" => &[
+            "border-top-style",
+            "border-right-style",
+            "border-bottom-style",
+            "border-left-style",
+        ],
+        "border-color" => &[
+            "border-top-color",
+            "border-right-color",
+            "border-bottom-color",
+            "border-left-color",
+        ],
+        "gap" => &["row-gap", "column-gap"],
+        _ => return vec![declaration.clone()],
+    };
+    let values = split_component_whitespace(&declaration.value);
+    if values.is_empty() {
+        return vec![declaration.clone()];
+    }
+    let expanded_values = match names.len() {
+        2 => vec![
+            values[0].clone(),
+            values.get(1).cloned().unwrap_or_else(|| values[0].clone()),
+        ],
+        4 => match values.len() {
+            1 => vec![values[0].clone(); 4],
+            2 => vec![
+                values[0].clone(),
+                values[1].clone(),
+                values[0].clone(),
+                values[1].clone(),
+            ],
+            3 => vec![
+                values[0].clone(),
+                values[1].clone(),
+                values[2].clone(),
+                values[1].clone(),
+            ],
+            _ => values.into_iter().take(4).collect(),
+        },
+        _ => Vec::new(),
+    };
+    let mut out = vec![declaration.clone()];
+    out.extend(
+        names
+            .iter()
+            .zip(expanded_values)
+            .map(|(name, value)| Declaration {
+                name: (*name).to_string(),
+                value,
+                important: declaration.important,
+            }),
+    );
+    out
+}
+
+fn split_component_whitespace(input: &str) -> Vec<String> {
+    let mut values = Vec::new();
+    let mut current = String::new();
+    let mut depth = 0u32;
+    for ch in input.chars() {
+        match ch {
+            '(' => {
+                depth += 1;
+                current.push(ch);
+            }
+            ')' => {
+                depth = depth.saturating_sub(1);
+                current.push(ch);
+            }
+            ch if ch.is_whitespace() && depth == 0 => {
+                if !current.is_empty() {
+                    values.push(std::mem::take(&mut current));
+                }
+            }
+            _ => current.push(ch),
+        }
+    }
+    if !current.is_empty() {
+        values.push(current);
+    }
+    values
+}
+
+fn resolve_vars(
+    input: &str,
+    variables: &HashMap<String, String>,
+    resolving: &mut HashSet<String>,
+    resolved: &mut HashMap<String, Option<String>>,
+    depth: usize,
+) -> String {
+    if depth > 32 {
+        return String::new();
+    }
+    let mut output = String::with_capacity(input.len());
+    let mut rest = input;
+    while let Some(start) = rest.find("var(") {
+        output.push_str(&rest[..start]);
+        let after = &rest[start + 4..];
+        let Some(end) = find_matching_paren(after) else {
+            output.push_str(&rest[start..]);
+            return output;
+        };
+        let args = &after[..end];
+        let (name, fallback) = split_var_args(args);
+        let name = name.trim();
+        let variable_value = if !name.starts_with("--") {
+            None
+        } else if let Some(value) = resolved.get(name) {
+            value.clone()
+        } else if resolving.insert(name.to_string()) {
+            let value = variables.get(name).and_then(|value| {
+                let value = resolve_vars(value, variables, resolving, resolved, depth + 1);
+                (!value.is_empty()).then_some(value)
+            });
+            resolving.remove(name);
+            resolved.insert(name.to_string(), value.clone());
+            value
+        } else {
+            None
+        };
+        let replacement = variable_value.unwrap_or_else(|| {
+            fallback
+                .map(|value| resolve_vars(value, variables, resolving, resolved, depth + 1))
+                .unwrap_or_default()
+        });
+        output.push_str(&replacement);
+        rest = &after[end + 1..];
+    }
+    output.push_str(rest);
+    output.trim().to_string()
+}
+
+fn find_matching_paren(input: &str) -> Option<usize> {
+    let mut depth = 0u32;
+    for (index, ch) in input.char_indices() {
+        match ch {
+            '(' => depth += 1,
+            ')' if depth == 0 => return Some(index),
+            ')' => depth -= 1,
+            _ => {}
+        }
+    }
+    None
+}
+
+fn split_var_args(input: &str) -> (&str, Option<&str>) {
+    let mut depth = 0u32;
+    for (index, ch) in input.char_indices() {
+        match ch {
+            '(' => depth += 1,
+            ')' => depth = depth.saturating_sub(1),
+            ',' if depth == 0 => return (&input[..index], Some(&input[index + 1..])),
+            _ => {}
+        }
+    }
+    (input, None)
+}
+
+fn normalize_value(property: &str, input: &str) -> String {
+    let value = input.trim();
+    if value == "0" && is_length_property(property) {
+        return "0px".to_string();
+    }
+    if is_length_property(property) {
+        for (unit, factor) in [
+            ("in", 96.0),
+            ("cm", 96.0 / 2.54),
+            ("mm", 96.0 / 25.4),
+            ("q", 96.0 / 101.6),
+            ("pt", 4.0 / 3.0),
+            ("pc", 16.0),
+        ] {
+            if let Some(number) = value.strip_suffix(unit).and_then(|raw| raw.parse::<f64>().ok()) {
+                let pixels = number * factor;
+                return if pixels.fract().abs() < f64::EPSILON {
+                    format!("{}px", pixels as i64)
+                } else {
+                    let number = format!("{pixels:.4}");
+                    format!("{}px", number.trim_end_matches('0').trim_end_matches('.'))
+                };
+            }
+        }
+    }
+    match value.to_ascii_lowercase().as_str() {
+        "transparent" => "rgba(0, 0, 0, 0)".to_string(),
+        "black" => "rgb(0, 0, 0)".to_string(),
+        "white" => "rgb(255, 255, 255)".to_string(),
+        "red" => "rgb(255, 0, 0)".to_string(),
+        "green" => "rgb(0, 128, 0)".to_string(),
+        "blue" => "rgb(0, 0, 255)".to_string(),
+        _ => value.to_string(),
+    }
+}
+
+fn is_length_property(name: &str) -> bool {
+    matches!(name, "top" | "right" | "bottom" | "left")
+        || name.contains("width")
+        || name.contains("height")
+        || name.contains("margin")
+        || name.contains("padding")
+        || name.contains("inset")
+        || name.contains("gap")
+        || name.contains("radius")
+        || name.ends_with("-size")
+        || name.ends_with("-spacing")
+        || name.ends_with("-offset")
+}
+
+fn is_inherited_property(name: &str) -> bool {
+    matches!(
+        name,
+        "color"
+            | "cursor"
+            | "direction"
+            | "font"
+            | "font-family"
+            | "font-size"
+            | "font-style"
+            | "font-variant"
+            | "font-weight"
+            | "letter-spacing"
+            | "line-height"
+            | "list-style"
+            | "text-align"
+            | "text-indent"
+            | "text-transform"
+            | "visibility"
+            | "white-space"
+            | "word-spacing"
+    )
+}
+
+fn supports_condition(input: &str) -> bool {
+    let value = input.trim();
+    value.starts_with('(') && value.contains(':') && value.ends_with(')')
+}
+
+/// Extract top-level `@import` targets without retaining or evaluating the
+/// stylesheet. The browser loader uses this only in compute mode; drop mode
+/// intentionally performs no CSS parsing at all.
+pub fn extract_imports(css: &str) -> Vec<(String, String)> {
+    let mut input = ParserInput::new(css);
+    let mut input = Parser::new(&mut input);
+    let mut capture = CaptureRuleParser;
+    StyleSheetParser::new(&mut input, &mut capture)
+        .filter_map(Result::ok)
+        .filter_map(|rule| match rule {
+            CapturedRule::At { name, prelude, .. } if name.eq_ignore_ascii_case("import") => {
+                parse_import_prelude(&prelude)
+            }
+            _ => None,
+        })
+        .collect()
+}
+
+fn parse_import_prelude(input: &str) -> Option<(String, String)> {
+    let input = input.trim();
+    if let Some(rest) = input.strip_prefix("url(") {
+        let end = rest.find(')')?;
+        let url = rest[..end].trim().trim_matches(['\'', '"']).to_string();
+        let media = rest[end + 1..].trim().to_string();
+        return (!url.is_empty()).then_some((url, media));
+    }
+    let quote = input.chars().next()?;
+    if quote == '\'' || quote == '"' {
+        let rest = &input[quote.len_utf8()..];
+        let end = rest.find(quote)?;
+        let url = rest[..end].to_string();
+        let media = rest[end + quote.len_utf8()..].trim().to_string();
+        return (!url.is_empty()).then_some((url, media));
+    }
+    None
+}
+
+fn media_matches(input: &str, environment: MediaEnvironment) -> bool {
+    let query = input.to_ascii_lowercase().replace(char::is_whitespace, "");
+    if query.is_empty() || query == "all" || query == "screen" {
+        return true;
+    }
+    if query.contains("print") && !query.contains("notprint") {
+        return false;
+    }
+    for part in query.split(',') {
+        let mut matched = true;
+        for condition in part.split("and") {
+            let condition = condition.trim_matches(|ch| ch == '(' || ch == ')');
+            if let Some(value) = condition.strip_prefix("min-width:").and_then(parse_px) {
+                matched &= environment.width >= value;
+            } else if let Some(value) = condition.strip_prefix("max-width:").and_then(parse_px) {
+                matched &= environment.width <= value;
+            } else if let Some(value) = condition.strip_prefix("min-height:").and_then(parse_px) {
+                matched &= environment.height >= value;
+            } else if let Some(value) = condition.strip_prefix("max-height:").and_then(parse_px) {
+                matched &= environment.height <= value;
+            } else if condition == "prefers-color-scheme:dark" {
+                matched &= environment.dark;
+            } else if condition == "prefers-color-scheme:light" {
+                matched &= !environment.dark;
+            } else if condition == "prefers-reduced-motion:reduce" {
+                matched &= environment.reduced_motion;
+            } else if condition == "prefers-reduced-motion:no-preference" {
+                matched &= !environment.reduced_motion;
+            } else if condition == "hover:hover" || condition == "any-hover:hover" {
+                matched &= environment.hover;
+            } else if condition == "pointer:fine" || condition == "any-pointer:fine" {
+                matched &= environment.pointer_fine;
+            } else if matches!(condition, "screen" | "all" | "" | "color") {
+            } else {
+                matched = false;
+            }
+        }
+        if matched {
+            return true;
+        }
+    }
+    false
+}
+
+fn parse_px(input: &str) -> Option<u32> {
+    input.strip_suffix("px")?.parse().ok()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::parse_html;
+
+    #[test]
+    fn cascade_specificity_important_inline_and_variables() {
+        let dom = parse_html(
+            "<html><body><div id='target' class='box' style='padding: 3px'></div></body></html>",
+        );
+        let node = dom.query_selector("#target").unwrap().unwrap();
+        let mut engine = StyleEngine::new();
+        engine.register_stylesheet(
+            None,
+            None,
+            String::new(),
+            true,
+            r#"
+            :root { --brand: blue; color: black; }
+            div { color: red; margin: 1px 2px; }
+            .box { color: var(--brand); }
+            #target { color: green !important; }
+        "#,
+        );
+        let style = engine.compute_style(&dom, node, MediaEnvironment::default());
+        assert_eq!(
+            style.get("color").map(String::as_str),
+            Some("rgb(0, 128, 0)")
+        );
+        assert_eq!(style.get("margin-left").map(String::as_str), Some("2px"));
+        assert_eq!(style.get("padding-top").map(String::as_str), Some("3px"));
+        assert_eq!(style.get("--brand").map(String::as_str), Some("blue"));
+    }
+
+    #[test]
+    fn media_and_parser_recovery_are_local() {
+        let dom = parse_html("<html><body><p class='x'>x</p></body></html>");
+        let node = dom.query_selector("p").unwrap().unwrap();
+        let mut engine = StyleEngine::new();
+        engine.register_stylesheet(
+            None,
+            None,
+            String::new(),
+            true,
+            r#"
+            .x:future-pseudo { color: red }
+            @media (min-width: 1000px) { .x { display: flex } }
+            broken !! { nope }
+            .x { opacity: .5 }
+        "#,
+        );
+        let style = engine.compute_style(&dom, node, MediaEnvironment::default());
+        assert_eq!(style.get("display").map(String::as_str), Some("flex"));
+        assert_eq!(style.get("opacity").map(String::as_str), Some(".5"));
+        assert!(!style.contains_key("color"));
+    }
+
+    #[test]
+    fn custom_property_cycles_use_fallback() {
+        let dom = parse_html("<html><body><div></div></body></html>");
+        let node = dom.query_selector("div").unwrap().unwrap();
+        let mut engine = StyleEngine::new();
+        engine.register_stylesheet(
+            None,
+            None,
+            String::new(),
+            true,
+            ":root { --a: var(--b); --b: var(--a); } div { color: var(--a, red); }",
+        );
+        let style = engine.compute_style(&dom, node, MediaEnvironment::default());
+        assert_eq!(
+            style.get("color").map(String::as_str),
+            Some("rgb(255, 0, 0)")
+        );
+    }
+
+    #[test]
+    fn custom_property_names_remain_case_sensitive() {
+        let dom = parse_html("<html><body><button class='button'></button></body></html>");
+        let node = dom.query_selector("button").unwrap().unwrap();
+        let mut engine = StyleEngine::new();
+        engine.register_stylesheet(
+            None,
+            None,
+            String::new(),
+            true,
+            ".button { --button--Display: inline-flex; display: var(--button--Display); }",
+        );
+        let style = engine.compute_style(&dom, node, MediaEnvironment::default());
+        assert_eq!(
+            style.get("--button--Display").map(String::as_str),
+            Some("inline-flex")
+        );
+        assert_eq!(style.get("display").map(String::as_str), Some("inline-flex"));
+    }
+
+    #[test]
+    fn shorthands_indexing_and_invalidation_work_together() {
+        let dom = parse_html("<html><body><div id='target' class='card'></div></body></html>");
+        let node = dom.query_selector("#target").unwrap().unwrap();
+        let mut engine = StyleEngine::new();
+        let sheet = engine
+            .register_stylesheet(
+                None,
+                None,
+                String::new(),
+                true,
+                ".unrelated { color: blue } .card { padding: 1px 2px 3px 4px; inset: 0; gap: 5px 6px; opacity: 0; width: 72pt; border: 2pt solid red }",
+            )
+            .unwrap();
+        assert!(engine.candidates(&dom, node).len() < engine.rules.len());
+        let style = engine.compute_style(&dom, node, MediaEnvironment::default());
+        assert_eq!(style.get("padding-left").map(String::as_str), Some("4px"));
+        assert_eq!(style.get("bottom").map(String::as_str), Some("0px"));
+        assert_eq!(style.get("column-gap").map(String::as_str), Some("6px"));
+        assert_eq!(style.get("opacity").map(String::as_str), Some("0"));
+        assert_eq!(style.get("width").map(String::as_str), Some("96px"));
+        assert_eq!(style.get("border-left-width").map(String::as_str), Some("2.6667px"));
+        assert_eq!(style.get("border-left-style").map(String::as_str), Some("solid"));
+        assert_eq!(style.get("border-left-color").map(String::as_str), Some("rgb(255, 0, 0)"));
+
+        assert!(engine.set_disabled(sheet, true));
+        assert!(engine
+            .compute_style(&dom, node, MediaEnvironment::default())
+            .get("padding-left")
+            .is_none());
+    }
+
+    #[test]
+    fn resource_limits_truncate_safely() {
+        let mut bytes = StyleEngine::new();
+        bytes.decoded_bytes = MAX_CSS_BYTES;
+        let byte_limited = bytes
+            .register_stylesheet(None, None, String::new(), true, ".x{}")
+            .expect("a truncated sheet should retain CSSOM metadata");
+        assert_eq!(bytes.sheet_rules(byte_limited).unwrap().len(), 0);
+        assert!(bytes.truncated);
+
+        let mut sheets = StyleEngine::new();
+        for _ in 0..MAX_SHEETS {
+            assert!(sheets
+                .register_stylesheet(None, None, String::new(), true, "")
+                .is_some());
+        }
+        assert!(sheets
+            .register_stylesheet(None, None, String::new(), true, "")
+            .is_none());
+        assert!(sheets.truncated);
+
+        let mut parser = SheetParser::new(1, 0, MAX_RULES);
+        parser.parse(".x { color: red }", Vec::new());
+        assert!(parser.hit_rule_limit);
+        assert!(parser.compiled.is_empty());
+        assert_eq!(MAX_IMPORT_DEPTH, 8);
+    }
+
+    #[test]
+    fn imported_sheets_follow_owner_lifetime() {
+        let dom = parse_html("<html><head><link id='owner'></head><body></body></html>");
+        let owner = dom.query_selector("#owner").unwrap().unwrap();
+        let body = dom.query_selector("body").unwrap().unwrap();
+        let mut engine = StyleEngine::new();
+        engine.register_import_stylesheet(
+            owner,
+            "https://example.test/import.css".to_string(),
+            String::new(),
+            true,
+            "body { color: red }",
+        );
+        engine.register_stylesheet(
+            Some(owner),
+            Some("https://example.test/root.css".to_string()),
+            String::new(),
+            true,
+            "body { display: block }",
+        );
+        assert_eq!(
+            engine
+                .compute_style(&dom, body, MediaEnvironment::default())
+                .get("color")
+                .map(String::as_str),
+            Some("rgb(255, 0, 0)")
+        );
+        engine.remove_owner(owner);
+        assert!(engine.sheet_infos().is_empty());
+        assert!(engine
+            .compute_style(&dom, body, MediaEnvironment::default())
+            .is_empty());
+    }
+}

--- a/crates/obscura-js/js/bootstrap.js
+++ b/crates/obscura-js/js/bootstrap.js
@@ -198,6 +198,59 @@ async function __processDynScriptQueue() {
     __dynScriptBusy = false;
   }
 }
+
+// Dynamic stylesheet loading. Vite's production preload helper appends
+// <link rel="stylesheet"> elements and waits for load/error before resolving a
+// lazy route import. Merely adding the node to the DOM leaves that promise
+// pending forever, so fetch the resource through the same guarded/proxied op as
+// fetch/XHR and deliver the element lifecycle event. Track the URL per element
+// so setting rel/href before insertion does not double-fetch, while changing
+// href after insertion still starts a new request.
+const __dynamicStylesheetLoads = new WeakMap();
+function __maybeLoadDynamicStylesheet(link) {
+  if (!link || link.tagName !== 'LINK' || !link.isConnected) return;
+  const rel = (link.getAttribute('rel') || '').toLowerCase().split(/\s+/);
+  const href = link.getAttribute('href');
+  if (!rel.includes('stylesheet') || !href) {
+    __dynamicStylesheetLoads.delete(link);
+    return;
+  }
+
+  let baseHref;
+  try {
+    const baseEl = globalThis.document?.querySelector('base[href]');
+    baseHref = baseEl ? baseEl.getAttribute('href') : null;
+  } catch(e) { baseHref = null; }
+  const docUrl = globalThis.location?.href || 'http://localhost/';
+  let baseUrl;
+  try { baseUrl = baseHref ? new URL(baseHref, docUrl).href : docUrl; }
+  catch(e) { baseUrl = docUrl; }
+  let fullUrl;
+  try { fullUrl = new URL(href, baseUrl).href; }
+  catch(e) {
+    Promise.resolve().then(() => link.dispatchEvent(new Event('error')));
+    return;
+  }
+  if (__dynamicStylesheetLoads.get(link) === fullUrl) return;
+  __dynamicStylesheetLoads.set(link, fullUrl);
+
+  const pageOrigin = (() => { try { return new URL(docUrl).origin; } catch(e) { return ''; } })();
+  Promise.resolve(Deno.core.ops.op_fetch_url(
+    fullUrl, 'GET', '{"accept":"text/css,*/*;q=0.1"}', '', pageOrigin, 'no-cors'
+  )).then(raw => {
+    if (__dynamicStylesheetLoads.get(link) !== fullUrl) return;
+    let response;
+    try { response = typeof raw === 'string' ? JSON.parse(raw) : raw; }
+    catch(e) { response = null; }
+    const loaded = response && response.status >= 200 && response.status < 400 && !response.blocked;
+    link.dispatchEvent(new Event(loaded ? 'load' : 'error'));
+  }).catch(() => {
+    if (__dynamicStylesheetLoads.get(link) === fullUrl) {
+      link.dispatchEvent(new Event('error'));
+    }
+  });
+}
+
 function _fpRand(salt) {
   let h = (_fpSeed ^ (salt || 0)) | 0;
   h = Math.imul(h ^ (h >>> 16), 0x45d9f3b);
@@ -687,6 +740,7 @@ class Node {
         }
       }
     }
+    __maybeLoadDynamicStylesheet(c);
     return c;
   }
   removeChild(c) {
@@ -705,6 +759,7 @@ class Node {
     if (!n) return n;
     if (!ref) { this.appendChild(n); return n; }
     _dom("insert_before", n._nid, ref._nid);
+    __maybeLoadDynamicStylesheet(n);
     return n;
   }
   contains(o) { return o ? _dom("contains", this._nid, o._nid) === "true" : false; }
@@ -1252,9 +1307,10 @@ class Element extends Node {
     _dom("set_attribute", this._nid, n + "\0" + String(v));
     if (popoverPrev !== undefined) this._popoverTypeMaybeChanged(popoverPrev);
     if (globalThis.__mutationObservers?.length) globalThis.__notifyMutation('attributes', this._nid, [], [], n);
+    if (this.tagName === 'LINK' && (n === 'rel' || n === 'href')) __maybeLoadDynamicStylesheet(this);
   }
   setAttributeNS(ns, n, v) { _dom("set_attribute", this._nid, String(n) + "\0" + String(v)); } // exact name, no HTML folding
-  removeAttribute(n) { n = _htmlAttrName(this, n); const popoverPrev = (n === "popover") ? this.popover : undefined; _dom("remove_attribute", this._nid, n); if (popoverPrev !== undefined) this._popoverTypeMaybeChanged(popoverPrev); }
+  removeAttribute(n) { n = _htmlAttrName(this, n); const popoverPrev = (n === "popover") ? this.popover : undefined; _dom("remove_attribute", this._nid, n); if (popoverPrev !== undefined) this._popoverTypeMaybeChanged(popoverPrev); if (this.tagName === 'LINK' && (n === 'rel' || n === 'href')) __maybeLoadDynamicStylesheet(this); }
   removeAttributeNS(ns, n) { _dom("remove_attribute", this._nid, String(n)); }
   hasAttribute(n) { return this.getAttribute(n) !== null; }
   hasAttributes() { return true; } // Simplified
@@ -1772,6 +1828,8 @@ class Element extends Node {
   set name(v) { this.setAttribute("name", v); }
   get placeholder() { return this.getAttribute("placeholder") || ""; }
   set placeholder(v) { this.setAttribute("placeholder", v); }
+  get rel() { return this.getAttribute("rel") || ""; }
+  set rel(v) { this.setAttribute("rel", v); }
   // For <a>/<area>, href returns the resolved absolute URL (the spec behavior,
   // and what scrapers want). It uses op_url_resolve, which returns just the
   // resolved string, rather than the full-component op the decomposition

--- a/crates/obscura-js/js/bootstrap.js
+++ b/crates/obscura-js/js/bootstrap.js
@@ -213,6 +213,7 @@ function __maybeLoadDynamicStylesheet(link) {
   const href = link.getAttribute('href');
   if (!rel.includes('stylesheet') || !href) {
     __dynamicStylesheetLoads.delete(link);
+    try { Deno.core.ops.op_css('remove-owner', String(link._nid), '', ''); } catch(e) {}
     return;
   }
 
@@ -231,21 +232,24 @@ function __maybeLoadDynamicStylesheet(link) {
     Promise.resolve().then(() => link.dispatchEvent(new Event('error')));
     return;
   }
-  if (__dynamicStylesheetLoads.get(link) === fullUrl) return;
-  __dynamicStylesheetLoads.set(link, fullUrl);
+  const mediaText = link.getAttribute('media') || '';
+  const loadKey = fullUrl + '\n' + mediaText;
+  if (__dynamicStylesheetLoads.get(link) === loadKey) return;
+  __dynamicStylesheetLoads.set(link, loadKey);
 
   const pageOrigin = (() => { try { return new URL(docUrl).origin; } catch(e) { return ''; } })();
-  Promise.resolve(Deno.core.ops.op_fetch_url(
-    fullUrl, 'GET', '{"accept":"text/css,*/*;q=0.1"}', '', pageOrigin, 'no-cors'
+  const sheetOrigin = (() => { try { return new URL(fullUrl).origin; } catch(e) { return ''; } })();
+  Promise.resolve(Deno.core.ops.op_load_stylesheet(
+    fullUrl, link._nid, mediaText, pageOrigin === sheetOrigin
   )).then(raw => {
-    if (__dynamicStylesheetLoads.get(link) !== fullUrl) return;
+    if (__dynamicStylesheetLoads.get(link) !== loadKey) return;
     let response;
     try { response = typeof raw === 'string' ? JSON.parse(raw) : raw; }
     catch(e) { response = null; }
     const loaded = response && response.status >= 200 && response.status < 400 && !response.blocked;
     link.dispatchEvent(new Event(loaded ? 'load' : 'error'));
   }).catch(() => {
-    if (__dynamicStylesheetLoads.get(link) === fullUrl) {
+    if (__dynamicStylesheetLoads.get(link) === loadKey) {
       link.dispatchEvent(new Event('error'));
     }
   });
@@ -523,19 +527,39 @@ const _CSS_PROPERTY_NAMES = [
 const _CSS_PROP_SET = new Set(_CSS_PROPERTY_NAMES);
 
 class CSSStyleDeclaration {
-  constructor() {
+  constructor(owner, initialText) {
     // Non-enumerable so it never leaks through the proxy's own-key traps.
     Object.defineProperty(this, "_props", { value: {}, writable: true, enumerable: false, configurable: true });
+    Object.defineProperty(this, "_owner", { value: owner || null, writable: true, enumerable: false, configurable: true });
+    Object.defineProperty(this, "_syncing", { value: false, writable: true, enumerable: false, configurable: true });
+    if (initialText) this._setFromAttribute(initialText);
+  }
+  _commit() {
+    if (!this._owner || this._syncing) return;
+    this._syncing = true;
+    try { this._owner.setAttribute("style", this.cssText); }
+    finally { this._syncing = false; }
+  }
+  _setFromAttribute(v) {
+    this._syncing = true;
+    try {
+      for (const k in this._props) delete this._props[k];
+      if (v) String(v).split(";").forEach((p) => {
+        const i = p.indexOf(":");
+        if (i > 0) { const k = p.slice(0, i).trim(); const val = p.slice(i + 1).trim(); if (k && val) this._props[_cssCamelToKebab(k)] = val; }
+      });
+    } finally { this._syncing = false; }
   }
   // Storage is keyed by the dashed CSS name, matching CSSOM. The proxy maps the
   // camelCase IDL access (el.style.fontSize) onto the dashed key (font-size), so
   // getPropertyValue('font-size') and el.style.fontSize stay in sync.
   setProperty(name, value) {
     const k = _cssCamelToKebab(String(name));
-    if (value === "" || value == null) { delete this._props[k]; return; }
+    if (value === "" || value == null) { delete this._props[k]; this._commit(); return; }
     this._props[k] = String(value);
+    this._commit();
   }
-  removeProperty(name) { const k = _cssCamelToKebab(String(name)); const old = this._props[k]; delete this._props[k]; return old || ""; }
+  removeProperty(name) { const k = _cssCamelToKebab(String(name)); const old = this._props[k]; delete this._props[k]; this._commit(); return old || ""; }
   getPropertyValue(name) { return this._props[_cssCamelToKebab(String(name))] || ""; }
   getPropertyPriority() { return ""; }
   get cssText() {
@@ -543,11 +567,8 @@ class CSSStyleDeclaration {
     return e.length ? e.map(([k, v]) => `${k}: ${v}`).join("; ") + ";" : "";
   }
   set cssText(v) {
-    for (const k in this._props) delete this._props[k];
-    if (v) String(v).split(";").forEach((p) => {
-      const i = p.indexOf(":");
-      if (i > 0) { const k = p.slice(0, i).trim(); const val = p.slice(i + 1).trim(); if (k && val) this._props[_cssCamelToKebab(k)] = val; }
-    });
+    this._setFromAttribute(v);
+    this._commit();
   }
   get length() { return Object.keys(this._props).length; }
   item(i) { return Object.keys(this._props)[i] || ""; }
@@ -561,6 +582,7 @@ const _styleProxy = (decl) => new Proxy(decl, {
   },
   set(t, p, v) {
     if (typeof p === "symbol") { t[p] = v; return true; }
+    if (typeof p === "string" && p.startsWith("_") && p in t) { t[p] = v; return true; }
     if (p === "cssText") { t.cssText = v; return true; }
     if (/^\d+$/.test(p) || p in Object.getPrototypeOf(t)) return true;
     t.setProperty(p, v);
@@ -649,6 +671,7 @@ class Node {
     if (globalThis.__mutationObservers?.length) {
       globalThis.__notifyMutation('childList', this._nid, added, oldChildren);
     }
+    if (this.tagName === 'STYLE') __syncInlineStyleSheet(this);
   }
   get nodeValue() {
     const t = this.nodeType;
@@ -741,11 +764,13 @@ class Node {
       }
     }
     __maybeLoadDynamicStylesheet(c);
+    if (c instanceof Element && c.tagName === 'STYLE') __syncInlineStyleSheet(c);
     return c;
   }
   removeChild(c) {
     if (!c) return c;
     _dom("remove_child", c._nid);
+    if (c instanceof Element && (c.tagName === 'STYLE' || c.tagName === 'LINK')) _cssOp("remove-owner", c._nid, "", "");
     if (globalThis.__mutationObservers?.length) globalThis.__notifyMutation('childList', this._nid, [], [c._nid]);
     return c;
   }
@@ -760,6 +785,7 @@ class Node {
     if (!ref) { this.appendChild(n); return n; }
     _dom("insert_before", n._nid, ref._nid);
     __maybeLoadDynamicStylesheet(n);
+    if (n instanceof Element && n.tagName === 'STYLE') __syncInlineStyleSheet(n);
     return n;
   }
   contains(o) { return o ? _dom("contains", this._nid, o._nid) === "true" : false; }
@@ -1160,7 +1186,7 @@ function _htmlAttrName(el, n) {
 class Element extends Node {
   constructor(nid) {
     super(nid);
-    this._style = _styleProxy(new CSSStyleDeclaration());
+    this._style = _styleProxy(new CSSStyleDeclaration(this, this.getAttribute("style") || ""));
   }
   // Element wrappers always back a nodeType-1 node (_wrap/_wrapEl only build an
   // Element for element nodes, and node ids are never freed-and-reused), so this
@@ -1293,6 +1319,10 @@ class Element extends Node {
   }
   get style() { return this._style; }
   set style(v) { if (typeof v === "string") this._style.cssText = v; }
+  get sheet() {
+    if (this.tagName !== "LINK" && this.tagName !== "STYLE") return undefined;
+    return globalThis.__obscuraSheetForOwner ? globalThis.__obscuraSheetForOwner(this._nid) : null;
+  }
   getAttribute(n) {
     // Fast path: HTML attributes are stored lowercase, so a direct hit needs no
     // case folding. Only on a miss do we lowercase (gated) and retry, so the hot
@@ -1305,12 +1335,15 @@ class Element extends Node {
     n = _htmlAttrName(this, n);
     const popoverPrev = (n === "popover") ? this.popover : undefined;
     _dom("set_attribute", this._nid, n + "\0" + String(v));
+    if (n === "style" && this._style && !this._style._syncing) this._style._setFromAttribute(String(v));
     if (popoverPrev !== undefined) this._popoverTypeMaybeChanged(popoverPrev);
     if (globalThis.__mutationObservers?.length) globalThis.__notifyMutation('attributes', this._nid, [], [], n);
-    if (this.tagName === 'LINK' && (n === 'rel' || n === 'href')) __maybeLoadDynamicStylesheet(this);
+    if (this.tagName === 'LINK' && (n === 'rel' || n === 'href' || n === 'media')) __maybeLoadDynamicStylesheet(this);
+    if ((this.tagName === 'LINK' || this.tagName === 'STYLE') && n === 'disabled') { const sheet = this.sheet; if (sheet) sheet.disabled = true; }
+    if (this.tagName === 'STYLE' && n === 'media') __syncInlineStyleSheet(this);
   }
   setAttributeNS(ns, n, v) { _dom("set_attribute", this._nid, String(n) + "\0" + String(v)); } // exact name, no HTML folding
-  removeAttribute(n) { n = _htmlAttrName(this, n); const popoverPrev = (n === "popover") ? this.popover : undefined; _dom("remove_attribute", this._nid, n); if (popoverPrev !== undefined) this._popoverTypeMaybeChanged(popoverPrev); if (this.tagName === 'LINK' && (n === 'rel' || n === 'href')) __maybeLoadDynamicStylesheet(this); }
+  removeAttribute(n) { n = _htmlAttrName(this, n); const popoverPrev = (n === "popover") ? this.popover : undefined; _dom("remove_attribute", this._nid, n); if (n === "style" && this._style && !this._style._syncing) this._style._setFromAttribute(""); if (popoverPrev !== undefined) this._popoverTypeMaybeChanged(popoverPrev); if (this.tagName === 'LINK' && (n === 'rel' || n === 'href' || n === 'media')) __maybeLoadDynamicStylesheet(this); if ((this.tagName === 'LINK' || this.tagName === 'STYLE') && n === 'disabled') { const sheet = this.sheet; if (sheet) sheet.disabled = false; } }
   removeAttributeNS(ns, n) { _dom("remove_attribute", this._nid, String(n)); }
   hasAttribute(n) { return this.getAttribute(n) !== null; }
   hasAttributes() { return true; } // Simplified
@@ -2696,7 +2729,9 @@ class Document extends Node {
       hasFeature() { return true; },
     };
   }
-  get styleSheets() { return []; }
+  get styleSheets() {
+    return globalThis.__obscuraStyleSheetList ? globalThis.__obscuraStyleSheetList() : [];
+  }
   get forms() { return this.querySelectorAll("form"); }
   get images() { return this.querySelectorAll("img"); }
   get links() { return this.querySelectorAll("a[href], area[href]"); }
@@ -3060,6 +3095,9 @@ class NetworkInformation {
   set onchange(v) {}
   get ontypechange() { return null; }
   set ontypechange(v) {}
+  addEventListener() {}
+  removeEventListener() {}
+  dispatchEvent() { return true; }
 }
 _markNative(NetworkInformation);
 globalThis.NetworkInformation = NetworkInformation;
@@ -4096,7 +4134,23 @@ globalThis.matchMedia = _markNative(function matchMedia(q) {
 });
 globalThis.getComputedStyle = (el) => {
   if (!el) el = document.body || {};
-  const style = el?.style || el?._style || new CSSStyleDeclaration();
+  let nativeValues = {};
+  try {
+    const environment = {
+      width: Number(globalThis.innerWidth || 1920),
+      height: Number(globalThis.innerHeight || 1000),
+      dark: !!globalThis.matchMedia?.('(prefers-color-scheme: dark)').matches,
+      reducedMotion: !!globalThis.matchMedia?.('(prefers-reduced-motion: reduce)').matches,
+      hover: !!globalThis.matchMedia?.('(hover: hover)').matches,
+      pointerFine: !!globalThis.matchMedia?.('(pointer: fine)').matches,
+    };
+    nativeValues = JSON.parse(_cssOp("computed", el?._nid ?? 0, JSON.stringify(environment), "") || "{}");
+  } catch (e) {}
+  const computedDeclaration = new CSSStyleDeclaration();
+  computedDeclaration._props = Object.assign({}, nativeValues);
+  const style = Object.keys(nativeValues).length
+    ? _styleProxy(computedDeclaration)
+    : (el?.style || el?._style || _styleProxy(computedDeclaration));
   // React virtualization libraries (react-window, tanstack-virtual,
   // react-virtuoso) all compute container dimensions via getComputedStyle.
   // The defaults table previously returned `auto` for width/height and
@@ -4150,6 +4204,7 @@ globalThis.getComputedStyle = (el) => {
     'will-change': 'auto', 'backface-visibility': 'visible',
   };
 
+  const target = style;
   const lookup = (rawProp) => {
     if (typeof rawProp !== 'string') return '';
     // Inline value first.
@@ -4163,17 +4218,16 @@ globalThis.getComputedStyle = (el) => {
     return '';
   };
 
-  const target = style;
   return new Proxy(style, {
     get(_, prop) {
       if (prop === Symbol.toPrimitive || prop === Symbol.toStringTag) return undefined;
-      if (prop in target) return target[prop];
       if (prop === 'getPropertyValue') return (name) => lookup(name);
-      if (prop === 'getPropertyPriority') return () => '';
-      if (prop === 'item') return (i) => '';
-      if (prop === 'length') return 0;
-      if (prop === 'cssText') return '';
+      if (prop === 'getPropertyPriority') return (name) => target.getPropertyPriority(name);
+      if (prop === 'item') return (i) => target.item(i);
+      if (prop === 'length') return target.length;
+      if (prop === 'cssText') return target.cssText;
       if (prop === 'parentRule') return null;
+      if (prop in CSSStyleDeclaration.prototype) return target[prop];
       if (typeof prop === 'string') return lookup(prop);
       return undefined;
     },
@@ -4191,41 +4245,111 @@ globalThis.getSelection = _markNative(function getSelection() {
   return _selectionFor(globalThis.document);
 });
 
+const _cssOp = (command, arg1, arg2, arg3) =>
+  Deno.core.ops.op_css(command, String(arg1 ?? ""), String(arg2 ?? ""), String(arg3 ?? ""));
+const _sheetCache = new Map();
+
+class CSSRuleList extends Array {
+  item(index) { return this[index] || null; }
+}
+
+class StyleSheetList extends Array {
+  item(index) { return this[index] || null; }
+}
+
 globalThis.CSSStyleSheet = class CSSStyleSheet {
-  constructor(options) {
-    this.cssRules = [];
+  constructor(options, metadata) {
     this.ownerRule = null;
-    this.disabled = false;
-    this._rules = [];
+    this._id = metadata?.id || +_cssOp("construct", "", "", "");
+    this._ownerNodeId = metadata?.ownerNode ?? null;
+    this.href = metadata?.href ?? null;
+    this.media = { mediaText: metadata?.media || "", length: metadata?.media ? 1 : 0, item(i) { return i === 0 ? this.mediaText : null; }, toString() { return this.mediaText; } };
+    this._disabled = !!metadata?.disabled;
+    this._sameOrigin = metadata?.sameOrigin !== false;
   }
+  _update(metadata) {
+    this._ownerNodeId = metadata.ownerNode ?? null;
+    this.href = metadata.href ?? null;
+    this.media.mediaText = metadata.media || "";
+    this.media.length = this.media.mediaText ? 1 : 0;
+    this._disabled = !!metadata.disabled;
+    this._sameOrigin = metadata.sameOrigin !== false;
+    return this;
+  }
+  get ownerNode() { return this._ownerNodeId == null ? null : _wrap(this._ownerNodeId); }
+  get disabled() { return this._disabled; }
+  set disabled(value) { this._disabled = !!value; _cssOp("disable", this._id, this._disabled, ""); }
+  get cssRules() {
+    if (!this._sameOrigin) throw new DOMException("Cannot access rules", "SecurityError");
+    const raw = JSON.parse(_cssOp("rules", this._id, "", "") || "[]");
+    const list = new CSSRuleList();
+    for (const rule of raw) list.push({ cssText: rule.cssText, type: rule.ruleType, parentStyleSheet: this, parentRule: null });
+    return list;
+  }
+  get rules() { return this.cssRules; }
   insertRule(rule, index) {
-    const idx = index ?? this._rules.length;
-    this._rules.splice(idx, 0, { cssText: rule, type: 1 });
-    this.cssRules = this._rules;
-    return idx;
+    const idx = index === undefined ? this.cssRules.length : Number(index);
+    const result = JSON.parse(_cssOp("insert", this._id, idx, String(rule)) || "{}");
+    if (!result.ok) throw new DOMException(result.error || "Invalid rule", result.error || "SyntaxError");
+    _sheetCache.delete(this._id);
+    this._id = result.id;
+    _sheetCache.set(this._id, this);
+    return result.index;
   }
   deleteRule(index) {
-    this._rules.splice(index, 1);
-    this.cssRules = this._rules;
+    const result = JSON.parse(_cssOp("delete", this._id, Number(index), "") || "{}");
+    if (!result.ok) throw new DOMException(result.error || "Invalid index", result.error || "IndexSizeError");
+    _sheetCache.delete(this._id);
+    this._id = result.id;
+    _sheetCache.set(this._id, this);
   }
-  addRule(selector, style, index) {
-    return this.insertRule(selector + '{' + style + '}', index);
-  }
+  addRule(selector, style, index) { return this.insertRule(selector + "{" + style + "}", index); }
   removeRule(index) { this.deleteRule(index); }
-  replace(text) {
-    this._rules = [{ cssText: text, type: 1 }];
-    this.cssRules = this._rules;
-    return Promise.resolve(this);
-  }
+  replace(text) { this.replaceSync(text); return Promise.resolve(this); }
   replaceSync(text) {
-    this._rules = [{ cssText: text, type: 1 }];
-    this.cssRules = this._rules;
+    const result = JSON.parse(_cssOp("replace", this._id, "", String(text)) || "{}");
+    if (!result.ok) throw new DOMException(result.error || "Invalid stylesheet", "SyntaxError");
+    _sheetCache.delete(this._id);
+    this._id = result.id;
+    _sheetCache.set(this._id, this);
   }
 };
 
+function _sheetFromMetadata(metadata) {
+  let sheet = _sheetCache.get(metadata.id);
+  if (!sheet) {
+    sheet = new CSSStyleSheet(undefined, metadata);
+    _sheetCache.set(metadata.id, sheet);
+  }
+  return sheet._update(metadata);
+}
+
+globalThis.__obscuraStyleSheetList = function() {
+  const list = new StyleSheetList();
+  if (_cssOp("enabled", "", "", "") !== "true") return list;
+  const metadata = JSON.parse(_cssOp("sheets", "", "", "") || "[]");
+  for (const entry of metadata) if (entry.ownerNode != null) list.push(_sheetFromMetadata(entry));
+  return list;
+};
+
+globalThis.__obscuraSheetForOwner = function(nid) {
+  const list = globalThis.__obscuraStyleSheetList();
+  for (const sheet of list) if (sheet._ownerNodeId === Number(nid)) return sheet;
+  return null;
+};
+
+function __syncInlineStyleSheet(element) {
+  if (!element || element.tagName !== "STYLE" || !element.isConnected) return;
+  const metadata = JSON.stringify({ href: null, media: element.getAttribute("media") || "", sameOrigin: true });
+  _cssOp("register", element._nid, metadata, element.textContent || "");
+}
+
 Object.defineProperty(Document.prototype, 'adoptedStyleSheets', {
   get() { return this._adoptedStyleSheets || []; },
-  set(sheets) { this._adoptedStyleSheets = sheets; },
+  set(sheets) {
+    this._adoptedStyleSheets = Array.from(sheets || []);
+    _cssOp("adopt", JSON.stringify(this._adoptedStyleSheets.map(sheet => sheet && sheet._id).filter(Boolean)), "", "");
+  },
 });
 
 globalThis.__mutationObservers = [];

--- a/crates/obscura-js/src/ops.rs
+++ b/crates/obscura-js/src/ops.rs
@@ -3,17 +3,21 @@ use std::collections::{HashMap, VecDeque};
 use std::rc::Rc;
 use std::sync::Arc;
 
-use deno_core::op2;
-use deno_core::OpState;
-use deno_core::Extension;
 use base64::{engine::general_purpose::STANDARD as BASE64, Engine as _};
-use obscura_dom::{DomTree, NodeData, NodeId};
-use obscura_net::{CookieJar, ObscuraHttpClient, RequestInfo, ResourceType, Response};
+use deno_core::op2;
+use deno_core::Extension;
+use deno_core::OpState;
+use obscura_dom::{DomTree, MediaEnvironment, NodeData, NodeId, StyleEngine};
 #[cfg(feature = "stealth")]
 use obscura_net::StealthHttpClient;
+use obscura_net::{CookieJar, ObscuraHttpClient, RequestInfo, ResourceType, Response};
 use tokio::sync::Mutex;
 
-pub type InterceptCallback = Arc<Mutex<Option<Box<dyn Fn(String, String, String) -> Option<(u16, String, String)> + Send + Sync>>>>;
+pub type InterceptCallback = Arc<
+    Mutex<
+        Option<Box<dyn Fn(String, String, String) -> Option<(u16, String, String)> + Send + Sync>>,
+    >,
+>;
 
 #[derive(Debug)]
 pub enum InterceptResolution {
@@ -77,6 +81,11 @@ pub struct ObscuraState {
     // order. Surfaced by `--dump assets` so resources pulled in by script, not
     // just static DOM attributes, are listed (issue #301).
     pub fetched_urls: Vec<String>,
+    /// Native author-style registry. External CSS is parsed here and never
+    /// interpolated into executable JavaScript.
+    pub style_engine: StyleEngine,
+    /// False for the explicit fetch-and-discard CSS mode.
+    pub css_enabled: bool,
 }
 
 impl ObscuraState {
@@ -100,6 +109,8 @@ impl ObscuraState {
             network_response_body_order: VecDeque::new(),
             network_response_body_counter: 0,
             fetched_urls: Vec::new(),
+            style_engine: StyleEngine::new(),
+            css_enabled: true,
         }
     }
 }
@@ -122,20 +133,379 @@ pub type SharedState = Rc<RefCell<ObscuraState>>;
 
 #[op2]
 #[string]
-fn op_dom(state: &OpState, #[string] cmd: String, #[string] arg1: String, #[string] arg2: String) -> String {
+fn op_dom(
+    state: &OpState,
+    #[string] cmd: String,
+    #[string] arg1: String,
+    #[string] arg2: String,
+) -> String {
     // Anti-panic boundary: a panic in a DOM op would unwind through deno_core
     // into V8's FFI frame, where V8_Fatal calls abort(3) and takes the whole
     // engine (and every CDP client) down. Catch it so one malformed selector or
     // inconsistent tree node degrades to a null result for that single call.
     // No per-call clone: on the happy path this is just a landing pad, so the
     // hot DOM path (querySelector/getAttribute/...) pays nothing measurable.
-    std::panic::catch_unwind(std::panic::AssertUnwindSafe(move || {
+    let invalidates_style = matches!(
+        cmd.as_str(),
+        "append_child"
+            | "insert_before"
+            | "remove_child"
+            | "set_attribute"
+            | "remove_attribute"
+            | "set_inner_html"
+            | "set_text_content"
+    );
+    let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
         op_dom_inner(state, cmd, arg1, arg2)
     }))
     .unwrap_or_else(|_| {
         tracing::error!("op_dom panicked; returning null");
         "null".to_string()
+    });
+    if invalidates_style {
+        let gs = state.borrow::<SharedState>().clone();
+        gs.borrow_mut().style_engine.invalidate();
+    }
+    result
+}
+
+#[derive(serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct SheetRegistration {
+    href: Option<String>,
+    #[serde(default)]
+    media: String,
+    #[serde(default = "default_true")]
+    same_origin: bool,
+}
+
+fn default_true() -> bool {
+    true
+}
+
+#[derive(Clone)]
+enum StylesheetFetchClient {
+    Regular(Arc<ObscuraHttpClient>),
+    #[cfg(feature = "stealth")]
+    Stealth(Arc<StealthHttpClient>),
+}
+
+impl StylesheetFetchClient {
+    async fn fetch(&self, url: &url::Url) -> Result<Response, String> {
+        match self {
+            Self::Regular(client) => client.fetch(url).await.map_err(|error| error.to_string()),
+            #[cfg(feature = "stealth")]
+            Self::Stealth(client) => client.fetch(url).await.map_err(|error| error.to_string()),
+        }
+    }
+}
+
+fn fetch_dynamic_css_imports<'a>(
+    client: &'a StylesheetFetchClient,
+    base_url: url::Url,
+    css: String,
+    inherited_media: String,
+    page_origin: Option<url::Origin>,
+    blocked_patterns: &'a [String],
+    depth: usize,
+    visited: &'a mut std::collections::HashSet<String>,
+) -> std::pin::Pin<
+    Box<dyn std::future::Future<Output = Vec<(String, String, bool, String)>> + 'a>,
+> {
+    Box::pin(async move {
+        if depth >= obscura_dom::style::MAX_IMPORT_DEPTH {
+            tracing::warn!(
+                limit = obscura_dom::style::MAX_IMPORT_DEPTH,
+                "dynamic CSS import depth limit reached"
+            );
+            return Vec::new();
+        }
+        let mut output = Vec::new();
+        for (href, import_media) in obscura_dom::extract_imports(&css) {
+            let Ok(import_url) = base_url.join(&href) else { continue };
+            let import_href = import_url.to_string();
+            let blocked = blocked_patterns.iter().any(|pattern| {
+                pattern == "*" || import_href.contains(pattern) || glob_match(pattern, &import_href)
+            });
+            if !visited.insert(import_href.clone()) || validate_fetch_url(&import_url).is_err() || blocked {
+                continue;
+            }
+            let Ok(response) = client.fetch(&import_url).await else { continue };
+            if !(200..400).contains(&response.status) {
+                continue;
+            }
+            let child_css = obscura_net::decode_non_html(&response.body, response.content_type());
+            let media = match (
+                inherited_media.trim().is_empty(),
+                import_media.trim().is_empty(),
+            ) {
+                (true, true) => String::new(),
+                (true, false) => import_media,
+                (false, true) => inherited_media.clone(),
+                (false, false) => format!("{} and {}", inherited_media, import_media),
+            };
+            output.extend(
+                fetch_dynamic_css_imports(
+                    client,
+                    import_url.clone(),
+                    child_css.clone(),
+                    media.clone(),
+                    page_origin.clone(),
+                    blocked_patterns,
+                    depth + 1,
+                    visited,
+                )
+                .await,
+            );
+            let same_origin = page_origin
+                .as_ref()
+                .map(|origin| origin == &import_url.origin())
+                .unwrap_or(true);
+            output.push((import_href, media, same_origin, child_css));
+        }
+        output
     })
+}
+
+/// Synchronous CSSOM/computed-style bridge. Only small metadata and requested
+/// results cross the V8 boundary; whole external stylesheets remain native.
+#[op2]
+#[string]
+fn op_css(
+    state: &OpState,
+    #[string] command: String,
+    #[string] arg1: String,
+    #[string] arg2: String,
+    #[string] arg3: String,
+) -> String {
+    let shared = state.borrow::<SharedState>().clone();
+    let mut gs = shared.borrow_mut();
+    match command.as_str() {
+        "enabled" => gs.css_enabled.to_string(),
+        "sheets" => {
+            serde_json::to_string(&gs.style_engine.sheet_infos()).unwrap_or_else(|_| "[]".into())
+        }
+        "rules" => {
+            let id = arg1.parse::<u32>().unwrap_or(0);
+            serde_json::to_string(&gs.style_engine.sheet_rules(id).unwrap_or_default())
+                .unwrap_or_else(|_| "[]".into())
+        }
+        "computed" => {
+            if !gs.css_enabled {
+                return "{}".to_string();
+            }
+            let node = NodeId::new(arg1.parse::<u32>().unwrap_or(0));
+            let environment: MediaEnvironment = serde_json::from_str(&arg2).unwrap_or_default();
+            let gs = &mut *gs;
+            let Some(dom) = gs.dom.as_ref() else {
+                return "{}".to_string();
+            };
+            let values = gs.style_engine.compute_style(dom, node, environment);
+            serde_json::to_string(&values).unwrap_or_else(|_| "{}".into())
+        }
+        "register" => {
+            if !gs.css_enabled {
+                return "0".to_string();
+            }
+            let owner = arg1.parse::<u32>().ok().map(NodeId::new);
+            let registration: SheetRegistration =
+                serde_json::from_str(&arg2).unwrap_or(SheetRegistration {
+                    href: None,
+                    media: String::new(),
+                    same_origin: true,
+                });
+            gs.style_engine
+                .replace_owner_stylesheet(
+                    owner.unwrap_or_else(|| NodeId::new(u32::MAX)),
+                    registration.href,
+                    registration.media,
+                    registration.same_origin,
+                    &arg3,
+                )
+                .unwrap_or(0)
+                .to_string()
+        }
+        "construct" => {
+            if !gs.css_enabled {
+                return "0".to_string();
+            }
+            gs.style_engine
+                .register_constructed(&arg3)
+                .unwrap_or(0)
+                .to_string()
+        }
+        "adopt" => {
+            let ids: Vec<u32> = serde_json::from_str(&arg1).unwrap_or_default();
+            gs.style_engine.set_adopted(&ids);
+            "true".to_string()
+        }
+        "remove-owner" => {
+            if let Ok(owner) = arg1.parse::<u32>() {
+                gs.style_engine.remove_owner(NodeId::new(owner));
+            }
+            "true".to_string()
+        }
+        "disable" => {
+            let id = arg1.parse::<u32>().unwrap_or(0);
+            gs.style_engine.set_disabled(id, arg2 == "true").to_string()
+        }
+        "insert" => {
+            let id = arg1.parse::<u32>().unwrap_or(0);
+            let index = arg2.parse::<usize>().unwrap_or(usize::MAX);
+            match gs.style_engine.insert_rule(id, &arg3, index) {
+                Ok((value, new_id)) => {
+                    serde_json::json!({"ok": true, "index": value, "id": new_id}).to_string()
+                }
+                Err(error) => serde_json::json!({"ok": false, "error": error}).to_string(),
+            }
+        }
+        "delete" => {
+            let id = arg1.parse::<u32>().unwrap_or(0);
+            let index = arg2.parse::<usize>().unwrap_or(usize::MAX);
+            match gs.style_engine.delete_rule(id, index) {
+                Ok(new_id) => serde_json::json!({"ok": true, "id": new_id}).to_string(),
+                Err(error) => serde_json::json!({"ok": false, "error": error}).to_string(),
+            }
+        }
+        "replace" => {
+            let id = arg1.parse::<u32>().unwrap_or(0);
+            match gs.style_engine.replace_sheet(id, &arg3) {
+                Ok(new_id) => serde_json::json!({"ok": true, "id": new_id}).to_string(),
+                Err(error) => serde_json::json!({"ok": false, "error": error}).to_string(),
+            }
+        }
+        _ => "null".to_string(),
+    }
+}
+
+/// Fetch and, in compute mode, register a dynamically inserted stylesheet.
+/// The response body is consumed entirely in Rust and never serialized through
+/// V8. Drop mode returns only lifecycle metadata after the body is drained.
+#[op2(async)]
+#[string]
+async fn op_load_stylesheet(
+    state: Rc<RefCell<OpState>>,
+    #[string] url: String,
+    owner_node: u32,
+    #[string] media: String,
+    same_origin: bool,
+) -> Result<String, deno_error::JsErrorBox> {
+    let parsed = url::Url::parse(&url)
+        .map_err(|error| deno_error::JsErrorBox::generic(error.to_string()))?;
+    if let Err(error) = validate_fetch_url(&parsed) {
+        return Ok(
+            serde_json::json!({"status": 0, "url": url, "blocked": true, "error": error})
+                .to_string(),
+        );
+    }
+
+    let (http_client, css_enabled, blocked, blocked_patterns, page_origin) = {
+        let state_borrow = state.borrow();
+        let shared = state_borrow.borrow::<SharedState>().clone();
+        let mut gs = shared.borrow_mut();
+        let blocked = gs
+            .blocked_urls
+            .iter()
+            .any(|pattern| pattern == "*" || url.contains(pattern) || glob_match(pattern, &url));
+        gs.fetched_urls.push(url.clone());
+        (
+            gs.http_client.clone(),
+            gs.css_enabled,
+            blocked,
+            gs.blocked_urls.clone(),
+            url::Url::parse(&gs.url).ok().map(|page| page.origin()),
+        )
+    };
+    if blocked {
+        return Ok(serde_json::json!({"status": 0, "url": url, "blocked": true}).to_string());
+    }
+
+    #[cfg(feature = "stealth")]
+    let stylesheet_client = {
+        let stealth = {
+            let state_borrow = state.borrow();
+            let shared = state_borrow.borrow::<SharedState>().clone();
+            let client = shared.borrow().stealth_client.clone();
+            client
+        };
+        if let Some(client) = stealth {
+            StylesheetFetchClient::Stealth(client)
+        } else {
+            let client = http_client
+                .clone()
+                .ok_or_else(|| deno_error::JsErrorBox::generic("HTTP client unavailable"))?;
+            StylesheetFetchClient::Regular(client)
+        }
+    };
+    #[cfg(not(feature = "stealth"))]
+    let stylesheet_client = {
+        let client = http_client
+            .ok_or_else(|| deno_error::JsErrorBox::generic("HTTP client unavailable"))?;
+        StylesheetFetchClient::Regular(client)
+    };
+
+    let response = stylesheet_client.fetch(&parsed).await;
+
+    let response = match response {
+        Ok(response) => response,
+        Err(error) => {
+            return Ok(
+                serde_json::json!({"status": 0, "url": url, "error": error.to_string()})
+                    .to_string(),
+            )
+        }
+    };
+    let status = response.status;
+    let body_size = response.body.len();
+    let loaded = (200..400).contains(&status);
+    let mut sheet_id = 0;
+    if loaded && css_enabled {
+        let css = obscura_net::decode_non_html(&response.body, response.content_type());
+        let mut visited = std::collections::HashSet::from([url.clone()]);
+        let imports = fetch_dynamic_css_imports(
+            &stylesheet_client,
+            parsed,
+            css.clone(),
+            media.clone(),
+            page_origin,
+            &blocked_patterns,
+            0,
+            &mut visited,
+        )
+        .await;
+        let state_borrow = state.borrow();
+        let shared = state_borrow.borrow::<SharedState>().clone();
+        let mut gs = shared.borrow_mut();
+        let owner = NodeId::new(owner_node);
+        gs.style_engine.remove_owner(owner);
+        for (import_url, import_media, import_same_origin, import_css) in imports {
+            gs.fetched_urls.push(import_url.clone());
+            gs.style_engine.register_import_stylesheet(
+                owner,
+                import_url,
+                import_media,
+                import_same_origin,
+                &import_css,
+            );
+        }
+        sheet_id = gs
+            .style_engine
+            .register_stylesheet(
+                Some(owner),
+                Some(url.clone()),
+                media,
+                same_origin,
+                &css,
+            )
+            .unwrap_or(0);
+    }
+    Ok(serde_json::json!({
+        "status": status,
+        "url": response.url.to_string(),
+        "bodySize": body_size,
+        "sheetId": sheet_id,
+    })
+    .to_string())
 }
 
 fn op_dom_inner(state: &OpState, cmd: String, arg1: String, arg2: String) -> String {
@@ -187,45 +557,74 @@ fn op_dom_inner(state: &OpState, cmd: String, arg1: String, arg2: String) -> Str
                 Some(n) => n.index().to_string(),
                 None => {
                     // Fall back to full scan for the live document.
-                    let sel = format!("[id=\"{}\"]", arg1.replace('\\', "\\\\").replace('"', "\\\""));
-                    dom.query_selector(&sel).ok().flatten()
-                        .map(|id| id.index().to_string()).unwrap_or("-1".into())
+                    let sel = format!(
+                        "[id=\"{}\"]",
+                        arg1.replace('\\', "\\\\").replace('"', "\\\"")
+                    );
+                    dom.query_selector(&sel)
+                        .ok()
+                        .flatten()
+                        .map(|id| id.index().to_string())
+                        .unwrap_or("-1".into())
                 }
             }
         }
-        "query_selector" => {
-            dom.query_selector(&arg1).ok().flatten().map(|id| id.index().to_string()).unwrap_or("-1".into())
-        }
+        "query_selector" => dom
+            .query_selector(&arg1)
+            .ok()
+            .flatten()
+            .map(|id| id.index().to_string())
+            .unwrap_or("-1".into()),
         "query_selector_all" => {
-            let ids: Vec<i32> = dom.query_selector_all(&arg1).ok()
-                .map(|ids| ids.iter().map(|id| id.index() as i32).collect()).unwrap_or_default();
+            let ids: Vec<i32> = dom
+                .query_selector_all(&arg1)
+                .ok()
+                .map(|ids| ids.iter().map(|id| id.index() as i32).collect())
+                .unwrap_or_default();
             serde_json::to_string(&ids).unwrap_or("[]".into())
         }
         "query_selector_scoped" => {
             let root_nid = arg1.parse::<u32>().unwrap_or(0);
-            dom.query_selector_from(NodeId::new(root_nid), &arg2).ok().flatten()
-                .map(|id| id.index().to_string()).unwrap_or("-1".into())
+            dom.query_selector_from(NodeId::new(root_nid), &arg2)
+                .ok()
+                .flatten()
+                .map(|id| id.index().to_string())
+                .unwrap_or("-1".into())
         }
         "query_selector_all_scoped" => {
             let root_nid = arg1.parse::<u32>().unwrap_or(0);
-            let ids: Vec<i32> = dom.query_selector_all_from(NodeId::new(root_nid), &arg2).ok()
-                .map(|ids| ids.iter().map(|id| id.index() as i32).collect()).unwrap_or_default();
+            let ids: Vec<i32> = dom
+                .query_selector_all_from(NodeId::new(root_nid), &arg2)
+                .ok()
+                .map(|ids| ids.iter().map(|id| id.index() as i32).collect())
+                .unwrap_or_default();
             serde_json::to_string(&ids).unwrap_or("[]".into())
         }
         "node_type" => {
             let nid = arg1.parse::<u32>().unwrap_or(0);
             dom.with_node(NodeId::new(nid), |n| match &n.data {
-                NodeData::Document => "9", NodeData::Element { .. } => "1", NodeData::Text { .. } => "3",
-                NodeData::Comment { .. } => "8", NodeData::Doctype { .. } => "10", NodeData::ProcessingInstruction { .. } => "7",
-            }).unwrap_or("0").into()
+                NodeData::Document => "9",
+                NodeData::Element { .. } => "1",
+                NodeData::Text { .. } => "3",
+                NodeData::Comment { .. } => "8",
+                NodeData::Doctype { .. } => "10",
+                NodeData::ProcessingInstruction { .. } => "7",
+            })
+            .unwrap_or("0")
+            .into()
         }
         "node_name" => {
             let nid = arg1.parse::<u32>().unwrap_or(0);
-            let name: String = dom.with_node(NodeId::new(nid), |n| match &n.data {
-                NodeData::Document => "#document".to_string(), NodeData::Element { name, .. } => name.local.as_ref().to_ascii_uppercase(),
-                NodeData::Text { .. } => "#text".to_string(), NodeData::Comment { .. } => "#comment".to_string(),
-                NodeData::Doctype { name, .. } => name.clone(), NodeData::ProcessingInstruction { target, .. } => target.clone(),
-            }).unwrap_or_default();
+            let name: String = dom
+                .with_node(NodeId::new(nid), |n| match &n.data {
+                    NodeData::Document => "#document".to_string(),
+                    NodeData::Element { name, .. } => name.local.as_ref().to_ascii_uppercase(),
+                    NodeData::Text { .. } => "#text".to_string(),
+                    NodeData::Comment { .. } => "#comment".to_string(),
+                    NodeData::Doctype { name, .. } => name.clone(),
+                    NodeData::ProcessingInstruction { target, .. } => target.clone(),
+                })
+                .unwrap_or_default();
             serde_json::to_string(&name).unwrap_or("\"\"".into())
         }
         "text_content" => {
@@ -235,24 +634,44 @@ fn op_dom_inner(state: &OpState, cmd: String, arg1: String, arg2: String) -> Str
         "parent_node" | "first_child" | "last_child" | "next_sibling" | "prev_sibling" => {
             let nid = arg1.parse::<u32>().unwrap_or(0);
             dom.with_node(NodeId::new(nid), |n| match cmd.as_str() {
-                "parent_node" => n.parent, "first_child" => n.first_child,
-                "last_child" => n.last_child, "next_sibling" => n.next_sibling,
-                "prev_sibling" => n.prev_sibling, _ => None,
-            }).flatten().map(|id| id.index().to_string()).unwrap_or("-1".into())
+                "parent_node" => n.parent,
+                "first_child" => n.first_child,
+                "last_child" => n.last_child,
+                "next_sibling" => n.next_sibling,
+                "prev_sibling" => n.prev_sibling,
+                _ => None,
+            })
+            .flatten()
+            .map(|id| id.index().to_string())
+            .unwrap_or("-1".into())
         }
         "child_nodes" => {
             let nid = arg1.parse::<u32>().unwrap_or(0);
-            let ids: Vec<i32> = dom.children(NodeId::new(nid)).iter().map(|id| id.index() as i32).collect();
+            let ids: Vec<i32> = dom
+                .children(NodeId::new(nid))
+                .iter()
+                .map(|id| id.index() as i32)
+                .collect();
             serde_json::to_string(&ids).unwrap_or("[]".into())
         }
         "tag_name" => {
             let nid = arg1.parse::<u32>().unwrap_or(0);
-            let name = dom.with_node(NodeId::new(nid), |n| n.as_element().map(|name| name.local.as_ref().to_ascii_uppercase())).flatten().unwrap_or_default();
+            let name = dom
+                .with_node(NodeId::new(nid), |n| {
+                    n.as_element()
+                        .map(|name| name.local.as_ref().to_ascii_uppercase())
+                })
+                .flatten()
+                .unwrap_or_default();
             serde_json::to_string(&name).unwrap_or("\"\"".into())
         }
         "get_attribute" => {
             let nid = arg1.parse::<u32>().unwrap_or(0);
-            let val = dom.with_node(NodeId::new(nid), |n| n.get_attribute(&arg2).map(|s| s.to_string())).flatten();
+            let val = dom
+                .with_node(NodeId::new(nid), |n| {
+                    n.get_attribute(&arg2).map(|s| s.to_string())
+                })
+                .flatten();
             serde_json::to_string(&val).unwrap_or("null".into())
         }
         "attribute_names" => {
@@ -260,7 +679,11 @@ fn op_dom_inner(state: &OpState, cmd: String, arg1: String, arg2: String) -> Str
             let names: Vec<String> = dom
                 .with_node(NodeId::new(nid), |n| {
                     n.attrs()
-                        .map(|a| a.iter().map(|x| x.name.local.as_ref().to_string()).collect())
+                        .map(|a| {
+                            a.iter()
+                                .map(|x| x.name.local.as_ref().to_string())
+                                .collect()
+                        })
                         .unwrap_or_default()
                 })
                 .unwrap_or_default();
@@ -338,37 +761,54 @@ fn op_dom_inner(state: &OpState, cmd: String, arg1: String, arg2: String) -> Str
         }
         "set_text_content" => {
             let nid = arg1.parse::<u32>().unwrap_or(0);
-            dom.with_node_mut(NodeId::new(nid), |n| {
-                match &mut n.data {
-                    NodeData::Text { contents } => { *contents = arg2.clone(); }
-                    NodeData::Comment { contents } => { *contents = arg2.clone(); }
-                    NodeData::ProcessingInstruction { data, .. } => { *data = arg2.clone(); }
-                    _ => {}
+            dom.with_node_mut(NodeId::new(nid), |n| match &mut n.data {
+                NodeData::Text { contents } => {
+                    *contents = arg2.clone();
                 }
+                NodeData::Comment { contents } => {
+                    *contents = arg2.clone();
+                }
+                NodeData::ProcessingInstruction { data, .. } => {
+                    *data = arg2.clone();
+                }
+                _ => {}
             });
             "true".into()
         }
-        "create_document_fragment" => {
-            dom.new_node(NodeData::Document).index().to_string()
-        }
-        "create_element" => {
-            dom.new_node(NodeData::Element {
-                name: html5ever::QualName::new(None, html5ever::ns!(html), html5ever::LocalName::from(arg1.as_str())),
-                attrs: vec![], template_contents: None, mathml_annotation_xml_integration_point: false,
-            }).index().to_string()
-        }
-        "create_text_node" => {
-            dom.new_node(NodeData::Text { contents: arg1.clone() }).index().to_string()
-        }
-        "create_comment_node" => {
-            dom.new_node(NodeData::Comment { contents: arg1.clone() }).index().to_string()
-        }
+        "create_document_fragment" => dom.new_node(NodeData::Document).index().to_string(),
+        "create_element" => dom
+            .new_node(NodeData::Element {
+                name: html5ever::QualName::new(
+                    None,
+                    html5ever::ns!(html),
+                    html5ever::LocalName::from(arg1.as_str()),
+                ),
+                attrs: vec![],
+                template_contents: None,
+                mathml_annotation_xml_integration_point: false,
+            })
+            .index()
+            .to_string(),
+        "create_text_node" => dom
+            .new_node(NodeData::Text {
+                contents: arg1.clone(),
+            })
+            .index()
+            .to_string(),
+        "create_comment_node" => dom
+            .new_node(NodeData::Comment {
+                contents: arg1.clone(),
+            })
+            .index()
+            .to_string(),
         "create_processing_instruction" => {
             // arg1 = target, arg2 = data
             dom.new_node(NodeData::ProcessingInstruction {
                 target: arg1.clone(),
                 data: arg2.clone(),
-            }).index().to_string()
+            })
+            .index()
+            .to_string()
         }
         "create_doctype" => {
             // arg1 = name, arg2 = public_id. system_id stored only in the
@@ -823,11 +1263,17 @@ async fn op_fetch_url(
             .header("Access-Control-Request-Method", method.as_str())
             .header(
                 "Access-Control-Request-Headers",
-                custom_headers.keys().cloned().collect::<Vec<_>>().join(", "),
+                custom_headers
+                    .keys()
+                    .cloned()
+                    .collect::<Vec<_>>()
+                    .join(", "),
             )
             .send()
             .await
-            .map_err(|e| deno_error::JsErrorBox::generic(format!("CORS preflight failed: {}", e)))?;
+            .map_err(|e| {
+                deno_error::JsErrorBox::generic(format!("CORS preflight failed: {}", e))
+            })?;
 
         let allowed_origin = preflight
             .headers()
@@ -1458,7 +1904,9 @@ fn op_subtle_aes_gcm(
             } else {
                 cipher
                     .decrypt(nonce, Payload { msg: data, aad })
-                    .map_err(|_| crypto_err("AES-GCM decryption failed: authentication tag mismatch"))?
+                    .map_err(|_| {
+                        crypto_err("AES-GCM decryption failed: authentication tag mismatch")
+                    })?
             }
         }};
     }
@@ -1547,7 +1995,11 @@ fn op_subtle_aes_ctr(
         128 => by_key!(Ctr128BE),
         64 => by_key!(Ctr64BE),
         32 => by_key!(Ctr32BE),
-        _ => return Err(crypto_err("AES-CTR supports counter lengths of 32, 64, or 128 bits")),
+        _ => {
+            return Err(crypto_err(
+                "AES-CTR supports counter lengths of 32, 64, or 128 bits",
+            ))
+        }
     }
     Ok(buf)
 }
@@ -1826,6 +2278,8 @@ pub fn build_extension() -> Extension {
         name: "obscura_dom",
         ops: std::borrow::Cow::Owned(vec![
             op_dom(),
+            op_css(),
+            op_load_stylesheet(),
             op_console_msg(),
             op_fetch_url(),
             op_get_cookies(),

--- a/crates/obscura-js/src/runtime.rs
+++ b/crates/obscura-js/src/runtime.rs
@@ -2176,6 +2176,120 @@ mod tests {
     }
 
     #[tokio::test(flavor = "current_thread")]
+    async fn test_dynamic_stylesheet_fetches_and_fires_load_or_error() {
+        let mut rt =
+            setup_runtime("<html><head><meta charset=\"utf-8\"></head><body></body></html>");
+        rt.run_page_init();
+        let result = rt
+            .call_function_on_for_cdp(
+                r#"async () => {
+                const originalFetchOp = Deno.core.ops.op_fetch_url;
+                const calls = [];
+                try {
+                    Deno.core.ops.op_fetch_url = (url, method, headers, body, origin, mode) => {
+                        calls.push({ url, method, headers: JSON.parse(headers), body, origin, mode });
+                        return JSON.stringify({
+                            status: url.endsWith('/missing.css') ? 404 : 200,
+                            headers: { 'content-type': 'text/css' },
+                            body: 'body { color: green; }',
+                            url,
+                        });
+                    };
+
+                    const loaded = document.createElement('link');
+                    loaded.rel = 'stylesheet';
+                    loaded.href = '/app.css';
+                    const loadEvent = new Promise(resolve => loaded.onload = () => resolve('load'));
+                    document.head.appendChild(loaded);
+
+                    const missing = document.createElement('link');
+                    missing.rel = 'stylesheet';
+                    missing.href = '/missing.css';
+                    const errorEvent = new Promise(resolve => missing.addEventListener('error', () => resolve('error')));
+                    document.head.insertBefore(missing, document.head.firstChild);
+
+                    const late = document.createElement('link');
+                    const lateEvent = new Promise(resolve => late.addEventListener('load', () => resolve('load')));
+                    document.head.appendChild(late);
+                    late.rel = 'stylesheet';
+                    late.href = 'late.css';
+
+                    const base = document.createElement('base');
+                    base.href = 'https://cdn.example/assets/';
+                    document.head.appendChild(base);
+                    const based = document.createElement('link');
+                    based.rel = 'stylesheet';
+                    based.href = 'theme.css';
+                    const basedEvent = new Promise(resolve => based.onload = () => resolve('load'));
+                    document.head.appendChild(based);
+
+                    return JSON.stringify({
+                        events: await Promise.all([loadEvent, errorEvent, lateEvent, basedEvent]),
+                        reflectedRel: loaded.getAttribute('rel'),
+                        calls,
+                    });
+                } catch (error) {
+                    return 'ERROR:' + String(error && (error.stack || error));
+                } finally {
+                    Deno.core.ops.op_fetch_url = originalFetchOp;
+                }
+            }"#,
+                None,
+                &[],
+                true,
+                true,
+            )
+            .await
+            .unwrap();
+
+        let raw = result.value.unwrap();
+        let raw = raw.as_str().unwrap();
+        assert!(!raw.starts_with("ERROR:"), "{}", raw);
+        let value: serde_json::Value = serde_json::from_str(raw).unwrap();
+        assert_eq!(
+            value,
+            serde_json::json!({
+                "events": ["load", "error", "load", "load"],
+                "reflectedRel": "stylesheet",
+                "calls": [
+                    {
+                        "url": "http://example.com/app.css",
+                        "method": "GET",
+                        "headers": { "accept": "text/css,*/*;q=0.1" },
+                        "body": "",
+                        "origin": "http://example.com",
+                        "mode": "no-cors",
+                    },
+                    {
+                        "url": "http://example.com/missing.css",
+                        "method": "GET",
+                        "headers": { "accept": "text/css,*/*;q=0.1" },
+                        "body": "",
+                        "origin": "http://example.com",
+                        "mode": "no-cors",
+                    },
+                    {
+                        "url": "http://example.com/late.css",
+                        "method": "GET",
+                        "headers": { "accept": "text/css,*/*;q=0.1" },
+                        "body": "",
+                        "origin": "http://example.com",
+                        "mode": "no-cors",
+                    },
+                    {
+                        "url": "https://cdn.example/assets/theme.css",
+                        "method": "GET",
+                        "headers": { "accept": "text/css,*/*;q=0.1" },
+                        "body": "",
+                        "origin": "http://example.com",
+                        "mode": "no-cors",
+                    },
+                ],
+            })
+        );
+    }
+
+    #[tokio::test(flavor = "current_thread")]
     async fn test_response_array_buffer_preserves_typed_array_view() {
         let mut rt = setup_runtime("<html><body></body></html>");
         let result = rt.call_function_on_for_cdp(

--- a/crates/obscura-js/src/runtime.rs
+++ b/crates/obscura-js/src/runtime.rs
@@ -164,6 +164,96 @@ impl ObscuraJsRuntime {
         self.state.borrow_mut().dom = Some(dom);
     }
 
+    pub fn set_css_enabled(&self, enabled: bool) {
+        let mut state = self.state.borrow_mut();
+        state.css_enabled = enabled;
+        if !enabled {
+            state.style_engine.clear();
+        }
+    }
+
+    pub fn register_stylesheet(
+        &self,
+        owner_node: Option<obscura_dom::NodeId>,
+        href: Option<String>,
+        media: String,
+        same_origin: bool,
+        css: &str,
+    ) -> Option<u32> {
+        let mut state = self.state.borrow_mut();
+        if !state.css_enabled {
+            return None;
+        }
+        let disabled = owner_node
+            .and_then(|node| {
+                state.dom.as_ref().and_then(|dom| {
+                    dom.with_node(node, |entry| entry.get_attribute("disabled").is_some())
+                })
+            })
+            .unwrap_or(false);
+        let id = state
+            .style_engine
+            .register_stylesheet(owner_node, href, media, same_origin, css);
+        if disabled {
+            if let Some(id) = id {
+                state.style_engine.set_disabled(id, true);
+            }
+        }
+        id
+    }
+
+    pub fn register_import_stylesheet(
+        &self,
+        owner_node: obscura_dom::NodeId,
+        href: String,
+        media: String,
+        same_origin: bool,
+        css: &str,
+    ) -> Option<u32> {
+        let mut state = self.state.borrow_mut();
+        if !state.css_enabled {
+            return None;
+        }
+        state.style_engine.register_import_stylesheet(
+            owner_node,
+            href,
+            media,
+            same_origin,
+            css,
+        )
+    }
+
+    /// Register parser-created `<style>` elements before page scripts run.
+    pub fn register_inline_stylesheets(&self) {
+        let inline = {
+            let state = self.state.borrow();
+            let Some(dom) = state.dom.as_ref() else {
+                return;
+            };
+            dom.query_selector_all("style")
+                .unwrap_or_default()
+                .into_iter()
+                .map(|node| {
+                    let media = dom
+                        .with_node(node, |entry| {
+                            entry.get_attribute("media").unwrap_or("").to_string()
+                        })
+                        .unwrap_or_default();
+                    (node, media, dom.text_content(node))
+                })
+                .collect::<Vec<_>>()
+        };
+        let mut state = self.state.borrow_mut();
+        if !state.css_enabled {
+            return;
+        }
+        for (node, media, css) in inline {
+            state
+                .style_engine
+                .register_stylesheet(Some(node), None, media, true, &css);
+        }
+    }
+
     pub fn set_url(&self, url: &str) {
         self.state.borrow_mut().url = url.to_string();
     }
@@ -346,13 +436,17 @@ impl ObscuraJsRuntime {
             let __t0 = std::time::Instant::now();
             let sentinel = format!("globalThis.__obscura_done_{done_counter} === true");
             self.resolve_promises_until(
-                |rt| rt.runtime.execute_script("<done?>", sentinel.clone())
-                    .ok()
-                    .and_then(|v| rt.v8_to_json(v).ok())
-                    .and_then(|j| j.as_bool())
-                    .unwrap_or(false),
+                |rt| {
+                    rt.runtime
+                        .execute_script("<done?>", sentinel.clone())
+                        .ok()
+                        .and_then(|v| rt.v8_to_json(v).ok())
+                        .and_then(|j| j.as_bool())
+                        .unwrap_or(false)
+                },
                 5000,
-            ).await;
+            )
+            .await;
             let __dt = __t0.elapsed();
             if __dt > std::time::Duration::from_secs(1) {
                 let preview: String = expression
@@ -450,13 +544,17 @@ impl ObscuraJsRuntime {
             let __t0 = std::time::Instant::now();
             let sentinel = format!("globalThis.__obscura_done_{done_counter} === true");
             self.resolve_promises_until(
-                |rt| rt.runtime.execute_script("<done?>", sentinel.clone())
-                    .ok()
-                    .and_then(|v| rt.v8_to_json(v).ok())
-                    .and_then(|j| j.as_bool())
-                    .unwrap_or(false),
+                |rt| {
+                    rt.runtime
+                        .execute_script("<done?>", sentinel.clone())
+                        .ok()
+                        .and_then(|v| rt.v8_to_json(v).ok())
+                        .and_then(|j| j.as_bool())
+                        .unwrap_or(false)
+                },
                 5000,
-            ).await;
+            )
+            .await;
             let __dt = __t0.elapsed();
             if __dt > std::time::Duration::from_secs(1) {
                 let preview: String = function_declaration
@@ -1275,10 +1373,11 @@ mod tests {
 
     fn setup_runtime(html: &str) -> ObscuraJsRuntime {
         let dom = parse_html(html);
-        let rt = ObscuraJsRuntime::new();
+        let mut rt = ObscuraJsRuntime::new();
         rt.set_dom(dom);
         rt.set_url("http://example.com/test");
         rt.set_title("Test Page");
+        rt.run_page_init();
         rt
     }
 
@@ -1470,6 +1569,131 @@ mod tests {
         assert_eq!(p["getByDash"], "14px");
     }
 
+    #[test]
+    fn native_stylesheet_drives_computed_style_and_cssom() {
+        let mut rt = setup_runtime("<html><head><link rel='stylesheet' href='/app.css'></head><body><div id='target' class='card'>x</div></body></html>");
+        let owner = rt
+            .with_dom(|dom| dom.query_selector("link").unwrap().unwrap())
+            .unwrap();
+        rt.register_stylesheet(
+            Some(owner),
+            Some("http://example.com/app.css".to_string()),
+            String::new(),
+            true,
+            ":root { --brand: blue } .card { color: var(--brand); margin: 1px 2px; display: flex }",
+        );
+        let result = rt
+            .evaluate(
+                r#"JSON.stringify((() => {
+            const el = document.getElementById('target');
+            const style = getComputedStyle(el);
+            return {
+                color: style.color,
+                display: style.display,
+                marginLeft: style.marginLeft,
+                custom: style.getPropertyValue('--brand'),
+                sheets: document.styleSheets.length,
+                rules: document.styleSheets[0].cssRules.length,
+                owner: document.styleSheets[0].ownerNode === document.querySelector('link'),
+                linked: document.querySelector('link').sheet === document.styleSheets[0]
+            };
+        })())"#,
+            )
+            .unwrap();
+        let value: serde_json::Value = serde_json::from_str(result.as_str().unwrap()).unwrap();
+        assert_eq!(value["color"], "rgb(0, 0, 255)");
+        assert_eq!(value["display"], "flex");
+        assert_eq!(value["marginLeft"], "2px");
+        assert_eq!(value["custom"], "blue");
+        assert_eq!(value["sheets"], 1);
+        assert_eq!(value["rules"], 2);
+        assert_eq!(value["owner"], true);
+        assert_eq!(value["linked"], true);
+    }
+
+    #[test]
+    fn cssom_mutations_constructed_sheets_and_invalidation_reach_native_engine() {
+        let mut rt = setup_runtime(
+            "<html><body><div id='target' class='card'>x</div></body></html>",
+        );
+        let result = rt
+            .evaluate(
+                r#"JSON.stringify((() => {
+            const el = document.getElementById('target');
+            const sheet = new CSSStyleSheet();
+            sheet.replaceSync('.card { display: grid; color: red }');
+            document.adoptedStyleSheets = [sheet];
+            const initial = getComputedStyle(el);
+            const before = { display: initial.display, color: initial.color };
+            const index = sheet.insertRule('.card { display: flex !important }', 1);
+            const inserted = getComputedStyle(el).display;
+            sheet.deleteRule(index);
+            const deleted = getComputedStyle(el).display;
+            el.className = 'other';
+            const classChanged = getComputedStyle(el).display;
+            return { before, inserted, deleted, classChanged, sheets: document.styleSheets.length,
+                     adopted: document.adoptedStyleSheets.length, rules: sheet.cssRules.length };
+        })())"#,
+            )
+            .unwrap();
+        let value: serde_json::Value = serde_json::from_str(result.as_str().unwrap()).unwrap();
+        assert_eq!(value["before"]["display"], "grid");
+        assert_eq!(value["before"]["color"], "rgb(255, 0, 0)");
+        assert_eq!(value["inserted"], "flex");
+        assert_eq!(value["deleted"], "grid");
+        assert_eq!(value["classChanged"], "block");
+        assert_eq!(value["sheets"], 0);
+        assert_eq!(value["adopted"], 1);
+        assert_eq!(value["rules"], 1);
+    }
+
+    #[test]
+    fn cross_origin_css_rules_throw_security_error() {
+        let mut rt = setup_runtime(
+            "<html><head><link rel='stylesheet' href='https://cdn.example/app.css'></head><body></body></html>",
+        );
+        let owner = rt
+            .with_dom(|dom| dom.query_selector("link").unwrap().unwrap())
+            .unwrap();
+        rt.register_stylesheet(
+            Some(owner),
+            Some("https://cdn.example/app.css".to_string()),
+            String::new(),
+            false,
+            "body { color: red }",
+        );
+        let result = rt
+            .evaluate(
+                r#"JSON.stringify((() => { try { document.styleSheets[0].cssRules; return null; }
+                    catch (error) { return { name: error.name, message: error.message }; } })())"#,
+            )
+            .unwrap();
+        let value: serde_json::Value = serde_json::from_str(result.as_str().unwrap()).unwrap();
+        assert_eq!(value["name"], "SecurityError");
+    }
+
+    #[test]
+    fn drop_mode_keeps_inline_style_but_exposes_no_sheets() {
+        let mut rt = setup_runtime("<html><head><style>.x { color: red }</style></head><body><div id='target' class='x' style='display: grid'></div></body></html>");
+        rt.set_css_enabled(false);
+        rt.register_inline_stylesheets();
+        let result = rt
+            .evaluate(
+                r#"JSON.stringify({
+            sheets: document.styleSheets.length,
+            sheet: document.querySelector('style').sheet,
+            color: getComputedStyle(document.getElementById('target')).color,
+            display: getComputedStyle(document.getElementById('target')).display
+        })"#,
+            )
+            .unwrap();
+        let value: serde_json::Value = serde_json::from_str(result.as_str().unwrap()).unwrap();
+        assert_eq!(value["sheets"], 0);
+        assert!(value["sheet"].is_null());
+        assert_eq!(value["color"], "rgb(0, 0, 0)");
+        assert_eq!(value["display"], "grid");
+    }
+
     /// Regression for #105: `element.querySelector` and `querySelectorAll`
     /// must scope to the receiver's subtree, not the whole document.
     #[test]
@@ -1507,12 +1731,29 @@ mod tests {
     /// `document.forms` and crashes when it's empty for pages that have forms.
     #[test]
     fn document_forms_images_links_are_live() {
-        let mut rt = setup_runtime(
-            r#"<form></form><form></form><img><a href="x">l</a><a>no-href</a>"#,
+        let mut rt =
+            setup_runtime(r#"<form></form><form></form><img><a href="x">l</a><a>no-href</a>"#);
+        assert_eq!(
+            rt.evaluate("document.forms.length")
+                .unwrap()
+                .as_f64()
+                .unwrap() as i64,
+            2
         );
-        assert_eq!(rt.evaluate("document.forms.length").unwrap().as_f64().unwrap() as i64, 2);
-        assert_eq!(rt.evaluate("document.images.length").unwrap().as_f64().unwrap() as i64, 1);
-        assert_eq!(rt.evaluate("document.links.length").unwrap().as_f64().unwrap() as i64, 1);
+        assert_eq!(
+            rt.evaluate("document.images.length")
+                .unwrap()
+                .as_f64()
+                .unwrap() as i64,
+            1
+        );
+        assert_eq!(
+            rt.evaluate("document.links.length")
+                .unwrap()
+                .as_f64()
+                .unwrap() as i64,
+            1
+        );
     }
 
     /// Regression for #105: `HTMLFormElement` must expose `.elements` so
@@ -1864,7 +2105,10 @@ mod tests {
             rt1b.set_url("http://example.com");
             rt1b.set_title("Page1");
             let mut rt1b = rt1b;
-            let title1b = rt1b.evaluate("document.querySelector('h1').textContent").unwrap();
+            rt1b.run_page_init();
+            let title1b = rt1b
+                .evaluate("document.querySelector('h1').textContent")
+                .unwrap();
             assert_eq!(title1b, serde_json::json!("Page1"));
         }
     }
@@ -1980,24 +2224,29 @@ mod tests {
         let mut rt = setup_runtime("<html><body></body></html>");
         let obj = rt
             .call_function_on("() => ({ x: 42 })", None, &[], false)
-            .await.unwrap();
+            .await
+            .unwrap();
         let oid = obj.object_id.unwrap();
 
         let args = vec![serde_json::json!({"objectId": oid})];
         let result = rt
             .call_function_on("(obj) => obj.x * 2", None, &args, true)
-            .await.unwrap();
+            .await
+            .unwrap();
         assert_eq!(result.value.unwrap().as_f64().unwrap() as i64, 84);
     }
 
-    fn setup_runtime_with_cookies(html: &str) -> (ObscuraJsRuntime, std::sync::Arc<obscura_net::CookieJar>) {
+    fn setup_runtime_with_cookies(
+        html: &str,
+    ) -> (ObscuraJsRuntime, std::sync::Arc<obscura_net::CookieJar>) {
         let dom = obscura_dom::parse_html(html);
         let jar = std::sync::Arc::new(obscura_net::CookieJar::new());
-        let rt = ObscuraJsRuntime::new();
+        let mut rt = ObscuraJsRuntime::new();
         rt.set_dom(dom);
         rt.set_url("http://example.com/test");
         rt.set_title("Test Page");
         rt.set_cookie_jar(jar.clone());
+        rt.run_page_init();
         (rt, jar)
     }
 
@@ -2179,19 +2428,16 @@ mod tests {
     async fn test_dynamic_stylesheet_fetches_and_fires_load_or_error() {
         let mut rt =
             setup_runtime("<html><head><meta charset=\"utf-8\"></head><body></body></html>");
-        rt.run_page_init();
         let result = rt
             .call_function_on_for_cdp(
                 r#"async () => {
-                const originalFetchOp = Deno.core.ops.op_fetch_url;
+                const originalLoadStylesheetOp = Deno.core.ops.op_load_stylesheet;
                 const calls = [];
                 try {
-                    Deno.core.ops.op_fetch_url = (url, method, headers, body, origin, mode) => {
-                        calls.push({ url, method, headers: JSON.parse(headers), body, origin, mode });
+                    Deno.core.ops.op_load_stylesheet = (url, ownerNode, media, sameOrigin) => {
+                        calls.push({ url, ownerNode, media, sameOrigin });
                         return JSON.stringify({
                             status: url.endsWith('/missing.css') ? 404 : 200,
-                            headers: { 'content-type': 'text/css' },
-                            body: 'body { color: green; }',
                             url,
                         });
                     };
@@ -2231,7 +2477,7 @@ mod tests {
                 } catch (error) {
                     return 'ERROR:' + String(error && (error.stack || error));
                 } finally {
-                    Deno.core.ops.op_fetch_url = originalFetchOp;
+                    Deno.core.ops.op_load_stylesheet = originalLoadStylesheetOp;
                 }
             }"#,
                 None,
@@ -2254,35 +2500,27 @@ mod tests {
                 "calls": [
                     {
                         "url": "http://example.com/app.css",
-                        "method": "GET",
-                        "headers": { "accept": "text/css,*/*;q=0.1" },
-                        "body": "",
-                        "origin": "http://example.com",
-                        "mode": "no-cors",
+                        "ownerNode": 5,
+                        "media": "",
+                        "sameOrigin": true,
                     },
                     {
                         "url": "http://example.com/missing.css",
-                        "method": "GET",
-                        "headers": { "accept": "text/css,*/*;q=0.1" },
-                        "body": "",
-                        "origin": "http://example.com",
-                        "mode": "no-cors",
+                        "ownerNode": 6,
+                        "media": "",
+                        "sameOrigin": true,
                     },
                     {
                         "url": "http://example.com/late.css",
-                        "method": "GET",
-                        "headers": { "accept": "text/css,*/*;q=0.1" },
-                        "body": "",
-                        "origin": "http://example.com",
-                        "mode": "no-cors",
+                        "ownerNode": 7,
+                        "media": "",
+                        "sameOrigin": true,
                     },
                     {
                         "url": "https://cdn.example/assets/theme.css",
-                        "method": "GET",
-                        "headers": { "accept": "text/css,*/*;q=0.1" },
-                        "body": "",
-                        "origin": "http://example.com",
-                        "mode": "no-cors",
+                        "ownerNode": 9,
+                        "media": "",
+                        "sameOrigin": false,
                     },
                 ],
             })

--- a/crates/obscura/src/browser.rs
+++ b/crates/obscura/src/browser.rs
@@ -1,7 +1,7 @@
-use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::Arc;
 
-use obscura_browser::BrowserContext;
+use obscura_browser::{BrowserContext, BrowserContextOptions};
 use obscura_net::CookieJar;
 
 use crate::config::BrowserConfig;
@@ -22,27 +22,25 @@ impl Browser {
     }
 
     pub fn build(config: BrowserConfig) -> Result<Self, Error> {
-        let context = if let Some(ref dir) = config.storage_dir {
-            BrowserContext::with_storage_full(
-                "api".to_string(),
-                config.proxy,
-                config.stealth,
-                config.user_agent,
-                Some(dir.clone()),
-            )
-        } else {
-            BrowserContext::with_full_options(
-                "api".to_string(),
-                config.proxy,
-                config.stealth,
-                config.user_agent,
-            )
-        };
+        let context = BrowserContext::with_config(
+            "api".to_string(),
+            BrowserContextOptions {
+                proxy_url: config.proxy,
+                stealth: config.stealth,
+                user_agent: config.user_agent,
+                storage_dir: config.storage_dir,
+                allow_private_network: false,
+                css_mode: config.css_mode,
+            },
+        );
 
         let context = Arc::new(context);
         let cookie_jar = context.cookie_jar.clone();
 
-        Ok(Browser { context, cookie_jar })
+        Ok(Browser {
+            context,
+            cookie_jar,
+        })
     }
 
     pub fn builder() -> BrowserBuilder {
@@ -86,6 +84,10 @@ impl BrowserBuilder {
     }
     pub fn storage_dir(mut self, dir: impl Into<std::path::PathBuf>) -> Self {
         self.config.storage_dir = Some(dir.into());
+        self
+    }
+    pub fn css_mode(mut self, mode: obscura_browser::CssMode) -> Self {
+        self.config.css_mode = mode;
         self
     }
     pub fn build(self) -> Result<Browser, Error> {

--- a/crates/obscura/src/config.rs
+++ b/crates/obscura/src/config.rs
@@ -1,3 +1,4 @@
+use obscura_browser::CssMode;
 use std::path::PathBuf;
 
 /// Configuration for launching a Browser instance.
@@ -10,6 +11,8 @@ pub struct BrowserConfig {
     pub user_agent: Option<String>,
     /// Directory for persistent cookie storage
     pub storage_dir: Option<PathBuf>,
+    /// Stylesheet processing policy. Defaults to lightweight computation.
+    pub css_mode: CssMode,
 }
 
 impl Default for BrowserConfig {
@@ -19,6 +22,7 @@ impl Default for BrowserConfig {
             stealth: false,
             user_agent: None,
             storage_dir: None,
+            css_mode: CssMode::Compute,
         }
     }
 }
@@ -52,6 +56,11 @@ impl BrowserConfigBuilder {
 
     pub fn storage_dir(mut self, dir: impl Into<PathBuf>) -> Self {
         self.config.storage_dir = Some(dir.into());
+        self
+    }
+
+    pub fn css_mode(mut self, mode: CssMode) -> Self {
+        self.config.css_mode = mode;
         self
     }
 

--- a/crates/obscura/src/lib.rs
+++ b/crates/obscura/src/lib.rs
@@ -28,5 +28,5 @@ pub use error::Error;
 pub use page::Page;
 
 // Request/response interception types (issue #306).
-pub use obscura_browser::{InterceptedRequest, InterceptResolution};
+pub use obscura_browser::{CssMode, InterceptResolution, InterceptedRequest};
 pub use obscura_net::{RequestCallback, RequestInfo, ResourceType, Response, ResponseCallback};

--- a/crates/obscura/tests/dynamic_stylesheet.rs
+++ b/crates/obscura/tests/dynamic_stylesheet.rs
@@ -2,7 +2,7 @@ use std::io::{Read, Write};
 use std::sync::atomic::{AtomicU32, Ordering};
 use std::sync::Arc;
 
-use obscura::Browser;
+use obscura::{Browser, CssMode};
 
 fn spawn_stylesheet_server() -> (String, Arc<AtomicU32>) {
     let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
@@ -22,7 +22,10 @@ fn spawn_stylesheet_server() -> (String, Arc<AtomicU32>) {
             let path = request.split_whitespace().nth(1).unwrap_or("/");
             let (content_type, body) = if path == "/dynamic.css" {
                 request_count.fetch_add(1, Ordering::SeqCst);
-                ("text/css", "body { color: green; }")
+                ("text/css", "@import url('/import.css'); body { color: green; }")
+            } else if path == "/import.css" {
+                request_count.fetch_add(1, Ordering::SeqCst);
+                ("text/css", "body { background-color: red; }")
             } else {
                 (
                     "text/html",
@@ -70,5 +73,40 @@ async fn dynamically_inserted_stylesheet_fetches_and_fires_load() {
         page.evaluate("globalThis.stylesheetEvent"),
         serde_json::json!("load")
     );
+    assert_eq!(
+        page.evaluate("getComputedStyle(document.body).backgroundColor"),
+        serde_json::json!("rgb(255, 0, 0)")
+    );
+    assert_eq!(
+        page.evaluate("document.styleSheets.length").as_f64(),
+        Some(1.0)
+    );
+    assert_eq!(stylesheet_requests.load(Ordering::SeqCst), 2);
+}
+
+#[tokio::test]
+async fn drop_mode_dynamic_stylesheet_still_fetches_and_fires_load() {
+    std::env::set_var("OBSCURA_ALLOW_PRIVATE_NETWORK", "1");
+    let (base_url, stylesheet_requests) = spawn_stylesheet_server();
+    let browser = Browser::builder()
+        .css_mode(CssMode::Drop)
+        .build()
+        .unwrap();
+    let mut page = browser.new_page().await.unwrap();
+
+    page.goto(&base_url).await.unwrap();
+    for _ in 0..20 {
+        page.settle(100).await;
+        if page.evaluate("globalThis.stylesheetEvent") == serde_json::json!("load") {
+            break;
+        }
+    }
+
+    assert_eq!(page.evaluate("globalThis.stylesheetEvent"), serde_json::json!("load"));
+    assert_eq!(
+        page.evaluate("document.styleSheets.length").as_f64(),
+        Some(0.0)
+    );
+    assert_eq!(page.evaluate("document.querySelector('link').sheet"), serde_json::Value::Null);
     assert_eq!(stylesheet_requests.load(Ordering::SeqCst), 1);
 }

--- a/crates/obscura/tests/dynamic_stylesheet.rs
+++ b/crates/obscura/tests/dynamic_stylesheet.rs
@@ -1,0 +1,74 @@
+use std::io::{Read, Write};
+use std::sync::atomic::{AtomicU32, Ordering};
+use std::sync::Arc;
+
+use obscura::Browser;
+
+fn spawn_stylesheet_server() -> (String, Arc<AtomicU32>) {
+    let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+    let addr = listener.local_addr().unwrap();
+    let stylesheet_requests = Arc::new(AtomicU32::new(0));
+    let request_count = stylesheet_requests.clone();
+
+    std::thread::spawn(move || {
+        for incoming in listener.incoming() {
+            let mut stream = match incoming {
+                Ok(stream) => stream,
+                Err(_) => continue,
+            };
+            let mut buffer = [0u8; 4096];
+            let bytes_read = stream.read(&mut buffer).unwrap_or(0);
+            let request = std::str::from_utf8(&buffer[..bytes_read]).unwrap_or("");
+            let path = request.split_whitespace().nth(1).unwrap_or("/");
+            let (content_type, body) = if path == "/dynamic.css" {
+                request_count.fetch_add(1, Ordering::SeqCst);
+                ("text/css", "body { color: green; }")
+            } else {
+                (
+                    "text/html",
+                    r#"<script>
+                        globalThis.stylesheetEvent = "pending";
+                        const link = document.createElement("link");
+                        link.rel = "stylesheet";
+                        link.href = "/dynamic.css";
+                        link.onload = () => globalThis.stylesheetEvent = "load";
+                        link.addEventListener("error", () => globalThis.stylesheetEvent = "error");
+                        document.head.appendChild(link);
+                    </script>"#,
+                )
+            };
+            let response = format!(
+                "HTTP/1.1 200 OK\r\nContent-Type: {}\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+                content_type,
+                body.len(),
+                body
+            );
+            let _ = stream.write_all(response.as_bytes());
+            let _ = stream.shutdown(std::net::Shutdown::Both);
+        }
+    });
+
+    (format!("http://{}", addr), stylesheet_requests)
+}
+
+#[tokio::test]
+async fn dynamically_inserted_stylesheet_fetches_and_fires_load() {
+    std::env::set_var("OBSCURA_ALLOW_PRIVATE_NETWORK", "1");
+    let (base_url, stylesheet_requests) = spawn_stylesheet_server();
+    let browser = Browser::new().unwrap();
+    let mut page = browser.new_page().await.unwrap();
+
+    page.goto(&base_url).await.unwrap();
+    for _ in 0..20 {
+        page.settle(100).await;
+        if page.evaluate("globalThis.stylesheetEvent") == serde_json::json!("load") {
+            break;
+        }
+    }
+
+    assert_eq!(
+        page.evaluate("globalThis.stylesheetEvent"),
+        serde_json::json!("load")
+    );
+    assert_eq!(stylesheet_requests.load(Ordering::SeqCst), 1);
+}


### PR DESCRIPTION
## tl;dr

on a controlled replay of the current live bootstrap 5.3 documentation page (70,809 bytes of html, 1,061 dom nodes, and 293,950 bytes of production css), this pr turns the existing all-cost/no-cssom behavior into an explicit choice:

- `compute` adds real css computation, 2 visible stylesheets, 3,377 retained rules, and the correct bootstrap body color for **+7.19 ms median wall time and only +0.47 mib median rss** versus current upstream obscura.
- `drop` preserves the no-css path while improving on current upstream obscura by **1.88 ms / 9.5% median wall time and 4.11 mib / 12.9% median rss**.
- current upstream obscura uses 31.77 mib and 19.80 ms but exposes **0 stylesheets** and returns no computed bootstrap body color. it pays more ram than drop without providing the fidelity of compute.

| mode | median wall time | vs current | p95 wall time | median rss | vs current | peak rss | css result |
|---|---:|---:|---:|---:|---:|---:|---|
| current upstream obscura (`a921668`) | 19.80 ms | baseline | 21.39 ms | 31.77 mib | baseline | 31.94 mib | 0 sheets; body color empty |
| this pr: `compute` | 26.99 ms | +7.19 ms / +36.3% | 29.16 ms | 32.24 mib | +0.47 mib / +1.5% | 32.47 mib | 2 sheets; 3,377 rules; `#212529` |
| this pr: `drop` | 17.92 ms | -1.88 ms / -9.5% | 25.19 ms | 27.66 mib | -4.11 mib / -12.9% | 27.77 mib | 0 sheets; synthetic defaults |

methodology: upstream main and this pr were both release builds. the page was captured from [the live bootstrap introduction page](https://getbootstrap.com/docs/5.3/getting-started/introduction/), its two real stylesheet responses were replayed unchanged over loopback, scripts were removed to isolate css cost, and each mode ran with two warmups plus twelve interleaved cold-process samples. rss comes from `/usr/bin/time -l`.

## why this is necessary

fetching stylesheet urls is not enough browser emulation. before this change, author css was not represented in the cascade or cssom, so `getComputedStyle()`, `document.styleSheets`, `link.sheet`, media-query-dependent values, custom properties, and cssom mutations could disagree with what a browser exposes.

that creates two practical problems:

1. compatibility: applications frequently use computed styles, css variables, and media queries while hydrating or deciding which component path to run. returning only synthetic defaults can change application behavior.
2. detectability: always discarding css is fast, but a site can directly verify that a loaded stylesheet did not affect computed style or appear in cssom.

the default `compute` mode closes that gap without adding layout, painting, fonts, or animation. the explicit `drop` mode preserves the lowest-overhead path for workloads that do not need css fidelity. both paths keep untrusted stylesheet bodies out of executable javascript and remove the former need for css-to-v8 transfer.

## measured impact

methodology: release build, local deterministic http fixtures, two warmups, twelve interleaved cold-process samples per case. wall time is median process time. rss is the highest `/usr/bin/time -l` peak observed across the samples. css overhead is measured against the empty fixture for the same mode.

the reproducible corpus, exact source pins, licenses, hashes, runner, and json output are in [obscura-benchmark #2](https://github.com/h4ckf0r0day/obscura-benchmark/pull/2).

| corpus | css bytes | retained rules | compute median | drop median | wall time saved | compute peak rss | drop peak rss | ram saved | css-only overhead reduction |
|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|
| bootstrap 5.3.8 | 280,311 | 2,664 | 24.85 ms | 13.68 ms | 44.9% / 11.17 ms | 30.25 mib | 21.19 mib | 30.0% / 9.06 mib | 90.0% |
| bulma website 1.0.4 | 1,430,123 | 6,724 | 62.13 ms | 15.59 ms | 74.9% / 46.54 ms | 50.47 mib | 23.50 mib | 53.4% / 26.97 mib | 93.7% |
| primer 22.3.0 | 1,061,415 | 3,231 | 44.31 ms | 18.01 ms | 59.4% / 26.30 ms | 45.03 mib | 23.62 mib | 47.5% / 21.41 mib | 82.5% |
| patternfly 6.6.0 | 1,993,226 | 6,749 | 53.83 ms | 14.63 ms | 72.8% / 39.20 ms | 53.61 mib | 26.05 mib | 51.4% / 27.56 mib | 94.7% |
| synthetic 160 kib | 163,840 | 3,715 | 24.30 ms | 14.51 ms | 40.3% / 9.79 ms | 29.86 mib | 21.17 mib | 29.1% / 8.69 mib | 82.6% |
| synthetic 1.875 mib | 1,966,080 | 41,655 | 129.32 ms | 26.02 ms | 79.9% / 103.30 ms | 92.44 mib | 25.97 mib | 71.9% / 66.47 mib | 88.4% |
| synthetic 10 mib | 10,485,760 | 50,000 rule cap | 240.40 ms | 75.95 ms | 68.4% / 164.45 ms | 114.47 mib | 50.97 mib | 55.5% / 63.50 mib | 72.1% |

across the four pinned production bundles, the benchmark parses 4,765,075 css bytes and retains 19,368 rules. every locked probe passes for computed values, stylesheet counts, exact rule counts, custom-property resolution, media behavior, and dynamic cssom mutation.

for every corpus at or above 1 mib, drop mode is both faster and lower-rss than compute mode. observed savings range from:

- 59.4% to 79.9% lower median wall time
- 47.5% to 71.9% lower peak rss
- 72.1% to 94.7% less css-only time above the empty fixture

the empty fixture is 12.42 ms in compute mode and 12.44 ms in drop mode, a 0.02 ms difference. this indicates that the mode plumbing and native style registry add effectively no measurable cost when a page has no stylesheets.

the earlier 10 mib retained-body prototype measured 55.37 ms and 91.58 mib versus 21.99 ms and 34.45 mib when dropped: 60.3% less wall time and 62.4% less rss. that result motivated making the low-memory path explicit rather than always retaining stylesheet bodies.

## implementation

- adds public css mode configuration through the rust api, browser context, and global `--css-mode` cli option
- implements a native rust author cascade with selector indexing and a 1,024-entry lazy computed-style cache
- supports specificity, `!important`, inheritance, custom properties, recursive `var()` fallback, common shorthands, media queries, supports blocks, layers, imports, and cssom mutation
- keeps static external sheets in document order and handles dynamic imports without css body transfer through v8
- exposes the required stylesheet/cssom surfaces and invalidates the style epoch on dom and stylesheet mutations
- caps decoded css at 16 mib, rules at 50,000, sheets at 256, and import nesting at eight
- keeps `drop` mode bodyless after the response has been fully received while preserving request and lifecycle behavior

## verification

- 213 nextest cases passed
- release build passed
- 33/33 obstacle-course stages passed
- all production and synthetic correctness probes passed
- all performance gates passed
- no untrusted css is interpolated into executable javascript

depends on #410.


