### PR TITLE
fix(js): validate the submitter argument to requestSubmit() (#424)

### DIFF
--- a/crates/obscura-cdp/tests/form_submit_method_bypasses_listener.rs
+++ b/crates/obscura-cdp/tests/form_submit_method_bypasses_listener.rs
@@ -182,3 +182,71 @@ async fn cdp_click_submit_button_is_vetoed_by_prevent_default_listener() {
         "a CDP click on a submit button must fire the cancelable submit event and be vetoable"
     );
 }
+
+// requestSubmit(submitter) must validate its argument before doing anything
+// else (issue #424): a TypeError if the submitter is not a submit button, and a
+// NotFoundError DOMException if it is not owned by the form. obscura accepted
+// anything and silently submitted. The form under test preventDefault()s its
+// own submit event so the valid-submitter case cannot navigate away.
+#[tokio::test(flavor = "current_thread")]
+async fn request_submit_validates_its_submitter_argument() {
+    std::env::set_var("OBSCURA_ALLOW_PRIVATE_NETWORK", "1");
+    let url = serve_form().await;
+    let mut ctx = CdpContext::new();
+    let page_id = ctx.create_page();
+    let session_id = "session-4";
+    ctx.sessions.insert(session_id.to_string(), page_id.clone());
+
+    navigate(&mut ctx, &url, session_id).await;
+
+    let v = cdp(
+        &mut ctx,
+        2,
+        "Runtime.evaluate",
+        json!({
+            "expression": r#"(() => {
+                document.body.innerHTML =
+                  '<form id="vf">' +
+                    '<div id="d"></div>' +
+                    '<button id="ok" type="submit">go</button>' +
+                    '<button id="plain" type="button">x</button>' +
+                    '<input id="inp" type="text">' +
+                  '</form>' +
+                  '<button id="outside" type="submit">y</button>';
+                const f = document.getElementById('vf');
+                f.addEventListener('submit', (e) => e.preventDefault());
+                const probe = (fn) => {
+                    try { fn(); return "no-throw"; }
+                    catch (e) {
+                        return (e instanceof DOMException) ? "DOMException:" + e.name
+                                                           : (e && e.constructor && e.constructor.name) || String(e);
+                    }
+                };
+                return JSON.stringify({
+                    div:      probe(() => f.requestSubmit(document.getElementById('d'))),
+                    plain:    probe(() => f.requestSubmit(document.getElementById('plain'))),
+                    text:     probe(() => f.requestSubmit(document.getElementById('inp'))),
+                    outside:  probe(() => f.requestSubmit(document.getElementById('outside'))),
+                    valid:    probe(() => f.requestSubmit(document.getElementById('ok'))),
+                    noArg:    probe(() => f.requestSubmit()),
+                    nullArg:  probe(() => f.requestSubmit(null)),
+                });
+            })()"#,
+            "returnByValue": true
+        }),
+        session_id,
+    )
+    .await;
+
+    let val = serde_json::from_str::<Value>(v["result"]["value"].as_str().unwrap()).unwrap();
+    assert_eq!(val["div"], "TypeError", "a non-button submitter must throw TypeError");
+    assert_eq!(val["plain"], "TypeError", "type=button is not a submit button");
+    assert_eq!(val["text"], "TypeError", "input type=text is not a submit button");
+    assert_eq!(
+        val["outside"], "DOMException:NotFoundError",
+        "a submit button not owned by the form must throw NotFoundError"
+    );
+    assert_eq!(val["valid"], "no-throw", "the form's own submit button must be accepted");
+    assert_eq!(val["noArg"], "no-throw", "requestSubmit() with no submitter is valid");
+    assert_eq!(val["nullArg"], "no-throw", "requestSubmit(null) means submit from the form itself");
+}

--- a/crates/obscura-js/js/bootstrap.js
+++ b/crates/obscura-js/js/bootstrap.js
@@ -1150,6 +1150,17 @@ function _htmlAttrName(el, n) {
   return n;
 }
 
+// A submit button per the HTML spec: a <button> whose type is submit — the
+// default, including when the type attribute is missing or invalid — or an
+// <input> of type submit/image. Used to validate requestSubmit's submitter.
+function _isSubmitButton(el) {
+  if (!el || typeof el.localName !== "string") return false;
+  const type = ((el.getAttribute && el.getAttribute("type")) || "").toLowerCase();
+  if (el.localName === "button") return type !== "reset" && type !== "button";
+  if (el.localName === "input") return type === "submit" || type === "image";
+  return false;
+}
+
 class Element extends Node {
   constructor(nid) {
     super(nid);
@@ -1501,8 +1512,11 @@ class Element extends Node {
           return;
         }
       }
-      const type = (this.getAttribute('type') || '').toLowerCase();
-      if (type === 'submit' || (this.localName === 'button' && type !== 'button' && type !== 'reset')) {
+      // Same predicate requestSubmit validates against, so an internal click
+      // can never hand it a submitter it would reject. Also matches the CDP
+      // click path in input.rs, which already treats <input type=image> as a
+      // submit button.
+      if (_isSubmitButton(this)) {
         const form = this.closest ? this.closest('form') : null;
         // A real submit-button click fires the cancelable submit event, so use
         // requestSubmit() (not the plain submit() method, which now bypasses it).
@@ -1975,6 +1989,22 @@ class Element extends Node {
     this._navigateSubmit(submitter);
   }
   requestSubmit(submitter) {
+    // Per spec, a given submitter must be a submit button owned by this form;
+    // both checks run before the submit event fires. A missing/null submitter
+    // means "submit from the form itself".
+    if (submitter !== undefined && submitter !== null) {
+      if (!_isSubmitButton(submitter)) {
+        throw new TypeError(
+          "Failed to execute 'requestSubmit' on 'HTMLFormElement': The specified element is not a submit button."
+        );
+      }
+      if (submitter.form !== this) {
+        throw new DOMException(
+          "Failed to execute 'requestSubmit' on 'HTMLFormElement': The specified element is not owned by this form element.",
+          'NotFoundError'
+        );
+      }
+    }
     const cancelled = !this.dispatchEvent(new Event('submit', { bubbles: true, cancelable: true }));
     if (cancelled) return;
     this._navigateSubmit(submitter);


### PR DESCRIPTION
## What
`HTMLFormElement.requestSubmit(submitter)` accepted **any** element and submitted silently. Per the HTML spec (and Chrome) it must throw:
- a `TypeError` if `submitter` is not a submit button, and
- a `NotFoundError` `DOMException` if `submitter` is not owned by the form,

both **before** the `submit` event fires. A missing/`null` submitter means "submit from the form itself".

## Fix
Adds an `_isSubmitButton` predicate — a `<button>` whose type is `submit` (the default, including a missing or invalid `type`), or an `<input>` of type `submit`/`image` — and validates the argument at the top of `requestSubmit`. `submit()` is untouched; it correctly bypasses the event per #395.

`Element.click()` now gates on that same predicate instead of its own looser check (`type === 'submit' || (localName === 'button' && …)`), so an internal click can never hand `requestSubmit` a submitter it would now reject. Two knock-on effects, both toward Chrome parity:
- `<div type="submit">` inside a form no longer submits on click (it is not a submit button; Chrome doesn't submit either).
- `<input type="image">` now submits on click, matching the CDP click path in `input.rs`, which already treated it as a submit button.

The `input.rs` call sites are already guarded by conditions equivalent to `_isSubmitButton` (and pass no submitter on the Enter-key path), so they are unaffected.

## Repro (before → after)
```js
document.body.innerHTML = '<form id="f"><div id="d"></div></form><button id="out" type="submit">y</button>';
const f = document.getElementById('f');
f.requestSubmit(document.getElementById('d'));    // before: silently submits | after: TypeError
f.requestSubmit(document.getElementById('out'));  // before: silently submits | after: NotFoundError
```

## Scope note — constraint validation excluded
Chrome's `requestSubmit()` also runs interactive constraint validation (aborting on an invalid `required` field, firing `invalid` events). That is **not** in this PR: obscura has no validity engine — `Element.prototype.checkValidity` is a stub that unconditionally returns `true` and `ValidityState` returns a fixed `_valid` — so wiring `requestSubmit` to it would be a no-op. Recorded in #424 as separate work.

## Tests
Adds `request_submit_validates_its_submitter_argument` to `form_submit_method_bypasses_listener.rs`, covering: a `<div>`, a `type="button"` button, an `<input type=text>` (all → `TypeError`), a submit button outside the form (→ `NotFoundError`), and the valid submitter / no-arg / `null` cases (→ no throw). Fails on `main`, passes after.

Full `obscura-cdp` suite green (72/72), including the existing submit-semantics and CDP-click tests that exercise the changed `click()` path.

Closes #424
