### PR TITLE
fix(js): implement Element scrollBy/scrollTo/scroll and functional scrollTop/scrollLeft

### DIFF
--- a/crates/obscura-js/js/bootstrap.js
+++ b/crates/obscura-js/js/bootstrap.js
@@ -2094,8 +2094,13 @@ class Element extends Node {
     const t = this.tagName;
     return t === 'HTML' || t === 'BODY';
   }
-  get scrollTop() { return 0; } set scrollTop(v) {}
-  get scrollLeft() { return 0; } set scrollLeft(v) {}
+  // No layout engine, so there is no real overflow to scroll. We still track a
+  // scroll offset so scrollTop/scrollLeft round-trip and the scroll methods
+  // below can report a position, which is what infinite-scroll code reads back.
+  get scrollTop() { return this._scrollTop || 0; }
+  set scrollTop(v) { v = +v; this._scrollTop = Number.isFinite(v) && v > 0 ? v : 0; }
+  get scrollLeft() { return this._scrollLeft || 0; }
+  set scrollLeft(v) { v = +v; this._scrollLeft = Number.isFinite(v) && v > 0 ? v : 0; }
   getBoundingClientRect() {
     globalThis.__obscura_click_target = this;
     // documentElement and body span the full viewport. Without this every
@@ -2153,6 +2158,31 @@ class Element extends Node {
   get ariaSelected() { return this.getAttribute('aria-selected'); }
   set ariaSelected(v) { if (v == null) this.removeAttribute('aria-selected'); else this.setAttribute('aria-selected', String(v)); }
   scrollIntoView() { globalThis.__obscura_click_target = this; }
+  // scrollTo/scrollBy/scroll accept either (x, y) or a ScrollToOptions object.
+  // Without layout the offset cannot be clamped to a real max, but updating it
+  // and firing a scroll event lets scroll-driven lazy loaders advance instead
+  // of throwing "scrollBy is not a function".
+  scrollTo(x, y) {
+    let left, top;
+    if (x !== null && typeof x === 'object') { left = x.left; top = x.top; }
+    else { left = x; top = y; }
+    if (left !== undefined) this.scrollLeft = +left || 0;
+    if (top !== undefined) this.scrollTop = +top || 0;
+    this._fireScroll();
+  }
+  scroll(x, y) { this.scrollTo(x, y); }
+  scrollBy(x, y) {
+    let dl, dt;
+    if (x !== null && typeof x === 'object') { dl = x.left; dt = x.top; }
+    else { dl = x; dt = y; }
+    this.scrollLeft = (this.scrollLeft || 0) + (+dl || 0);
+    this.scrollTop = (this.scrollTop || 0) + (+dt || 0);
+    this._fireScroll();
+  }
+  _fireScroll() {
+    const self = this;
+    setTimeout(() => { try { self.dispatchEvent(new Event('scroll', { bubbles: false })); } catch (e) {} }, 0);
+  }
   animate(keyframes, options) {
     const duration = typeof options === 'number' ? options : (options?.duration || 0);
     return {
@@ -5933,6 +5963,7 @@ _markNative(globalThis.Selection);
   Element.prototype.cloneNode, Element.prototype.attachShadow,
   Element.prototype.insertAdjacentHTML, Element.prototype.insertAdjacentText,
   Element.prototype.insertAdjacentElement, Element.prototype.scrollIntoView,
+  Element.prototype.scrollTo, Element.prototype.scrollBy, Element.prototype.scroll,
   Element.prototype.append, Element.prototype.prepend, Element.prototype.remove,
   Element.prototype.before, Element.prototype.after, Element.prototype.replaceWith,
   HTMLFormElement.prototype.reset,


### PR DESCRIPTION
## What

Adds `Element.prototype.scrollBy`, `scrollTo` and `scroll`, and makes `scrollTop`/`scrollLeft` round-trip instead of being no-op stubs.

Closes #429.

## Why

`scrollBy`/`scrollTo`/`scroll` existed only on `window` (as no-ops), never on `Element`. Scraping code that scrolls a specific container (the standard infinite-scroll idiom) hit `TypeError: el.scrollBy is not a function`, and `el.scrollTop = N` silently did nothing.

## Change

`crates/obscura-js/js/bootstrap.js`, class `Element`:
- `scrollTop`/`scrollLeft` now store and return a per-element offset.
- `scrollTo(x, y)` / `scroll(x, y)` / `scrollBy(x, y)` accept `(x, y)` or a `ScrollToOptions` object, update the offset, and dispatch a `scroll` event.
- The three methods are added to the native-function masking list so their `toString` stays `[native code]`.

No layout engine, so the offset is not clamped to a real overflow max (consistent with the placeholder `scrollHeight`/`clientHeight` in #391). This fixes the "throws / does nothing" case; geometry-driven `IntersectionObserver` lazy-loading stays #391's scope.

## Verification

- `cargo build --release -p obscura-cli` clean.
- Obstacle course: **33/33** (`OBSCURA_BIN=./target/release/obscura python3 obstacle-course/run.py --runs 1 --warmup 0`), including `observer-intersection`.
- Manual, against the release binary via CDP `Runtime.evaluate`:
  - `typeof document.createElement('div').scrollBy === 'function'` (same for `scrollTo`/`scroll`).
  - `el.scrollTop = 250; el.scrollBy(0, 100)` -> `el.scrollTop === 350`.
  - a `scroll` listener fires after `scrollBy`/`scrollTo`.
  - `el.scrollBy.toString()` -> `function scrollBy() { [native code] }`.

Note: I could not get the `obscura-js` unit suite to run in my local checkout: most `runtime::tests::*` fail with the DOM unbuilt (e.g. `querySelector` returns `Null`), and the same set fails identically on clean `main` with this change stashed, so it looks like a missing local test asset rather than anything from this diff. No scroll-specific test exists or regresses. Happy to adjust if you can point me at the right test setup, and to add a unit test for the new methods.
