### PR TITLE
feat(js): size the scroll box from content so virtualized feeds paginate

### DIFF
--- a/crates/obscura-js/js/bootstrap.js
+++ b/crates/obscura-js/js/bootstrap.js
@@ -2086,21 +2086,53 @@ class Element extends Node {
   // documentElement / body / window expose VIEWPORT geometry, not their own content box.
   // Puppeteer's #clickableBox clips boxes to document.documentElement.clientWidth/Height;
   // returning 100x20 there made every element appear off-screen and broke .click().
-  get clientWidth() { return this._isViewportRoot() ? (globalThis.innerWidth || 1280) : 100; }
-  get clientHeight() { return this._isViewportRoot() ? (globalThis.innerHeight || 720) : 20; }
-  get scrollWidth() { return this._isViewportRoot() ? (globalThis.innerWidth || 1280) : 100; }
-  get scrollHeight() { return this._isViewportRoot() ? (globalThis.innerHeight || 720) : 20; }
+  // With no layout engine, a scroll container needs a viewport-sized client box
+  // and a content-sized scroll box, otherwise scrollTop has no range and the
+  // scroll-driven lazy loaders that PR #431 unblocked still never page in more
+  // rows. Expose the viewport size as the client box for every element (the
+  // click/hit-test path uses getBoundingClientRect, not this) and derive the
+  // scroll box from the subtree size below.
+  get clientWidth() { return globalThis.innerWidth || 1280; }
+  get clientHeight() { return globalThis.innerHeight || 720; }
+  get scrollWidth() { return globalThis.innerWidth || 1280; }
+  get scrollHeight() {
+    if (this._isViewportRoot()) return (globalThis.innerHeight || 720);
+    // Approximate content height from the descendant count so virtualized lists
+    // (which page in more rows as scrollTop nears scrollHeight) can advance past
+    // their first batch. childElementCount is unreliable on these synthetic
+    // subtrees, so count descendants. Leaf elements keep the old 20px height.
+    let n = 0;
+    try { n = this.querySelectorAll('*').length; } catch (e) {}
+    const synthetic = n * 40;
+    return synthetic > 20 ? synthetic : 20;
+  }
   _isViewportRoot() {
     const t = this.tagName;
     return t === 'HTML' || t === 'BODY';
   }
-  // No layout engine, so there is no real overflow to scroll. We still track a
-  // scroll offset so scrollTop/scrollLeft round-trip and the scroll methods
-  // below can report a position, which is what infinite-scroll code reads back.
+  // No layout engine, so there is no real overflow to scroll. We track a scroll
+  // offset so scrollTop/scrollLeft round-trip, clamp it to the synthetic scroll
+  // box above (so virtualized lists render the window at the content bottom
+  // instead of overshooting into empty space), and fire a scroll event on direct
+  // assignment -- lazy loaders that set `el.scrollTop = el.scrollHeight` rely on
+  // that event, which the scroll methods below would otherwise be the only source of.
   get scrollTop() { return this._scrollTop || 0; }
-  set scrollTop(v) { v = +v; this._scrollTop = Number.isFinite(v) && v > 0 ? v : 0; }
+  set scrollTop(v) {
+    v = +v;
+    const max = Math.max(0, this.scrollHeight - this.clientHeight);
+    const nv = Number.isFinite(v) && v > 0 ? Math.min(v, max) : 0;
+    const changed = nv !== (this._scrollTop || 0);
+    this._scrollTop = nv;
+    if (changed && !this._scrollSuppress) this._fireScroll();
+  }
   get scrollLeft() { return this._scrollLeft || 0; }
-  set scrollLeft(v) { v = +v; this._scrollLeft = Number.isFinite(v) && v > 0 ? v : 0; }
+  set scrollLeft(v) {
+    v = +v;
+    const nv = Number.isFinite(v) && v > 0 ? v : 0;
+    const changed = nv !== (this._scrollLeft || 0);
+    this._scrollLeft = nv;
+    if (changed && !this._scrollSuppress) this._fireScroll();
+  }
   getBoundingClientRect() {
     globalThis.__obscura_click_target = this;
     // documentElement and body span the full viewport. Without this every
@@ -2159,15 +2191,17 @@ class Element extends Node {
   set ariaSelected(v) { if (v == null) this.removeAttribute('aria-selected'); else this.setAttribute('aria-selected', String(v)); }
   scrollIntoView() { globalThis.__obscura_click_target = this; }
   // scrollTo/scrollBy/scroll accept either (x, y) or a ScrollToOptions object.
-  // Without layout the offset cannot be clamped to a real max, but updating it
-  // and firing a scroll event lets scroll-driven lazy loaders advance instead
-  // of throwing "scrollBy is not a function".
+  // The setters clamp the offset and fire the scroll event; suppress their
+  // per-axis events so the whole operation emits a single scroll event, the way
+  // a real browser coalesces one scroll per movement.
   scrollTo(x, y) {
     let left, top;
     if (x !== null && typeof x === 'object') { left = x.left; top = x.top; }
     else { left = x; top = y; }
+    this._scrollSuppress = true;
     if (left !== undefined) this.scrollLeft = +left || 0;
     if (top !== undefined) this.scrollTop = +top || 0;
+    this._scrollSuppress = false;
     this._fireScroll();
   }
   scroll(x, y) { this.scrollTo(x, y); }
@@ -2175,8 +2209,10 @@ class Element extends Node {
     let dl, dt;
     if (x !== null && typeof x === 'object') { dl = x.left; dt = x.top; }
     else { dl = x; dt = y; }
+    this._scrollSuppress = true;
     this.scrollLeft = (this.scrollLeft || 0) + (+dl || 0);
     this.scrollTop = (this.scrollTop || 0) + (+dt || 0);
+    this._scrollSuppress = false;
     this._fireScroll();
   }
   _fireScroll() {

--- a/crates/obscura-js/js/bootstrap.js
+++ b/crates/obscura-js/js/bootstrap.js
@@ -2094,8 +2094,13 @@ class Element extends Node {
     const t = this.tagName;
     return t === 'HTML' || t === 'BODY';
   }
-  get scrollTop() { return 0; } set scrollTop(v) {}
-  get scrollLeft() { return 0; } set scrollLeft(v) {}
+  // No layout engine, so there is no real overflow to scroll. We still track a
+  // scroll offset so scrollTop/scrollLeft round-trip and the scroll methods
+  // below can report a position, which is what infinite-scroll code reads back.
+  get scrollTop() { return this._scrollTop || 0; }
+  set scrollTop(v) { v = +v; this._scrollTop = Number.isFinite(v) && v > 0 ? v : 0; }
+  get scrollLeft() { return this._scrollLeft || 0; }
+  set scrollLeft(v) { v = +v; this._scrollLeft = Number.isFinite(v) && v > 0 ? v : 0; }
   getBoundingClientRect() {
     globalThis.__obscura_click_target = this;
     // documentElement and body span the full viewport. Without this every
@@ -2153,6 +2158,31 @@ class Element extends Node {
   get ariaSelected() { return this.getAttribute('aria-selected'); }
   set ariaSelected(v) { if (v == null) this.removeAttribute('aria-selected'); else this.setAttribute('aria-selected', String(v)); }
   scrollIntoView() { globalThis.__obscura_click_target = this; }
+  // scrollTo/scrollBy/scroll accept either (x, y) or a ScrollToOptions object.
+  // Without layout the offset cannot be clamped to a real max, but updating it
+  // and firing a scroll event lets scroll-driven lazy loaders advance instead
+  // of throwing "scrollBy is not a function".
+  scrollTo(x, y) {
+    let left, top;
+    if (x !== null && typeof x === 'object') { left = x.left; top = x.top; }
+    else { left = x; top = y; }
+    if (left !== undefined) this.scrollLeft = +left || 0;
+    if (top !== undefined) this.scrollTop = +top || 0;
+    this._fireScroll();
+  }
+  scroll(x, y) { this.scrollTo(x, y); }
+  scrollBy(x, y) {
+    let dl, dt;
+    if (x !== null && typeof x === 'object') { dl = x.left; dt = x.top; }
+    else { dl = x; dt = y; }
+    this.scrollLeft = (this.scrollLeft || 0) + (+dl || 0);
+    this.scrollTop = (this.scrollTop || 0) + (+dt || 0);
+    this._fireScroll();
+  }
+  _fireScroll() {
+    const self = this;
+    setTimeout(() => { try { self.dispatchEvent(new Event('scroll', { bubbles: false })); } catch (e) {} }, 0);
+  }
   animate(keyframes, options) {
     const duration = typeof options === 'number' ? options : (options?.duration || 0);
     return {
@@ -5933,6 +5963,7 @@ _markNative(globalThis.Selection);
   Element.prototype.cloneNode, Element.prototype.attachShadow,
   Element.prototype.insertAdjacentHTML, Element.prototype.insertAdjacentText,
   Element.prototype.insertAdjacentElement, Element.prototype.scrollIntoView,
+  Element.prototype.scrollTo, Element.prototype.scrollBy, Element.prototype.scroll,
   Element.prototype.append, Element.prototype.prepend, Element.prototype.remove,
   Element.prototype.before, Element.prototype.after, Element.prototype.replaceWith,
   HTMLFormElement.prototype.reset,


### PR DESCRIPTION
Closes #441.

**Stacked on #431** (functional Element scroll methods). This PR's first commit is #431's; the second is the change under review here. Please review/merge after #431 — once it lands I will rebase so only the geometry commit remains.

## Problem

With #431, `scrollTop`/`scrollBy`/`scrollTo` are functional, but every element still reports a 20px scroll box (`scrollHeight === clientHeight`), so `scrollTop` has no range and scroll-driven lazy loaders never page in more rows. A virtualized list such as the Google Maps `/maps/search/` feed renders its first batch (~30 rows) and stalls. Full detail in #441.

## Change

`crates/obscura-js/js/bootstrap.js`, `Element`:

- **`scrollHeight`** is derived from the descendant count (`querySelectorAll('*').length`) so it grows as rows load. `childElementCount` is unreliable on these synthetic subtrees. Leaf elements keep the old 20px height.
- **`clientWidth`/`clientHeight`/`scrollWidth`** expose the viewport size for every element, giving `scrollTop` real range. The click/hit-test path uses `getBoundingClientRect`, not these, so actionability is unaffected.
- The **`scrollTop` setter** clamps to the synthetic scroll box (so virtualized lists render the window at the content bottom instead of overshooting into empty space) and fires a `scroll` event on direct assignment. Lazy loaders do `el.scrollTop = el.scrollHeight` and rely on that event.
- **`scrollTo`/`scrollBy`** suppress the per-axis setter events so a full operation emits a single `scroll` event, the way a real browser coalesces one scroll per movement.

## Validation

- Google Maps `/maps/search/` (driven with `waitUntil: networkidle2` so the loop is pumped past load): the feed pages from ~30 to the full result set (~113 unique `/maps/place/` rows) instead of plateauing at ~31.
- obstacle-course **33/33**, median latency ~12ms (no perf regression).
- `cargo nextest run -p obscura-js -p obscura-browser`: failing tests are identical to the `fix/element-scroll-methods` baseline (pre-existing `runtime::tests` unit-harness failures); this change introduces none.