### PR TITLE
fix: add missing #[ignore] gate and local fixture for concurrent fetch test

### DIFF
--- a/crates/obscura-cdp/tests/concurrent_navigations.rs
+++ b/crates/obscura-cdp/tests/concurrent_navigations.rs
@@ -110,6 +110,7 @@ async fn one_client(port: u16, id_base: u64) -> Result<(), String> {
     }
 }
 
+#[ignore]
 #[tokio::test(flavor = "current_thread")]
 
 async fn concurrency_5_does_not_abort_v8() {

--- a/crates/obscura-cdp/tests/concurrent_navigations_with_fetch.rs
+++ b/crates/obscura-cdp/tests/concurrent_navigations_with_fetch.rs
@@ -146,6 +146,9 @@ async fn one_client_with_fetch(port: u16, id_base: u64, target_url: &str) -> Res
 
         // navigate response?
         if v.get("id").and_then(|x| x.as_u64()) == Some(id_base + 2) {
+            if let Some(err) = v.get("result").and_then(|r| r.get("errorText")).and_then(|e| e.as_str()) {
+                return Err(format!("navigation failed: {}", err));
+            }
             return Ok(());
         }
 
@@ -171,13 +174,41 @@ async fn one_client_with_fetch(port: u16, id_base: u64, target_url: &str) -> Res
     }
 }
 
-/// PR #36 maintainer's exact repro.
+/// Minimal local HTML fixture with a subresource so the Fetch interception
+/// path is exercised without hitting the public internet.
+const FIXTURE_HTML: &str = "<!DOCTYPE html><html><head><script src=\"/app.js\"></script></head><body><h1>ok</h1></body></html>";
+
+const FIXTURE_JS: &str = "console.log('fixture');";
+
+async fn serve_fixture(port: u16) {
+    let listener = std::net::TcpListener::bind(("127.0.0.1", port)).unwrap();
+    loop {
+        let (mut stream, _) = listener.accept().unwrap();
+        let mut buf = [0u8; 4096];
+        let _ = std::io::Read::read(&mut stream, &mut buf);
+        let req = String::from_utf8_lossy(&buf);
+        let (body, ctype) = if req.contains("GET /app.js") {
+            (FIXTURE_JS, "application/javascript")
+        } else {
+            (FIXTURE_HTML, "text/html")
+        };
+        let resp = format!(
+            "HTTP/1.1 200 OK\r\nContent-Type: {}\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+            ctype,
+            body.len(),
+            body
+        );
+        let _ = std::io::Write::write_all(&mut stream, resp.as_bytes());
+    }
+}
+
+/// PR #36 maintainer's exact repro, using a local fixture instead of example.com.
+#[ignore]
 #[tokio::test(flavor = "current_thread")]
 
 async fn fetch_intercept_concurrency_5_does_not_abort_v8() {
-    // Use example.com first — minimal subresources but real network. If this
-    // doesn't reproduce, escalate to a JS-heavy page in a follow-up.
-    let target_url = "https://example.com/";
+    let fixture_port = pick_port().await;
+    let target_url = format!("http://127.0.0.1:{}/", fixture_port);
 
     let port = pick_port().await;
     let local = tokio::task::LocalSet::new();
@@ -185,6 +216,9 @@ async fn fetch_intercept_concurrency_5_does_not_abort_v8() {
         .run_until(async {
             tokio::task::spawn_local(async move {
                 let _ = obscura_cdp::server::start(port).await;
+            });
+            tokio::task::spawn_local(async move {
+                serve_fixture(fixture_port).await;
             });
             tokio::time::sleep(Duration::from_millis(250)).await;
 

--- a/crates/obscura-cdp/tests/concurrent_navigations_with_fetch.rs
+++ b/crates/obscura-cdp/tests/concurrent_navigations_with_fetch.rs
@@ -24,6 +24,7 @@ use std::time::Duration;
 
 use futures_util::{SinkExt, StreamExt};
 use serde_json::{json, Value};
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::net::TcpListener;
 use tokio_tungstenite::{connect_async, tungstenite::Message};
 
@@ -146,7 +147,11 @@ async fn one_client_with_fetch(port: u16, id_base: u64, target_url: &str) -> Res
 
         // navigate response?
         if v.get("id").and_then(|x| x.as_u64()) == Some(id_base + 2) {
-            if let Some(err) = v.get("result").and_then(|r| r.get("errorText")).and_then(|e| e.as_str()) {
+            if let Some(err) = v
+                .get("result")
+                .and_then(|r| r.get("errorText"))
+                .and_then(|e| e.as_str())
+            {
                 return Err(format!("navigation failed: {}", err));
             }
             return Ok(());
@@ -180,13 +185,12 @@ const FIXTURE_HTML: &str = "<!DOCTYPE html><html><head><script src=\"/app.js\"><
 
 const FIXTURE_JS: &str = "console.log('fixture');";
 
-async fn serve_fixture(port: u16) {
-    let listener = std::net::TcpListener::bind(("127.0.0.1", port)).unwrap();
+async fn serve_fixture(listener: TcpListener) {
     loop {
-        let (mut stream, _) = listener.accept().unwrap();
+        let (mut stream, _) = listener.accept().await.unwrap();
         let mut buf = [0u8; 4096];
-        let _ = std::io::Read::read(&mut stream, &mut buf);
-        let req = String::from_utf8_lossy(&buf);
+        let read = stream.read(&mut buf).await.unwrap_or(0);
+        let req = String::from_utf8_lossy(&buf[..read]);
         let (body, ctype) = if req.contains("GET /app.js") {
             (FIXTURE_JS, "application/javascript")
         } else {
@@ -198,7 +202,7 @@ async fn serve_fixture(port: u16) {
             body.len(),
             body
         );
-        let _ = std::io::Write::write_all(&mut stream, resp.as_bytes());
+        let _ = stream.write_all(resp.as_bytes()).await;
     }
 }
 
@@ -207,7 +211,8 @@ async fn serve_fixture(port: u16) {
 #[tokio::test(flavor = "current_thread")]
 
 async fn fetch_intercept_concurrency_5_does_not_abort_v8() {
-    let fixture_port = pick_port().await;
+    let fixture = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let fixture_port = fixture.local_addr().unwrap().port();
     let target_url = format!("http://127.0.0.1:{}/", fixture_port);
 
     let port = pick_port().await;
@@ -218,7 +223,7 @@ async fn fetch_intercept_concurrency_5_does_not_abort_v8() {
                 let _ = obscura_cdp::server::start(port).await;
             });
             tokio::task::spawn_local(async move {
-                serve_fixture(fixture_port).await;
+                serve_fixture(fixture).await;
             });
             tokio::time::sleep(Duration::from_millis(250)).await;
 

--- a/crates/obscura-cdp/tests/control_plane_unblocked.rs
+++ b/crates/obscura-cdp/tests/control_plane_unblocked.rs
@@ -34,6 +34,7 @@ async fn pick_port() -> u16 {
     port
 }
 
+#[ignore]
 #[tokio::test(flavor = "current_thread")]
 
 async fn http_control_plane_unblocked_during_long_js() {


### PR DESCRIPTION
## Issue
Closes #448

## What

Three test files document an `#[ignore]` gate that does not exist in the code. All three run by default in the test suite. One of them (`concurrent_navigations_with_fetch.rs`) navigates to `https://example.com/` on every run, hitting the public internet.

### Changes

**`concurrent_navigations.rs`** — added `#[ignore]` before the `#[tokio::test]` attribute. The doc comment already promised this gate. Now it exists.

**`control_plane_unblocked.rs`** — same. The doc comment says `#[ignore]`, the attribute wasn't there. Added it.

**`concurrent_navigations_with_fetch.rs`** — three fixes:
1. Added `#[ignore]` (same as above).
2. Replaced `https://example.com/` with a local HTTP fixture (`serve_fixture`). The fixture serves a minimal HTML page with a `<script src="/app.js">` subresource, so the Fetch interception path is still exercised. No outbound network calls.
3. The navigate response handler now checks `result.errorText`. Before, it returned `Ok(())` on any response with the matching `id`, whether the navigation succeeded or failed. A failed navigation counted as success. Now it returns an error if `errorText` is present.

### Why

- Tests that boot a real CDP server should not run in the default suite. The comments already said this. The code didn't.
- Hitting `example.com` in a unit test is wrong. Offline runners, firewalled CI, airplanes. The test passed anyway because it never checked for errors.
- The local fixture exercises the same code path (Fetch.enable, requestPaused, continueRequest) without the network dependency.
