### PR TITLE
Fix NetworkInformation event listeners

### DIFF
--- a/crates/obscura-js/js/bootstrap.js
+++ b/crates/obscura-js/js/bootstrap.js
@@ -3108,6 +3108,7 @@ _markNative(MimeTypeArray.prototype.item);
 _markNative(MimeTypeArray.prototype.namedItem);
 
 class NetworkInformation {
+  constructor() { _makeListenerBox(this); }
   get downlink() { return 10; }
   get downlinkMax() { return Infinity; }
   get effectiveType() { return '4g'; }

--- a/crates/obscura-js/src/runtime.rs
+++ b/crates/obscura-js/src/runtime.rs
@@ -2689,14 +2689,35 @@ mod tests {
         let result = rt
             .evaluate(
                 r#"
+                const connection = navigator.connection;
+                let calls = 0;
+                let receiverMatches = false;
+                function listener(event) {
+                    calls += 1;
+                    receiverMatches = this === connection && event.type === 'change';
+                }
+                connection.addEventListener('change', listener);
+                const dispatchResult = connection.dispatchEvent(new Event('change'));
+                connection.removeEventListener('change', listener);
+                connection.dispatchEvent(new Event('change'));
                 return [
-                    typeof navigator.connection.addEventListener,
+                    typeof connection.addEventListener,
+                    typeof connection.removeEventListener,
+                    typeof connection.dispatchEvent,
                     typeof navigator.serviceWorker.addEventListener,
+                    dispatchResult,
+                    calls,
+                    receiverMatches,
                 ];
                 "#,
             )
             .unwrap();
-        assert_eq!(result, serde_json::json!(["function", "function"]));
+        assert_eq!(
+            result,
+            serde_json::json!([
+                "function", "function", "function", "function", true, 1, true
+            ])
+        );
     }
 
     /// Regression test for #285: DDoS-Guard's challenge calls


### PR DESCRIPTION
`navigator.connection` exposed `addEventListener`, but its listener storage was never initialized. Calling it threw instead of registering the listener.

This initializes the listener box when `NetworkInformation` is created and adds regression coverage for its EventTarget methods.