### PR TITLE
fix(js): report a content-sized scroll box so virtualized feeds paginate

### DIFF
--- a/.github/workflows/docker-ghcr.yml
+++ b/.github/workflows/docker-ghcr.yml
@@ -1,0 +1,60 @@
+name: Docker (GHCR)
+
+# Fork-specific image publish. The upstream docker.yml pushes to Docker Hub with
+# repo secrets we do not carry on the fork; this publishes to GHCR under the fork
+# org using the built-in GITHUB_TOKEN, so `ghcr.io/<owner>/<repo>` tracks the fork
+# (thread-per-connection concurrency + virtualized-scroll geometry) for downstream
+# pinning. The image name follows the repository, so renaming the repo moves the
+# image with it.
+on:
+  push:
+    branches: [main]
+    tags: ['v*']
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Image metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/${{ github.repository }}
+          tags: |
+            type=ref,event=branch
+            type=semver,pattern={{version}}
+            type=sha,format=short
+            type=raw,value=latest,enable={{is_default_branch}}
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          build-args: |
+            OBSCURA_VERSION=${{ steps.meta.outputs.version }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          # amd64 only: the ASAP VPS is amd64, and cross-building V8 for arm64 in
+          # CI multiplies an already long V8-from-source build. Add arm64 here if
+          # a multi-arch pull is ever needed.
+          platforms: linux/amd64
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/Dockerfile
+++ b/Dockerfile
@@ -46,6 +46,10 @@ COPY --from=builder /build/target/release/obscura-worker /obscura-worker
 
 EXPOSE 9222
 
+# The glibc malloc arena cap that used to live here as MALLOC_ARENA_MAX=2 is now
+# done by the binary itself: `serve` calls mallopt(M_ARENA_MAX, 2) at startup
+# (upstream crates/obscura-cdp/src/server.rs, merged with #435). No ENV needed.
+
 # Bind to 0.0.0.0 so the port is reachable via `docker run -p 9222:9222`.
 # Native binary still defaults to 127.0.0.1 (loopback only) — this override
 # is just for the container.

--- a/FORK.md
+++ b/FORK.md
@@ -25,9 +25,21 @@ Everything this fork adds on top of `upstream/main`. Two buckets:
 
 | Change | Bucket | Upstream | Files |
 |---|---|---|---|
-| Virtualized scroll geometry: content-sized scroll box + viewport client box so SPA feeds (Google Maps search) paginate to their full result set | **fork-only** | issue [#441](https://github.com/h4ckf0r0day/obscura/issues/441) closed: upstream is doing scroll geometry in the rendering engine instead. PR [#442](https://github.com/h4ckf0r0day/obscura/pull/442) closed. **Carries a known cost**: `scrollHeight` runs `querySelectorAll('*')` on every read, measured at 194–240 ms per 200 reads on a 5,000-node container. Cache it on mutation if sourcing gets slow. | `crates/obscura-js/js/bootstrap.js` |
+| Fire a `scroll` event when `scrollTop` / `scrollLeft` are assigned directly (upstream only fires from `scrollTo`/`scrollBy`), so scroll-driven lazy loaders advance | in-flight | Verified against real Chrome: assigning `scrollTop` fires exactly one `scroll` event there, zero on upstream obscura, one with this patch. PR to open. | `crates/obscura-js/js/bootstrap.js` |
 | GHCR image publish workflow (upstream publishes to Docker Hub with secrets we do not carry) | **fork-only** | n/a | `.github/workflows/docker-ghcr.yml`, `Dockerfile` |
 | This manifest + the sync script | **fork-only** | n/a | `FORK.md`, `scripts/sync-upstream.sh` |
+
+The virtualized **scroll geometry** heuristic (synthetic `scrollHeight` from
+`querySelectorAll('*').length * 40`, viewport-sized `clientHeight` on every
+element, and a `scrollTop` clamped to that box) was dropped rather than carried.
+It made pagination *worse*, and non-deterministically so: the clamp resolves to
+`max(0, descendants * 40 - innerHeight)`, and obscura's stealth layer randomises
+`innerHeight` per session (measured 640 / 640 / 688 / 970 across four runs). So
+whether a feed paginated or froze at its first batch depended on the viewport
+draw — same page, same code, different outcome per run. Measured on a
+progress-gated feed fixture: 20/120 items on an unlucky draw, 120/120 without
+the heuristic. What survives is the scroll-event dispatch above, which is the
+part that was actually load-bearing.
 
 The thread-per-connection V8 isolate confinement and the `--max-connections` /
 glibc-arena caps that used to be carried here landed upstream via

--- a/FORK.md
+++ b/FORK.md
@@ -25,7 +25,7 @@ Everything this fork adds on top of `upstream/main`. Two buckets:
 
 | Change | Bucket | Upstream | Files |
 |---|---|---|---|
-| Fire a `scroll` event when `scrollTop` / `scrollLeft` are assigned directly (upstream only fires from `scrollTo`/`scrollBy`), so scroll-driven lazy loaders advance | in-flight | Verified against real Chrome: assigning `scrollTop` fires exactly one `scroll` event there, zero on upstream obscura, one with this patch. PR to open. | `crates/obscura-js/js/bootstrap.js` |
+| Fire a `scroll` event when `scrollTop` / `scrollLeft` are assigned directly (upstream only fires from `scrollTo`/`scrollBy`), so scroll-driven lazy loaders advance | in-flight | issue [#459](https://github.com/h4ckf0r0day/obscura/issues/459), PR [#458](https://github.com/h4ckf0r0day/obscura/pull/458). Verified against real Chrome: assigning `scrollTop` fires exactly one `scroll` event there, zero on upstream obscura, one with this patch. Measured impact: a scroll-listener loader runs 0 times instead of 2, collecting 2 rows instead of 12 — silently, with no error. | `crates/obscura-js/js/bootstrap.js`, `crates/obscura-cdp/tests/scroll_event_on_assignment.rs` |
 | GHCR image publish workflow (upstream publishes to Docker Hub with secrets we do not carry) | **fork-only** | n/a | `.github/workflows/docker-ghcr.yml`, `Dockerfile` |
 | This manifest + the sync script | **fork-only** | n/a | `FORK.md`, `scripts/sync-upstream.sh` |
 

--- a/FORK.md
+++ b/FORK.md
@@ -1,0 +1,73 @@
+# Fork manifest
+
+`asap-cool/obscura` is a long-lived fork of [`h4ckf0r0day/obscura`](https://github.com/h4ckf0r0day/obscura),
+maintained so the ASAP platform can pin a browser engine it controls (leads
+sourcing: concurrent Google Maps scraping) instead of depending on an upstream
+release. The fork **tracks upstream continuously** — see [Sync policy](#sync-policy).
+
+The fork keeps the upstream name (crate, binary, CLI all stay `obscura`) so
+upstream merges keep applying cleanly.
+
+## License
+
+Apache-2.0 (unchanged from upstream). Per Apache-2.0 §4(b), the files listed
+below carry changes relative to upstream. `LICENSE` and `NOTICE` are retained.
+This fork does not imply endorsement by the upstream authors.
+
+## Carry set
+
+Everything this fork adds on top of `upstream/main`. Two buckets:
+
+- **in-flight** — proposed upstream; when the PR merges, the code returns via the
+  next sync and the local carry drops out. No permanent divergence.
+- **fork-only** — will not be upstreamed; carried indefinitely. Keep these small
+  and localized so they survive upstream churn.
+
+| Change | Bucket | Upstream | Files |
+|---|---|---|---|
+| Virtualized scroll geometry: content-sized scroll box + viewport client box so SPA feeds (Google Maps search) paginate to their full result set | **fork-only** | issue [#441](https://github.com/h4ckf0r0day/obscura/issues/441) closed: upstream is doing scroll geometry in the rendering engine instead. PR [#442](https://github.com/h4ckf0r0day/obscura/pull/442) closed. **Carries a known cost**: `scrollHeight` runs `querySelectorAll('*')` on every read, measured at 194–240 ms per 200 reads on a 5,000-node container. Cache it on mutation if sourcing gets slow. | `crates/obscura-js/js/bootstrap.js` |
+| GHCR image publish workflow (upstream publishes to Docker Hub with secrets we do not carry) | **fork-only** | n/a | `.github/workflows/docker-ghcr.yml`, `Dockerfile` |
+| This manifest + the sync script | **fork-only** | n/a | `FORK.md`, `scripts/sync-upstream.sh` |
+
+The thread-per-connection V8 isolate confinement and the `--max-connections` /
+glibc-arena caps that used to be carried here landed upstream via
+PR [#435](https://github.com/h4ckf0r0day/obscura/pull/435) (`Closes #430`) and
+came back through the sync, so they are no longer a local carry. Same for the
+Element scroll methods (PR [#431](https://github.com/h4ckf0r0day/obscura/pull/431))
+and the CDP context isolation (issue
+[#449](https://github.com/h4ckf0r0day/obscura/issues/449) →
+PR [#456](https://github.com/h4ckf0r0day/obscura/pull/456)).
+
+When you add a change that upstream will not take, append a **fork-only** row here
+and keep the patch surgical.
+
+## Sync policy
+
+Run `scripts/sync-upstream.sh`. It fetches `upstream/main`, merges it into `main`,
+builds, and runs the hard gate (concurrency test + obstacle-course). It never
+pushes: review, then push and re-pin yourself.
+
+```sh
+git remote add upstream https://github.com/h4ckf0r0day/obscura.git  # once
+scripts/sync-upstream.sh
+```
+
+Gate (must be green before pushing a sync):
+
+- `cargo nextest run -p obscura-cdp` — 100% (includes the concurrency regression).
+- obstacle-course **33/33** (from the `obscura-benchmark` repo, path via `OBSCURA_BENCH`).
+- Manual: the live Google Maps feed still paginates to its full result set.
+
+The pre-existing `obscura-js runtime::tests::*` failures are an upstream unit-harness
+limitation (no DOM built), not a regression — the gate ignores them.
+
+## Downstream pinning (ASAP)
+
+Pin the **digest**, never a moving tag, so nothing changes under the runtime
+without a deliberate re-pin:
+
+```
+ghcr.io/asap-cool/obscura@sha256:<digest>
+```
+
+Sync on your cadence, run the gate, rebuild the image, then re-pin.

--- a/FORK.md
+++ b/FORK.md
@@ -26,20 +26,33 @@ Everything this fork adds on top of `upstream/main`. Two buckets:
 | Change | Bucket | Upstream | Files |
 |---|---|---|---|
 | Fire a `scroll` event when `scrollTop` / `scrollLeft` are assigned directly (upstream only fires from `scrollTo`/`scrollBy`), so scroll-driven lazy loaders advance | in-flight | issue [#459](https://github.com/h4ckf0r0day/obscura/issues/459), PR [#458](https://github.com/h4ckf0r0day/obscura/pull/458). Verified against real Chrome: assigning `scrollTop` fires exactly one `scroll` event there, zero on upstream obscura, one with this patch. Measured impact: a scroll-listener loader runs 0 times instead of 2, collecting 2 rows instead of 12 — silently, with no error. | `crates/obscura-js/js/bootstrap.js`, `crates/obscura-cdp/tests/scroll_event_on_assignment.rs` |
+| Report a content-sized scroll box on non-viewport elements (`clientHeight` = a constant instead of `20`, `scrollHeight` = `max(that, descendants * 40)`), so `scrollTop = scrollHeight` keeps *moving* across passes and a virtualized feed pages past its first batch | in-flight | issue [#441](https://github.com/h4ckf0r0day/obscura/issues/441). Reporting only: `scrollTop` stays unclamped, and neither number tracks `innerHeight` — see below for why both matter. Measured on live Google Maps search: **31 → 110** unique results for `plombier marseille`, **36 → 108** for `restaurant lyon`. | `crates/obscura-js/js/bootstrap.js`, `crates/obscura-cdp/tests/scroll_box_geometry.rs` |
 | GHCR image publish workflow (upstream publishes to Docker Hub with secrets we do not carry) | **fork-only** | n/a | `.github/workflows/docker-ghcr.yml`, `Dockerfile` |
 | This manifest + the sync script | **fork-only** | n/a | `FORK.md`, `scripts/sync-upstream.sh` |
 
-The virtualized **scroll geometry** heuristic (synthetic `scrollHeight` from
-`querySelectorAll('*').length * 40`, viewport-sized `clientHeight` on every
-element, and a `scrollTop` clamped to that box) was dropped rather than carried.
-It made pagination *worse*, and non-deterministically so: the clamp resolves to
-`max(0, descendants * 40 - innerHeight)`, and obscura's stealth layer randomises
-`innerHeight` per session (measured 640 / 640 / 688 / 970 across four runs). So
-whether a feed paginated or froze at its first batch depended on the viewport
-draw — same page, same code, different outcome per run. Measured on a
-progress-gated feed fixture: 20/120 items on an unlucky draw, 120/120 without
-the heuristic. What survives is the scroll-event dispatch above, which is the
-part that was actually load-bearing.
+The **scroll geometry** carry above is the second attempt. The first one bundled
+three things and was dropped for the two that were wrong:
+
+- a `scrollTop` **clamped** to the synthetic box — the harmful half. Clamping to
+  a made-up maximum pins the offset on a loader that has not been handed content
+  to scroll over yet, and it deadlocks: no scroll, no content, no scroll.
+  Re-measured on live Maps while reintroducing only this: the feed freezes at 20
+  results. `scrollTop` therefore stays unclamped.
+- a `clientHeight` derived from **`innerHeight`** — the non-deterministic half.
+  The stealth layer randomises the viewport per session (measured 640 / 640 /
+  688 / 970 across four runs), so the same page paginated or stalled depending on
+  the draw: 20/120 items on an unlucky one. Both numbers are now constants.
+- the **reporting** itself, which was the load-bearing part and is what the row
+  above carries. With a 20px box, `scrollTop = scrollHeight` lands on the same
+  offset every pass; an unchanged offset is not a scroll, so the loader is never
+  reached again and the feed plateaus after its first batch.
+
+`crates/obscura-cdp/tests/scroll_box_geometry.rs` locks all three in: the box
+grows with the subtree, it does not move when `innerHeight` does, and a
+virtualized feed pages to its last row. The subtree walk behind `scrollHeight` is
+memoized against a DOM epoch bumped by the structural `op_dom` commands, so
+repeat reads inside one scroll operation are free while the first read after an
+insertion measures the new rows.
 
 The thread-per-connection V8 isolate confinement and the `--max-connections` /
 glibc-arena caps that used to be carried here landed upstream via

--- a/crates/obscura-cdp/tests/scroll_box_geometry.rs
+++ b/crates/obscura-cdp/tests/scroll_box_geometry.rs
@@ -1,0 +1,205 @@
+//! A non-viewport element must report a scroll box sized from its content, and
+//! must report the same box whatever viewport the stealth layer drew.
+//!
+//! Scroll-driven virtualized feeds (Google Maps search results, infinite lists)
+//! page by "the user moved one viewport further, load the next batch". With the
+//! 20px stub box every element used to report, `el.scrollTop = el.scrollHeight`
+//! lands on 20 every time: the first assignment is progress, the rest are
+//! no-ops, and the feed freezes after its first batch no matter how many scroll
+//! passes the driver makes.
+//!
+//! This is a *reporting* fix: `scrollTop` stays unclamped (see
+//! `scroll_event_on_assignment.rs`), because clamping to a synthetic maximum
+//! deadlocks a loader that has not been given content to scroll over yet. And
+//! the box is built from constants rather than `innerHeight` — the stealth layer
+//! randomises the viewport per session, so a viewport-derived box paginates or
+//! stalls depending on the draw.
+
+use obscura_cdp::dispatch::{dispatch, CdpContext};
+use obscura_cdp::types::CdpRequest;
+use serde_json::{json, Value};
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::TcpListener;
+
+/// Rows the fixture feed holds in total; the loader hands them out in batches.
+const TOTAL_ROWS: usize = 120;
+
+async fn serve_once() -> String {
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    tokio::spawn(async move {
+        let (mut socket, _) = listener.accept().await.unwrap();
+        tokio::spawn(async move {
+            let mut buf = [0u8; 2048];
+            let _ = socket.read(&mut buf).await.unwrap();
+            let body = "<html><body><div id=\"feed\"><p>a</p><p>b</p></div></body></html>";
+            let resp = format!(
+                "HTTP/1.1 200 OK\r\nContent-Type: text/html\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{body}",
+                body.len()
+            );
+            let _ = socket.write_all(resp.as_bytes()).await;
+        });
+    });
+    format!("http://{addr}/")
+}
+
+async fn cdp(ctx: &mut CdpContext, id: u64, method: &str, params: Value, session_id: &str) -> Value {
+    let resp = dispatch(
+        &CdpRequest {
+            id,
+            method: method.to_string(),
+            params,
+            session_id: Some(session_id.to_string()),
+        },
+        ctx,
+    )
+    .await;
+    assert!(resp.error.is_none(), "CDP {method} failed: {:?}", resp.error);
+    resp.result.unwrap_or_else(|| json!({}))
+}
+
+/// The probes below settle their scroll events through `setTimeout`, so every
+/// evaluation is awaited.
+async fn eval(ctx: &mut CdpContext, id: u64, expr: &str, session_id: &str) -> Value {
+    let v = cdp(
+        ctx,
+        id,
+        "Runtime.evaluate",
+        json!({"expression": expr, "returnByValue": true, "awaitPromise": true}),
+        session_id,
+    )
+    .await;
+    let raw = v["result"]["value"]
+        .as_str()
+        .unwrap_or_else(|| panic!("probe returned no value: {v}"));
+    serde_json::from_str::<Value>(raw).unwrap()
+}
+
+async fn setup() -> (CdpContext, String) {
+    std::env::set_var("OBSCURA_ALLOW_PRIVATE_NETWORK", "1");
+    let url = serve_once().await;
+    let mut ctx = CdpContext::new();
+    let page_id = ctx.create_page();
+    let session_id = "session-1";
+    ctx.sessions.insert(session_id.to_string(), page_id.clone());
+    cdp(
+        &mut ctx,
+        1,
+        "Page.navigate",
+        json!({"url": url, "waitUntil": "load"}),
+        session_id,
+    )
+    .await;
+    (ctx, session_id.to_string())
+}
+
+/// A container with many descendants must report a scroll range, not a 20px
+/// stub: without a range there is nothing for a lazy loader to scroll through.
+#[tokio::test(flavor = "current_thread")]
+async fn scroll_box_is_sized_from_the_subtree() {
+    let (mut ctx, sid) = setup().await;
+    let r = eval(
+        &mut ctx,
+        2,
+        r#"(() => {
+            const el = document.getElementById('feed');
+            const empty = el.scrollHeight;
+            for (let i = 0; i < 100; i++) el.appendChild(document.createElement('p'));
+            return Promise.resolve(JSON.stringify({
+                empty,
+                clientHeight: el.clientHeight,
+                filled: el.scrollHeight,
+            }));
+        })()"#,
+        &sid,
+    )
+    .await;
+    assert_eq!(
+        r["clientHeight"], 800,
+        "the client box must be the synthetic viewport constant"
+    );
+    assert_eq!(
+        r["empty"], 800,
+        "an element with no content still reports at least one client box"
+    );
+    assert!(
+        r["filled"].as_i64().unwrap() > r["empty"].as_i64().unwrap(),
+        "adding 100 rows must grow the scroll box (got {})",
+        r["filled"]
+    );
+}
+
+/// The stealth layer randomises `innerHeight` per session. A scroll box that
+/// tracked it paginated or stalled depending on the draw, so the box must be
+/// invariant under it.
+#[tokio::test(flavor = "current_thread")]
+async fn scroll_box_does_not_track_the_randomised_viewport() {
+    let (mut ctx, sid) = setup().await;
+    let r = eval(
+        &mut ctx,
+        2,
+        r#"(() => {
+            const el = document.getElementById('feed');
+            for (let i = 0; i < 100; i++) el.appendChild(document.createElement('p'));
+            const read = () => ({ ch: el.clientHeight, sh: el.scrollHeight });
+            globalThis.innerHeight = 640;
+            const small = read();
+            globalThis.innerHeight = 970;
+            const large = read();
+            return Promise.resolve(JSON.stringify({ small, large }));
+        })()"#,
+        &sid,
+    )
+    .await;
+    assert_eq!(
+        r["small"], r["large"],
+        "the scroll box must be identical across viewport draws"
+    );
+}
+
+/// The behaviour the geometry exists for. The fixture loader is the real
+/// virtualized-feed contract: hand out the next batch once the driver has
+/// scrolled a further client box down. With the stub box every pass landed on
+/// the same offset, so this stopped at the first batch.
+#[tokio::test(flavor = "current_thread")]
+async fn virtualized_feed_pages_to_its_full_result_set() {
+    let (mut ctx, sid) = setup().await;
+    let r = eval(
+        &mut ctx,
+        2,
+        &format!(
+            r#"(async () => {{
+            const el = document.getElementById('feed');
+            const TOTAL = {TOTAL_ROWS};
+            let served = 0;
+            // A paginating feed hands out its next batch when it is scrolled.
+            // Nothing here reads the geometry: what the geometry decides is
+            // whether `scrollTop = scrollHeight` still MOVES on the next pass,
+            // and a scroll that does not move is not a scroll event. With a
+            // fixed-size box every pass after the first lands on the same
+            // offset, so this listener is never reached again.
+            el.addEventListener('scroll', () => {{
+                for (let i = 0; i < 30 && served < TOTAL; i++, served++) {{
+                    const row = document.createElement('p');
+                    row.className = 'row';
+                    el.appendChild(row);
+                }}
+            }});
+            const sleep = ms => new Promise(r => setTimeout(r, ms));
+            for (let pass = 0; pass < 40; pass++) {{
+                el.scrollTop = el.scrollHeight;
+                // The scroll event is dispatched from a timer, so yield to let
+                // the batch it triggers land before measuring the next pass.
+                await sleep(0);
+            }}
+            return JSON.stringify({{ rows: el.querySelectorAll('p.row').length }});
+        }})()"#
+        ),
+        &sid,
+    )
+    .await;
+    assert_eq!(
+        r["rows"], TOTAL_ROWS as i64,
+        "the feed must page in every row, not plateau on its first batch"
+    );
+}

--- a/crates/obscura-cdp/tests/scroll_event_on_assignment.rs
+++ b/crates/obscura-cdp/tests/scroll_event_on_assignment.rs
@@ -1,0 +1,165 @@
+//! Assigning `scrollTop` / `scrollLeft` must fire a `scroll` event.
+//!
+//! `scrollTo`/`scrollBy` already dispatched one; direct assignment did not, so
+//! the very common lazy-load idiom
+//!
+//! ```js
+//! el.addEventListener('scroll', loadMore);
+//! el.scrollTop = el.scrollHeight;      // never reached loadMore
+//! ```
+//!
+//! silently did nothing and scroll-driven feeds stalled after their first batch.
+//!
+//! Checked against a real Chrome over CDP with this same probe: assigning
+//! `scrollTop` fires exactly one `scroll` event there. These tests assert the
+//! same observable behaviour, not the synthetic geometry around it — the offset
+//! is intentionally not clamped, since without layout any maximum is a guess.
+
+use obscura_cdp::dispatch::{dispatch, CdpContext};
+use obscura_cdp::types::CdpRequest;
+use serde_json::{json, Value};
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::TcpListener;
+
+async fn serve_once() -> String {
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    tokio::spawn(async move {
+        let (mut socket, _) = listener.accept().await.unwrap();
+        tokio::spawn(async move {
+            let mut buf = [0u8; 2048];
+            let _ = socket.read(&mut buf).await.unwrap();
+            let body = "<html><body><div id=\"box\"><p>a</p><p>b</p></div></body></html>";
+            let resp = format!(
+                "HTTP/1.1 200 OK\r\nContent-Type: text/html\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{body}",
+                body.len()
+            );
+            let _ = socket.write_all(resp.as_bytes()).await;
+        });
+    });
+    format!("http://{addr}/")
+}
+
+async fn cdp(ctx: &mut CdpContext, id: u64, method: &str, params: Value, session_id: &str) -> Value {
+    let resp = dispatch(
+        &CdpRequest {
+            id,
+            method: method.to_string(),
+            params,
+            session_id: Some(session_id.to_string()),
+        },
+        ctx,
+    )
+    .await;
+    assert!(resp.error.is_none(), "CDP {method} failed: {:?}", resp.error);
+    resp.result.unwrap_or_else(|| json!({}))
+}
+
+/// `awaitPromise` matters here: the scroll event is dispatched from a
+/// `setTimeout(..., 0)`, so the probe has to yield before reading the counter.
+async fn eval(ctx: &mut CdpContext, id: u64, expr: &str, session_id: &str) -> Value {
+    cdp(
+        ctx,
+        id,
+        "Runtime.evaluate",
+        json!({"expression": expr, "returnByValue": true, "awaitPromise": true}),
+        session_id,
+    )
+    .await
+}
+
+async fn setup() -> (CdpContext, String) {
+    std::env::set_var("OBSCURA_ALLOW_PRIVATE_NETWORK", "1");
+    let url = serve_once().await;
+    let mut ctx = CdpContext::new();
+    let page_id = ctx.create_page();
+    let session_id = "session-1";
+    ctx.sessions.insert(session_id.to_string(), page_id.clone());
+    cdp(&mut ctx, 1, "Page.navigate", json!({"url": url, "waitUntil": "load"}), session_id).await;
+    (ctx, session_id.to_string())
+}
+
+async fn probe(ctx: &mut CdpContext, sid: &str, body: &str) -> Value {
+    let expr = format!(
+        r#"(() => {{
+            const el = document.getElementById('box');
+            let fired = 0;
+            el.addEventListener('scroll', () => {{ fired++; }});
+            {body}
+            return new Promise(r => setTimeout(() => r(JSON.stringify({{
+                fired, top: el.scrollTop, left: el.scrollLeft,
+            }})), 0));
+        }})()"#
+    );
+    let v = eval(ctx, 2, &expr, sid).await;
+    serde_json::from_str::<Value>(v["result"]["value"].as_str().unwrap()).unwrap()
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn assigning_scroll_top_fires_one_scroll_event() {
+    let (mut ctx, sid) = setup().await;
+    let r = probe(&mut ctx, &sid, "el.scrollTop = 100;").await;
+    assert_eq!(r["fired"], 1, "scrollTop assignment must fire exactly one scroll event");
+    assert_eq!(r["top"], 100, "scrollTop must round-trip the assigned value");
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn assigning_scroll_left_fires_one_scroll_event() {
+    let (mut ctx, sid) = setup().await;
+    let r = probe(&mut ctx, &sid, "el.scrollLeft = 40;").await;
+    assert_eq!(r["fired"], 1, "scrollLeft assignment must fire exactly one scroll event");
+    assert_eq!(r["left"], 40, "scrollLeft must round-trip the assigned value");
+}
+
+/// Re-assigning the same offset is not a scroll, so it must stay silent —
+/// otherwise a loader that writes `scrollTop` on every frame re-enters forever.
+#[tokio::test(flavor = "current_thread")]
+async fn reassigning_the_same_offset_is_silent() {
+    let (mut ctx, sid) = setup().await;
+    let r = probe(&mut ctx, &sid, "el.scrollTop = 100; el.scrollTop = 100;").await;
+    assert_eq!(r["fired"], 1, "only the offset change fires; the repeat must not");
+}
+
+/// `scrollTo` moves both axes, and a real browser reports one scroll per
+/// movement rather than one per axis. The setters suppress their own event
+/// inside `scrollTo`/`scrollBy` so the operation stays a single event.
+#[tokio::test(flavor = "current_thread")]
+async fn scroll_to_coalesces_both_axes_into_one_event() {
+    let (mut ctx, sid) = setup().await;
+    let r = probe(&mut ctx, &sid, "el.scrollTo(30, 60);").await;
+    assert_eq!(r["fired"], 1, "scrollTo must fire one event, not one per axis");
+    assert_eq!(r["top"], 60);
+    assert_eq!(r["left"], 30);
+}
+
+/// The lazy-load idiom the fix exists for: a listener that appends more rows
+/// when the feed is scrolled. Before the fix this counted 0 and feeds froze.
+#[tokio::test(flavor = "current_thread")]
+async fn scroll_driven_lazy_loader_advances() {
+    let (mut ctx, sid) = setup().await;
+    let v = eval(
+        &mut ctx,
+        2,
+        r#"(() => {
+            const el = document.getElementById('box');
+            let batches = 0;
+            el.addEventListener('scroll', () => {
+                if (batches >= 3) return;
+                batches++;
+                for (let i = 0; i < 5; i++) el.appendChild(document.createElement('p'));
+            });
+            el.scrollTop = 500;
+            return new Promise(r => setTimeout(() => {
+                el.scrollTop = 1000;
+                setTimeout(() => r(JSON.stringify({
+                    batches, rows: el.querySelectorAll('p').length,
+                })), 0);
+            }, 0));
+        })()"#,
+        &sid,
+    )
+    .await;
+    let r = serde_json::from_str::<Value>(v["result"]["value"].as_str().unwrap()).unwrap();
+    assert_eq!(r["batches"], 2, "each forward scroll must reach the loader");
+    assert_eq!(r["rows"], 12, "2 starting rows + 2 batches of 5");
+}

--- a/crates/obscura-js/js/bootstrap.js
+++ b/crates/obscura-js/js/bootstrap.js
@@ -68,7 +68,23 @@ globalThis.dispatchEvent = function(event) {
   return !event.defaultPrevented;
 };
 
-const _dom = (cmd, a1, a2) => Deno.core.ops.op_dom(cmd, String(a1 ?? ""), String(a2 ?? ""));
+// Commands that change the tree. Element's synthetic scroll box is derived from
+// a subtree walk, which is far too costly to redo on every read; bumping an
+// epoch here lets that value be memoized and invalidated exactly when the shape
+// it measures actually changed, in the one place every mutation goes through.
+const _domStructuralCmds = new Set([
+  "append_child",
+  "insert_before",
+  "remove_child",
+  "set_inner_html",
+  "set_text_content",
+]);
+globalThis.__domEpoch = 0;
+
+const _dom = (cmd, a1, a2) => {
+  if (_domStructuralCmds.has(cmd)) globalThis.__domEpoch++;
+  return Deno.core.ops.op_dom(cmd, String(a1 ?? ""), String(a2 ?? ""));
+};
 
 const _nativeFns = new Set();
 // Exact toString override for members whose native form is not just
@@ -1177,6 +1193,12 @@ function _isSubmitButton(el) {
   return false;
 }
 
+// Synthetic scroll-box constants for non-viewport elements. There is no layout
+// engine, so these stand in for a measured box; they are fixed values on purpose
+// (see the scrollHeight getter for why they must not track the viewport).
+const SYNTHETIC_CLIENT_HEIGHT = 800;
+const SYNTHETIC_ROW_HEIGHT = 40;
+
 class Element extends Node {
   constructor(nid) {
     super(nid);
@@ -2103,9 +2125,35 @@ class Element extends Node {
   // Puppeteer's #clickableBox clips boxes to document.documentElement.clientWidth/Height;
   // returning 100x20 there made every element appear off-screen and broke .click().
   get clientWidth() { return this._isViewportRoot() ? (globalThis.innerWidth || 1280) : 100; }
-  get clientHeight() { return this._isViewportRoot() ? (globalThis.innerHeight || 720) : 20; }
+  get clientHeight() { return this._isViewportRoot() ? (globalThis.innerHeight || 720) : SYNTHETIC_CLIENT_HEIGHT; }
   get scrollWidth() { return this._isViewportRoot() ? (globalThis.innerWidth || 1280) : 100; }
-  get scrollHeight() { return this._isViewportRoot() ? (globalThis.innerHeight || 720) : 20; }
+  // Scroll-driven lazy loaders page while `scrollTop + clientHeight < scrollHeight`.
+  // With a 20px stub box that predicate is false immediately, so a virtualized
+  // feed stops after its first batch. Report a box sized from the subtree so the
+  // predicate keeps holding as content arrives.
+  //
+  // Both numbers are deliberately CONSTANTS rather than `innerHeight`: the
+  // stealth layer randomises the viewport per session, and a scroll box derived
+  // from it paginates or stalls depending on the draw. This is reporting only --
+  // `scrollTop` below stays unclamped, because clamping to a synthetic max is
+  // what deadlocks a loader that has not yet been given content to scroll over.
+  get scrollHeight() {
+    if (this._isViewportRoot()) return globalThis.innerHeight || 720;
+    return Math.max(SYNTHETIC_CLIENT_HEIGHT, this._syntheticContentHeight());
+  }
+  // `querySelectorAll('*')` walks the subtree, and a loader reads scrollHeight
+  // several times per scroll operation. Memoize against the DOM epoch: repeat
+  // reads are free, and the first read after any insertion or removal walks
+  // again, so a feed that just appended rows measures them immediately.
+  _syntheticContentHeight() {
+    const epoch = globalThis.__domEpoch;
+    if (this._scrollBoxEpoch === epoch) return this._scrollBox;
+    let descendants = 0;
+    try { descendants = this.querySelectorAll('*').length; } catch (e) { /* detached subtree */ }
+    this._scrollBox = descendants * SYNTHETIC_ROW_HEIGHT;
+    this._scrollBoxEpoch = epoch;
+    return this._scrollBox;
+  }
   _isViewportRoot() {
     const t = this.tagName;
     return t === 'HTML' || t === 'BODY';

--- a/crates/obscura-js/js/bootstrap.js
+++ b/crates/obscura-js/js/bootstrap.js
@@ -2102,41 +2102,25 @@ class Element extends Node {
   // documentElement / body / window expose VIEWPORT geometry, not their own content box.
   // Puppeteer's #clickableBox clips boxes to document.documentElement.clientWidth/Height;
   // returning 100x20 there made every element appear off-screen and broke .click().
-  // With no layout engine, a scroll container needs a viewport-sized client box
-  // and a content-sized scroll box, otherwise scrollTop has no range and the
-  // scroll-driven lazy loaders that PR #431 unblocked still never page in more
-  // rows. Expose the viewport size as the client box for every element (the
-  // click/hit-test path uses getBoundingClientRect, not this) and derive the
-  // scroll box from the subtree size below.
-  get clientWidth() { return globalThis.innerWidth || 1280; }
-  get clientHeight() { return globalThis.innerHeight || 720; }
-  get scrollWidth() { return globalThis.innerWidth || 1280; }
-  get scrollHeight() {
-    if (this._isViewportRoot()) return (globalThis.innerHeight || 720);
-    // Approximate content height from the descendant count so virtualized lists
-    // (which page in more rows as scrollTop nears scrollHeight) can advance past
-    // their first batch. childElementCount is unreliable on these synthetic
-    // subtrees, so count descendants. Leaf elements keep the old 20px height.
-    let n = 0;
-    try { n = this.querySelectorAll('*').length; } catch (e) {}
-    const synthetic = n * 40;
-    return synthetic > 20 ? synthetic : 20;
-  }
+  get clientWidth() { return this._isViewportRoot() ? (globalThis.innerWidth || 1280) : 100; }
+  get clientHeight() { return this._isViewportRoot() ? (globalThis.innerHeight || 720) : 20; }
+  get scrollWidth() { return this._isViewportRoot() ? (globalThis.innerWidth || 1280) : 100; }
+  get scrollHeight() { return this._isViewportRoot() ? (globalThis.innerHeight || 720) : 20; }
   _isViewportRoot() {
     const t = this.tagName;
     return t === 'HTML' || t === 'BODY';
   }
-  // No layout engine, so there is no real overflow to scroll. We track a scroll
-  // offset so scrollTop/scrollLeft round-trip, clamp it to the synthetic scroll
-  // box above (so virtualized lists render the window at the content bottom
-  // instead of overshooting into empty space), and fire a scroll event on direct
-  // assignment -- lazy loaders that set `el.scrollTop = el.scrollHeight` rely on
-  // that event, which the scroll methods below would otherwise be the only source of.
+  // No layout engine, so there is no real overflow to scroll and the offset is
+  // deliberately NOT clamped: without real geometry any synthetic max is a
+  // guess, and a max derived from a stub scroll box pins scrollTop at 0, which
+  // deadlocks scroll-driven lazy loaders (no scroll -> no content -> no scroll).
+  // We track the offset so scrollTop/scrollLeft round-trip, and fire a scroll
+  // event on direct assignment -- lazy loaders that set `el.scrollTop = N` rely
+  // on that event, and scrollTo/scrollBy below would otherwise be its only source.
   get scrollTop() { return this._scrollTop || 0; }
   set scrollTop(v) {
     v = +v;
-    const max = Math.max(0, this.scrollHeight - this.clientHeight);
-    const nv = Number.isFinite(v) && v > 0 ? Math.min(v, max) : 0;
+    const nv = Number.isFinite(v) && v > 0 ? v : 0;
     const changed = nv !== (this._scrollTop || 0);
     this._scrollTop = nv;
     if (changed && !this._scrollSuppress) this._fireScroll();
@@ -2207,9 +2191,9 @@ class Element extends Node {
   set ariaSelected(v) { if (v == null) this.removeAttribute('aria-selected'); else this.setAttribute('aria-selected', String(v)); }
   scrollIntoView() { globalThis.__obscura_click_target = this; }
   // scrollTo/scrollBy/scroll accept either (x, y) or a ScrollToOptions object.
-  // The setters clamp the offset and fire the scroll event; suppress their
-  // per-axis events so the whole operation emits a single scroll event, the way
-  // a real browser coalesces one scroll per movement.
+  // The setters fire a scroll event of their own, so suppress the per-axis ones
+  // here and emit a single event for the whole movement, the way a real browser
+  // coalesces one scroll per scroll operation rather than one per axis.
   scrollTo(x, y) {
     let left, top;
     if (x !== null && typeof x === 'object') { left = x.left; top = x.top; }

--- a/crates/obscura-js/js/bootstrap.js
+++ b/crates/obscura-js/js/bootstrap.js
@@ -2102,21 +2102,53 @@ class Element extends Node {
   // documentElement / body / window expose VIEWPORT geometry, not their own content box.
   // Puppeteer's #clickableBox clips boxes to document.documentElement.clientWidth/Height;
   // returning 100x20 there made every element appear off-screen and broke .click().
-  get clientWidth() { return this._isViewportRoot() ? (globalThis.innerWidth || 1280) : 100; }
-  get clientHeight() { return this._isViewportRoot() ? (globalThis.innerHeight || 720) : 20; }
-  get scrollWidth() { return this._isViewportRoot() ? (globalThis.innerWidth || 1280) : 100; }
-  get scrollHeight() { return this._isViewportRoot() ? (globalThis.innerHeight || 720) : 20; }
+  // With no layout engine, a scroll container needs a viewport-sized client box
+  // and a content-sized scroll box, otherwise scrollTop has no range and the
+  // scroll-driven lazy loaders that PR #431 unblocked still never page in more
+  // rows. Expose the viewport size as the client box for every element (the
+  // click/hit-test path uses getBoundingClientRect, not this) and derive the
+  // scroll box from the subtree size below.
+  get clientWidth() { return globalThis.innerWidth || 1280; }
+  get clientHeight() { return globalThis.innerHeight || 720; }
+  get scrollWidth() { return globalThis.innerWidth || 1280; }
+  get scrollHeight() {
+    if (this._isViewportRoot()) return (globalThis.innerHeight || 720);
+    // Approximate content height from the descendant count so virtualized lists
+    // (which page in more rows as scrollTop nears scrollHeight) can advance past
+    // their first batch. childElementCount is unreliable on these synthetic
+    // subtrees, so count descendants. Leaf elements keep the old 20px height.
+    let n = 0;
+    try { n = this.querySelectorAll('*').length; } catch (e) {}
+    const synthetic = n * 40;
+    return synthetic > 20 ? synthetic : 20;
+  }
   _isViewportRoot() {
     const t = this.tagName;
     return t === 'HTML' || t === 'BODY';
   }
-  // No layout engine, so there is no real overflow to scroll. We still track a
-  // scroll offset so scrollTop/scrollLeft round-trip and the scroll methods
-  // below can report a position, which is what infinite-scroll code reads back.
+  // No layout engine, so there is no real overflow to scroll. We track a scroll
+  // offset so scrollTop/scrollLeft round-trip, clamp it to the synthetic scroll
+  // box above (so virtualized lists render the window at the content bottom
+  // instead of overshooting into empty space), and fire a scroll event on direct
+  // assignment -- lazy loaders that set `el.scrollTop = el.scrollHeight` rely on
+  // that event, which the scroll methods below would otherwise be the only source of.
   get scrollTop() { return this._scrollTop || 0; }
-  set scrollTop(v) { v = +v; this._scrollTop = Number.isFinite(v) && v > 0 ? v : 0; }
+  set scrollTop(v) {
+    v = +v;
+    const max = Math.max(0, this.scrollHeight - this.clientHeight);
+    const nv = Number.isFinite(v) && v > 0 ? Math.min(v, max) : 0;
+    const changed = nv !== (this._scrollTop || 0);
+    this._scrollTop = nv;
+    if (changed && !this._scrollSuppress) this._fireScroll();
+  }
   get scrollLeft() { return this._scrollLeft || 0; }
-  set scrollLeft(v) { v = +v; this._scrollLeft = Number.isFinite(v) && v > 0 ? v : 0; }
+  set scrollLeft(v) {
+    v = +v;
+    const nv = Number.isFinite(v) && v > 0 ? v : 0;
+    const changed = nv !== (this._scrollLeft || 0);
+    this._scrollLeft = nv;
+    if (changed && !this._scrollSuppress) this._fireScroll();
+  }
   getBoundingClientRect() {
     globalThis.__obscura_click_target = this;
     // documentElement and body span the full viewport. Without this every
@@ -2175,15 +2207,17 @@ class Element extends Node {
   set ariaSelected(v) { if (v == null) this.removeAttribute('aria-selected'); else this.setAttribute('aria-selected', String(v)); }
   scrollIntoView() { globalThis.__obscura_click_target = this; }
   // scrollTo/scrollBy/scroll accept either (x, y) or a ScrollToOptions object.
-  // Without layout the offset cannot be clamped to a real max, but updating it
-  // and firing a scroll event lets scroll-driven lazy loaders advance instead
-  // of throwing "scrollBy is not a function".
+  // The setters clamp the offset and fire the scroll event; suppress their
+  // per-axis events so the whole operation emits a single scroll event, the way
+  // a real browser coalesces one scroll per movement.
   scrollTo(x, y) {
     let left, top;
     if (x !== null && typeof x === 'object') { left = x.left; top = x.top; }
     else { left = x; top = y; }
+    this._scrollSuppress = true;
     if (left !== undefined) this.scrollLeft = +left || 0;
     if (top !== undefined) this.scrollTop = +top || 0;
+    this._scrollSuppress = false;
     this._fireScroll();
   }
   scroll(x, y) { this.scrollTo(x, y); }
@@ -2191,8 +2225,10 @@ class Element extends Node {
     let dl, dt;
     if (x !== null && typeof x === 'object') { dl = x.left; dt = x.top; }
     else { dl = x; dt = y; }
+    this._scrollSuppress = true;
     this.scrollLeft = (this.scrollLeft || 0) + (+dl || 0);
     this.scrollTop = (this.scrollTop || 0) + (+dt || 0);
+    this._scrollSuppress = false;
     this._fireScroll();
   }
   _fireScroll() {

--- a/scripts/sync-upstream.sh
+++ b/scripts/sync-upstream.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+#
+# Gated upstream sync for the asap-cool/obscura fork.
+#
+# Fetches upstream/main, merges it into the local integration branch, builds, and
+# runs the hard gate. It NEVER pushes: on green, review and push/re-pin yourself.
+# See FORK.md for the carry set and the pinning policy.
+#
+# Env:
+#   UPSTREAM_REMOTE  upstream git remote name        (default: upstream)
+#   MAIN_BRANCH      fork integration branch         (default: main)
+#   OBSCURA_BENCH    path to the obscura-benchmark repo for obstacle-course
+#                    (default: $HOME/Workspace/obscura-benchmark; skipped if absent)
+set -euo pipefail
+
+UPSTREAM_REMOTE="${UPSTREAM_REMOTE:-upstream}"
+MAIN_BRANCH="${MAIN_BRANCH:-main}"
+OBSCURA_BENCH="${OBSCURA_BENCH:-$HOME/Workspace/obscura-benchmark}"
+
+repo_root="$(git rev-parse --show-toplevel)"
+cd "$repo_root"
+bin="$repo_root/target/release/obscura"
+
+say()  { printf '\n\033[1m==> %s\033[0m\n' "$*"; }
+fail() { printf '\n\033[31mSYNC FAILED: %s\033[0m\n' "$*" >&2; exit 1; }
+
+# 0. Preconditions.
+git remote get-url "$UPSTREAM_REMOTE" >/dev/null 2>&1 \
+  || fail "remote '$UPSTREAM_REMOTE' not set (git remote add $UPSTREAM_REMOTE https://github.com/h4ckf0r0day/obscura.git)"
+[ -z "$(git status --porcelain)" ] || fail "working tree is dirty; commit or stash first"
+
+# 1. Fetch upstream and show what is incoming.
+say "Fetching $UPSTREAM_REMOTE"
+git fetch "$UPSTREAM_REMOTE" --quiet
+git checkout --quiet "$MAIN_BRANCH"
+
+incoming="$(git log --oneline "${MAIN_BRANCH}..${UPSTREAM_REMOTE}/main")"
+if [ -z "$incoming" ]; then
+  say "Already up to date with ${UPSTREAM_REMOTE}/main. Nothing to sync."
+  exit 0
+fi
+say "Incoming from ${UPSTREAM_REMOTE}/main:"
+echo "$incoming"
+
+# 2. Merge upstream. Abort cleanly on conflict so the tree is left untouched.
+say "Merging ${UPSTREAM_REMOTE}/main into ${MAIN_BRANCH}"
+if ! git merge --no-edit "${UPSTREAM_REMOTE}/main"; then
+  git merge --abort
+  fail "merge conflict with upstream. Resolve manually, then re-run the gate:
+      git merge ${UPSTREAM_REMOTE}/main    # resolve conflicts (likely the carry in FORK.md)
+      scripts/sync-upstream.sh             # or run the gate steps below by hand"
+fi
+
+# 3. Build.
+say "Building release"
+cargo build --release --bin obscura || fail "release build broke after the merge"
+
+# 4. Hard gate: concurrency + full obscura-cdp suite (the fork's load-bearing carry).
+say "Gate 1/2: cargo nextest run -p obscura-cdp"
+cargo nextest run -p obscura-cdp || fail "obscura-cdp tests red after sync (concurrency regression?)"
+
+# 5. Hard gate: obstacle-course must stay fully green.
+if [ -f "$OBSCURA_BENCH/obstacle-course/run.py" ]; then
+  say "Gate 2/2: obstacle-course ($OBSCURA_BENCH)"
+  oc_out="$(cd "$OBSCURA_BENCH" && OBSCURA_BIN="$bin" python3 obstacle-course/run.py --runs 1 --warmup 0 2>&1)"
+  echo "$oc_out" | grep -iE "correctness:|stages passed" || true
+  score="$(echo "$oc_out" | grep -oE '[0-9]+/[0-9]+ stages passed' | head -1)"
+  [ -n "$score" ] || fail "could not read obstacle-course score"
+  passed="${score%%/*}"; total="${score#*/}"; total="${total%% *}"
+  [ "$passed" = "$total" ] || fail "obstacle-course regressed: $score"
+  say "obstacle-course: $score"
+else
+  printf '\n\033[33mWARN: obstacle-course skipped (set OBSCURA_BENCH to the obscura-benchmark repo).\033[0m\n'
+fi
+
+# 6. Green. Human does the outward steps.
+head_sha="$(git rev-parse --short HEAD)"
+cat <<EOF
+
+$(printf '\033[32mSYNC OK\033[0m') — ${MAIN_BRANCH} is now at ${head_sha}, gate green.
+
+Not pushed. To publish and re-pin:
+  1. Manual check: the live Google Maps feed still paginates to its full result set.
+  2. git push origin ${MAIN_BRANCH}          # triggers the GHCR image build
+  3. Re-pin ASAP to the new digest: ghcr.io/asap-cool/obscura@sha256:<digest>
+EOF


### PR DESCRIPTION
Reopens the problem from #441 with, I hope, the objection answered.

#442 tried to fix this and was rightly closed: it bundled three changes and two of them were wrong. This carries only the third.

### What was wrong with #442

- **It clamped `scrollTop`** to the synthetic box. That pins the offset of a loader which has not been handed any content to scroll over yet, and deadlocks it. Re-measured by reintroducing only this half against live Google Maps: the feed freezes at 20 results.
- **It derived the box from `innerHeight`**, which the stealth layer randomises per session (640 / 640 / 688 / 970 across four runs here). Same page, same code, different outcome per run — 20/120 items on an unlucky draw.

### What is left

Reporting only, for non-viewport elements:

- `clientHeight` → a constant instead of `20`
- `scrollHeight` → `max(that constant, descendants * 40)`

`scrollTop` keeps the unclamped, event-firing behaviour from #458. Viewport roots (`HTML`/`BODY`) are untouched, as is `clientWidth`/`scrollWidth`.

### Why it matters

A feed advances by assigning `el.scrollTop = el.scrollHeight`. With a 20px box that lands on the same offset every pass, an unchanged offset is not a scroll, so the listener is never reached again and the feed plateaus on its first batch.

Live Google Maps search, same driver, same day:

| query | before | after |
|---|---|---|
| `plombier marseille` | 31 unique results | **110** |
| `restaurant lyon` | 36 unique results | **108** |

### Cost

The subtree walk behind `scrollHeight` is memoized against a DOM epoch bumped by the structural `op_dom` commands, so repeat reads inside one scroll operation are free and the first read after an insertion still measures the new rows. That was the other objection to #442, where every read walked the tree.

### Tests

`crates/obscura-cdp/tests/scroll_box_geometry.rs` — the box grows with the subtree, it does not move when `innerHeight` does, and a virtualized feed pages to its last row. Two of the three fail without the patch; the viewport-invariance one exists to stop the `innerHeight` dependency coming back.

`cargo nextest run -p obscura-cdp` 94/94, obstacle-course 33/33.

### Note

Stacked on #458 (the scroll-event fix), so its commit shows here too. Happy to rebase once that lands, or to close this if the rendering engine you mentioned in #441 is close enough that a stopgap is not worth it.