### PR TITLE
test(js): initialize runtime fixtures before evaluation

### DIFF
--- a/crates/obscura-js/src/runtime.rs
+++ b/crates/obscura-js/src/runtime.rs
@@ -1297,10 +1297,11 @@ mod tests {
 
     fn setup_runtime(html: &str) -> ObscuraJsRuntime {
         let dom = parse_html(html);
-        let rt = ObscuraJsRuntime::new();
+        let mut rt = ObscuraJsRuntime::new();
         rt.set_dom(dom);
         rt.set_url("http://example.com/test");
         rt.set_title("Test Page");
+        rt.run_page_init();
         rt
     }
 
@@ -1380,7 +1381,6 @@ mod tests {
     #[test]
     fn append_child_flattens_document_fragment() {
         let mut rt = setup_runtime(r#"<main id="host"></main>"#);
-        rt.run_page_init();
         let result = rt
             .evaluate(
                 r#"
@@ -1415,7 +1415,6 @@ mod tests {
     #[test]
     fn insert_before_flattens_document_fragment_in_order() {
         let mut rt = setup_runtime(r#"<main id="host"><article id="last"></article></main>"#);
-        rt.run_page_init();
         let result = rt
             .evaluate(
                 r#"
@@ -1451,7 +1450,6 @@ mod tests {
         let mut rt = setup_runtime(
             r#"<main id="host"><article id="old"></article><article id="tail"></article></main>"#,
         );
-        rt.run_page_init();
         let result = rt
             .evaluate(
                 r#"
@@ -1987,11 +1985,11 @@ mod tests {
         drop(rt2);
 
         if let Some(dom) = dom1 {
-            let rt1b = ObscuraJsRuntime::new();
+            let mut rt1b = ObscuraJsRuntime::new();
             rt1b.set_dom(dom);
             rt1b.set_url("http://example.com");
             rt1b.set_title("Page1");
-            let mut rt1b = rt1b;
+            rt1b.run_page_init();
             let title1b = rt1b.evaluate("document.querySelector('h1').textContent").unwrap();
             assert_eq!(title1b, serde_json::json!("Page1"));
         }
@@ -2121,11 +2119,12 @@ mod tests {
     fn setup_runtime_with_cookies(html: &str) -> (ObscuraJsRuntime, std::sync::Arc<obscura_net::CookieJar>) {
         let dom = obscura_dom::parse_html(html);
         let jar = std::sync::Arc::new(obscura_net::CookieJar::new());
-        let rt = ObscuraJsRuntime::new();
+        let mut rt = ObscuraJsRuntime::new();
         rt.set_dom(dom);
         rt.set_url("http://example.com/test");
         rt.set_title("Test Page");
         rt.set_cookie_jar(jar.clone());
+        rt.run_page_init();
         (rt, jar)
     }
 


### PR DESCRIPTION
## Summary

- initialize shared runtime fixtures after all per-page properties are set
- initialize cookie-backed and reconstructed runtime fixtures consistently
- remove redundant per-test page initialization calls

`run_page_init()` became an explicit lifecycle step, but the `obscura-js`
test fixtures were not updated. Most runtime tests therefore evaluated against
a null document. This restores the production initialization order in the test
helpers and ensures each fixture is initialized exactly once.

The complete `obscura-js` suite changes from 32/99 passing on current main to
99/99 passing with this patch.

## Testing

- `cargo nextest run -p obscura-js --no-fail-fast` (99/99)
- `cargo build --release -p obscura-cli`
- obstacle course (33/33)
- `git diff --check`
