### PR TITLE
fix(js): implement DOM parentNode() traversal in TreeWalker (#475)

### DIFF
--- a/crates/obscura-js/js/bootstrap.js
+++ b/crates/obscura-js/js/bootstrap.js
@@ -2713,11 +2713,17 @@ class Document extends Node {
         }
         return null;
       },
+      // DOM 6.1 "parentNode" (issue #475). The old version looked only at the
+      // immediate parent, so it couldn't climb past a skipped ancestor; it also
+      // excluded `root` as a result yet stepped to root's own parent when
+      // currentNode was root — returning a node OUTSIDE the walker's subtree.
+      // The loop's `node !== this.root` guard is what keeps the walk inside
+      // root while still allowing root itself to be returned.
       parentNode() {
-        let parent = this.currentNode.parentNode;
-        if (parent && parent !== this.root && this._accept(parent)) {
-          this.currentNode = parent;
-          return parent;
+        let node = this.currentNode;
+        while (node && node !== this.root) {
+          node = node.parentNode;
+          if (node && this._accept(node)) { this.currentNode = node; return node; }
         }
         return null;
       },

--- a/crates/obscura-js/src/runtime.rs
+++ b/crates/obscura-js/src/runtime.rs
@@ -1513,6 +1513,75 @@ mod tests {
 
     /// Issue #461: NodeIterator has no subtree pruning — DOM 6.2 says
     /// FILTER_REJECT behaves as FILTER_SKIP there. The shared walker must not
+    /// Issue #475: parentNode() must never surface a node above `root`. With
+    /// currentNode at root, the old guard stepped to root's own parent and
+    /// returned it — escaping the walker's subtree entirely.
+    #[test]
+    fn tree_walker_parent_node_does_not_escape_above_root() {
+        let mut rt = setup_runtime(r#"<div id="root"><a></a></div>"#);
+        let result = rt
+            .evaluate(
+                r#"
+                const root = document.getElementById('root');
+                const w = document.createTreeWalker(root, NodeFilter.SHOW_ELEMENT);
+                const escaped = w.parentNode();
+                return [escaped, w.currentNode.id];
+                "#,
+            )
+            .unwrap();
+        // No parent within the subtree, and currentNode stays put at root.
+        assert_eq!(result, serde_json::json!([null, "root"]));
+    }
+
+    /// Issue #475: when the accepted ancestor is `root` itself, parentNode()
+    /// returns it and moves currentNode there — the old `parent !== root` guard
+    /// wrongly excluded it.
+    #[test]
+    fn tree_walker_parent_node_can_return_the_root() {
+        let mut rt = setup_runtime(r#"<div id="root"><a></a></div>"#);
+        let result = rt
+            .evaluate(
+                r#"
+                const root = document.getElementById('root');
+                const w = document.createTreeWalker(root, NodeFilter.SHOW_ELEMENT);
+                w.currentNode = root.querySelector('a');
+                const p = w.parentNode();
+                return [p ? p.id : null, w.currentNode === root];
+                "#,
+            )
+            .unwrap();
+        assert_eq!(result, serde_json::json!(["root", true]));
+    }
+
+    /// Issue #475: parentNode() climbs past a skipped ancestor to the first
+    /// accepted one, instead of stopping at the immediate parent.
+    #[test]
+    fn tree_walker_parent_node_climbs_past_skipped_ancestors() {
+        let mut rt = setup_runtime(
+            r#"<div id="root"><main id="m"><section><a></a></section></main></div>"#,
+        );
+        let result = rt
+            .evaluate(
+                r#"
+                const root = document.getElementById('root');
+                const w = document.createTreeWalker(root, NodeFilter.SHOW_ELEMENT, {
+                    acceptNode(n) {
+                        return n.tagName === 'SECTION'
+                            ? NodeFilter.FILTER_SKIP
+                            : NodeFilter.FILTER_ACCEPT;
+                    }
+                });
+                w.currentNode = root.querySelector('a');
+                const p = w.parentNode();
+                return p ? p.id : null;
+                "#,
+            )
+            .unwrap();
+        // <a>'s parent <section> is skipped, so <main> is the first accepted
+        // ancestor — not null, and not the immediate <section>.
+        assert_eq!(result, serde_json::json!("m"));
+    }
+
     /// leak TreeWalker's pruning into it.
     #[test]
     fn node_iterator_treats_filter_reject_as_skip() {


### PR DESCRIPTION
Fixes #475.

Independent of the other open DOM PRs in behaviour — it reuses the three-valued `_filter` from #461 (merged) and needs nothing from #466/#470/#472. It does **textually conflict with #471** (issue #469): both rewrite adjacent functions in the same TreeWalker block of `bootstrap.js`. There is no logical overlap — whichever lands second needs a trivial rebase. Verified with a local test-merge.

`TreeWalker.parentNode()` inspected only the immediate parent, which produced three deviations from the [DOM 6.1 algorithm](https://dom.spec.whatwg.org/#dom-treewalker-parentnode):

```js
parentNode() {
  let parent = this.currentNode.parentNode;
  if (parent && parent !== this.root && this._accept(parent)) {
    this.currentNode = parent;
    return parent;
  }
  return null;
}
```

### 1. It escaped above `root` (containment violation)

The most serious, and the one I didn't expect until I probed it. With `currentNode` at `root`, the `parent !== this.root` guard does not fire — `parent` is `root`'s *own* parent — so a node **outside the walker's subtree** was returned:

```js
document.body.innerHTML = '<div id="root"><a></a></div>';
document.createTreeWalker(document.getElementById('root'), NodeFilter.SHOW_ELEMENT).parentNode();
// before: <body>      Chrome: null
```

A TreeWalker must never surface a node above its `root`; this broke the invariant every consumer relies on.

### 2. It could not return `root`

The same guard excluded `root` as a *result*, so when `currentNode`'s accepted ancestor was `root` itself, it returned `null` instead of `root` (and left `currentNode` unmoved):

```js
w.currentNode = document.querySelector('#root a');
w.parentNode();   // before: null   Chrome: <div id="root">, currentNode now #root
```

### 3. It did not climb past a skipped ancestor

Only the immediate parent was consulted, so a `FILTER_SKIP` parent ended the search:

```js
// <div id="root"><main id="m"><section><a></a></section></main></div>, SECTION -> FILTER_SKIP
w.currentNode = document.querySelector('#root a');
w.parentNode();   // before: null   Chrome: <main id="m">
```

### Approach

Replaced with the DOM 6.1 "parent" traversal: climb from `currentNode`, returning the first ancestor that filters to `FILTER_ACCEPT` and updating `currentNode`. The loop's `node !== this.root` guard is what keeps the walk inside `root` while still allowing `root` itself to be returned — fixing all three at once. Reuses the three-valued `_filter` from #461.

This is the last of the TreeWalker mover deviations, after `nextNode` (#461), `previousNode` (#462) and the child/sibling movers (#469 / #471).

### Tests

- `tree_walker_parent_node_does_not_escape_above_root` — the containment fix, asserting `currentNode` also stays put.
- `tree_walker_parent_node_can_return_the_root` — root is returned and becomes `currentNode`.
- `tree_walker_parent_node_climbs_past_skipped_ancestors` — climbs past a `FILTER_SKIP` parent to the first accepted ancestor.

All three verified RED first.

### Verification

Branched off current `main` (post-#473, so the suite is fully green). Full `obscura-js` suite: **107 passed / 0 failed**, the 3 added tests included.
