### PR TITLE
fix(js,dom): keep parsed SVG in the SVG namespace so href reflects an SVGAnimatedString

### DIFF
--- a/crates/obscura-js/js/bootstrap.js
+++ b/crates/obscura-js/js/bootstrap.js
@@ -1210,11 +1210,21 @@ class Element extends Node {
   set className(v) { this.setAttribute("class", v); }
   get namespaceURI() {
     // createElementNS records the requested namespace on _ns; an empty string
-    // maps to the null namespace per spec. Elements made via createElement (or
-    // parsed) have no _ns: default to XHTML, except <svg> which is SVG.
+    // maps to the null namespace per spec.
     if (this._ns !== undefined) return this._ns === "" ? null : this._ns;
-    if (this.localName === "svg") return "http://www.w3.org/2000/svg";
-    return "http://www.w3.org/1999/xhtml";
+    // Otherwise use the namespace the HTML tree builder assigned. Foreign
+    // content puts the WHOLE <svg>/<math> subtree in that namespace, not just
+    // the root, so deriving it from the tag name (the old `localName === "svg"`
+    // check) left every descendant looking like HTML and skipped the SVG-only
+    // reflections -- notably `get href()`, which then returned a plain string
+    // instead of an SVGAnimatedString. An element's namespace never changes,
+    // so cache it like _lname.
+    if (this._nsCache !== undefined) return this._nsCache;
+    let ns = _domParse("namespace_uri", this._nid) || "";
+    // Nodes with no element name recorded fall back to the previous heuristic.
+    if (!ns) ns = this.localName === "svg" ? "http://www.w3.org/2000/svg" : "http://www.w3.org/1999/xhtml";
+    this._nsCache = ns;
+    return ns;
   }
   // `inner_html` resolves a <template> to its contents document on the Rust
   // side (issue #463), so this needs no template special case.

--- a/crates/obscura-js/src/ops.rs
+++ b/crates/obscura-js/src/ops.rs
@@ -303,6 +303,14 @@ fn op_dom_inner(state: &OpState, cmd: String, arg1: String, arg2: String) -> Str
             let name = dom.with_node(NodeId::new(nid), |n| n.as_element().map(|name| name.local.as_ref().to_ascii_uppercase())).flatten().unwrap_or_default();
             serde_json::to_string(&name).unwrap_or("\"\"".into())
         }
+        // The tree builder already assigns foreign content (an <svg>/<math>
+        // subtree) its own namespace; expose it so JS does not have to guess
+        // the namespace from the tag name.
+        "namespace_uri" => {
+            let nid = arg1.parse::<u32>().unwrap_or(0);
+            let ns = dom.with_node(NodeId::new(nid), |n| n.as_element().map(|name| name.ns.as_ref().to_string())).flatten().unwrap_or_default();
+            serde_json::to_string(&ns).unwrap_or("\"\"".into())
+        }
         "get_attribute" => {
             let nid = arg1.parse::<u32>().unwrap_or(0);
             let val = dom.with_node(NodeId::new(nid), |n| n.get_attribute(&arg2).map(|s| s.to_string())).flatten();


### PR DESCRIPTION
Fixes #484.

## Problem

#330 added `SVGAnimatedString` for SVG `className` / `href` and it shipped in 0.1.10, but the `href` reflection only reaches elements built with `createElementNS` — **not** SVG parsed from markup, which is how essentially every real page gets its SVG.

`get namespaceURI()` derived the namespace from the tag name and recognised only the `<svg>` root:

```js
if (this._ns !== undefined) return this._ns === "" ? null : this._ns;
if (this.localName === "svg") return "http://www.w3.org/2000/svg";
return "http://www.w3.org/1999/xhtml";
```

`_ns` is set only by `createElementNS`, so parsed descendants of an `<svg>` fell through to XHTML. `get href()` gates the `SVGAnimatedString` reflection on the SVG namespace, so for parsed content the gate never opened: `href` returned a plain string, `.animVal` / `.baseVal` were `undefined`, and `new URL(el.href.animVal)` threw `TypeError: Failed to construct 'URL': Invalid URL`.

`className` was unaffected only because the `<svg>` root itself matched the heuristic.

## Fix

The namespace is already correct one layer down: the tree builder applies the HTML5 foreign-content rules, so `QualName.ns` for a parsed `<svg><image>` is already `ns!(svg)` — it just was not reachable from JS.

- **`crates/obscura-js/src/ops.rs`** — add a `namespace_uri` op, mirroring the existing `tag_name` op.
- **`crates/obscura-js/js/bootstrap.js`** — `get namespaceURI()` reads that op instead of guessing from the tag name. `createElementNS`'s `_ns` keeps priority, and an element with no recorded name falls back to the previous heuristic, so nothing regresses. A namespace never changes after creation, so the value is cached like `_lname` — one op per element, not per access.

This fixes the class of bug rather than adding another per-property special case: any SVG-only reflection gated on `namespaceURI` now works for parsed content too.

## Verification

Built through the Dockerfile (aarch64) and compared against the 0.1.10 release binary as a control, plus Chromium as the reference. Repro is `about:blank` + `innerHTML`, no external site (full script in #484).

**The bug, and the fix:**

| | 0.1.10 release | **this PR** | Chromium |
|---|---|---|---|
| parsed `<image>.namespaceURI` | ❌ `…/1999/xhtml` | ✅ `…/2000/svg` | `…/2000/svg` |
| parsed `<image>.href` constructor | ❌ `String` | ✅ `SVGAnimatedString` | `SVGAnimatedString` |
| parsed `<image>.href.animVal` | ❌ `undefined` | ✅ `https://example.com/x.png` | `https://example.com/x.png` |
| `new URL(parsed.href.animVal)` | ❌ **throws** | ✅ resolves | resolves |
| parsed `<use>.href.animVal` | ❌ `undefined` | ✅ `#s` | `#s` |
| `createElementNS <image>.href` ctor | ✅ `SVGAnimatedString` | ✅ unchanged | `SVGAnimatedString` |

**No regression on plain HTML** — on a normal page the patched and unpatched builds return byte-identical results:

```
a.namespaceURI  http://www.w3.org/1999/xhtml     (unchanged)
a.tagName       A                                (unchanged)
a.href          https://example.com/rel/path?q=1 (still the resolved absolute URL)
a.pathname      /rel/path                        (unchanged)
div.className   "c1 c2", typeof "string"         (still a plain string, not SVGAnimatedString)
input.value / querySelectorAll counts            (unchanged)
```

I did **not** run `cargo nextest run --workspace` — I have no local Rust toolchain and built via the Dockerfile, so please treat the workspace suite as unrun on my side.

## Out of scope (same root cause, not changed here)

Deliberately left out to keep this reviewable; happy to follow up if you want them:

- `tagName` still uppercases unconditionally, so a parsed SVG `<image>` reports `IMAGE` rather than `image`. Per DOM spec only HTML-namespace elements uppercase.
- Because `localName` is `tagName.toLowerCase()`, the `ln === 'linearGradient' / 'textPath' / 'mpath'` branches already present in `get href()` remain unreachable — they need the SVG tag-name adjustment to survive to JS.
