### PR TITLE
security(deps): bump quinn-proto 0.11.14 -> 0.11.15 (GHSA-4w2j-m93h-cj5j)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2040,9 +2040,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.14"
+version = "0.11.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+checksum = "4fcb935c5bec503c2f0e306bdd3e58bb9029dcb14fa8d9ac76e3a5256ac0763e"
 dependencies = [
  "bytes",
  "getrandom 0.3.4",


### PR DESCRIPTION
Closes #486.

Bumps `quinn-proto` **0.11.14 → 0.11.15** to pull in the fix for **GHSA-4w2j-m93h-cj5j** (HIGH: remote memory exhaustion in the QUIC state machine — advisory: <https://github.com/advisories/GHSA-4w2j-m93h-cj5j>).

### Diff
`Cargo.lock` only — `version` + `checksum` on the `quinn-proto` entry. Non-optional runtime deps of 0.11.15 are byte-identical to 0.11.14 (verified against crates.io `/api/v1/crates/quinn-proto/<v>/dependencies`), so the surrounding `dependencies = [...]` block does not change.

```
-version = "0.11.14"
-checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+version = "0.11.15"
+checksum = "4fcb935c5bec503c2f0e306bdd3e58bb9029dcb14fa8d9ac76e3a5256ac0763e"
```

`quinn-proto` is pulled in transitively via `reqwest 0.12` (HTTP/3 path); no source in this repo names it directly, so no `Cargo.toml` or `.rs` change is needed.

### Verification
- Advisory + fix: <https://github.com/advisories/GHSA-4w2j-m93h-cj5j>
- Trivy scan on my fork (fails on `main`, passes on this branch): <https://github.com/ulises2k/obscura/actions/runs/30188742640/job/89757904152>
- The same `cargo update -p quinn-proto --precise 0.11.15` locally produces this exact diff.

### Notes
- Semver-compatible patch bump; no MSRV impact.
- Trivy still reports `DS-0002` (Dockerfile missing `USER` non-root) as HIGH misconfig — out of scope of this PR; happy to open a separate one if you want.

---
Same downstream user as #484 / #485 (SVG namespace work).
