### PR TITLE
fix(js): keep the current URL when pushState/replaceState omit url

### DIFF
--- a/crates/obscura-js/js/bootstrap.js
+++ b/crates/obscura-js/js/bootstrap.js
@@ -5613,7 +5613,10 @@ globalThis.atob = globalThis.atob || ((s) => { const c="ABCDEFGHIJKLMNOPQRSTUVWX
   const stack = [{state: null, url: undefined}]; // initial entry; url=undefined means "use document URL"
   let idx = 0;
   const resolveOrFallback = (url) => {
-    if (url === null || url === undefined) return undefined;
+    // A missing url (pushState/replaceState called with < 3 args) keeps the
+    // current document URL per the HTML spec — capture it so the entry does not
+    // reset location back to the original document URL.
+    if (url === null || url === undefined) return __currentUrl();
     try { return new URL(String(url), __currentUrl()).href; } catch (e) { return String(url); }
   };
   const applyVirtual = () => {

--- a/crates/obscura-js/src/runtime.rs
+++ b/crates/obscura-js/src/runtime.rs
@@ -1318,6 +1318,28 @@ mod tests {
     }
 
     #[test]
+    fn replace_state_without_url_preserves_current_location() {
+        let mut rt = setup_runtime("<html><body></body></html>");
+        let path = rt
+            .evaluate(
+                "(function(){history.pushState({}, '', '/dashboard'); history.replaceState({scroll:1}); return location.pathname;})()",
+            )
+            .unwrap();
+        assert_eq!(path, serde_json::json!("/dashboard"));
+    }
+
+    #[test]
+    fn push_state_without_url_preserves_current_location() {
+        let mut rt = setup_runtime("<html><body></body></html>");
+        let path = rt
+            .evaluate(
+                "(function(){history.pushState({}, '', '/a'); history.pushState({b:1}); return location.pathname;})()",
+            )
+            .unwrap();
+        assert_eq!(path, serde_json::json!("/a"));
+    }
+
+    #[test]
     fn test_document_title() {
         let mut rt = setup_runtime("<html><head><title>Test</title></head><body></body></html>");
         let title = rt.evaluate("document.title").unwrap();


### PR DESCRIPTION
Fixes #496.

## Problem
`history.pushState`/`replaceState` called **without** a `url` argument wiped the virtual URL: `resolveOrFallback(undefined)` returned `undefined`, `applyVirtual` set `__virtualUrl` to `null`, and `location` reverted to the document URL.

## Fix
Per the HTML spec a missing url keeps the current document URL. Return `__currentUrl()` for a null/undefined url so the new entry captures the current location.

## Tests
Two `runtime.rs` tests (RED→GREEN): `replaceState`/`pushState` without url preserve `location.pathname`. obscura-js 122/122.
