### PR TITLE
fix(js): make performance.now() monotonic

### DIFF
--- a/crates/obscura-js/js/bootstrap.js
+++ b/crates/obscura-js/js/bootstrap.js
@@ -5360,11 +5360,16 @@ globalThis.XMLSerializer = class XMLSerializer {
 };
 globalThis.performance = globalThis.performance || {
   now: (function() {
-    var _lastMs = -1, _sub = 0;
+    // Monotonically non-decreasing: return the wall-clock offset, but never a
+    // value below the last one. The previous version added an uncapped per-call
+    // sub-millisecond bump that could exceed 1.0, so when the millisecond then
+    // ticked over and the bump reset to 0 the result went backwards.
+    var _last = 0;
     return function() {
       var ms = Date.now() - (globalThis.performance.timeOrigin || 0);
-      if (ms !== _lastMs) { _lastMs = ms; _sub = 0; } else { _sub += 0.1; }
-      return ms + _sub;
+      if (ms > _last) _last = ms;
+      else _last += 0.001; // same/earlier ms: advance by a tiny epsilon
+      return _last;
     };
   })(),
   mark(){}, measure(){},

--- a/crates/obscura-js/src/runtime.rs
+++ b/crates/obscura-js/src/runtime.rs
@@ -1318,6 +1318,19 @@ mod tests {
     }
 
     #[test]
+    fn performance_now_is_monotonic_under_bursty_calls() {
+        let mut rt = setup_runtime("<html><body></body></html>");
+        // Hammer performance.now() so many calls land in the same millisecond and
+        // the wall clock rolls over repeatedly; the value must never go backwards.
+        let violations = rt
+            .evaluate(
+                "(function(){var prev=-Infinity, bad=0; for(var i=0;i<500000;i++){var t=performance.now(); if(t<prev) bad++; prev=t;} return bad;})()",
+            )
+            .unwrap();
+        assert_eq!(violations.as_f64(), Some(0.0), "performance.now() went backwards");
+    }
+
+    #[test]
     fn test_document_title() {
         let mut rt = setup_runtime("<html><head><title>Test</title></head><body></body></html>");
         let title = rt.evaluate("document.title").unwrap();


### PR DESCRIPTION
Fixes #497.

## Problem
`performance.now()` added an uncapped `_sub += 0.1` within a millisecond; after >10 calls it exceeded 1.0, and when the wall clock ticked over and `_sub` reset to 0 the function returned a value **below** the previous call.

## Fix
Track the last returned value and never go below it (advance by a tiny epsilon when the clock has not moved past it).

## Tests
`runtime.rs` test hammering `now()` 500k times asserting no backward step (RED→GREEN). obscura-js 121/121.
