### PR TITLE
fix(mcp): bound the request read with a timeout (slowloris)

### DIFF
--- a/crates/obscura-mcp/src/http.rs
+++ b/crates/obscura-mcp/src/http.rs
@@ -12,6 +12,20 @@ use crate::{dispatch, BrowserState};
 /// is far above any real JSON-RPC tool call.
 const MAX_BODY_BYTES: usize = 16 * 1024 * 1024;
 
+/// Per-request read deadline. Without one, a client that opens a connection and
+/// then sends its request line/headers/body slowly (or not at all) holds the
+/// connection open forever; because connections are served sequentially, that
+/// stalls every other MCP client (slowloris). Configurable via
+/// `OBSCURA_MCP_READ_TIMEOUT_MS` (default 30s, floored at 50ms).
+fn read_timeout() -> tokio::time::Duration {
+    let ms = std::env::var("OBSCURA_MCP_READ_TIMEOUT_MS")
+        .ok()
+        .and_then(|s| s.parse::<u64>().ok())
+        .unwrap_or(30_000)
+        .max(50);
+    tokio::time::Duration::from_millis(ms)
+}
+
 /// Origin allowlist for browser callers, read from `OBSCURA_MCP_ALLOWED_ORIGINS`
 /// (comma-separated). Unset/empty → permissive (unchanged `*`) so hosted
 /// dashboards keep working (issue #175).
@@ -87,9 +101,21 @@ async fn handle_connection(
     let mut reader = BufReader::new(reader);
 
     loop {
+        // Bound the whole request read (line + headers + body) by a single
+        // deadline so a slow/stalled client cannot pin the connection — and thus
+        // the sequential accept loop — indefinitely.
+        let read_deadline = tokio::time::Instant::now() + read_timeout();
+
         // ── request line ─────────────────────────────────────────────────────
         let mut request_line = String::new();
-        if reader.read_line(&mut request_line).await? == 0 {
+        let n = match tokio::time::timeout_at(read_deadline, reader.read_line(&mut request_line)).await {
+            Ok(r) => r?,
+            Err(_) => {
+                let _ = respond(&mut writer, 408, b"{\"error\":\"request timeout\"}").await;
+                break;
+            }
+        };
+        if n == 0 {
             break;
         }
         let request_line = request_line.trim().to_string();
@@ -112,7 +138,13 @@ async fn handle_connection(
 
         loop {
             let mut line = String::new();
-            reader.read_line(&mut line).await?;
+            match tokio::time::timeout_at(read_deadline, reader.read_line(&mut line)).await {
+                Ok(r) => { r?; }
+                Err(_) => {
+                    let _ = respond(&mut writer, 408, b"{\"error\":\"request timeout\"}").await;
+                    return Ok(());
+                }
+            }
             let trimmed = line.trim_end_matches("\r\n").trim_end_matches('\n');
             if trimmed.is_empty() {
                 break;
@@ -207,7 +239,13 @@ async fn handle_connection(
                 }
 
                 let mut body = vec![0u8; len];
-                reader.read_exact(&mut body).await?;
+                match tokio::time::timeout_at(read_deadline, reader.read_exact(&mut body)).await {
+                    Ok(r) => { r?; }
+                    Err(_) => {
+                        let _ = respond(&mut writer, 408, b"{\"error\":\"request timeout\"}").await;
+                        break;
+                    }
+                }
 
                 let response = process_body(&body, state).await;
                 let bytes = serde_json::to_vec(&response)?;

--- a/crates/obscura-mcp/tests/read_timeout.rs
+++ b/crates/obscura-mcp/tests/read_timeout.rs
@@ -1,0 +1,68 @@
+//! Regression test: the MCP HTTP server must not let a slow/stalled client hold
+//! a connection open forever. Connections are served sequentially, so one
+//! slowloris client would otherwise block every other MCP client. The request
+//! read (line + headers + body) is bounded by a deadline
+//! (`OBSCURA_MCP_READ_TIMEOUT_MS`).
+
+use std::net::TcpListener as StdListener;
+use std::time::Duration;
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::TcpStream;
+use tokio::task::LocalSet;
+use tokio::time::{sleep, timeout};
+
+fn pick_free_port() -> u16 {
+    let l = StdListener::bind("127.0.0.1:0").unwrap();
+    let p = l.local_addr().unwrap().port();
+    drop(l);
+    p
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn slow_client_is_disconnected_by_read_timeout() {
+    std::env::set_var("OBSCURA_MCP_READ_TIMEOUT_MS", "300");
+    let port = pick_free_port();
+    let local = LocalSet::new();
+
+    let server = local.spawn_local(async move {
+        let _ = obscura_mcp::http::run("127.0.0.1".to_string(), port, None, None, false).await;
+    });
+
+    local
+        .run_until(async {
+            for _ in 0..40 {
+                if TcpStream::connect(("127.0.0.1", port)).await.is_ok() {
+                    break;
+                }
+                sleep(Duration::from_millis(50)).await;
+            }
+
+            let mut stream = TcpStream::connect(("127.0.0.1", port))
+                .await
+                .expect("MCP server did not come up");
+
+            // Partial request: request line + one header, then stall — never send
+            // the terminating blank line. Pre-fix the server blocks on the header
+            // read forever; with the deadline it gives up after ~300ms.
+            stream
+                .write_all(b"POST /mcp HTTP/1.1\r\nHost: 127.0.0.1\r\n")
+                .await
+                .unwrap();
+            stream.flush().await.unwrap();
+
+            let mut buf = [0u8; 1024];
+            let n = timeout(Duration::from_secs(3), stream.read(&mut buf))
+                .await
+                .expect("server did not time out the slow client")
+                .expect("read failed");
+
+            server.abort();
+
+            let resp = String::from_utf8_lossy(&buf[..n]).to_string();
+            assert!(
+                n == 0 || resp.starts_with("HTTP/1.1 408"),
+                "expected a 408 or a closed connection, got ({n} bytes):\n{resp}"
+            );
+        })
+        .await;
+}


### PR DESCRIPTION
Fixes #501.

## Problem
The MCP HTTP server's request-line, header, and body reads all awaited with no time bound, so a client that connected and then sent its request slowly (or stalled) held the connection forever; because connections are served sequentially, that blocked every other MCP client (slowloris).

## Fix
Bound the whole request read with a single per-request deadline (`OBSCURA_MCP_READ_TIMEOUT_MS`, default 30s, floored at 50ms); on expiry send 408 and close.

## Tests
New integration test `read_timeout.rs`: a client that stalls mid-request is disconnected within the (shortened) timeout; RED before, GREEN after. obscura-mcp 6/6.
