### PR TITLE
fix(dom): implement Document.referrer and a navigation PerformanceEntry (both returned undefined)

### DIFF
--- a/crates/obscura-js/js/bootstrap.js
+++ b/crates/obscura-js/js/bootstrap.js
@@ -16,7 +16,7 @@
     '__obscura_platform', '__obscura_ua_platform', '__obscura_ua_platform_version',
     '__obscura_stealth', '__obscura_markTrusted',
     '__obscura_hw', '__obscura_mem',
-    '__documentReadyState__', '__currentUrl',
+    '__documentReadyState__', '__currentUrl', '__documentReferrer__',
     // internal helpers (var-declared throughout the file)
     '__processDynScriptQueue', '_markNative', '_fpRand', '_fpNoise',
     '_fpCache', '_getFp', '_fp', '_splitAsciiWhitespace',
@@ -2496,6 +2496,13 @@ class Document extends Node {
   set title(v) {}
   get URL() { return _domParse("document_url") ?? ""; }
   get documentURI() { return this.URL; }
+  // Chrome always exposes document.referrer as a string: the referring URL, or
+  // "" when there is none (the usual case for a CDP-driven top-level goto with
+  // no referrer). Returning undefined here regresses anti-fraud sensors that do
+  // `new URL(document.referrer)` unguarded (e.g. BGSensors) -> "Invalid URL".
+  // page.rs may set __documentReferrer__ from the navigation's Referer header;
+  // absent that, "" is the spec-correct value. HTML: Document/referrer -> USVString.
+  get referrer() { return globalThis.__documentReferrer__ ?? ""; }
   get location() { return globalThis.location; }
   set location(url) { Deno.core.ops.op_navigate(_resolveUrl(String(url)), 'GET', ''); }
   get defaultView() { return globalThis; }
@@ -5369,7 +5376,36 @@ globalThis.performance = globalThis.performance || {
   })(),
   mark(){}, measure(){},
   clearMarks(){}, clearMeasures(){}, clearResourceTimings(){},
-  getEntries(){return [];}, getEntriesByName(){return [];}, getEntriesByType(){return [];},
+  // Chrome always has one PerformanceNavigationTiming whose `.name` is the
+  // document URL. Sensors read getEntriesByType('navigation')[0].name and feed
+  // it to `new URL(...)`; returning [] made that undefined -> "Invalid URL".
+  // We synthesize a single navigation entry (timing fields zeroed — sensors
+  // that only want the URL don't care) so the shape matches a real browser.
+  getEntriesByType(type){
+    if (type !== 'navigation') return [];
+    var _u = (globalThis.location && globalThis.location.href) || 'about:blank';
+    var e = {
+      name: _u, entryType: 'navigation', startTime: 0, duration: 0,
+      initiatorType: 'navigation', deliveryType: '', nextHopProtocol: 'h2',
+      workerStart: 0, redirectStart: 0, redirectEnd: 0, fetchStart: 0,
+      domainLookupStart: 0, domainLookupEnd: 0, connectStart: 0, connectEnd: 0,
+      secureConnectionStart: 0, requestStart: 0, responseStart: 0,
+      firstInterimResponseStart: 0, finalResponseHeadersStart: 0, responseEnd: 0,
+      transferSize: 0, encodedBodySize: 0, decodedBodySize: 0, responseStatus: 200,
+      serverTiming: [], unloadEventStart: 0, unloadEventEnd: 0, domInteractive: 0,
+      domContentLoadedEventStart: 0, domContentLoadedEventEnd: 0, domComplete: 0,
+      loadEventStart: 0, loadEventEnd: 0, type: 'navigate', redirectCount: 0,
+      activationStart: 0, criticalCHRestart: 0,
+    };
+    e.toJSON = function(){ var o = {}; for (var k in this) { if (typeof this[k] !== 'function') o[k] = this[k]; } return o; };
+    return [e];
+  },
+  getEntries(){ return globalThis.performance.getEntriesByType('navigation'); },
+  getEntriesByName(name, type){
+    if (type && type !== 'navigation') return [];
+    var _u = (globalThis.location && globalThis.location.href) || 'about:blank';
+    return name === _u ? globalThis.performance.getEntriesByType('navigation') : [];
+  },
   setResourceTimingBufferSize(){},
   timeOrigin: 0,
   timing: { navigationStart: 0, domContentLoadedEventEnd: 0, loadEventEnd: 0 },


### PR DESCRIPTION
Adds two Web APIs that returned `undefined` in obscura where every real browser returns a **string**. Anti-fraud sensors (and analytics scripts) that feed those values straight into `new URL(...)` throw `TypeError: Failed to construct 'URL': Invalid URL` and abort — the same *class* of "engine returns `undefined` where the spec says string" bug that #485 fixed for SVG `href`.

### The two gaps

1. **`document.referrer` was never implemented on `class Document`.** The only `referrer` in `bootstrap.js` was on `Request`. Reading `document.referrer` returned `undefined`; Chrome returns the referring URL, or `""` when there is none. Now returns `globalThis.__documentReferrer__ ?? ""` — `""` is the spec-correct value for a top-level CDP navigation with no referrer, and `page.rs` can later populate the global from the navigation's `Referer` header without a fingerprint leak (the internal name is added to the pre-hide list).

2. **`performance.getEntriesByType('navigation')` returned `[]`.** So `getEntriesByType('navigation')[0].name` was `undefined`; Chrome always has exactly one `PerformanceNavigationTiming` whose `.name` is the document URL. Now synthesizes a single navigation entry (timing fields zeroed — consumers that only want the URL don't care) with `.name === location.href`; `getEntries()` / `getEntriesByName()` route through it.

### Verification (aarch64, Raspberry Pi 5, official 0.1.11 vs this branch built from source)

A/B with a tiny CDP harness (`obscura --stealth serve` + puppeteer-core), same script both engines:

| probe | stock 0.1.11 | this branch |
|---|---|---|
| `typeof document.referrer` | `undefined` | `string` (`""`) |
| `getEntriesByType('navigation').length` | `0` | `1` |
| `getEntriesByType('navigation')[0].name` | `undefined` | the document URL |
| `new URL(getEntriesByType('navigation')[0].name)` | **throws** | **OK** |

Then instrumenting `window.URL` on a real-world page that runs a bot-manager sensor doing `new URL(...)` unguarded:

- **stock obscura:** 3 failing `new URL(...)` — **one with `arg0 === undefined`** (obscura-exclusive, aborts the sensor) + 2 with `arg0 === ""`.
- **this branch:** 2 failing `new URL(...)`, **both `arg0 === ""`** — byte-identical stack offsets to Chromium's two failures (an Adobe DTM analytics script that throws the same way in Chrome → benign). **The obscura-exclusive `new URL(undefined)` is eliminated**, and the sensor now progresses far enough to set two bot-manager cookies it previously never got.

`node --check` passes and the V8 snapshot builds (bootstrap.js is `include_str!`'d and executed at snapshot time, so a syntax error would fail the build).

### Honest scope

This does **not** claim to fully unblock that sensor — on my target site the login still fails because a *third* engine gap remains (a bot-manager cookie, `cdSNum`, that Chromium sets and obscura still doesn't). I'm tracking that separately in **#518** and hunting it now; this PR is the isolated, independently-correct half: two spec-compliance fixes that make `document.referrer` and the navigation timing entry behave like a real browser. Worth landing on its own merit regardless of that site.

Refs #518. Same downstream user as #484/#485/#487.
