### PR TITLE
fix(js): execute chained dynamic data scripts

### DIFF
--- a/crates/obscura-cdp/tests/dynamic_script_onload_fires.rs
+++ b/crates/obscura-cdp/tests/dynamic_script_onload_fires.rs
@@ -117,3 +117,148 @@ async fn dynamic_external_scripts_execute_and_fire_load() {
         "dynamic scripts must execute and fire load before navigation settles"
     );
 }
+
+#[tokio::test(flavor = "current_thread")]
+async fn dynamic_data_script_onload_chain_executes_in_order() {
+    let mut ctx = CdpContext::new();
+    let page_id = ctx.create_page();
+    let session_id = "session-1";
+    ctx.sessions.insert(session_id.to_string(), page_id);
+
+    cdp(
+        &mut ctx,
+        1,
+        "Page.navigate",
+        json!({"url": "data:text/html,<html><head></head><body></body></html>", "waitUntil": "load"}),
+        session_id,
+    )
+    .await;
+
+    let kick = cdp(
+        &mut ctx,
+        2,
+        "Runtime.callFunctionOn",
+        json!({
+            "functionDeclaration": r#"function () {
+                var state = {
+                    aExec: false, aLoad: false,
+                    bExec: false, bLoad: false,
+                    cExec: false, cLoad: false,
+                    errors: [], order: []
+                };
+                window.__dataScriptChain = state;
+
+                var a = document.createElement('script');
+                a.src = "data:text/javascript,window.__dataScriptChain.aExec%3Dtrue%3Bwindow.__dataScriptChain.order.push(%27aExec%27)";
+                a.onerror = function () { state.errors.push('aError'); };
+                a.onload = function () {
+                    state.aLoad = true;
+                    state.order.push('aLoad');
+
+                    var b = document.createElement('script');
+                    b.src = 'data:text/javascript;base64,' + btoa("window.__dataScriptChain.bExec=true;window.__dataScriptChain.order.push('bExec')");
+                    b.onerror = function () { state.errors.push('bError'); };
+                    b.onload = function () {
+                        state.bLoad = true;
+                        state.order.push('bLoad');
+
+                        var c = document.createElement('script');
+                        c.src = "data:text/javascript,window.__dataScriptChain.cExec%3Dtrue%3Bwindow.__dataScriptChain.order.push(%27cExec%27)";
+                        c.onerror = function () { state.errors.push('cError'); };
+                        c.onload = function () {
+                            state.cLoad = true;
+                            state.order.push('cLoad');
+                        };
+                        document.head.appendChild(c);
+                    };
+                    document.head.appendChild(b);
+                };
+                document.head.appendChild(a);
+                return 'kicked';
+            }"#,
+            "awaitPromise": true,
+            "returnByValue": true,
+        }),
+        session_id,
+    )
+    .await;
+    assert_eq!(kick["result"]["value"], "kicked");
+
+    // Match a Puppeteer-side wait: no page promise is awaited between the
+    // synchronous kick and read commands.
+    tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+    let result = cdp(
+        &mut ctx,
+        3,
+        "Runtime.callFunctionOn",
+        json!({
+            "functionDeclaration": "function () { return JSON.stringify(window.__dataScriptChain); }",
+            "awaitPromise": true,
+            "returnByValue": true,
+        }),
+        session_id,
+    )
+    .await;
+    let actual: Value = serde_json::from_str(result["result"]["value"].as_str().unwrap()).unwrap();
+    assert_eq!(
+        actual,
+        json!({
+            "aExec": true, "aLoad": true,
+            "bExec": true, "bLoad": true,
+            "cExec": true, "cLoad": true,
+            "errors": [],
+            "order": ["aExec", "aLoad", "bExec", "bLoad", "cExec", "cLoad"]
+        }),
+        "data: script bodies must execute before load and chained insertions must drain"
+    );
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn invalid_dynamic_data_script_fires_error_not_load() {
+    let mut ctx = CdpContext::new();
+    let page_id = ctx.create_page();
+    let session_id = "session-1";
+    ctx.sessions.insert(session_id.to_string(), page_id);
+
+    cdp(
+        &mut ctx,
+        1,
+        "Page.navigate",
+        json!({"url": "data:text/html,<html><head></head><body></body></html>", "waitUntil": "load"}),
+        session_id,
+    )
+    .await;
+
+    cdp(
+        &mut ctx,
+        2,
+        "Runtime.callFunctionOn",
+        json!({
+            "functionDeclaration": r#"function () {
+                window.__invalidDataScript = { error: false, load: false };
+                var script = document.createElement('script');
+                script.src = 'data:text/javascript;base64,!';
+                script.onerror = function () { window.__invalidDataScript.error = true; };
+                script.onload = function () { window.__invalidDataScript.load = true; };
+                document.head.appendChild(script);
+            }"#,
+            "awaitPromise": true,
+        }),
+        session_id,
+    )
+    .await;
+
+    tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+    let result = cdp(
+        &mut ctx,
+        3,
+        "Runtime.evaluate",
+        json!({
+            "expression": "JSON.stringify(window.__invalidDataScript)",
+            "returnByValue": true,
+        }),
+        session_id,
+    )
+    .await;
+    assert_eq!(result["result"]["value"], r#"{"error":true,"load":false}"#);
+}

--- a/crates/obscura-js/js/bootstrap.js
+++ b/crates/obscura-js/js/bootstrap.js
@@ -18,7 +18,7 @@
     '__obscura_hw', '__obscura_mem',
     '__documentReadyState__', '__currentUrl',
     // internal helpers (var-declared throughout the file)
-    '__processDynScriptQueue', '_markNative', '_fpRand', '_fpNoise',
+    '__processDynScriptQueue', '_decodeDataScriptSource', '_markNative', '_fpRand', '_fpNoise',
     '_fpCache', '_getFp', '_fp', '_splitAsciiWhitespace',
     '_getElementsByClassName', '_docEncoding', '_docIsUtf8',
     '_isSpecialScheme', '_applyDocQueryEncoding', '_anchorBase',
@@ -163,6 +163,52 @@ let _fpSeed = 0;
 // when SPAs dynamically insert multiple <script module> tags at once.
 let __dynScriptQueue = [];
 let __dynScriptBusy = false;
+
+function _decodeDataScriptSource(url) {
+  const comma = url.indexOf(',');
+  if (!url.startsWith('data:') || comma < 5) {
+    throw new TypeError('Invalid data URL');
+  }
+
+  const meta = url.slice(5, comma);
+  const payload = url.slice(comma + 1);
+  if (meta.split(';').some(part => part.toLowerCase() === 'base64')) {
+    let encoded = payload.replace(/[\r\n\t\f ]/g, '');
+    const remainder = encoded.length % 4;
+    if (remainder === 1 || !/^[A-Za-z0-9+/]*={0,2}$/.test(encoded) || /=/.test(encoded.slice(0, -2))) {
+      throw new TypeError('Invalid base64 data URL');
+    }
+    if (remainder > 0) encoded += '='.repeat(4 - remainder);
+    if (!/^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$/.test(encoded)) {
+      throw new TypeError('Invalid base64 data URL');
+    }
+    return new TextDecoder().decode(_base64ToUint8Array(encoded));
+  }
+
+  const bytes = [];
+  for (let i = 0; i < payload.length; i++) {
+    const code = payload.charCodeAt(i);
+    if (code === 0x25 && i + 2 < payload.length) {
+      const hi = _hexv(payload.charCodeAt(i + 1));
+      const lo = _hexv(payload.charCodeAt(i + 2));
+      if (hi >= 0 && lo >= 0) {
+        bytes.push(hi * 16 + lo);
+        i += 2;
+        continue;
+      }
+    }
+    if (code < 0x80) {
+      bytes.push(code);
+    } else {
+      const character = String.fromCodePoint(payload.codePointAt(i));
+      if (character.length === 2) i++;
+      const encoded = new TextEncoder().encode(character);
+      for (let j = 0; j < encoded.length; j++) bytes.push(encoded[j]);
+    }
+  }
+  return new TextDecoder().decode(new Uint8Array(bytes));
+}
+
 async function __processDynScriptQueue() {
   if (__dynScriptBusy) return;
   __dynScriptBusy = true;
@@ -176,11 +222,23 @@ async function __processDynScriptQueue() {
         if (task.isModule) {
           await import(task.url);
         } else {
-          const raw = await Deno.core.ops.op_fetch_url(task.url, "GET", "{}", "", task.pageOrigin, "no-cors");
-          const parsed = JSON.parse(raw);
-          if (parsed.body) {
+          let source;
+          if (task.url.startsWith('data:')) {
+            // Dynamic scripts are async by default. Keep an async boundary even
+            // though data: URLs are decoded locally without a network fetch.
+            await Promise.resolve();
+            source = _decodeDataScriptSource(task.url);
+          } else {
+            const raw = await Deno.core.ops.op_fetch_url(task.url, "GET", "{}", "", task.pageOrigin, "no-cors");
+            const parsed = JSON.parse(raw);
+            if (parsed.blocked || parsed.status === 0 || parsed.status >= 400) {
+              throw new Error(parsed.error || 'Script request failed with status ' + parsed.status);
+            }
+            source = parsed.body || '';
+          }
+          if (source) {
             globalThis.__currentScriptNid = task.nid;
-            try { (0, eval)(parsed.body); }
+            try { (0, eval)(source); }
             catch(e) { console.error('Dynamic script error (' + task.url + '):', e.message); }
             finally { globalThis.__currentScriptNid = task.prevNid || 0; }
           }


### PR DESCRIPTION
## Summary

- decode dynamically inserted `data:` script sources locally, including percent-encoded and base64 payloads
- preserve the asynchronous script boundary while executing each body before dispatching its `load` event
- dispatch `error` instead of a false `load` for malformed data URLs and blocked or failed script requests

## Tests

- `cargo nextest run -p obscura-cdp --test dynamic_script_onload_fires` (3/3)
- `cargo nextest run -p obscura-js -p obscura-browser -p obscura-cdp` (222/222)
- `cargo build --release`
- obstacle course (33/33)

Fixes #520
