### PR TITLE
fix(js): wrap bootstrap in an IIFE so DOM classes stop leaking into the shared script scope

### DIFF
--- a/crates/obscura-js/js/bootstrap.js
+++ b/crates/obscura-js/js/bootstrap.js
@@ -1,4 +1,5 @@
 "use strict";
+(function () {
 
 // Pre-declare all internal globals as non-enumerable so they are invisible
 // to Object.keys(window) / for-in enumeration. Must run before any var
@@ -8855,4 +8856,6 @@ if (typeof Response !== 'undefined' && Response.prototype && !Response.prototype
     try { val = globalThis[name]; } catch (e) { continue; }
     if (typeof val === 'function') { walk(val); }
   }
+})();
+
 })();


### PR DESCRIPTION
Fixes #536.

`bootstrap.js` is evaluated as a classic script, so its 23 top-level `class` declarations become **lexical bindings in the shared script scope** — the same scope every page `<script>` is compiled into. A page that declares `var Node` then fails to compile **in its entirety**:

```
SyntaxError: Identifier 'Node' has already been declared
```

That guard — `if (!window.Node) { var Node = {} }` — ships inside **Prototype.js**, so it is present on every **ajax4jsf / RichFaces / JSF** page. The 319 KB `framework.pack.js` never executes a line, and jQuery / A4J / RichFaces go down with it.

## The change

```diff
 "use strict";
+(function () {
 
 // … 8,858 lines …
 
+})();
```

Declarations move to a function scope. The existing `globalThis.X = X` exports keep the interfaces reachable, and internal references (`class Element extends Node`, `new Element(...)`) now resolve to the **local** classes — so they survive a page overwriting `globalThis.Element`, which is what a real browser does.

## Before / after

Three-script page, middle one containing the guard:

| | `r1` | `r2` | `r3` |
|---|---|---|---|
| before | `ran` | **`null`** | `ran` |
| after | `ran` | `ran` | `ran` |

Real JSF/RichFaces page (public case search of a Brazilian federal court — ajax4jsf 3.3.3 + Prototype.js + jQuery):

| signal | before | after |
|---|---|---|
| `typeof jQuery` | `undefined` | `function` |
| `typeof A4J` | `undefined` | `object` |
| `typeof RichFaces` | `undefined` | `object` |
| `typeof Prototype` | `undefined` | `object` |
| ViewState present | ✅ | ✅ |

## Alternatives rejected

* **Block scope `{ }`** — the file is `"use strict"`, where function declarations inside a block stay in the block; the 85 top-level functions would disappear.
* **`globalThis.X = class X {}`** — fixes the `var Node` case but breaks interop. With no lexical binding to shadow it, Prototype.js overwrites `globalThis.Element` and the bootstrap's own `document.createElement` starts instantiating the page's class:
  ```
  TypeError: D.toLowerCase is not a function
      at new Element (<script>:618:5)
      at _wrapEl (<obscura:bootstrap>:3189:13)
  ```
  The lexical binding was *protecting* the internal classes; only the IIFE gives both properties at once.

## Safety check

Every symbol the Rust side calls (`globalThis.__obscura_init`, `__obscura_setFieldValue`, …) is either already assigned onto `globalThis` inside the bootstrap or created from Rust — none rely on a top-level binding surviving. The 5 top-level `var`s are `_`-prefixed internals.

## Regression

`example.com` renders · `document.querySelector('h1')` works · `body instanceof Node` and `instanceof Element` both true · Hacker News still yields 30 `.titleline > a` · `--stealth` unaffected · snapshot builds clean (`cargo build --release -p obscura-cli --features stealth`).

Possibly the same root cause behind #72 / #73 (`CharacterData` breaking jQuery DataTables) and #105, approached from a different angle.