### PR TITLE
fix(net): honor SSL_CERT_FILE / SSL_CERT_DIR in the stealth client (#525 follow-up)

### DIFF
--- a/crates/obscura-net/src/wreq_client.rs
+++ b/crates/obscura-net/src/wreq_client.rs
@@ -57,6 +57,39 @@ impl StealthHttpClient {
             .timeout(Duration::from_secs(30))
             .redirect(wreq::redirect::Policy::none());
 
+        // Honor SSL_CERT_FILE / SSL_CERT_DIR in the stealth client too.
+        //
+        // `client.rs` (the reqwest path) already reads these via `configured_root_paths()` and
+        // feeds `add_root_certificate`, so a private CA works there. This client did not, which
+        // made the *better-fingerprinted* transport the only one unable to reach hosts behind a
+        // private/national CA (measured against a Brazilian government portal whose leaf is
+        // issued by an ICP-Brasil intermediate: `--stealth` failed with CERTIFICATE_VERIFY_FAILED
+        // while the reqwest path, with SSL_CERT_FILE set, completed the handshake).
+        //
+        // Two deliberate constraints:
+        //
+        // 1. `tls_cert_store` is used, NOT `tls_options`. `emulation()` overwrites `tls_options`
+        //    wholesale ("This will overwrite the existing configuration"), so setting TLS options
+        //    here would silently discard the Chrome fingerprint — the whole point of this client.
+        //    `tls_cert_store` is a separate field on the config and composes with emulation.
+        //
+        // 2. Opt-in only. Supplying a store REPLACES the webpki roots (see `set_cert_store` in
+        //    `tls/conn/ext.rs`), it does not add to them. Applying it unconditionally would break
+        //    every ordinary site whenever the bundle is incomplete. With neither variable set,
+        //    behaviour is byte-for-byte what it was before.
+        if std::env::var_os("SSL_CERT_FILE").is_some()
+            || std::env::var_os("SSL_CERT_DIR").is_some()
+        {
+            match wreq::tls::trust::CertStore::builder().set_default_paths().build() {
+                Ok(store) => builder = builder.tls_cert_store(store),
+                Err(error) => tracing::warn!(
+                    %error,
+                    "SSL_CERT_FILE/SSL_CERT_DIR set but the certificate store failed to build; \
+                     continuing with the default roots"
+                ),
+            }
+        }
+
         if let Some(proxy) = proxy_url {
             if let Ok(p) = wreq::Proxy::all(proxy) {
                 builder = builder.proxy(p);


### PR DESCRIPTION
Fixes #538. Follow-up to #525.

The #525 fix landed on the `reqwest` path (`client.rs`: `configured_root_paths()` → `add_root_certificate`) but did not reach `wreq_client.rs`. The stealth client builds its `wreq::Client` without a certificate store, so `SSL_CERT_FILE` / `SSL_CERT_DIR` are silently ignored whenever `--stealth` is on.

The result is inverted from what you'd want: **the transport with the best TLS fingerprint is the only one that cannot reach a host behind a private or incomplete CA chain** — precisely the environments #525 described.

## Same binary, same server, only the flag differs

Current `main` (`eab2a5e`), private-CA HTTPS server on `127.0.0.1:8443` (setup identical to #525):

```console
$ SSL_CERT_FILE=ca.pem obscura --allow-private-network \
    fetch https://127.0.0.1:8443/ --eval "document.title"
private-ca-ok                       # ✅ reqwest path

$ SSL_CERT_FILE=ca.pem obscura --stealth --allow-private-network \
    fetch https://127.0.0.1:8443/ --eval "document.title"
Error: ... error sending request    # ❌ stealth path
```

## The change

`wreq` already exposes the hook — it is simply never called:

```rust
if std::env::var_os("SSL_CERT_FILE").is_some()
    || std::env::var_os("SSL_CERT_DIR").is_some()
{
    match wreq::tls::trust::CertStore::builder().set_default_paths().build() {
        Ok(store) => builder = builder.tls_cert_store(store),
        Err(error) => tracing::warn!(%error, "… continuing with the default roots"),
    }
}
```

`CertStore::builder().set_default_paths()` reads both variables, mirroring what `configured_root_paths()` does on the reqwest side — so the two clients now agree on where CAs come from.

## Two constraints, both of which fail silently if got wrong

1. **`tls_cert_store`, not `tls_options`.** `emulation()` is documented as *"This will overwrite the existing configuration"* and internally does `self.tls_options(emulation.tls_options)`. Injecting the CA through TLS options would discard the Chrome fingerprint — the entire purpose of this client. `tls_cert_store` is a separate config field and composes with emulation.
2. **Opt-in only.** Supplying a store *replaces* the webpki roots (`set_cert_store` in `tls/conn/ext.rs`), it does not add to them. Applying it unconditionally would break ordinary sites whenever the bundle is incomplete. With neither variable set, behaviour is byte-for-byte unchanged.

## Verified

| case | result |
|---|---|
| `--stealth` + `SSL_CERT_FILE` → private-CA host | ✅ `private-ca-ok` |
| `--stealth`, **no** env var → private-CA host | ✅ still fails (default preserved) |
| **empty** bundle → `example.com` | ✅ fails — proves the store is actually applied |
| no env var → `example.com` | ✅ works |
| no env var → Hacker News, `--stealth` | ✅ 30 results, fingerprint intact |

The third row is the control that matters: without it, *"the patch works"* and *"the bundle happened to be right"* are indistinguishable.

## Related real-world case

This also affects hosts serving an **incomplete chain** — leaf only, no intermediate — where the root is perfectly public. Clients that do AIA chasing (macOS Security.framework, curl) fetch the missing intermediate from the leaf's `CA Issuers` URL and never notice; BoringSSL/webpki do not, and fail with `CERTIFICATE_VERIFY_FAILED`. With no AIA fetching in obscura, `SSL_CERT_FILE` with a hand-completed bundle is the only workaround today — which makes this gap more visible in practice than the private-CA case alone.

Tested on macOS arm64, rustc 1.97.1, `--features stealth`.