### PR TITLE
fix(js): expose WebIDL interfaces as non-enumerable, like a real browser

### DIFF
--- a/crates/obscura-js/js/bootstrap.js
+++ b/crates/obscura-js/js/bootstrap.js
@@ -36,6 +36,18 @@
     '_rngAncestors', '_rngOrder', '_rngCmp', '_rngCheckOffset',
     '_idbRequest', '_idbObjectStore', '_idbTransaction', '_idbDatabase',
     '_makeListenerBox',
+    // WebIDL interfaces. A real browser exposes these on the global as
+    // enumerable:false; here they were assigned with `globalThis.X = X`, which
+    // defaults to enumerable:true and is detectable in one line:
+    //   Object.getOwnPropertyDescriptor(window, 'Node').enumerable
+    // Pre-declaring them non-enumerable here is enough -- per the note above,
+    // the later `globalThis.X = X` assignments only update the value.
+    'Node', 'Element', 'Document', 'DocumentFragment', 'DocumentType',
+    'Text', 'Comment', 'CDATASection', 'ProcessingInstruction', 'CharacterData',
+    'CSSStyleDeclaration', 'DOMTokenList', 'Screen', 'NetworkInformation',
+    'MessageChannel', 'MessagePort', 'CustomElementRegistry',
+    'XMLHttpRequestEventTarget', 'HTMLMediaElement', 'HTMLVideoElement',
+    'HTMLAudioElement', 'WebGL2RenderingContext',
   ];
   var _desc = { value: undefined, writable: true, enumerable: false, configurable: true };
   for (var _i = 0; _i < _names.length; _i++) {


### PR DESCRIPTION
`bootstrap.js` publishes its DOM interfaces with `globalThis.Node = Node`, which defaults to `enumerable: true`. A real browser exposes every WebIDL interface on the global as `enumerable: false` — so the difference is a one-liner for any script that cares:

```js
Object.getOwnPropertyDescriptor(window, 'Node').enumerable
// real Chrome: false
// obscura:     true
```

It also means `Object.keys(window)` and `for...in` over the global enumerate 22 names a browser would never list.

## The change

The file already has the mechanism — `_preHideInternals()` pre-declares internal globals as `enumerable: false`, and its own comment explains why that is enough:

> once a property is defined with `enumerable:false` here, subsequent `var x = value` assignments will find the property already exists and only update the value, leaving the descriptor intact.

So this adds the 22 WebIDL names to that existing list. **No assignment site changes**, no new machinery.

## Before / after

| | enumerable interfaces (sample of 10) |
|---|---|
| before | **9 / 10** |
| after | **0 / 10** — matches Chrome |

```console
$ obscura fetch https://example.com \
    --eval "JSON.stringify(Object.getOwnPropertyDescriptor(globalThis,'Node'))"
{"writable":true,"enumerable":false,"configurable":true}
```

## Regression

`typeof Node === 'function'` · `document.body instanceof Node` and `instanceof Element` both true · `document.querySelector('h1')` works · Hacker News still yields 30 `.titleline > a` under `--stealth` · snapshot builds clean.

## Composability

Verified together with #537 (the IIFE fix) — with both applied: pages declaring `var Node` run, the JSF/RichFaces case loads with `jQuery`/`A4J`/`RichFaces` all live, and enumerability stays at 0/10. The two are independent and can land in either order.

Tested on macOS arm64, rustc 1.97.1, `--features stealth`.