### PR TITLE
fix(js): DOMParser XML mime types produce parsererror on malformed XML

### DIFF
--- a/crates/obscura-js/js/bootstrap.js
+++ b/crates/obscura-js/js/bootstrap.js
@@ -5480,7 +5480,7 @@ const _checkXmlWellFormed = (html) => {
     const fullTag = match[0];
     const tagName = match[1];
     const isClosing = fullTag.startsWith('</');
-    const isSelfClosing = match[2] === '/' || fullTag.endsWith('/>');
+    const isSelfClosing = match[2] === '/';
 
     if (isClosing) {
       if (stack.length === 0) {
@@ -5524,18 +5524,14 @@ globalThis.DOMParser = class DOMParser {
     const html = String(source ?? "");
     const isXml = typeof mimeType === "string" && /xml/i.test(mimeType);
     const root = document.createElement("html");
-    let _xmlError = null;
 
     // For XML mime types, check well-formedness first (conservative: only
     // clear errors like tag mismatch / extra root are flagged).  If the
     // check fires, build a <parsererror> root so callers doing
     // doc.querySelector('parsererror') get the same signal as in Chrome.
-    if (isXml) {
-      const wf = _checkXmlWellFormed(html);
-      if (!wf.wellFormed) _xmlError = wf.error;
-    }
-    if (_xmlError) {
-      root.innerHTML = '<parsererror>' + _xmlError + '</parsererror>';
+    const xmlError = isXml ? _checkXmlWellFormed(html) : null;
+    if (xmlError && !xmlError.wellFormed) {
+      root.innerHTML = '<parsererror>' + xmlError.error + '</parsererror>';
       // Make sure querySelector('parsererror') finds the root element.
       root._parserError = true;
     } else {
@@ -5568,7 +5564,7 @@ globalThis.DOMParser = class DOMParser {
       get documentElement() {
         // For XML parsererror docs, return the <parsererror> child, not the
         // <html> wrapper — matches Chrome's behavior.
-        if (root._parserError) return root.firstElementChild || root;
+        if (root._parserError) return root.firstElementChild;
         return root;
       },
       get body() { return findByTagName("BODY"); },
@@ -5599,7 +5595,7 @@ globalThis.DOMParser = class DOMParser {
       querySelector(s) {
         // For XML parsererror docs, check the root element as well —
         // the <parsererror> is the documentElement, not a descendant.
-        return root.querySelector(s) || (root._parserError && root.matches && root.matches(s) ? root : null);
+        return root.querySelector(s) || (root._parserError && root.matches(s) ? root : null);
       },
       querySelectorAll(s) { return root.querySelectorAll(s); },
       getElementById(id) {

--- a/crates/obscura-js/js/bootstrap.js
+++ b/crates/obscura-js/js/bootstrap.js
@@ -5457,6 +5457,55 @@ if (typeof URLSearchParams === "undefined") globalThis.URLSearchParams = class U
   [Symbol.iterator](){ return this.entries(); }
 };
 
+// Conservative XML well-formedness check for DOMParser. Only detects clear
+// errors (tag balance / single root); defaults to well-formed when unsure so
+// valid XML is never falsely flagged.
+const _checkXmlWellFormed = (html) => {
+  // Strip comments, CDATA sections, processing instructions, and DOCTYPE
+  // declarations — they may contain angle brackets.
+  let s = html
+    .replace(/<!--[\s\S]*?-->/g, '')
+    .replace(/<!\[CDATA\[[\s\S]*?\]\]>/g, '')
+    .replace(/<\?[\s\S]*?\?>/g, '')
+    .replace(/<!DOCTYPE\s[^>]*?>/gi, '');
+
+  const stack = [];
+  // Match open / close / self-closing tags.
+  // Group 1: tag name.  Group 2: optional '/' before '>'.
+  const tagRe = /<\/?([a-zA-Z_][\w.\-:]*)(?:\s[^>]*?)?(\/)?>/g;
+  let rootFound = false;
+  let match;
+
+  while ((match = tagRe.exec(s)) !== null) {
+    const fullTag = match[0];
+    const tagName = match[1];
+    const isClosing = fullTag.startsWith('</');
+    const isSelfClosing = match[2] === '/' || fullTag.endsWith('/>');
+
+    if (isClosing) {
+      if (stack.length === 0) {
+        return { wellFormed: false, error: 'error on line 1: extra closing tag </' + tagName + '>' };
+      }
+      const open = stack.pop();
+      if (open !== tagName) {
+        return { wellFormed: false, error: 'error on line 1: opening and ending tag mismatch: ' + open + ' and ' + tagName };
+      }
+      if (stack.length === 0) rootFound = true;
+    } else if (!isSelfClosing) {
+      if (stack.length === 0 && rootFound) {
+        return { wellFormed: false, error: 'error on line 1: extra content after root element' };
+      }
+      stack.push(tagName);
+    }
+  }
+
+  if (stack.length > 0) {
+    return { wellFormed: false, error: 'error on line 1: unclosed tag <' + stack[stack.length - 1] + '>' };
+  }
+
+  return { wellFormed: true };
+};
+
 // Real-enough DOMParser. The previous one-liner returned `globalThis.document`,
 // so anything that did `new DOMParser().parseFromString(s, 'text/html')` and
 // then read `.body.innerHTML` mutated the LIVE page (jQuery 3.x's selector
@@ -5469,11 +5518,27 @@ globalThis.DOMParser = class DOMParser {
     const html = String(source ?? "");
     const isXml = typeof mimeType === "string" && /xml/i.test(mimeType);
     const root = document.createElement("html");
-    // innerHTML parses children via html5ever fragment-parsing rules. Most
-    // HTML inputs start with `<!DOCTYPE>` / `<html>` / `<head>` etc.; the
-    // fragment parser strips the outer `<html>` and emits its head+body
-    // children, which is what callers want.
-    try { root.innerHTML = html; } catch (e) { /* leave empty on parse error */ }
+    let _xmlError = null;
+
+    // For XML mime types, check well-formedness first (conservative: only
+    // clear errors like tag mismatch / extra root are flagged).  If the
+    // check fires, build a <parsererror> root so callers doing
+    // doc.querySelector('parsererror') get the same signal as in Chrome.
+    if (isXml) {
+      const wf = _checkXmlWellFormed(html);
+      if (!wf.wellFormed) _xmlError = wf.error;
+    }
+    if (_xmlError) {
+      root.innerHTML = '<parsererror>' + _xmlError + '</parsererror>';
+      // Make sure querySelector('parsererror') finds the root element.
+      root._parserError = true;
+    } else {
+      // innerHTML parses children via html5ever fragment-parsing rules. Most
+      // HTML inputs start with `<!DOCTYPE>` / `<html>` / `<head>` etc.; the
+      // fragment parser strips the outer `<html>` and emits its head+body
+      // children, which is what callers want.
+      try { root.innerHTML = html; } catch (e) { /* leave empty on parse error */ }
+    }
 
     // Helper: depth-first walk to find an element by predicate.
     const walk = (node, pred) => {
@@ -5494,7 +5559,12 @@ globalThis.DOMParser = class DOMParser {
       nodeName: "#document",
       nodeType: 9,
       contentType: isXml ? (mimeType || "application/xml") : "text/html",
-      get documentElement() { return root; },
+      get documentElement() {
+        // For XML parsererror docs, return the <parsererror> child, not the
+        // <html> wrapper — matches Chrome's behavior.
+        if (root._parserError) return root.firstElementChild || root;
+        return root;
+      },
       get body() { return findByTagName("BODY"); },
       get head() { return findByTagName("HEAD"); },
       get title() {
@@ -5520,7 +5590,11 @@ globalThis.DOMParser = class DOMParser {
       get ownerDocument() { return null; },
       createTreeWalker(r, ws, f) { return document.createTreeWalker(r || root, ws, f); },
       createNodeIterator(r, ws, f) { return document.createNodeIterator(r || root, ws, f); },
-      querySelector(s) { return root.querySelector(s); },
+      querySelector(s) {
+        // For XML parsererror docs, check the root element as well —
+        // the <parsererror> is the documentElement, not a descendant.
+        return root.querySelector(s) || (root._parserError && root.matches && root.matches(s) ? root : null);
+      },
       querySelectorAll(s) { return root.querySelectorAll(s); },
       getElementById(id) {
         return walk(root, n => n.getAttribute && n.getAttribute("id") === id);

--- a/crates/obscura-js/js/bootstrap.js
+++ b/crates/obscura-js/js/bootstrap.js
@@ -5491,11 +5491,17 @@ const _checkXmlWellFormed = (html) => {
         return { wellFormed: false, error: 'error on line 1: opening and ending tag mismatch: ' + open + ' and ' + tagName };
       }
       if (stack.length === 0) rootFound = true;
-    } else if (!isSelfClosing) {
+    } else {
+      // Opening or self-closing tag. Check for extra content after root.
       if (stack.length === 0 && rootFound) {
         return { wellFormed: false, error: 'error on line 1: extra content after root element' };
       }
-      stack.push(tagName);
+      if (isSelfClosing) {
+        // Self-closing: complete element, mark rootFound if at root level.
+        if (stack.length === 0) rootFound = true;
+      } else {
+        stack.push(tagName);
+      }
     }
   }
 

--- a/crates/obscura-js/js/bootstrap.js
+++ b/crates/obscura-js/js/bootstrap.js
@@ -5463,7 +5463,7 @@ if (typeof URLSearchParams === "undefined") globalThis.URLSearchParams = class U
 const _checkXmlWellFormed = (html) => {
   // Strip comments, CDATA sections, processing instructions, and DOCTYPE
   // declarations — they may contain angle brackets.
-  let s = html
+  const s = html
     .replace(/<!--[\s\S]*?-->/g, '')
     .replace(/<!\[CDATA\[[\s\S]*?\]\]>/g, '')
     .replace(/<\?[\s\S]*?\?>/g, '')
@@ -5530,10 +5530,9 @@ globalThis.DOMParser = class DOMParser {
     // check fires, build a <parsererror> root so callers doing
     // doc.querySelector('parsererror') get the same signal as in Chrome.
     const xmlError = isXml ? _checkXmlWellFormed(html) : null;
-    if (xmlError && !xmlError.wellFormed) {
+    const isParserError = xmlError && !xmlError.wellFormed;
+    if (isParserError) {
       root.innerHTML = '<parsererror>' + xmlError.error + '</parsererror>';
-      // Make sure querySelector('parsererror') finds the root element.
-      root._parserError = true;
     } else {
       // innerHTML parses children via html5ever fragment-parsing rules. Most
       // HTML inputs start with `<!DOCTYPE>` / `<html>` / `<head>` etc.; the
@@ -5564,7 +5563,7 @@ globalThis.DOMParser = class DOMParser {
       get documentElement() {
         // For XML parsererror docs, return the <parsererror> child, not the
         // <html> wrapper — matches Chrome's behavior.
-        if (root._parserError) return root.firstElementChild;
+        if (isParserError) return root.firstElementChild;
         return root;
       },
       get body() { return findByTagName("BODY"); },
@@ -5595,7 +5594,7 @@ globalThis.DOMParser = class DOMParser {
       querySelector(s) {
         // For XML parsererror docs, check the root element as well —
         // the <parsererror> is the documentElement, not a descendant.
-        return root.querySelector(s) || (root._parserError && root.matches(s) ? root : null);
+        return root.querySelector(s) || (isParserError && root.matches(s) ? root : null);
       },
       querySelectorAll(s) { return root.querySelectorAll(s); },
       getElementById(id) {


### PR DESCRIPTION
XML mime types (`application/xml`, `text/xml`, `image/svg+xml`, etc.) were always parsed as HTML, so malformed XML never yielded a `\<parsererror\>` element. This adds a conservative tag-balance well-formedness check for XML mime types; when a clear error is detected, the returned document's root is `\<parsererror\>` so `doc.querySelector('parsererror')` works as in Chrome.

## Changes

- Add `_checkXmlWellFormed` helper: conservative tag-balance check that strips comments, CDATA, processing instructions, and DOCTYPE before matching open/close tags
- On XML mime types with a detected error, the document root is `\<parsererror\>`
- `documentElement` returns the `\<parsererror\>` child, matching Chrome's behavior
- `querySelector` also checks the root element so `doc.querySelector('parsererror')` finds it
- HTML mime types are not affected
- Well-formed XML is never falsely flagged

## Verification

- 13 manual test cases passed (various XML mime types, comments, CDATA, DOCTYPE, self-closing tags)
- `cargo nextest run -p obscura-js -p obscura-dom`: **200/200 passed**, 0 regressions

Closes #504.