### PR TITLE
fix(js): expose CSSStyleDeclaration as a real global interface

### DIFF
--- a/crates/obscura-js/js/bootstrap.js
+++ b/crates/obscura-js/js/bootstrap.js
@@ -6041,6 +6041,12 @@ globalThis.DocumentType = DocumentType;
 globalThis.Node = Node;
 globalThis.Element = Element;
 globalThis.Document = Document;
+// CSSStyleDeclaration is the type of element.style and getComputedStyle(); it is
+// pre-declared non-enumerable in _preHideInternals, but unlike the other WebIDL
+// interfaces it had no value assignment, leaving `window.CSSStyleDeclaration`
+// undefined (so `el.style instanceof CSSStyleDeclaration` threw). Assigning here
+// only fills the value; the property stays enumerable:false, matching Chrome.
+globalThis.CSSStyleDeclaration = CSSStyleDeclaration;
 globalThis.XPathResult = globalThis.XPathResult || class XPathResult {};
 Object.assign(globalThis.XPathResult, {
   ANY_TYPE: 0,

--- a/crates/obscura-js/src/runtime.rs
+++ b/crates/obscura-js/src/runtime.rs
@@ -3485,6 +3485,20 @@ mod tests {
     }
 
     #[test]
+    fn cssstyledeclaration_is_a_usable_global_interface() {
+        // CSSStyleDeclaration was pre-declared non-enumerable but never assigned
+        // a value (the only WebIDL interface missing its globalThis.X = X line),
+        // so it was `undefined` while `'CSSStyleDeclaration' in window` was true,
+        // and `el.style instanceof CSSStyleDeclaration` threw. It must be a real
+        // constructor, non-enumerable like a browser, and the type of .style.
+        let mut rt = setup_runtime("<html><body></body></html>");
+        let v = rt
+            .evaluate("(function(){var d=Object.getOwnPropertyDescriptor(window,'CSSStyleDeclaration');return (typeof window.CSSStyleDeclaration)+'|'+(document.body.style instanceof CSSStyleDeclaration)+'|'+(d?d.enumerable:'missing');})()")
+            .unwrap();
+        assert_eq!(v, serde_json::json!("function|true|false"));
+    }
+
+    #[test]
     fn test_create_event_unknown_type_returns_event() {
         let mut rt = setup_runtime("<html><body></body></html>");
         let kind = rt


### PR DESCRIPTION
## What & why

`window.CSSStyleDeclaration` was an own property whose value was `undefined`, so it could not be used as a constructor or `instanceof` target — unlike every other WebIDL interface and unlike real Chrome.

Commit c7e7c70 added the 22 WebIDL interface names to the `_preHideInternals` non-enumerable pre-declaration list, on the assumption that each name's later `globalThis.X = X` assignment fills in the value. `CSSStyleDeclaration` was the **only** one with no such assignment (it exists only as a bare `class CSSStyleDeclaration { … }`), so its pre-declared `value: undefined` was never overwritten.

Because it is the type of `element.style` and `getComputedStyle()`, this was both a functional break and an observable inconsistency:

```js
typeof window.CSSStyleDeclaration            // "undefined"  (Chrome: "function")
'CSSStyleDeclaration' in window              // true         (own prop, value undefined)
document.body.style instanceof CSSStyleDeclaration
// before: TypeError: Right-hand side of 'instanceof' is not callable
// after / Chrome: true
```

## Fix

Assign `globalThis.CSSStyleDeclaration = CSSStyleDeclaration` alongside the other WebIDL interface globals. The property was already declared `writable:true, configurable:true, enumerable:false` by `_preHideInternals`, so the assignment only updates the value and the interface stays non-enumerable — matching Chrome.

## Test

`cssstyledeclaration_is_a_usable_global_interface` (runtime.rs) asserts `typeof` is `"function"`, `document.body.style instanceof CSSStyleDeclaration` is `true`, and the own-property descriptor is `enumerable:false`. It fails before the fix (the `instanceof` throws) and passes after. Full `obscura-js` suite: 155/155.

Fixes #546
