### PR TITLE
fix(dom): match setAttribute by qualified name, not local name only

### DIFF
--- a/crates/obscura-dom/src/tree.rs
+++ b/crates/obscura-dom/src/tree.rs
@@ -136,7 +136,11 @@ impl Node {
 
     pub fn set_attribute(&mut self, name: &str, value: String) {
         if let NodeData::Element { attrs, .. } = &mut self.data {
-            if let Some(attr) = attrs.iter_mut().find(|a| a.name.local.as_ref() == name) {
+            // Match by qualified name, consistent with get_attribute and the
+            // remove_attribute op. A parsed namespaced attribute is stored with
+            // a separate prefix (e.g. xlink:href -> prefix="xlink", local="href");
+            // matching on local name alone would miss it and push a duplicate.
+            if let Some(attr) = attrs.iter_mut().find(|a| a.qualified_name_eq(name)) {
                 attr.value = value;
             } else {
                 attrs.push(Attribute {

--- a/crates/obscura-js/src/runtime.rs
+++ b/crates/obscura-js/src/runtime.rs
@@ -1663,6 +1663,22 @@ mod tests {
     }
 
     #[test]
+    fn set_attribute_updates_a_parsed_namespaced_attribute_in_place() {
+        // setAttribute matched the stored attribute by local name only, so a
+        // parsed `xlink:href` (prefix=xlink, local=href) was never found by the
+        // qualified name "xlink:href": the update was pushed as a *second*
+        // attribute, getAttribute kept returning the stale original, and the
+        // element serialized `xlink:href` twice.
+        let mut rt = setup_runtime(
+            r##"<html><body><svg><use id="u" xlink:href="#a"></use></svg></body></html>"##,
+        );
+        let v = rt
+            .evaluate("(function(){var u=document.getElementById('u');u.setAttribute('xlink:href','#b');var dup=(u.outerHTML.match(/xlink:href/g)||[]).length;return u.getAttribute('xlink:href')+'|'+u.getAttributeNS('http://www.w3.org/1999/xlink','href')+'|'+u.getAttributeNames().join(',')+'|'+dup;})()")
+            .unwrap();
+        assert_eq!(v, serde_json::json!("#b|#b|id,xlink:href|1"));
+    }
+
+    #[test]
     fn set_attribute_ns_validates_namespace_constraints() {
         let mut rt = setup_runtime("<html><body></body></html>");
         let v = rt


### PR DESCRIPTION
## What & why

`element.setAttribute("prefix:local", …)` on a parsed namespaced attribute (e.g. `xlink:href`) created a **duplicate** attribute, serialized the qualified name twice, and silently dropped the intended update.

`Node::get_attribute` and the `remove_attribute` op both match by **qualified name** (`qualified_name_eq`, comparing `prefix:local`). `Node::set_attribute` was the lone outlier — it matched by **local name only**. A parser-created `xlink:href` is stored as `prefix=Some("xlink")`, `local="href"` (see commit 76e5280, which made the serializer reconstruct `prefix:local`), so `setAttribute("xlink:href", v)` never matched it and pushed a second attribute with `local="xlink:href", prefix=None`.

```js
// page: <svg><use id="u" xlink:href="#a"></use></svg>
const u = document.getElementById('u');
u.setAttribute('xlink:href', '#b');
u.getAttribute('xlink:href');   // before: "#a" (update lost)  ->  after: "#b"
u.outerHTML;                    // before: ...xlink:href="#a" xlink:href="#b"...  ->  after: single attr
```

## Fix

Match `set_attribute`'s lookup by `qualified_name_eq`, consistent with the read and remove paths, so the update lands in place and no duplicate is created.

## Test

`set_attribute_updates_a_parsed_namespaced_attribute_in_place` (runtime.rs) parses an SVG `xlink:href`, calls `setAttribute('xlink:href', '#b')`, and asserts `getAttribute`, `getAttributeNS`, `getAttributeNames()`, and the serialized-occurrence count. Before: `#a|#a|id,xlink:href,xlink:href|2`; after: `#b|#b|id,xlink:href|1`. Full suites: `obscura-dom` 46/46, `obscura-js` 155/155.

Fixes #547
