### PR TITLE
fix(mcp): fill_form check/uncheck/select use the native setter and trusted events

### DIFF
--- a/crates/obscura-mcp/src/lib.rs
+++ b/crates/obscura-mcp/src/lib.rs
@@ -1298,15 +1298,17 @@ fn tool_fill_form(args: &Value, state: &mut BrowserState) -> Result<String, Stri
             "check" => format!(r#"(function(){{
                 var el = document.querySelector({sel});
                 if (!el) return "error:not found";
-                el.checked = true;
-                el.dispatchEvent(new Event('change', {{bubbles:true}}));
+                globalThis.__obscura_setFieldValue(el, 'checked', true);
+                el.dispatchEvent(globalThis.__obscura_markTrusted(new Event('input', {{bubbles:true}})));
+                el.dispatchEvent(globalThis.__obscura_markTrusted(new Event('change', {{bubbles:true}})));
                 return "ok";
             }})()"#, sel = serde_json::to_string(&selector).unwrap()),
             "uncheck" => format!(r#"(function(){{
                 var el = document.querySelector({sel});
                 if (!el) return "error:not found";
-                el.checked = false;
-                el.dispatchEvent(new Event('change', {{bubbles:true}}));
+                globalThis.__obscura_setFieldValue(el, 'checked', false);
+                el.dispatchEvent(globalThis.__obscura_markTrusted(new Event('input', {{bubbles:true}})));
+                el.dispatchEvent(globalThis.__obscura_markTrusted(new Event('change', {{bubbles:true}})));
                 return "ok";
             }})()"#, sel = serde_json::to_string(&selector).unwrap()),
             "select" => format!(r#"(function(){{
@@ -1323,7 +1325,8 @@ fn tool_fill_form(args: &Value, state: &mut BrowserState) -> Result<String, Stri
                     }}
                 }}
                 if (!matched) return "error:no matching option";
-                el.dispatchEvent(new Event('change', {{bubbles:true}}));
+                el.dispatchEvent(globalThis.__obscura_markTrusted(new Event('input', {{bubbles:true}})));
+                el.dispatchEvent(globalThis.__obscura_markTrusted(new Event('change', {{bubbles:true}})));
                 return "ok";
             }})()"#, sel = serde_json::to_string(&selector).unwrap(), val = serde_json::to_string(value).unwrap()),
             _ => format!(r#"(function(){{
@@ -1844,6 +1847,78 @@ mod tests {
         assert_eq!(
             actual,
             json!(r#"{"domValue":"form-filled","controlledState":"form-filled","controlledUpdates":3,"lastInputTarget":"field","lastInputTrusted":true}"#),
+        );
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn fill_form_check_and_select_use_native_setter_and_trusted_events() {
+        let mut state = BrowserState::new(None, None, false);
+        state
+            .page_mut()
+            .navigate(
+                "data:text/html,<div id=root><input id=box type=checkbox>\
+                 <select id=sel><option value=a>a</option><option value=b>b</option></select></div>",
+            )
+            .await
+            .expect("test page should navigate");
+
+        // Install a React-style tracker on the checkbox's `checked`, redefined on
+        // the instance. A direct `el.checked = true` runs this wrapper in lockstep,
+        // so a change handler comparing target.checked to the tracked value sees no
+        // change and never commits. Writing through the prototype setter (what
+        // __obscura_setFieldValue does) leaves the tracker stale so the edit
+        // registers. Also record whether the dispatched change is trusted.
+        state.page_mut().evaluate(
+            r#"(function () {
+                var box = document.getElementById('box');
+                var root = document.getElementById('root');
+                var d = Object.getOwnPropertyDescriptor(box.constructor.prototype, 'checked');
+                var tracked = box.checked;
+                Object.defineProperty(box, 'checked', {
+                    configurable: true,
+                    get: function () { return d.get.call(this); },
+                    set: function (v) { tracked = !!v; d.set.call(this, v); }
+                });
+                window.__checkedCommitted = false;
+                window.__checkTrusted = false;
+                window.__selectTrusted = false;
+                root.addEventListener('change', function (event) {
+                    if (event.target.id === 'box') {
+                        window.__checkTrusted = event.isTrusted;
+                        if (event.target.checked !== tracked) {
+                            tracked = event.target.checked;
+                            window.__checkedCommitted = true;
+                        }
+                    } else if (event.target.id === 'sel') {
+                        window.__selectTrusted = event.isTrusted;
+                    }
+                });
+            })()"#,
+        );
+
+        tool_fill_form(
+            &json!({
+                "fields": [
+                    { "selector": "#box", "type": "check" },
+                    { "selector": "#sel", "type": "select", "value": "b" }
+                ]
+            }),
+            &mut state,
+        )
+        .expect("browser_fill_form should succeed");
+
+        let actual = state.page_mut().evaluate(
+            r#"JSON.stringify({
+                domChecked: document.getElementById('box').checked,
+                checkedCommitted: window.__checkedCommitted,
+                checkTrusted: window.__checkTrusted,
+                selValue: document.getElementById('sel').value,
+                selectTrusted: window.__selectTrusted
+            })"#,
+        );
+        assert_eq!(
+            actual,
+            json!(r#"{"domChecked":true,"checkedCommitted":true,"checkTrusted":true,"selValue":"b","selectTrusted":true}"#),
         );
     }
 }


### PR DESCRIPTION
## What & why

`browser_fill_form`'s `check` / `uncheck` / `select` branches were left on the pre-#530 pattern — a direct property assignment plus a raw, untrusted `change` event — while the text branch two lines away was fixed to use the native setter and trusted events. This is the same bug class #530 set out to fix.

For a React-controlled checkbox (`<input type=checkbox checked={s} onChange=…>`), `el.checked = true` runs the framework's value tracker in lockstep, so the synthetic `change` looks unchanged and `onChange` never commits — React re-renders the box to its prior state. And every branch dispatched untrusted events, so any handler / anti-bot layer gating on `event.isTrusted` ignored them.

## Fix

- `check` / `uncheck`: write through `__obscura_setFieldValue(el, 'checked', …)`, which walks to the prototype `checked` setter and leaves the framework's instance tracker stale, so the edit registers.
- All three branches: dispatch `input` + `change` wrapped in `__obscura_markTrusted`, matching the text branch.

The `select` branch keeps its match-by-value-or-visible-label logic (setting `selectedIndex` already leaves React's `value` tracker stale); only the events needed to become trusted.

## Test

`fill_form_check_and_select_use_native_setter_and_trusted_events` (lib.rs) installs a React-style `checked` tracker on a checkbox and drives `browser_fill_form` with a `check` and a `select`. Before: `checkedCommitted:false, checkTrusted:false, selectTrusted:false`. After: all true, box checked, select value updated. Existing `fill_tools_notify_controlled_input_tracker` still passes; full `obscura-mcp` suite 11/11.

Fixes #550
