### PR TITLE
fix(cdp): escape backslashes in objectId JS interpolation

### DIFF
--- a/crates/obscura-cdp/src/domains/dom.rs
+++ b/crates/obscura-cdp/src/domains/dom.rs
@@ -4,6 +4,17 @@ use serde_json::{json, Value};
 
 use crate::dispatch::CdpContext;
 
+/// Escape a client-supplied objectId for interpolation into a single-quoted JS
+/// string literal (`__obscura_objects['<here>']`). Backslashes must be escaped
+/// before single quotes, otherwise an id ending in `\` turns the closing quote
+/// into `\'` and produces a syntax error. All three objectId lookup sites route
+/// through this so they cannot diverge; not an injection vector (every `'` stays
+/// escaped, so the worst case is an unterminated string -> clean resolution
+/// failure), but a robustness fix.
+fn escape_object_id(oid: &str) -> String {
+    oid.replace('\\', "\\\\").replace('\'', "\\'")
+}
+
 /// Resolve a DOM `nodeId` from CDP params. Honors `nodeId`, `backendNodeId`,
 /// and `objectId` in that order. Playwright commonly passes only `objectId`
 /// (returned by a prior `DOM.resolveNode`); without this fallback those
@@ -19,7 +30,7 @@ fn resolve_node_id(page: &mut Page, params: &Value) -> Result<u64, String> {
         let code = format!(
             "(function() {{ var o = globalThis.__obscura_objects && globalThis.__obscura_objects['{}']; \
              return (o && typeof o._nid === 'number') ? o._nid : -1; }})()",
-            oid.replace('\'', "\\'")
+            escape_object_id(oid)
         );
         let result = page.evaluate(&code);
         let nid = result.as_f64().map(|n| n as i64).unwrap_or(-1);
@@ -140,7 +151,7 @@ pub async fn handle(
             {
                 nid
             } else if let Some(oid) = params.get("objectId").and_then(|v| v.as_str()) {
-                let escaped_oid = oid.replace('\\', "\\\\").replace('\'', "\\'");
+                let escaped_oid = escape_object_id(oid);
                 let code = format!(
                     "(function() {{ var o = globalThis.__obscura_objects['{}']; if (!o) return -1; return (typeof o._nid === 'number') ? o._nid : -1; }})()",
                     escaped_oid
@@ -165,7 +176,7 @@ pub async fn handle(
             } else if let Some(oid) = params.get("objectId").and_then(|v| v.as_str()) {
                 let code = format!(
                     "(function() {{ var o = globalThis.__obscura_objects['{}']; return (o && typeof o._nid === 'number') ? o._nid : -1; }})()",
-                    oid
+                    escape_object_id(oid)
                 );
                 let result = page.evaluate(&code);
                 result.as_f64().map(|n| n as u64).unwrap_or(0)
@@ -504,6 +515,17 @@ fn serialize_node(dom: &DomTree, node_id: NodeId, max_depth: u32, current_depth:
 mod tests {
     use super::*;
     use crate::dispatch::CdpContext;
+
+    #[test]
+    fn escape_object_id_escapes_backslash_before_quote() {
+        // A trailing backslash must be doubled so it cannot escape the closing
+        // quote of __obscura_objects['...']; the old resolve_node_id path escaped
+        // only the quote, producing ['x\'] (syntax error) for the id `x\`.
+        assert_eq!(escape_object_id(r"x\"), r"x\\");
+        assert_eq!(escape_object_id("a'b"), r"a\'b");
+        assert_eq!(escape_object_id(r"a\'b"), r"a\\\'b");
+        assert_eq!(escape_object_id("plain"), "plain");
+    }
 
     #[tokio::test]
     async fn dom_focus_sets_active_element() {


### PR DESCRIPTION
## What & why

The three objectId lookup sites in the CDP DOM domain escaped the client-supplied objectId inconsistently before interpolating it into evaluated JS (`__obscura_objects['<oid>']`): `resolve_node_id` escaped only the single quote, `resolveNode` escaped nothing, and `describeNode` escaped both. An objectId ending in a backslash (e.g. `x\`) turned the closing quote into `\'`, producing a JS syntax error, so the node failed to resolve with "could not be resolved to a node" (affecting `DOM.scrollIntoViewIfNeeded` / `focus` / `getBoxModel` and any handler routing through `resolve_node_id`).

Not an injection: every `'` stays escaped, so a crafted id cannot break out of the string to execute code — the worst case is an unterminated string literal → clean resolution failure. But the divergence is a robustness bug, and `resolveNode` escaping nothing was the worst of the three.

## Fix

Route all three sites through a single `escape_object_id` helper that doubles backslashes **before** escaping single quotes (the correct order, matching what `describeNode` already did). Consolidating removes the duplication that let them drift.

## Test

`escape_object_id_escapes_backslash_before_quote` pins the escaping contract (`x\` → `x\\`, `a'b` → `a\'b`, order-sensitive `a\'b` → `a\\\'b`). Verified it fails against the old single-escape logic. Full `obscura-cdp` suite 96/96.

Fixes #557
