### PR TITLE
fix(js): run string timer handlers as global-scope scripts at fire time

### DIFF
--- a/crates/obscura-js/js/bootstrap.js
+++ b/crates/obscura-js/js/bootstrap.js
@@ -481,7 +481,15 @@ const _scheduleAfter = (delay, fn) => {
 // call silently no-ops and JS-triggered navigations (cookie → reload) never fire.
 const _coerceTimerFn = (fn) => {
   if (typeof fn === "string") {
-    try { return new Function(fn); } catch (_) { return null; }
+    // Per HTML, a string handler is compiled and run as a classic script in
+    // global scope *at fire time*. Indirect eval ((0, eval)) runs in the true
+    // global scope, so top-level var/function declarations become globals (a
+    // `new Function(fn)` wrapper kept them local); deferring to fire time also
+    // surfaces a SyntaxError when the timer elapses, matching a real browser,
+    // instead of swallowing it eagerly at scheduling. The dynamic-script path
+    // uses the same indirect eval for the same reason.
+    const src = fn;
+    return () => { (0, eval)(src); };
   }
   return typeof fn === "function" ? fn : null;
 };

--- a/crates/obscura-js/src/runtime.rs
+++ b/crates/obscura-js/src/runtime.rs
@@ -1331,6 +1331,26 @@ mod tests {
     }
 
     #[tokio::test(flavor = "current_thread")]
+    async fn string_timeout_declarations_reach_global_scope() {
+        // A string timer handler runs as a classic script in global scope, so a
+        // top-level var/function declaration in it becomes a global. new Function()
+        // kept those declarations local to the compiled function, so they never
+        // reached globalThis.
+        let mut rt = setup_runtime("<html><body></body></html>");
+        rt.evaluate(
+            "setTimeout('var __leaked = 42; function __leakedFn(){ return 7; }', 0)",
+        )
+        .unwrap();
+        rt.run_event_loop_bounded(100).await.unwrap();
+        let v = rt
+            .evaluate(
+                "String(globalThis.__leaked) + '|' + (typeof globalThis.__leakedFn === 'function' ? globalThis.__leakedFn() : 'missing')",
+            )
+            .unwrap();
+        assert_eq!(v, serde_json::json!("42|7"));
+    }
+
+    #[tokio::test(flavor = "current_thread")]
     async fn string_interval_handler_repeats_and_can_clear_itself() {
         let mut rt = setup_runtime("<html><body></body></html>");
         rt.evaluate("globalThis.__ticks=0").unwrap();


### PR DESCRIPTION
## What & why

A string `setTimeout`/`setInterval` handler was compiled with `new Function(fn)` at scheduling time. Two divergences from the HTML spec / Chrome resulted:

1. **Declarations didn't reach global scope.** `new Function(body)` resolves names against the global scope (so assignments to existing globals worked), but top-level `var`/`function`/`class` declarations inside the body stayed local to the compiled function — `setTimeout('var x = 5', 0)` left `window.x` undefined (Chrome: `5`).
2. **Syntax errors were swallowed at scheduling.** `new Function` compiles eagerly, so a malformed body was caught at scheduling and turned into a silent no-op (that still returned a timer id). Chrome compiles at fire time and reports the `SyntaxError` when the timer elapses.

## Fix

For a string handler, defer to fire-time indirect `eval` (`(0, eval)(src)`), which runs in the true global scope as a classic script — so top-level declarations become global and a `SyntaxError` surfaces when the timer fires. This matches the dynamic-script path, which already uses indirect `eval` for the same reason. Function handlers are unchanged.

## Test

`string_timeout_declarations_reach_global_scope` schedules `setTimeout('var __leaked = 42; function __leakedFn(){ return 7; }', 0)`, pumps the event loop, and asserts both are global. Before: `undefined|missing`; after: `42|7`. The existing `string_timeout_handler_executes_in_global_scope` and `string_interval_handler_repeats_and_can_clear_itself` still pass; full `obscura-js` suite 155/155.

Fixes #558
