### PR TITLE
fix(cdp): setExtraHTTPHeaders not applied in stealth mode

### DIFF
--- a/crates/obscura-cdp/src/domains/network.rs
+++ b/crates/obscura-cdp/src/domains/network.rs
@@ -50,7 +50,11 @@ pub async fn handle(
                         .iter()
                         .map(|(k, v)| (k.clone(), v.as_str().unwrap_or("").to_string()))
                         .collect();
-                    page.http_client.set_extra_headers(header_map).await;
+                    page.http_client.set_extra_headers(header_map.clone()).await;
+                    #[cfg(feature = "stealth")]
+                    if let Some(stealth_client) = &page.stealth_client {
+                        stealth_client.set_extra_headers(header_map).await;
+                    }
                 }
             }
             Ok(json!({}))


### PR DESCRIPTION
## Summary

Fixes #571. `page.setExtraHTTPHeaders()` (Puppeteer/Playwright) silently fails when Obscura runs with `--stealth`. In normal mode the custom headers are sent correctly, but in stealth mode they're dropped entirely.

## Root cause

Stealth mode sends all HTTP requests through `StealthHttpClient` (wreq/BoringSSL) instead of `ObscuraHttpClient` (reqwest/rustls). Both clients maintain their own `extra_headers` map, but the `Network.setExtraHTTPHeaders` CDP handler only updated `ObscuraHttpClient`.

As a result, the stealth client's header map remained empty, so both `StealthHttpClient::fetch()` (navigation) and `send_single()` (fetch/XHR) sent requests without the custom headers.

## Fix

When `Network.setExtraHTTPHeaders` updates `ObscuraHttpClient`, it now also updates `StealthHttpClient` if stealth mode is enabled:

```rust
page.http_client.set_extra_headers(header_map.clone()).await;

#[cfg(feature = "stealth")]
if let Some(stealth_client) = &page.stealth_client {
    stealth_client.set_extra_headers(header_map).await;
}
```

Since both `fetch()` and `send_single()` read from the same `extra_headers` map, this restores support for custom headers across all requests in stealth mode.
