### PR TITLE
fix(cdp): validate Runtime.removeBinding name to prevent JS injection

### DIFF
--- a/crates/obscura-cdp/src/domains/runtime.rs
+++ b/crates/obscura-cdp/src/domains/runtime.rs
@@ -4,6 +4,19 @@ use serde_json::{json, Value};
 
 use crate::dispatch::CdpContext;
 
+/// Whether a binding name is a plain JS identifier and therefore safe to
+/// interpolate into the generated shim / teardown scripts. Chromium bindings
+/// are identifiers; anything else (quotes, brackets, spaces, operators) could
+/// break out of the surrounding string literal and inject arbitrary JS into the
+/// page. `Runtime.addBinding` always enforced this, but `Runtime.removeBinding`
+/// did not, so a crafted name escaped `delete globalThis['{name}']` and ran in
+/// the page context. Both handlers now share this guard.
+fn is_valid_binding_name(name: &str) -> bool {
+    !name.is_empty()
+        && name.chars().all(|c| c.is_alphanumeric() || c == '_' || c == '$')
+        && !name.chars().next().unwrap_or('0').is_ascii_digit()
+}
+
 /// Drain pending JS-initiated navigation (form.submit, location.assign, etc),
 /// then emit the same CDP nav-event sequence Page.navigate emits so
 /// Puppeteer's waitForNavigation / Playwright's wait_for_url resolves.
@@ -337,10 +350,7 @@ pub async fn handle(
         }
         "addBinding" => {
             let name = params.get("name").and_then(|v| v.as_str()).unwrap_or("");
-            if !name.is_empty()
-                && name.chars().all(|c| c.is_alphanumeric() || c == '_' || c == '$')
-                && !name.chars().next().unwrap_or('0').is_ascii_digit()
-            {
+            if is_valid_binding_name(name) {
                 // The shim forwards every call back to Rust through
                 // op_binding_called; the CDP dispatcher then drains the
                 // queue and emits Runtime.bindingCalled events the same
@@ -375,7 +385,7 @@ pub async fn handle(
         }
         "removeBinding" => {
             let name = params.get("name").and_then(|v| v.as_str()).unwrap_or("");
-            if !name.is_empty() {
+            if is_valid_binding_name(name) {
                 let key = format!("__obscura_binding__{}", name);
                 ctx.preload_scripts.retain(|(k, _)| k != &key);
                 if let Some(page) = ctx.get_session_page_mut(session_id) {
@@ -586,5 +596,56 @@ mod tests {
             .await
             .expect("Runtime.enable must succeed even with no session");
         assert_eq!(result, json!({}));
+    }
+
+    /// SEC-002 / #578 — Runtime.removeBinding must validate the binding name the
+    /// same way addBinding does. Before the fix the name was interpolated
+    /// straight into `delete globalThis['{name}']`, so a CDP client could break
+    /// out of the string delimiter and run arbitrary JS in the page. This drives
+    /// the real handler against a live page and asserts the injected statement
+    /// never executes.
+    #[tokio::test(flavor = "current_thread")]
+    async fn remove_binding_rejects_injection_in_name() {
+        let mut ctx = CdpContext::new();
+        let page_id = ctx.create_page();
+        let session = Some(format!("{page_id}-session"));
+        ctx.sessions.insert(session.clone().unwrap(), page_id);
+
+        crate::domains::page::handle(
+            "navigate",
+            &json!({ "url": "data:text/html,<p>hi</p>", "waitUntil": "load" }),
+            &mut ctx,
+            &session,
+        )
+        .await
+        .expect("navigate should succeed");
+
+        // Canary the injection would flip from 0 to 1.
+        ctx.get_session_page_mut(&session)
+            .unwrap()
+            .evaluate("globalThis.__pwned = 0");
+
+        // The generated code is `delete globalThis['{name}']`, which the runtime
+        // wraps as `return ( ... )`. A comma-expression payload stays a single
+        // valid expression through that wrapper and runs the assignment:
+        //   delete globalThis['x'] , (globalThis.__pwned = 1) , globalThis['y']
+        handle(
+            "removeBinding",
+            &json!({ "name": "x'] , (globalThis.__pwned = 1) , globalThis['y" }),
+            &mut ctx,
+            &session,
+        )
+        .await
+        .expect("removeBinding must return Ok regardless of the name");
+
+        let pwned = ctx
+            .get_session_page_mut(&session)
+            .unwrap()
+            .evaluate("globalThis.__pwned");
+        assert_ne!(
+            pwned.as_f64(),
+            Some(1.0),
+            "removeBinding must not execute JS injected via the binding name (got {pwned:?})"
+        );
     }
 }


### PR DESCRIPTION
Fixes a JS-injection vector: `Runtime.removeBinding` interpolated the client-supplied binding name straight into `delete globalThis['{name}']` with no validation, so a crafted name (`x'] , (evil()) , globalThis['y`) executed arbitrary JS in the page. `addBinding` already required a plain-identifier name; this extracts that check into a shared `is_valid_binding_name` helper and gates `removeBinding` behind it too.

TDD: an end-to-end test drives `removeBinding` against a live page with a comma-expression payload and asserts the injected assignment never runs (RED flipped a canary to 1.0; GREEN keeps it 0). All 116 obscura-cdp tests pass.

Closes #578