### PR TITLE
fix(obscura): escape Element::attribute() name and make Element borrow Page safely

### DIFF
--- a/crates/obscura/src/browser.rs
+++ b/crates/obscura/src/browser.rs
@@ -1,3 +1,4 @@
+use std::cell::RefCell;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, Ordering};
 
@@ -56,7 +57,7 @@ impl Browser {
             self.context.clone(),
         );
         Ok(Page {
-            inner: page,
+            inner: RefCell::new(page),
         })
     }
 

--- a/crates/obscura/src/page.rs
+++ b/crates/obscura/src/page.rs
@@ -1,3 +1,4 @@
+use std::cell::RefCell;
 use std::time::Duration;
 
 use obscura_browser::lifecycle::WaitUntil;
@@ -16,14 +17,21 @@ fn nid_from_value(v: &Value) -> Option<u64> {
 }
 
 /// A browser tab/page.
+///
+/// The wrapped [`InnerPage`] lives behind a `RefCell` so that read-style
+/// operations — including [`Page::evaluate`] — take `&self`. That lets an
+/// [`Element`] borrow the page immutably and drive evaluation through a safe
+/// shared reference, instead of the previous lifetime-less raw pointer that
+/// could dangle if the page was dropped or moved.
 pub struct Page {
-    pub(crate) inner: InnerPage,
+    pub(crate) inner: RefCell<InnerPage>,
 }
 
 impl Page {
     /// Navigate to URL and wait for load.
     pub async fn goto(&mut self, url: &str) -> Result<(), Error> {
         self.inner
+            .get_mut()
             .navigate_with_wait(url, WaitUntil::Load)
             .await
             .map_err(|e| Error::Navigation(e.to_string()))
@@ -31,37 +39,40 @@ impl Page {
 
     /// Get current URL.
     pub fn url(&self) -> String {
-        self.inner.url_string()
+        self.inner.borrow().url_string()
     }
 
     /// Execute JS in the page.
-    pub fn evaluate(&mut self, expression: &str) -> Value {
-        self.inner.evaluate(expression)
+    ///
+    /// Takes `&self` via interior mutability so element handles that borrow the
+    /// page immutably can drive evaluation without any `unsafe` aliasing.
+    pub fn evaluate(&self, expression: &str) -> Value {
+        self.inner.borrow_mut().evaluate(expression)
     }
 
     /// Get page HTML content.
-    pub fn content(&mut self) -> String {
+    pub fn content(&self) -> String {
         let val = self.evaluate("document.documentElement.outerHTML");
         val.as_str().unwrap_or("").to_string()
     }
 
     /// Query a single element by CSS selector.
-    pub fn query_selector(&mut self, selector: &str) -> Option<Element> {
+    pub fn query_selector(&self, selector: &str) -> Option<Element<'_>> {
         let escaped = selector.replace('\\', "\\\\").replace('\'', "\\'");
         let js = format!(
             "(function() {{ var el = document.querySelector('{}'); return el ? el._nid : null; }})()",
             escaped
         );
         let val = self.evaluate(&js);
-        nid_from_value(&val).map(|nid| Element { node_id: nid, page: self as *const Page })
+        nid_from_value(&val).map(|nid| Element { node_id: nid, page: self })
     }
 
     /// Wait for CSS selector to appear (polls every 100ms).
     pub async fn wait_for_selector(
-        &mut self,
+        &self,
         selector: &str,
         timeout: Duration,
-    ) -> Result<Element, Error> {
+    ) -> Result<Element<'_>, Error> {
         let start = std::time::Instant::now();
         let escaped = selector.replace('\\', "\\\\").replace('\'', "\\'");
         loop {
@@ -71,7 +82,7 @@ impl Page {
             );
             let val = self.evaluate(&js);
             if let Some(nid) = nid_from_value(&val) {
-                return Ok(Element { node_id: nid, page: self as *const Page });
+                return Ok(Element { node_id: nid, page: self });
             }
             if start.elapsed() > timeout {
                 return Err(Error::Timeout(format!(
@@ -90,7 +101,7 @@ impl Page {
     /// setTimeout, RxJS subscribers) to let the V8 event loop pump and
     /// resolve scheduled microtasks/macrotasks before the next `evaluate()`.
     pub async fn settle(&mut self, max_ms: u64) {
-        self.inner.settle(max_ms).await
+        self.inner.get_mut().settle(max_ms).await
     }
 
     /// Register a script that runs before any of the page's own `<script>` tags,
@@ -98,7 +109,7 @@ impl Page {
     /// `goto()` / navigation. Use it to install a fetch()/XHR interceptor or any
     /// other page-init logic before the page's bootstrap runs.
     pub fn add_preload_script(&mut self, script: &str) {
-        self.inner.add_preload_script(script);
+        self.inner.get_mut().add_preload_script(script);
     }
 
     /// Enable CDP-Fetch-style interception of every JS `fetch()`/XHR. Returns a
@@ -108,7 +119,7 @@ impl Page {
     pub fn enable_interception(
         &mut self,
     ) -> tokio::sync::mpsc::UnboundedReceiver<InterceptedRequest> {
-        self.inner.enable_interception()
+        self.inner.get_mut().enable_interception()
     }
 
     /// Register a passive callback fired for every request the page makes
@@ -116,7 +127,7 @@ impl Page {
     /// and before it is sent. Non-blocking; use `enable_interception` to mutate
     /// or block. Returns a stable id; pass it to `off_request` to detach.
     pub fn on_request(&mut self, cb: RequestCallback) -> u64 {
-        self.inner.on_request(cb)
+        self.inner.get_mut().on_request(cb)
     }
 
     /// Register a passive callback fired with every response the page receives
@@ -124,7 +135,7 @@ impl Page {
     /// main path for capturing API response payloads from SPAs. Returns a stable
     /// id; pass it to `off_response` to detach.
     pub fn on_response(&mut self, cb: ResponseCallback) -> u64 {
-        self.inner.on_response(cb)
+        self.inner.get_mut().on_response(cb)
     }
 
     /// Detach a request callback previously registered with `on_request`.
@@ -132,29 +143,31 @@ impl Page {
     /// scoped to this page — they never fire for sibling pages and are
     /// dropped with the page (issue #408).
     pub fn off_request(&mut self, id: u64) -> bool {
-        self.inner.off_request(id)
+        self.inner.get_mut().off_request(id)
     }
 
     /// Detach a response callback previously registered with `on_response`.
     /// Returns true if a callback with that id was removed.
     pub fn off_response(&mut self, id: u64) -> bool {
-        self.inner.off_response(id)
+        self.inner.get_mut().off_response(id)
     }
 }
 
 /// Handle to a DOM element.
 ///
-/// Created via [`Page::query_selector`] or [`Page::wait_for_selector`].
-pub struct Element {
+/// Created via [`Page::query_selector`] or [`Page::wait_for_selector`]. The
+/// handle borrows the [`Page`] for `'p`, so the borrow checker guarantees the
+/// page outlives every element derived from it — a dangling handle is a compile
+/// error rather than undefined behaviour.
+pub struct Element<'p> {
     node_id: u64,
-    page: *const Page,
+    page: &'p Page,
 }
 
-impl Element {
+impl Element<'_> {
     /// Get text content of this element.
     pub fn text(&self) -> String {
-        let page = unsafe { &mut *(self.page as *mut Page) };
-        let val = page.evaluate(&format!(
+        let val = self.page.evaluate(&format!(
             "(function() {{ var el = globalThis._wrap && globalThis._wrap({}); return el ? el.textContent : ''; }})()",
             self.node_id
         ));
@@ -163,12 +176,11 @@ impl Element {
 
     /// Get an attribute value.
     pub fn attribute(&self, name: &str) -> Option<String> {
-        let page = unsafe { &mut *(self.page as *mut Page) };
         // Escape the name like query_selector escapes its selector, so a name
         // containing a quote/backslash cannot break out of the JS string literal
         // and inject code into the page.
         let escaped = name.replace('\\', "\\\\").replace('\'', "\\'");
-        let val = page.evaluate(&format!(
+        let val = self.page.evaluate(&format!(
             "(function() {{ var el = globalThis._wrap && globalThis._wrap({}); return el ? el.getAttribute('{}') : null; }})()",
             self.node_id, escaped
         ));
@@ -177,14 +189,13 @@ impl Element {
 
     /// Click this element.
     pub fn click(&self) -> Result<(), Error> {
-        let page = unsafe { &mut *(self.page as *mut Page) };
         // Scroll into view
-        page.evaluate(&format!(
+        self.page.evaluate(&format!(
             "(function() {{ var el = globalThis._wrap && globalThis._wrap({}); if (el) el.scrollIntoView({{block:'center'}}); }})()",
             self.node_id
         ));
         // Click
-        let result = page.evaluate(&format!(
+        let result = self.page.evaluate(&format!(
             "(function() {{ var el = globalThis._wrap && globalThis._wrap({}); if (el) {{ el.click(); return true; }} return false; }})()",
             self.node_id
         ));

--- a/crates/obscura/src/page.rs
+++ b/crates/obscura/src/page.rs
@@ -164,9 +164,13 @@ impl Element {
     /// Get an attribute value.
     pub fn attribute(&self, name: &str) -> Option<String> {
         let page = unsafe { &mut *(self.page as *mut Page) };
+        // Escape the name like query_selector escapes its selector, so a name
+        // containing a quote/backslash cannot break out of the JS string literal
+        // and inject code into the page.
+        let escaped = name.replace('\\', "\\\\").replace('\'', "\\'");
         let val = page.evaluate(&format!(
             "(function() {{ var el = globalThis._wrap && globalThis._wrap({}); return el ? el.getAttribute('{}') : null; }})()",
-            self.node_id, name
+            self.node_id, escaped
         ));
         if val.is_null() { None } else { Some(val.as_str().unwrap_or("").to_string()) }
     }

--- a/crates/obscura/tests/attribute_injection.rs
+++ b/crates/obscura/tests/attribute_injection.rs
@@ -1,0 +1,50 @@
+//! SEC-007 / #583 — `Element::attribute()` must escape the attribute name
+//! before interpolating it into page JS. A name containing a quote must not be
+//! able to break out of the `getAttribute('{name}')` string literal and run
+//! arbitrary JS in the page, the same guarantee `Page::query_selector` already
+//! gives for selectors.
+
+use obscura::Browser;
+
+#[tokio::test]
+async fn attribute_name_cannot_inject_js() {
+    let browser = Browser::new().unwrap();
+    let mut page = browser.new_page().await.unwrap();
+    page.goto("data:text/html,<div id=x data-safe=ok></div>")
+        .await
+        .unwrap();
+
+    // Canary the injection would flip from 0 to 1.
+    page.evaluate("globalThis.__pwned = 0");
+
+    let el = page.query_selector("#x").expect("element #x should be found");
+
+    // Payload breaks out of `getAttribute('{name}')` while staying a single
+    // valid expression (the wrapper places it inside `el ? ... : null`, which
+    // forbids a top-level comma). String concatenation carries the assignment:
+    //   el.getAttribute('x' + (globalThis.__pwned = 1) + '')
+    let _ = el.attribute("x' + (globalThis.__pwned = 1) + '");
+
+    let pwned = page.evaluate("globalThis.__pwned");
+    assert_ne!(
+        pwned.as_f64(),
+        Some(1.0),
+        "attribute() must not execute JS injected via the attribute name (got {pwned:?})"
+    );
+}
+
+#[tokio::test]
+async fn attribute_reads_ordinary_names() {
+    let browser = Browser::new().unwrap();
+    let mut page = browser.new_page().await.unwrap();
+    page.goto("data:text/html,<div id=x data-safe=ok></div>")
+        .await
+        .unwrap();
+
+    let el = page.query_selector("#x").expect("element #x should be found");
+    assert_eq!(
+        el.attribute("data-safe").as_deref(),
+        Some("ok"),
+        "escaping must not break reading a normal attribute name"
+    );
+}


### PR DESCRIPTION
Two fixes to the public `obscura::Page` API in one file:

- **#583** — `Element::attribute(name)` interpolated the attribute name into `getAttribute('{name}')` unescaped (unlike `query_selector`). A quote in the name could break out and run JS. Now escaped like the selector methods.
- **#584** — `Element` held a lifetime-less `*const Page` cast to `*mut` per method: a use-after-free + aliasing hazard. Adopted interior mutability (option B): the page lives in a `RefCell`, `evaluate`/query methods take `&self`, and `Element<'p>` holds a plain `&'p Page` — the borrow checker now guarantees the page outlives every handle and all `unsafe` is gone. `Element` is not re-exported, so the added lifetime is not a breaking change.

TDD: an end-to-end test asserts an injection-shaped attribute name does not execute (RED flipped a canary to 1.0; GREEN keeps it 0); the full obscura suite (9 tests) still passes after the soundness refactor.

Closes #583
Closes #584