### PR TITLE
fix(js): expose globals in iframe realms

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -43,13 +43,41 @@ body:
     validations:
       required: true
   - type: dropdown
+    id: area
+    attributes:
+      label: Affected area
+      options:
+        - JavaScript or DOM behavior
+        - Rendering, layout, or paint
+        - Screenshot, screencast, or PDF output
+        - CDP, Puppeteer, or Playwright compatibility
+        - Networking, cookies, or proxies
+        - CLI or MCP
+        - Build, packaging, or installation
+        - Other
+    validations:
+      required: true
+  - type: dropdown
+    id: build
+    attributes:
+      label: Build variant
+      description: Official default and stealth archives include rendering. No-render archives and source builds without the render feature do not.
+      options:
+        - Render-enabled (official default archive or --features render)
+        - Render-enabled with stealth (official stealth archive or --features render,stealth)
+        - No-render (official no-render archive or source build without render)
+        - No-render with stealth (official no-render-stealth archive or --features stealth)
+        - I do not know
+    validations:
+      required: true
+  - type: dropdown
     id: stealth
     attributes:
       label: Stealth mode
       options:
-        - "Off (default build)"
-        - "On (--stealth, default build)"
-        - "On (--stealth, --features stealth build)"
+        - "Off"
+        - "On (--stealth)"
+        - "Not applicable"
     validations:
       required: false
   - type: textarea
@@ -73,6 +101,17 @@ body:
       label: Actual behavior
     validations:
       required: true
+  - type: textarea
+    id: render_details
+    attributes:
+      label: Rendering details
+      description: For layout, screenshot, screencast, or PDF bugs, include viewport size, device scale factor, output options, and before/after or Chrome reference images. Drag images or output files here.
+      placeholder: |
+        Viewport: 1280x720, DPR 1
+        Output: full-page PNG / A4 PDF / screencast frame
+        Options: --screenshot page.png, printBackground=true, etc.
+    validations:
+      required: false
   - type: dropdown
     id: chrome
     attributes:

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -6,6 +6,22 @@ body:
     attributes:
       value: |
         For larger API proposals, consider opening a Discussion first so the design can be talked through before you build it.
+  - type: dropdown
+    id: area
+    attributes:
+      label: Area
+      options:
+        - JavaScript or DOM behavior
+        - Rendering, layout, or paint
+        - Screenshot, screencast, or PDF output
+        - CDP, Puppeteer, or Playwright compatibility
+        - Networking, cookies, or proxies
+        - CLI or MCP
+        - Rust API
+        - Build or packaging
+        - Other
+    validations:
+      required: true
   - type: textarea
     id: problem
     attributes:
@@ -32,6 +48,8 @@ body:
       description: Obscura targets web scraping and AI-agent automation, with performance and stability as hard constraints.
       options:
         - label: This should not regress performance (obscura's speed and memory footprint are a hard constraint).
+          required: false
+        - label: I described the expected visual output if this affects rendering.
           required: false
         - label: This is not detection-evasion for abusive purposes.
           required: false

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,23 @@
+## What changed
+
+Describe the behavior change and the reason for it. Link the issue with `Fixes #...` when applicable.
+
+## Validation
+
+List the commands and manual checks you ran. Include focused regression tests and the full relevant test suite.
+
+## Rendering
+
+If this changes layout, paint, screenshots, screencast, or PDF output, include the viewport, device scale factor, output options, and before/after images. Write `Not applicable` otherwise.
+
+## Performance
+
+Include before/after measurements for hot paths, memory changes, or rendering work. Write `No expected impact` only when the changed code is outside a runtime path.
+
+## Checklist
+
+- [ ] The change is focused and does not remove existing behavior without justification.
+- [ ] Tests cover the failure or feature.
+- [ ] Existing tests pass, including render and no-render configurations when affected.
+- [ ] I checked for CPU, latency, and memory regressions.
+- [ ] Public API or user-facing behavior changes are documented.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,8 +29,24 @@ A few notes to keep the project maintainable:
 
 ## Building
 
+Obscura supports four release configurations. Keep all four building when you
+change feature gates or shared code:
+
+| Configuration | Command |
+| --- | --- |
+| Rendering | `cargo build --release -p obscura-cli --bins --features render` |
+| Rendering and stealth | `cargo build --release -p obscura-cli --bins --features render,stealth` |
+| No rendering | `cargo build --release -p obscura-cli --bins --no-default-features` |
+| No rendering, with stealth | `cargo build --release -p obscura-cli --bins --no-default-features --features stealth` |
+
+The standard release archives and Docker image include rendering. The
+`-no-render` release variants keep the smaller DOM, JavaScript, networking,
+CDP, and automation runtime but intentionally omit screenshots, screencast,
+and PDF output.
+
 ```bash
-cargo build --release --features render  # binary at ./target/release/obscura
+cargo build --release -p obscura-cli --bins --features render
+# binary at ./target/release/obscura
 ```
 
 - The first build compiles V8 from source: roughly 5 minutes and a few GB of
@@ -52,6 +68,11 @@ cargo nextest run --release --features render -p <crate>
 cargo nextest run --release --features render --no-fail-fast
 ```
 
+If you changed shared DOM, JavaScript, CDP, CLI, or feature-gated code, also
+run the affected tests without rendering and build the no-render variant. A
+render-only request made through a no-render binary must return a clear
+unsupported error rather than panic or silently produce an invalid result.
+
 `cargo test` runs the whole test binary in one process, but the engine holds a
 single V8 isolate per process, so the runtime tests fail under it. `nextest`
 runs each test in its own process, which is the only supported way.
@@ -66,13 +87,56 @@ OBSCURA_BIN=./target/release/obscura python3 obstacle-course/run.py --runs 1 --w
 
 It serves local fixtures, so it is deterministic and offline.
 
+## Rendering changes
+
+The native renderer is shared by every capture surface:
+
+- CLI `fetch --screenshot` (`-s`), including viewport and full-page captures.
+- CDP `Page.captureScreenshot`, `Page.startScreencast`,
+  `Page.stopScreencast`, and `Page.printToPDF`.
+- Puppeteer and Playwright screenshot and PDF calls made through CDP.
+- MCP `browser_screenshot` and `browser_pdf`.
+
+It currently covers block, inline, flex, grid, table, float, positioned,
+overflow, and transformed layout, plus text, images, SVG, canvas, backgrounds,
+borders, animation, fixed and sticky elements, and screen and print output.
+This is an independent engine, not Chromium, so long-tail CSS, media,
+compositor behavior, and platform font rasterization can still differ. Fix the
+underlying layout or paint rule instead of adding site-specific behavior.
+
+For layout, style, paint, image, animation, viewport, scrolling, or pagination
+changes:
+
+1. Add or update a small deterministic fixture in `render-repros/` that
+   isolates the behavior.
+2. Build the render binary, then run `render-repros/run.sh`. This captures each
+   fixture in Obscura and Chromium and runs the structural checks.
+3. Run `render-repros/representative-suite/run.sh <new-output-dir>` at the top
+   of the configured pages, then run it again with `bottom` as the second
+   argument. The output directory must not already exist.
+4. Exercise the affected public surface, not just the renderer internally. In
+   particular, cover clipped and full-page screenshots, viewport size and
+   device-pixel ratio, and a scrolled page when geometry is involved.
+5. If lifecycle or animation scheduling changed, verify screencast frame
+   delivery and acknowledgment. If print layout changed, verify PDF page size,
+   margins, backgrounds, page ranges, and stream output where relevant.
+6. Compare old and new revisions with identical release builds, fixtures,
+   viewport, device-pixel ratio, fonts, network state, settle time, scroll
+   position, and capture options. Confirm resources loaded successfully before
+   interpreting image differences.
+
+Pixel deltas are useful tripwires, but they are not a fidelity score by
+themselves. Include the focused repro, before and after images, structural
+metrics, and any remaining expected difference in the PR. Rendering work must
+also preserve non-render automation behavior and the no-render build.
+
 ## Before you open a PR
 
 For any code change:
 
 1. `cargo nextest run --release --features render` passes for the crates you touched.
 2. The full render-feature nextest command above passes.
-3. `CARGO_INCREMENTAL=0 CARGO_BUILD_JOBS=2 cargo build --release --features render` compiles clean.
+3. `CARGO_INCREMENTAL=0 CARGO_BUILD_JOBS=2 cargo build --release -p obscura-cli --bins --features render` compiles clean.
 4. The obstacle course still reports **33/33**.
 5. **Performance is a hard constraint.** Obscura is roughly 12x faster and uses
    about 6x less memory than headless Chrome on framework pages. Keep native
@@ -81,11 +145,8 @@ For any code change:
    with identical release builds, fixtures, networks, viewport, settle policy,
    and capture path. Report a distribution and memory use; the noise floor is
    about plus or minus 10%.
-6. For rendering changes, run the deterministic `render-repros` fixtures and
-   the representative real-site suite at both the top and bottom of pages.
-   Confirm resource and navigation success before interpreting image diffs;
-   pixel error is a tripwire, not a verdict. Never add hostname-specific layout
-   or style behavior.
+6. For rendering changes, complete the rendering checks above. For shared or
+   feature-gated changes, also build and test without the `render` feature.
 7. For stealth changes, re-test with `--stealth`. A non-stealth binary does not
    exercise the `wreq` path.
 
@@ -130,11 +191,15 @@ Fixes #316.
 Open an issue with enough detail to reproduce:
 
 - The obscura version or commit, plus OS and architecture.
+- The build configuration: render, render and stealth, no-render, or no-render
+  and stealth.
 - A repro: a URL, an `--eval` snippet, or a short CDP sequence.
 - What you expected and what actually happened.
 - If it is a rendering or compatibility issue, whether headless Chrome behaves
-  the same. Anti-bot, CAPTCHA, and login walls block headless Chrome too from a
-  datacenter IP, so those are not engine bugs.
+  the same. Include the viewport, device-pixel ratio, scroll position, capture
+  mode, screenshot clip or full-page setting, and PDF options where applicable.
+  Anti-bot, CAPTCHA, and login walls block headless Chrome too from a datacenter
+  IP, so those are not engine bugs.
 
 Multi-statement `--eval` that starts with `const` returns `null` (V8 gives
 `const` an empty completion value). Wrap repro snippets in an IIFE:

--- a/crates/obscura-js/js/bootstrap.js
+++ b/crates/obscura-js/js/bootstrap.js
@@ -11468,15 +11468,115 @@ class _IframeDocument {
   close() {}
 }
 
+const _iframeRealmGlobalCache = new WeakMap();
+let _iframeRealmGlobalNames = [];
+let _iframeRealmGlobalNameSet = new Set();
+
+function _iframeSourceIsConstructor(value) {
+  try {
+    Reflect.construct(Object, [], value);
+    return true;
+  } catch (e) {
+    return false;
+  }
+}
+
+function _iframeRealmFunction(target, name, source) {
+  let wrapped;
+  if (_iframeSourceIsConstructor(source)) {
+    wrapped = function (...args) {
+      if (new.target) return Reflect.construct(source, args, new.target);
+      return Reflect.apply(source, this === target ? globalThis : this, args);
+    };
+    if (source.prototype && (typeof source.prototype === 'object' || typeof source.prototype === 'function')) {
+      const prototype = Object.create(source.prototype);
+      Object.defineProperty(prototype, 'constructor', {
+        value: wrapped,
+        writable: true,
+        configurable: true,
+      });
+      wrapped.prototype = prototype;
+    }
+  } else {
+    wrapped = (...args) => Reflect.apply(source, globalThis, args);
+  }
+  // Inherit static members such as Promise.resolve, Object.keys, and
+  // Array.isArray while keeping the constructor identity realm-local.
+  try { Object.setPrototypeOf(wrapped, source); } catch (e) {}
+  try { Object.defineProperty(wrapped, 'name', { value: name, configurable: true }); } catch (e) {}
+  try { Object.defineProperty(wrapped, 'length', { value: source.length, configurable: true }); } catch (e) {}
+  return _markNative(wrapped);
+}
+
+function _iframeRealmGlobal(target, name) {
+  let cache = _iframeRealmGlobalCache.get(target);
+  if (!cache) {
+    cache = new Map();
+    _iframeRealmGlobalCache.set(target, cache);
+  }
+  if (cache.has(name)) return cache.get(name);
+
+  const source = globalThis[name];
+  let value = source;
+  if (typeof source === 'function') {
+    value = _iframeRealmFunction(target, name, source);
+  } else if (source && typeof source === 'object') {
+    // Namespace objects such as Math, JSON, Reflect, and Intl belong to the
+    // child global too. A lightweight facade gives each iframe a stable,
+    // distinct object without copying large immutable tables.
+    value = Object.create(source);
+  }
+  cache.set(name, value);
+  return value;
+}
+
+const _iframeWindowProxyHandler = {
+  get(target, key, receiver) {
+    if (key === 'globalThis') return receiver;
+    if (Reflect.has(target, key)) return Reflect.get(target, key, receiver);
+    if (typeof key === 'string' && _iframeRealmGlobalNameSet.has(key)) {
+      return _iframeRealmGlobal(target, key);
+    }
+    return undefined;
+  },
+  has(target, key) {
+    return key === 'globalThis'
+      || Reflect.has(target, key)
+      || (typeof key === 'string' && _iframeRealmGlobalNameSet.has(key));
+  },
+  ownKeys(target) {
+    const keys = Reflect.ownKeys(target);
+    const seen = new Set(keys);
+    for (const name of _iframeRealmGlobalNames) {
+      if (!seen.has(name)) keys.push(name);
+    }
+    if (!seen.has('globalThis')) keys.push('globalThis');
+    return keys;
+  },
+  getOwnPropertyDescriptor(target, key) {
+    const own = Reflect.getOwnPropertyDescriptor(target, key);
+    if (own) return own;
+    if (key === 'globalThis') {
+      return { value: target.self, writable: true, enumerable: false, configurable: true };
+    }
+    if (typeof key === 'string' && _iframeRealmGlobalNameSet.has(key)) {
+      return {
+        value: _iframeRealmGlobal(target, key),
+        writable: true,
+        enumerable: false,
+        configurable: true,
+      };
+    }
+    return undefined;
+  },
+};
+
 class _IframeWindow {
   constructor(doc, url) {
     this.document = doc;
     this._url = url;
-    this.self = this;
     this.top = globalThis;
     this.parent = globalThis;
-    this.window = this;
-    this.frames = this;
     this.frameElement = null;
     this.length = 0;
     this.name = '';
@@ -11506,6 +11606,12 @@ class _IframeWindow {
     } catch(e) {
       this.location = { href: url, origin: '', protocol: '', host: '', hostname: '', port: '', pathname: '/', search: '', hash: '', toString() { return url; }, assign(){}, reload(){}, replace(){} };
     }
+
+    const proxy = new Proxy(this, _iframeWindowProxyHandler);
+    this.self = proxy;
+    this.window = proxy;
+    this.frames = proxy;
+    return proxy;
   }
 
   postMessage(data, origin) {
@@ -14461,6 +14567,25 @@ if (typeof Response !== 'undefined' && Response.prototype && !Response.prototype
 // accessors) plus the constructor itself native. This runs once at snapshot
 // build time, so it costs nothing per page, and genuinely-native V8 builtins
 // already report native, so only the JS-backed members are affected.
+(function _collectIframeRealmGlobals() {
+  const standardGlobals = [
+    'Infinity', 'NaN', 'undefined',
+    'eval', 'isFinite', 'isNaN', 'parseFloat', 'parseInt',
+    'decodeURI', 'decodeURIComponent', 'encodeURI', 'encodeURIComponent',
+    'escape', 'unescape',
+    'Atomics', 'Intl', 'JSON', 'Math', 'Reflect', 'WebAssembly',
+    'atob', 'btoa', 'queueMicrotask', 'reportError', 'structuredClone',
+  ];
+  const constructors = Object.getOwnPropertyNames(globalThis).filter(name => {
+    if (!/^[A-Z]/.test(name)) return false;
+    try { return typeof globalThis[name] === 'function'; }
+    catch (e) { return false; }
+  });
+  _iframeRealmGlobalNames = Array.from(new Set(constructors.concat(standardGlobals)))
+    .filter(name => name in globalThis);
+  _iframeRealmGlobalNameSet = new Set(_iframeRealmGlobalNames);
+})();
+
 (function _markBuiltinsNative() {
   var seen = new Set();
   function walk(ctor) {

--- a/crates/obscura-js/src/runtime.rs
+++ b/crates/obscura-js/src/runtime.rs
@@ -2550,6 +2550,58 @@ mod tests {
     }
 
     #[test]
+    fn iframe_content_window_exposes_realm_globals() {
+        let mut rt = setup_runtime("<html><body></body></html>");
+
+        assert_eq!(
+            rt.evaluate(
+                r#"(() => {
+                    const iframe = document.createElement("iframe");
+                    document.body.appendChild(iframe);
+                    const child = iframe.contentWindow;
+                    const names = [
+                        "Object", "Function", "Error", "Promise", "Proxy",
+                        "XMLHttpRequest", "Worker", "Blob", "FormData",
+                        "WebSocket", "MutationObserver",
+                    ];
+                    return {
+                        types: names.map(name => typeof child[name]),
+                        separate: [
+                            child.Object !== Object,
+                            child.Promise !== Promise,
+                            child.XMLHttpRequest !== XMLHttpRequest,
+                            child.Math !== Math,
+                        ],
+                        constructible: [
+                            new child.Object() instanceof child.Object,
+                            new child.Promise(resolve => resolve()) instanceof child.Promise,
+                            new child.XMLHttpRequest() instanceof child.XMLHttpRequest,
+                            new child.Blob([]) instanceof child.Blob,
+                            new child.FormData() instanceof child.FormData,
+                            new child.MutationObserver(() => {}) instanceof child.MutationObserver,
+                        ],
+                        utilities: [
+                            child.Object.keys({ first: 1 })[0] === "first",
+                            child.Array.isArray([]),
+                            child.Promise.resolve(1) instanceof child.Promise,
+                            child.Function("return 7")() === 7,
+                            Object.getOwnPropertyNames(child).includes("XMLHttpRequest"),
+                            child.globalThis === child,
+                        ],
+                    };
+                })()"#,
+            )
+            .unwrap(),
+            serde_json::json!({
+                "types": vec!["function"; 11],
+                "separate": vec![true; 4],
+                "constructible": vec![true; 6],
+                "utilities": vec![true; 6],
+            })
+        );
+    }
+
+    #[test]
     fn document_domain_getter_and_valid_relaxation_match_effective_host() {
         let dom = parse_html("<html><body></body></html>");
         let mut rt = ObscuraJsRuntime::new();


### PR DESCRIPTION
Closes #592.

Iframe realms now expose their own standard browser globals, including constructors such as `XMLHttpRequest`. This covers empty iframes, `about:blank`, and `srcdoc` without leaking the parent realm's objects.

Also updates the issue and PR templates for rendering reports, and documents the current render feature matrix and validation requirements in `CONTRIBUTING.md`.

## Testing

• Empty iframe, `about:blank`, and `srcdoc` realm regression tests pass
• `new iframe.contentWindow.XMLHttpRequest()` works
• CDP iframe tests pass
• Render and no-render release builds pass
• Render screenshot smoke test produces a valid 1280x720 PNG
• Obstacle course result matches the existing baseline
• Full `obscura-js` suite matches `main`; the only failure is the existing 100 ms scheduler timing test
• No measurable performance or RSS regression