### PR TITLE
fix(cdp): Hermes-driver compatibility (getTargets, getBoxModel ints, insertText)

### DIFF
--- a/crates/obscura-cdp/src/domains/dom.rs
+++ b/crates/obscura-cdp/src/domains/dom.rs
@@ -87,6 +87,15 @@ fn guess_mime(path: &str) -> &'static str {
     }
 }
 
+// The CDP BoxModel protocol types its coordinates as integers (Quad is an
+// array of 8 integer pairs; x/y/width/height are integers too).
+// getBoundingClientRect returns CSS floats, and Hermes refuses to deserialize
+// them ("invalid type: floating point 32.0, expected i64"), so round every
+// emitted coordinate to the nearest whole pixel.
+fn round_px(v: f64) -> i64 {
+    v.round() as i64
+}
+
 pub async fn handle(
     method: &str,
     params: &Value,
@@ -310,13 +319,13 @@ pub async fn handle(
             let (quad, w, h) = if let Some(arr) = val.as_array() {
                 let nums: Vec<f64> = arr.iter().filter_map(|v| v.as_f64()).collect();
                 if nums.len() >= 10 {
-                    let q: Vec<Value> = nums[..8].iter().map(|n| json!(n)).collect();
-                    (q, nums[8], nums[9])
+                    let q: Vec<Value> = nums[..8].iter().map(|n| json!(round_px(*n))).collect();
+                    (q, round_px(nums[8]), round_px(nums[9]))
                 } else {
-                    (vec![json!(8),json!(8),json!(108),json!(8),json!(108),json!(28),json!(8),json!(28)], 100.0, 20.0)
+                    (vec![json!(8),json!(8),json!(108),json!(8),json!(108),json!(28),json!(8),json!(28)], 100, 20)
                 }
             } else {
-                (vec![json!(8),json!(8),json!(108),json!(8),json!(108),json!(28),json!(8),json!(28)], 100.0, 20.0)
+                (vec![json!(8),json!(8),json!(108),json!(8),json!(108),json!(28),json!(8),json!(28)], 100, 20)
             };
             Ok(json!({
                 "model": {
@@ -346,7 +355,7 @@ pub async fn handle(
             let val = page.evaluate(&code);
             let quad = if let Some(arr) = val.as_array() {
                 let nums: Vec<f64> = arr.iter().filter_map(|v| v.as_f64()).collect();
-                if nums.len() == 8 { nums.iter().map(|n| json!(n)).collect::<Vec<_>>() }
+                if nums.len() == 8 { nums.iter().map(|n| json!(round_px(*n))).collect::<Vec<_>>() }
                 else { vec![json!(8),json!(8),json!(108),json!(8),json!(108),json!(28),json!(8),json!(28)] }
             } else {
                 vec![json!(8),json!(8),json!(108),json!(8),json!(108),json!(28),json!(8),json!(28)]
@@ -542,6 +551,57 @@ mod tests {
             active,
             json!("INPUT"),
             "DOM.focus must set document.activeElement to the focused input"
+        );
+    }
+
+    // Hermes deserializes DOM.getBoxModel coordinates as i64 and fails on the
+    // float pixels getBoundingClientRect returns ("invalid type: floating
+    // point 32.0, expected i64"). Every coordinate in the model must be an
+    // integer.
+    #[tokio::test]
+    async fn get_box_model_returns_integer_coordinates() {
+        let mut ctx = CdpContext::new();
+        let page_id = ctx.create_page();
+        let session = Some(format!("{page_id}-session"));
+        ctx.sessions.insert(session.clone().unwrap(), page_id.clone());
+
+        crate::domains::page::handle(
+            "navigate",
+            &json!({ "url": "data:text/html,<div id=b style='position:absolute;left:10.5px;top:20.25px;width:100px;height:50px'>x</div>", "waitUntil": "load" }),
+            &mut ctx,
+            &session,
+        )
+        .await
+        .expect("navigate should succeed");
+
+        let qs = handle("querySelector", &json!({ "selector": "#b" }), &mut ctx, &session)
+            .await
+            .expect("querySelector should succeed");
+        let nid = qs["nodeId"].as_u64().expect("div nodeId");
+
+        let model = handle("getBoxModel", &json!({ "nodeId": nid }), &mut ctx, &session)
+            .await
+            .expect("getBoxModel should succeed");
+
+        for quad in ["content", "padding", "border", "margin"] {
+            let coords = model["model"][quad].as_array().expect("quad array");
+            assert_eq!(coords.len(), 8, "{quad} quad must have 8 coordinates");
+            for c in coords {
+                assert!(
+                    c.as_i64().is_some(),
+                    "{quad} coordinate must be an integer, got {c}"
+                );
+            }
+        }
+        assert!(
+            model["model"]["width"].as_i64().is_some(),
+            "width must be an integer, got {}",
+            model["model"]["width"]
+        );
+        assert!(
+            model["model"]["height"].as_i64().is_some(),
+            "height must be an integer, got {}",
+            model["model"]["height"]
         );
     }
 

--- a/crates/obscura-cdp/src/domains/input.rs
+++ b/crates/obscura-cdp/src/domains/input.rs
@@ -343,8 +343,78 @@ pub async fn handle(
 
             Ok(json!({}))
         }
+        "insertText" => {
+            // CDP Input.insertText: insert `text` at the caret of the focused
+            // editable element, replacing any non-collapsed selection. Hermes
+            // uses it for typing into React/Vue controlled inputs, which only
+            // register a change when a trusted `input` event follows a value
+            // write through the prototype setter (see __obscura_setFieldValue).
+            // The same JS path the dispatchKeyEvent text/char branches use
+            // satisfies that, so reuse it rather than inventing a divergent
+            // mutation.
+            let text = params.get("text").and_then(|v| v.as_str()).unwrap_or("");
+            if let Some(page) = ctx.get_session_page_mut(session_id) {
+                let escaped_text = text.replace('\\', "\\\\").replace('\'', "\\'");
+                page.evaluate(&insert_text_js(&escaped_text));
+                // Pump the event loop so framework change detection picks up
+                // the mutation (same as the char branch above).
+                page.settle(50).await;
+            }
+            Ok(json!({}))
+        }
         "dispatchTouchEvent" => Ok(json!({})),
         "setIgnoreInputEvents" => Ok(json!({})),
         _ => Err(format!("Unknown Input method: {}", method)),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::dispatch::CdpContext;
+
+    // Hermes types into React/Vue controlled inputs via Input.insertText. It
+    // must insert at the caret of the focused element and dispatch a trusted
+    // `input` event so framework change detection picks the value up.
+    #[tokio::test]
+    async fn insert_text_types_into_focused_input() {
+        let mut ctx = CdpContext::new();
+        let page_id = ctx.create_page();
+        let session = Some(format!("{page_id}-session"));
+        ctx.sessions.insert(session.clone().unwrap(), page_id.clone());
+
+        crate::domains::page::handle(
+            "navigate",
+            &json!({
+                "url": "data:text/html,<input id=t><script>var seen=[];var el=document.getElementById('t');el.addEventListener('input',function(){seen.push(el.value)});</script>",
+                "waitUntil": "load",
+            }),
+            &mut ctx,
+            &session,
+        )
+        .await
+        .expect("navigate should succeed");
+
+        // Focus the input and park the caret at position 2 of an existing value.
+        ctx.get_session_page_mut(&session)
+            .unwrap()
+            .evaluate("(function(){var el=document.getElementById('t');el.value='ab';el.focus();el.setSelectionRange(1,1);})()");
+
+        handle("insertText", &json!({ "text": "XY" }), &mut ctx, &session)
+            .await
+            .expect("insertText should succeed");
+
+        let value = ctx
+            .get_session_page_mut(&session)
+            .unwrap()
+            .evaluate("document.getElementById('t').value");
+        assert_eq!(value, json!("aXYb"), "text must be inserted at the caret");
+
+        // The trusted input event must have fired so React/Vue see the change.
+        let seen = ctx
+            .get_session_page_mut(&session)
+            .unwrap()
+            .evaluate("window.seen.join(',') || ''");
+        assert_eq!(seen, json!("aXYb"), "an input event must announce the new value");
     }
 }

--- a/crates/obscura-cdp/src/server.rs
+++ b/crates/obscura-cdp/src/server.rs
@@ -842,9 +842,19 @@ async fn cdp_processor(
         match msg {
             ServerMessage::NewConnection { reply_tx } => {
                 connection_reply_tx = Some(reply_tx.clone());
+                // Issue #543: a browser-level client that connects and immediately
+                // calls Target.getTargets must see the existing page targets (the
+                // CDP spec makes targets globally visible). Without this, a fresh
+                // connection's CdpContext has an empty `pages` registry and
+                // getTargets returns [], which breaks puppeteer/playwright-style
+                // clients before they can call Target.createTarget/attachToTarget.
+                // Mirror the interception path below, which already creates a
+                // page + session per new connection.
+                let pid = ctx.create_page();
+                let sid = format!("{pid}-session");
+                ctx.sessions.insert(sid.clone(), pid.clone());
                 let _ = reply_tx.send(
-                    json!({"__init": true})
-                        .to_string(),
+                    json!({"__init": true, "pageId": pid, "sessionId": sid}).to_string(),
                 );
             }
             ServerMessage::Cdp(cdp_msg) => {
@@ -1726,6 +1736,76 @@ mod tests {
                     .unwrap();
                     if value["id"] == 3 {
                         assert_eq!(value["result"]["result"]["value"], "yes");
+                        break;
+                    }
+                }
+
+                drop(server_tx);
+                tokio::time::timeout(std::time::Duration::from_secs(2), processor)
+                    .await
+                    .expect("processor shutdown timeout")
+                    .expect("processor task");
+            })
+            .await;
+    }
+
+    // Issue #543: a browser-level client that connects and immediately calls
+    // Target.getTargets must see the existing page targets. A fresh connection
+    // used to start with an empty pages registry (pages only appeared after a
+    // session-scoped event like Target.createTarget), so getTargets returned
+    // [] and puppeteer/playwright-style clients broke before driving any page.
+    #[tokio::test(flavor = "current_thread")]
+    async fn fresh_connection_sees_page_targets_in_get_targets() {
+        tokio::task::LocalSet::new()
+            .run_until(async {
+                let (server_tx, server_rx) = tokio::sync::mpsc::unbounded_channel();
+                let (reply_tx, mut reply_rx) = tokio::sync::mpsc::unbounded_channel();
+                let shutdown = std::sync::Arc::new(tokio::sync::Notify::new());
+                let default_context = crate::dispatch::CdpContext::new().default_context;
+                let processor = tokio::task::spawn_local(super::cdp_processor(
+                    server_rx,
+                    default_context,
+                    shutdown,
+                ));
+
+                server_tx
+                    .send(super::ServerMessage::NewConnection {
+                        reply_tx: reply_tx.clone(),
+                    })
+                    .unwrap();
+                let init = reply_rx.recv().await.expect("processor init");
+                assert!(init.contains("__init"));
+
+                let send = |value: serde_json::Value| {
+                    server_tx
+                        .send(super::ServerMessage::Cdp(super::CdpMessage {
+                            text: value.to_string(),
+                            reply_tx: reply_tx.clone(),
+                        }))
+                        .unwrap();
+                };
+                send(json!({"id": 1, "method": "Target.getTargets", "params": {}}));
+
+                loop {
+                    let value: serde_json::Value = serde_json::from_str(
+                        &tokio::time::timeout(
+                            std::time::Duration::from_secs(2),
+                            reply_rx.recv(),
+                        )
+                        .await
+                        .expect("getTargets response timeout")
+                        .expect("getTargets response channel"),
+                    )
+                    .unwrap();
+                    if value["id"] == 1 {
+                        let targets = value["result"]["targetInfos"]
+                            .as_array()
+                            .expect("targetInfos must be an array");
+                        assert!(
+                            !targets.is_empty(),
+                            "getTargets must list the connection's page target"
+                        );
+                        assert_eq!(targets[0]["type"], "page");
                         break;
                     }
                 }


### PR DESCRIPTION
Fixes three CDP quirks that break Hermes Agent (and other puppeteer/playwright-style clients) driving obscura:

1. **Target.getTargets returns empty on fresh browser connections** (#543, #570). A browser-level client that connects and immediately calls Target.getTargets saw `[]` because the pages registry was only populated by session-scoped events. Now `NewConnection` creates a page + session mirroring the interception path, so targets are globally visible per the CDP spec.

2. **DOM.getBoxModel emits float coordinates** where the spec requires integers. Clients deserializing coordinates as i64 (Hermes: "invalid type: floating point 32.0, expected i64") fail. All quad coords + width/height now rounded to integers.

3. **Input.insertText not implemented** ("Unknown Input method: insertText"). Implemented via the existing prototype-setter JS path (`__obscura_setFieldValue`), caret-aware with selection replacement, and dispatches a trusted `input` event so React/Vue controlled inputs register typed text.

All three verified live driving the patched build from Hermes: fresh-connection getTargets lists targets, getBoxModel returns integer coords, insertText types into a login form and submits.

Tests added: `get_box_model_returns_integer_coordinates`, `insert_text_types_into_focused_input`, `fresh_connection_sees_page_targets_in_get_targets`. Full workspace: 81 tests pass, release build clean.
