### PR TITLE
fix(js): avoid duplicate module evaluation

### DIFF
--- a/crates/obscura-browser/src/page.rs
+++ b/crates/obscura-browser/src/page.rs
@@ -4603,6 +4603,53 @@ mod tests {
     }
 
     #[tokio::test(flavor = "current_thread")]
+    async fn duplicate_external_module_scripts_evaluate_once() {
+        use std::io::{Read as _, Write as _};
+
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+        let address = listener.local_addr().unwrap();
+        std::thread::spawn(move || {
+            let (mut stream, _) = listener.accept().unwrap();
+            let mut request = [0u8; 2048];
+            let length = stream.read(&mut request).unwrap();
+            let path = String::from_utf8_lossy(&request[..length])
+                .lines()
+                .next()
+                .and_then(|line| line.split_ascii_whitespace().nth(1))
+                .unwrap_or("/")
+                .to_string();
+            assert_eq!(path, "/app/shared.js");
+            let body = "globalThis.__duplicate_module_runs = \
+                (globalThis.__duplicate_module_runs || 0) + 1;";
+            let response = format!(
+                "HTTP/1.1 200 OK\r\nContent-Type: application/javascript\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{body}",
+                body.len(),
+            );
+            stream.write_all(response.as_bytes()).unwrap();
+        });
+
+        let base = format!("http://{address}");
+        let mut page = import_map_test_page(
+            "duplicate-external-module",
+            &base,
+            r#"<html><head>
+                <script type="module" src="./shared.js"></script>
+                <script type="module" src="./shared.js"></script>
+            </head><body></body></html>"#,
+        );
+        page.execute_scripts().await;
+
+        assert_eq!(
+            page.js
+                .as_mut()
+                .unwrap()
+                .evaluate("globalThis.__duplicate_module_runs")
+                .unwrap(),
+            serde_json::json!(1.0),
+        );
+    }
+
+    #[tokio::test(flavor = "current_thread")]
     async fn module_graph_and_evaluation_share_one_active_budget() {
         use std::io::{Read as _, Write as _};
 

--- a/crates/obscura-js/src/runtime.rs
+++ b/crates/obscura-js/src/runtime.rs
@@ -1,5 +1,5 @@
 use std::cell::RefCell;
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::rc::Rc;
 
 use deno_core::{JsRuntime, RuntimeOptions};
@@ -85,6 +85,7 @@ pub struct ObscuraJsRuntime {
     state: Rc<RefCell<ObscuraState>>,
     object_store: HashMap<String, String>,
     object_counter: u64,
+    started_module_evaluations: HashSet<deno_core::ModuleId>,
     import_map: Rc<RefCell<ImportMap>>,
     /// Loader-owned signal for pending dynamic-import graph fetches. This is
     /// intentionally separate from page fetch/XHR activity so analytics does
@@ -257,6 +258,7 @@ impl ObscuraJsRuntime {
             state,
             object_store: HashMap::new(),
             object_counter: 0,
+            started_module_evaluations: HashSet::new(),
             import_map,
             module_load_activity,
             isolate_handle,
@@ -1548,6 +1550,12 @@ impl ObscuraJsRuntime {
             module_id,
             description,
         } = prepared;
+        // The module map returns the same id when multiple external script
+        // elements resolve to one module. V8 caches both successful and failed
+        // evaluation, and deno_core panics if mod_evaluate is called again.
+        if !self.started_module_evaluations.insert(module_id) {
+            return Ok(());
+        }
         // Tokio timeouts cannot run while synchronous top-level module work
         // pins the runtime thread in V8. Pair the async timeout with a hard V8
         // watchdog so this budget is a real wall-clock ceiling for both forms


### PR DESCRIPTION
## Summary

- track ES module IDs once evaluation starts
- skip duplicate evaluation when multiple external module script elements share one module
- add a regression with two identical module `src` attributes that verifies one fetch and one execution

Fixes #591.

## Verification

- RED: `cargo nextest run -p obscura-browser duplicate_external_module_scripts_evaluate_once --no-capture` panicked in `deno_core::mod_evaluate` with `Module already evaluated`
- `cargo nextest run -p obscura-browser duplicate_external_module_scripts_evaluate_once`
- `cargo nextest run -p obscura-js -p obscura-browser` (327 passed)
- `cargo build --release`
- obstacle course: 32/33 on both this branch and `upstream/main` at `41f24d7`; `observer-intersection` is the shared baseline failure, while all other stages including `es-modules` pass
- `git diff --check`
