### PR TITLE
fix(cdp): global target registry — targets visible & attachable across connections (#570)

### DIFF
--- a/crates/obscura-cdp/src/dispatch.rs
+++ b/crates/obscura-cdp/src/dispatch.rs
@@ -7,6 +7,7 @@ use serde_json::json;
 
 use crate::domains;
 use crate::domains::fetch::FetchInterceptState;
+use crate::registry::{TargetInfo, TargetRegistry};
 use crate::types::{CdpEvent, CdpRequest, CdpResponse};
 
 #[cfg(feature = "render")]
@@ -51,7 +52,14 @@ pub struct CdpContext {
     next_screencast_session_id: i64,
     pub default_context: Arc<BrowserContext>,
     pub browser_contexts: HashMap<String, Arc<BrowserContext>>,
-    page_counter: u32,
+    /// Process-wide page target registry (issue #544). `pages` below holds the
+    /// live `Page` objects this connection owns (thread-confined V8 isolates),
+    /// while the shared registry mirrors their metadata so `Target.getTargets`
+    /// on ANY connection and `/json/list` on the accept thread see every live
+    /// page with its current url/title. The registry is also the source of
+    /// globally-unique page ids: per-connection counters used to collide on
+    /// "page-1" across connections, which broke any shared target view.
+    pub registry: TargetRegistry,
     browser_context_counter: u32,
     target_session_counter: u64,
     pub preload_scripts: Vec<(String, String)>, // (identifier, source)
@@ -140,9 +148,20 @@ impl CdpContext {
     }
 
     /// Build a CDP context around an already-constructed default browser
-    /// context. The server passes a fresh isolated context per WebSocket; tests
-    /// and embedders may construct their own.
+    /// context, backed by its own private target registry. The server passes a
+    /// fresh isolated context per WebSocket; tests and embedders may construct
+    /// their own.
     pub fn new_with_shared_context(default_context: Arc<BrowserContext>) -> Self {
+        Self::new_with_shared_context_and_registry(default_context, TargetRegistry::default())
+    }
+
+    /// As `new_with_shared_context`, but joined to a process-wide target
+    /// registry shared with every other connection (and the HTTP accept
+    /// thread). Pages this context creates become globally visible targets.
+    pub fn new_with_shared_context_and_registry(
+        default_context: Arc<BrowserContext>,
+        registry: TargetRegistry,
+    ) -> Self {
         // Pre-seed with the default-frame execution context ids that
         // `Runtime.enable` (1) and post-navigation re-emission (2) advertise via
         // Runtime.executionContextCreated. Anything else has to be registered
@@ -162,7 +181,7 @@ impl CdpContext {
             next_screencast_session_id: 0,
             default_context,
             browser_contexts: HashMap::new(),
-            page_counter: 0,
+            registry,
             browser_context_counter: 0,
             target_session_counter: 0,
             preload_scripts: Vec::new(),
@@ -219,14 +238,36 @@ impl CdpContext {
                 .ok_or_else(|| format!("Browser context not found: {}", id))?,
             None => self.default_context.clone(),
         };
-        self.page_counter += 1;
-        let page_id = format!("page-{}", self.page_counter);
+        let page_id = format!("page-{}", self.registry.next_page_id());
         let mut page = Page::new(page_id.clone(), context);
         page.navigate_blank();
+        let browser_context_id = page.context.id.clone();
         self.pages.push(page);
         self.current_loader_ids
             .insert(page_id.clone(), format!("loader-blank-{page_id}"));
+        // The new page is a live target: register it so every connection's
+        // Target.getTargets and the HTTP /json/list control plane see it.
+        self.registry.upsert(TargetInfo {
+            target_id: page_id.clone(),
+            title: String::new(),
+            url: "about:blank".into(),
+            browser_context_id,
+        });
         Ok(page_id)
+    }
+
+    /// Refresh this context's pages' metadata in the shared registry. The
+    /// registry mirrors live `Page` fields, so after any navigation (or just
+    /// before `Target.getTargets`) this keeps the shared view current.
+    pub fn sync_registry(&mut self) {
+        for page in &self.pages {
+            self.registry.upsert(TargetInfo {
+                target_id: page.id.clone(),
+                title: page.title.clone(),
+                url: page.url_string(),
+                browser_context_id: page.context.id.clone(),
+            });
+        }
     }
 
     pub fn browser_context(&self, id: &str) -> Option<&Arc<BrowserContext>> {
@@ -285,6 +326,7 @@ impl CdpContext {
 
     pub fn remove_page(&mut self, id: &str) {
         self.pages.retain(|p| p.id != id);
+        self.registry.remove_pages(&[id.to_string()]);
         self.current_loader_ids.remove(id);
         #[cfg(feature = "render")]
         {
@@ -334,6 +376,19 @@ impl CdpContext {
         }
 
         self.get_page_mut(&page_id)
+    }
+}
+
+impl Drop for CdpContext {
+    fn drop(&mut self) {
+        // When this connection goes away — clean close, task abort, or panic —
+        // its pages die with it, so their global target entries must too.
+        // Otherwise a closed connection's stale page would keep shadowing
+        // live pages in other connections' Target.getTargets and /json/list.
+        let page_ids: Vec<String> = self.pages.iter().map(|p| p.id.clone()).collect();
+        if !page_ids.is_empty() {
+            self.registry.remove_pages(&page_ids);
+        }
     }
 }
 

--- a/crates/obscura-cdp/src/domains/dom.rs
+++ b/crates/obscura-cdp/src/domains/dom.rs
@@ -87,6 +87,15 @@ fn guess_mime(path: &str) -> &'static str {
     }
 }
 
+// The CDP BoxModel protocol types its coordinates as integers (Quad is an
+// array of 8 integer pairs; x/y/width/height are integers too).
+// getBoundingClientRect returns CSS floats, and Hermes refuses to deserialize
+// them ("invalid type: floating point 32.0, expected i64"), so round every
+// emitted coordinate to the nearest whole pixel.
+fn round_px(v: f64) -> i64 {
+    v.round() as i64
+}
+
 pub async fn handle(
     method: &str,
     params: &Value,
@@ -310,13 +319,13 @@ pub async fn handle(
             let (quad, w, h) = if let Some(arr) = val.as_array() {
                 let nums: Vec<f64> = arr.iter().filter_map(|v| v.as_f64()).collect();
                 if nums.len() >= 10 {
-                    let q: Vec<Value> = nums[..8].iter().map(|n| json!(n)).collect();
-                    (q, nums[8], nums[9])
+                    let q: Vec<Value> = nums[..8].iter().map(|n| json!(round_px(*n))).collect();
+                    (q, round_px(nums[8]), round_px(nums[9]))
                 } else {
-                    (vec![json!(8),json!(8),json!(108),json!(8),json!(108),json!(28),json!(8),json!(28)], 100.0, 20.0)
+                    (vec![json!(8),json!(8),json!(108),json!(8),json!(108),json!(28),json!(8),json!(28)], 100, 20)
                 }
             } else {
-                (vec![json!(8),json!(8),json!(108),json!(8),json!(108),json!(28),json!(8),json!(28)], 100.0, 20.0)
+                (vec![json!(8),json!(8),json!(108),json!(8),json!(108),json!(28),json!(8),json!(28)], 100, 20)
             };
             Ok(json!({
                 "model": {
@@ -346,7 +355,7 @@ pub async fn handle(
             let val = page.evaluate(&code);
             let quad = if let Some(arr) = val.as_array() {
                 let nums: Vec<f64> = arr.iter().filter_map(|v| v.as_f64()).collect();
-                if nums.len() == 8 { nums.iter().map(|n| json!(n)).collect::<Vec<_>>() }
+                if nums.len() == 8 { nums.iter().map(|n| json!(round_px(*n))).collect::<Vec<_>>() }
                 else { vec![json!(8),json!(8),json!(108),json!(8),json!(108),json!(28),json!(8),json!(28)] }
             } else {
                 vec![json!(8),json!(8),json!(108),json!(8),json!(108),json!(28),json!(8),json!(28)]
@@ -542,6 +551,57 @@ mod tests {
             active,
             json!("INPUT"),
             "DOM.focus must set document.activeElement to the focused input"
+        );
+    }
+
+    // Hermes deserializes DOM.getBoxModel coordinates as i64 and fails on the
+    // float pixels getBoundingClientRect returns ("invalid type: floating
+    // point 32.0, expected i64"). Every coordinate in the model must be an
+    // integer.
+    #[tokio::test]
+    async fn get_box_model_returns_integer_coordinates() {
+        let mut ctx = CdpContext::new();
+        let page_id = ctx.create_page();
+        let session = Some(format!("{page_id}-session"));
+        ctx.sessions.insert(session.clone().unwrap(), page_id.clone());
+
+        crate::domains::page::handle(
+            "navigate",
+            &json!({ "url": "data:text/html,<div id=b style='position:absolute;left:10.5px;top:20.25px;width:100px;height:50px'>x</div>", "waitUntil": "load" }),
+            &mut ctx,
+            &session,
+        )
+        .await
+        .expect("navigate should succeed");
+
+        let qs = handle("querySelector", &json!({ "selector": "#b" }), &mut ctx, &session)
+            .await
+            .expect("querySelector should succeed");
+        let nid = qs["nodeId"].as_u64().expect("div nodeId");
+
+        let model = handle("getBoxModel", &json!({ "nodeId": nid }), &mut ctx, &session)
+            .await
+            .expect("getBoxModel should succeed");
+
+        for quad in ["content", "padding", "border", "margin"] {
+            let coords = model["model"][quad].as_array().expect("quad array");
+            assert_eq!(coords.len(), 8, "{quad} quad must have 8 coordinates");
+            for c in coords {
+                assert!(
+                    c.as_i64().is_some(),
+                    "{quad} coordinate must be an integer, got {c}"
+                );
+            }
+        }
+        assert!(
+            model["model"]["width"].as_i64().is_some(),
+            "width must be an integer, got {}",
+            model["model"]["width"]
+        );
+        assert!(
+            model["model"]["height"].as_i64().is_some(),
+            "height must be an integer, got {}",
+            model["model"]["height"]
         );
     }
 

--- a/crates/obscura-cdp/src/domains/input.rs
+++ b/crates/obscura-cdp/src/domains/input.rs
@@ -343,8 +343,78 @@ pub async fn handle(
 
             Ok(json!({}))
         }
+        "insertText" => {
+            // CDP Input.insertText: insert `text` at the caret of the focused
+            // editable element, replacing any non-collapsed selection. Hermes
+            // uses it for typing into React/Vue controlled inputs, which only
+            // register a change when a trusted `input` event follows a value
+            // write through the prototype setter (see __obscura_setFieldValue).
+            // The same JS path the dispatchKeyEvent text/char branches use
+            // satisfies that, so reuse it rather than inventing a divergent
+            // mutation.
+            let text = params.get("text").and_then(|v| v.as_str()).unwrap_or("");
+            if let Some(page) = ctx.get_session_page_mut(session_id) {
+                let escaped_text = text.replace('\\', "\\\\").replace('\'', "\\'");
+                page.evaluate(&insert_text_js(&escaped_text));
+                // Pump the event loop so framework change detection picks up
+                // the mutation (same as the char branch above).
+                page.settle(50).await;
+            }
+            Ok(json!({}))
+        }
         "dispatchTouchEvent" => Ok(json!({})),
         "setIgnoreInputEvents" => Ok(json!({})),
         _ => Err(format!("Unknown Input method: {}", method)),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::dispatch::CdpContext;
+
+    // Hermes types into React/Vue controlled inputs via Input.insertText. It
+    // must insert at the caret of the focused element and dispatch a trusted
+    // `input` event so framework change detection picks the value up.
+    #[tokio::test]
+    async fn insert_text_types_into_focused_input() {
+        let mut ctx = CdpContext::new();
+        let page_id = ctx.create_page();
+        let session = Some(format!("{page_id}-session"));
+        ctx.sessions.insert(session.clone().unwrap(), page_id.clone());
+
+        crate::domains::page::handle(
+            "navigate",
+            &json!({
+                "url": "data:text/html,<input id=t><script>var seen=[];var el=document.getElementById('t');el.addEventListener('input',function(){seen.push(el.value)});</script>",
+                "waitUntil": "load",
+            }),
+            &mut ctx,
+            &session,
+        )
+        .await
+        .expect("navigate should succeed");
+
+        // Focus the input and park the caret at position 2 of an existing value.
+        ctx.get_session_page_mut(&session)
+            .unwrap()
+            .evaluate("(function(){var el=document.getElementById('t');el.value='ab';el.focus();el.setSelectionRange(1,1);})()");
+
+        handle("insertText", &json!({ "text": "XY" }), &mut ctx, &session)
+            .await
+            .expect("insertText should succeed");
+
+        let value = ctx
+            .get_session_page_mut(&session)
+            .unwrap()
+            .evaluate("document.getElementById('t').value");
+        assert_eq!(value, json!("aXYb"), "text must be inserted at the caret");
+
+        // The trusted input event must have fired so React/Vue see the change.
+        let seen = ctx
+            .get_session_page_mut(&session)
+            .unwrap()
+            .evaluate("window.seen.join(',') || ''");
+        assert_eq!(seen, json!("aXYb"), "an input event must announce the new value");
     }
 }

--- a/crates/obscura-cdp/src/domains/page.rs
+++ b/crates/obscura-cdp/src/domains/page.rs
@@ -1118,6 +1118,11 @@ async fn do_navigate(
         reached_network_idle,
     );
 
+    // The page now points at a new document: refresh its global target entry
+    // so every connection's Target.getTargets and /json/list report the new
+    // url/title instead of the pre-navigation about:blank (issue #544).
+    ctx.sync_registry();
+
     Ok(json!({
         "frameId": frame_id,
         "loaderId": loader_id,
@@ -1384,6 +1389,7 @@ pub async fn handle(
                     WaitUntil::DomContentLoaded,
                     reached_idle,
                 );
+                ctx.sync_registry();
             }
             Ok(json!({}))
         }

--- a/crates/obscura-cdp/src/domains/target.rs
+++ b/crates/obscura-cdp/src/domains/target.rs
@@ -45,18 +45,29 @@ pub async fn handle(
             Ok(json!({}))
         }
         "getTargets" => {
+            // Refresh this connection's own pages first: the shared registry
+            // is a mirror, and the live Page objects are the freshest source
+            // for url/title after any navigation (issue #544).
+            ctx.sync_registry();
             let targets: Vec<Value> = ctx
-                .pages
-                .iter()
-                .map(|page| {
+                .registry
+                .all()
+                .into_iter()
+                .map(|target| {
+                    // attached means this caller can route a session to the
+                    // target (it owns the page and has a session for it).
+                    let attached = ctx
+                        .sessions
+                        .values()
+                        .any(|page_id| *page_id == target.target_id);
                     json!({
-                        "targetId": page.id,
+                        "targetId": target.target_id,
                         "type": "page",
-                        "title": page.title,
-                        "url": page.url_string(),
-                        "attached": true,
+                        "title": target.title,
+                        "url": target.url,
+                        "attached": attached,
                         "canAccessOpener": false,
-                        "browserContextId": page.context.id,
+                        "browserContextId": target.browser_context_id,
                     })
                 })
                 .collect();
@@ -95,6 +106,9 @@ pub async fn handle(
                     let _ = page.navigate(url).await;
                 }
             }
+            // createTarget may have navigated the page: refresh its global
+            // target entry so getTargets and /json/list report the real url.
+            ctx.sync_registry();
 
             ctx.sessions.insert(session_id.clone(), page_id.clone());
 
@@ -168,37 +182,62 @@ pub async fn handle(
                 .get("targetId")
                 .and_then(|v| v.as_str())
                 .ok_or("targetId required")?;
-            if ctx.get_page(target_id).is_none() {
-                return Err("Target not found".to_string());
-            }
+            // Issue #544 makes targets globally visible: Target.getTargets
+            // lists every live page in the process, so attachToTarget must
+            // accept any target the caller can see, not only pages this
+            // connection owns. A page created by another connection used to
+            // be listed but rejected here with "Target not found" (Hermes
+            // repro). Resolve through the shared registry; the session stays
+            // per-connection (sessions are connection-local), only the lookup
+            // is global.
+            ctx.sync_registry();
+            let registry_target = ctx
+                .registry
+                .all()
+                .into_iter()
+                .find(|t| t.target_id == target_id)
+                .ok_or_else(|| "Target not found".to_string())?;
             let session_id = ctx.next_target_session(target_id);
             ctx.sessions
                 .insert(session_id.clone(), target_id.to_string());
 
-            if let Some(page) = ctx.get_page(target_id) {
-                let params = json!({
-                    "sessionId": session_id,
-                    "targetInfo": {
-                        "targetId": target_id,
-                        "type": "page",
-                        "title": page.title,
-                        "url": page.url_string(),
-                        "attached": true,
-                        "canAccessOpener": false,
-                        "browserContextId": page.context.id,
-                    },
-                    "waitingForDebugger": false,
-                });
-                let event = match parent_session_id {
-                    Some(parent_session_id) => CdpEvent::with_session(
-                        "Target.attachedToTarget",
-                        params,
-                        parent_session_id.clone(),
-                    ),
-                    None => CdpEvent::new("Target.attachedToTarget", params),
-                };
-                ctx.pending_events.push(event);
-            }
+            // Prefer the live Page when this connection owns it (freshest
+            // url/title); for a remote target fall back to the registry
+            // mirror, which the owning connection keeps current.
+            let (title, url, browser_context_id) = match ctx.get_page(target_id) {
+                Some(page) => (
+                    page.title.clone(),
+                    page.url_string(),
+                    page.context.id.clone(),
+                ),
+                None => (
+                    registry_target.title,
+                    registry_target.url,
+                    registry_target.browser_context_id,
+                ),
+            };
+            let params = json!({
+                "sessionId": session_id,
+                "targetInfo": {
+                    "targetId": target_id,
+                    "type": "page",
+                    "title": title,
+                    "url": url,
+                    "attached": true,
+                    "canAccessOpener": false,
+                    "browserContextId": browser_context_id,
+                },
+                "waitingForDebugger": false,
+            });
+            let event = match parent_session_id {
+                Some(parent_session_id) => CdpEvent::with_session(
+                    "Target.attachedToTarget",
+                    params,
+                    parent_session_id.clone(),
+                ),
+                None => CdpEvent::new("Target.attachedToTarget", params),
+            };
+            ctx.pending_events.push(event);
 
             Ok(json!({ "sessionId": session_id }))
         }
@@ -207,6 +246,27 @@ pub async fn handle(
                 .get("targetId")
                 .and_then(|v| v.as_str())
                 .ok_or("targetId required")?;
+            // Like attachToTarget, closeTarget is browser-global in Chrome:
+            // any connection may close any target listed by getTargets,
+            // owned by this connection or not. Resolve through the shared
+            // registry first so unknown targets surface a protocol error
+            // instead of emitting destroy events for phantom pages. The
+            // registry removal happens in `remove_page`, which already
+            // removes the global entry regardless of ownership. Known
+            // limitation: a remote-owned page's live `Page` lives on its
+            // owner's thread (thread-per-connection #430), so it cannot be
+            // torn down from here; if the owner later syncs the registry
+            // (getTargets, navigation) the entry returns. Fully closing a
+            // remote page needs registry tombstones or cross-connection
+            // teardown, both out of scope for this fix.
+            if !ctx
+                .registry
+                .all()
+                .iter()
+                .any(|t| t.target_id == target_id)
+            {
+                return Err("Target not found".to_string());
+            }
             let session_id = format!("{}-session", target_id);
 
             ctx.pending_events.push(CdpEvent::new(
@@ -362,6 +422,232 @@ mod tests {
         assert!(ctx.get_page(&isolated_page).is_none());
         assert!(ctx.get_page(&default_page).is_some());
         assert!(ctx.browser_contexts.is_empty());
+    }
+
+    /// Issue #544: targets are globally visible. A page created (and
+    /// navigated) by one connection must show up in another connection's
+    /// Target.getTargets with its current url, and a freshly created page
+    /// must not stay shadowed by a stale about:blank entry.
+    #[tokio::test]
+    async fn get_targets_lists_pages_from_other_connections() {
+        let registry = crate::registry::TargetRegistry::default();
+        let mut owner = CdpContext::new_with_shared_context_and_registry(
+            CdpContext::new().default_context.clone(),
+            registry.clone(),
+        );
+        let mut observer = CdpContext::new_with_shared_context_and_registry(
+            CdpContext::new().default_context.clone(),
+            registry,
+        );
+
+        let page_id = owner.create_page();
+        // createTarget wires a managed session for the new page; mirror that
+        // here so the owner connection lists the page as attached.
+        let session_id = format!("{page_id}-session");
+        owner.sessions.insert(session_id, page_id.clone());
+        // Simulate a completed navigation without touching the network: the
+        // shared registry must pick up the new url/title on the next
+        // getTargets, not keep reporting the initial about:blank.
+        {
+            let page = owner.get_page_mut(&page_id).unwrap();
+            page.url = Some(url::Url::parse("https://example.com/").unwrap());
+            page.title = "Example".into();
+        }
+
+        // The owner connection lists the page as attached (it holds the
+        // session); the observer lists it as a remote, unattached target.
+        let owner_targets = handle("getTargets", &json!({}), &mut owner, &None)
+            .await
+            .unwrap();
+        assert_eq!(owner_targets["targetInfos"][0]["targetId"], page_id);
+        assert_eq!(owner_targets["targetInfos"][0]["attached"], true);
+        assert_eq!(
+            owner_targets["targetInfos"][0]["url"],
+            "https://example.com/",
+            "getTargets must report the navigated url, not about:blank"
+        );
+
+        let observer_targets = handle("getTargets", &json!({}), &mut observer, &None)
+            .await
+            .expect("observer getTargets should succeed");
+        assert_eq!(observer_targets["targetInfos"][0]["targetId"], page_id);
+        assert_eq!(
+            observer_targets["targetInfos"][0]["url"],
+            "https://example.com/",
+            "observer must see the navigated url, not a stale about:blank"
+        );
+        assert_eq!(observer_targets["targetInfos"][0]["attached"], false);
+        assert_eq!(
+            observer_targets["targetInfos"][0]["type"],
+            "page",
+            "every listed target must carry type page"
+        );
+    }
+
+    /// Issue #544: when the owning connection goes away its pages must leave
+    /// the shared registry, so they stop shadowing live targets elsewhere.
+    #[tokio::test]
+    async fn dropped_connection_unregisters_its_pages() {
+        let registry = crate::registry::TargetRegistry::default();
+        let page_id = {
+            let mut owner = CdpContext::new_with_shared_context_and_registry(
+                CdpContext::new().default_context.clone(),
+                registry.clone(),
+            );
+            let created = handle(
+                "createTarget",
+                &json!({"url": "about:blank"}),
+                &mut owner,
+                &None,
+            )
+            .await
+            .expect("createTarget should succeed");
+            created["targetId"].as_str().unwrap().to_string()
+        };
+        // `owner` dropped at end of block → its page must be gone globally.
+        assert!(
+            registry.all().is_empty(),
+            "dropped connection must unregister its pages, got: {:?}",
+            registry.all()
+        );
+        let _ = page_id;
+    }
+
+    /// Issue #544 follow-up: any target listed by getTargets must be
+    /// attachable. A page created (and owned) by connection A must accept
+    /// attachToTarget from a second connection with a fresh session id,
+    /// instead of the old per-connection "Target not found" (Hermes repro).
+    #[tokio::test]
+    async fn attach_to_target_accepts_targets_from_other_connections() {
+        let registry = crate::registry::TargetRegistry::default();
+        let mut owner = CdpContext::new_with_shared_context_and_registry(
+            CdpContext::new().default_context.clone(),
+            registry.clone(),
+        );
+        let mut observer = CdpContext::new_with_shared_context_and_registry(
+            CdpContext::new().default_context.clone(),
+            registry,
+        );
+
+        // Connection A creates a page via the real createTarget path, which
+        // also wires its managed session, mirroring the repro.
+        let created = handle(
+            "createTarget",
+            &json!({"url": "about:blank"}),
+            &mut owner,
+            &None,
+        )
+        .await
+        .expect("createTarget should succeed");
+        let page_id = created["targetId"].as_str().unwrap().to_string();
+
+        // Connection B sees the page globally…
+        let targets = handle("getTargets", &json!({}), &mut observer, &None)
+            .await
+            .expect("observer getTargets should succeed");
+        assert_eq!(targets["targetInfos"][0]["targetId"], page_id);
+
+        // …and must be able to attach to it, not fail with Target not found.
+        let attached = handle(
+            "attachToTarget",
+            &json!({"targetId": page_id, "flatten": true}),
+            &mut observer,
+            &None,
+        )
+        .await
+        .expect("attachToTarget must accept targets listed by getTargets");
+        let session_id = attached["sessionId"].as_str().unwrap();
+        assert!(!session_id.is_empty());
+        assert_eq!(
+            observer.sessions.get(session_id).map(String::as_str),
+            Some(page_id.as_str()),
+            "the attaching connection must hold its own session route"
+        );
+
+        // The attachedToTarget event carries the page metadata from the
+        // registry mirror, since the observer does not own the page.
+        let evt = observer
+            .pending_events
+            .iter()
+            .find(|e| e.method == "Target.attachedToTarget")
+            .expect("attachedToTarget event must be emitted");
+        assert_eq!(evt.params["targetInfo"]["targetId"], page_id);
+        assert_eq!(evt.params["targetInfo"]["url"], "about:blank");
+        assert_eq!(evt.params["targetInfo"]["type"], "page");
+    }
+
+    /// A target that is not registered anywhere must still be rejected, so
+    /// attachToTarget does not hand out sessions for phantom ids.
+    #[tokio::test]
+    async fn attach_to_target_unknown_target_still_errors() {
+        let mut ctx = CdpContext::new();
+        let err = handle(
+            "attachToTarget",
+            &json!({"targetId": "page-999"}),
+            &mut ctx,
+            &None,
+        )
+        .await
+        .expect_err("unknown targets must still error");
+        assert_eq!(err, "Target not found");
+    }
+
+    /// Issue #544 follow-up: closeTarget is browser-global in Chrome, so a
+    /// connection may close a page owned by another connection. The target
+    /// must leave the shared registry (its global entry), matching what any
+    /// other connection's getTargets would report.
+    #[tokio::test]
+    async fn close_target_removes_targets_owned_by_other_connections() {
+        let registry = crate::registry::TargetRegistry::default();
+        let mut owner = CdpContext::new_with_shared_context_and_registry(
+            CdpContext::new().default_context.clone(),
+            registry.clone(),
+        );
+        let mut observer = CdpContext::new_with_shared_context_and_registry(
+            CdpContext::new().default_context.clone(),
+            registry.clone(),
+        );
+
+        let created = handle(
+            "createTarget",
+            &json!({"url": "about:blank"}),
+            &mut owner,
+            &None,
+        )
+        .await
+        .expect("createTarget should succeed");
+        let page_id = created["targetId"].as_str().unwrap().to_string();
+
+        // Connection B closes connection A's page: allowed, matching Chrome.
+        let closed = handle(
+            "closeTarget",
+            &json!({"targetId": page_id}),
+            &mut observer,
+            &None,
+        )
+        .await
+        .expect("closing another connection's target should succeed");
+        assert_eq!(closed["success"], true);
+        assert!(
+            !registry.all().iter().any(|t| t.target_id == page_id),
+            "closed target must leave the global registry"
+        );
+    }
+
+    /// Closing a target that was never registered must surface a protocol
+    /// error instead of acking and emitting destroy events for a phantom.
+    #[tokio::test]
+    async fn close_target_unknown_target_errors() {
+        let mut ctx = CdpContext::new();
+        let err = handle(
+            "closeTarget",
+            &json!({"targetId": "page-999"}),
+            &mut ctx,
+            &None,
+        )
+        .await
+        .expect_err("unknown targets must error");
+        assert_eq!(err, "Target not found");
     }
 
     #[tokio::test]

--- a/crates/obscura-cdp/src/lib.rs
+++ b/crates/obscura-cdp/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod server;
 pub mod dispatch;
+pub mod registry;
 pub mod types;
 pub mod domains;
 pub mod cookie_params;

--- a/crates/obscura-cdp/src/registry.rs
+++ b/crates/obscura-cdp/src/registry.rs
@@ -1,0 +1,135 @@
+use std::sync::{Arc, Mutex};
+
+/// Metadata snapshot for a live page target, visible to every CDP connection
+/// and to the HTTP control plane (`/json/list`).
+///
+/// Only plain, sync-readable fields live here. The actual `Page` objects stay
+/// owned by their creating connection's `CdpContext` (thread-per-connection
+/// #430 confines each page's V8 isolate to one OS thread); the registry is a
+/// lightweight mirror that lets `Target.getTargets` on *any* connection and
+/// `/json/list` on the accept thread report every live page with its current
+/// url/title.
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct TargetInfo {
+    pub target_id: String,
+    pub title: String,
+    pub url: String,
+    pub browser_context_id: String,
+}
+
+#[derive(Default)]
+struct RegistryState {
+    /// All live page targets, in creation order (Chrome lists targets in
+    /// creation order; preserving it keeps clients' bookkeeping stable).
+    targets: Vec<TargetInfo>,
+    /// Globally-unique page id counter. Each connection used to mint its own
+    /// `page-N` ids from a per-context counter, so every connection's first
+    /// page collided on "page-1" in any shared view. The registry hands out
+    /// ids so target ids are unique across the whole server.
+    next_page_id: u64,
+}
+
+/// Process-wide page target registry, shared by every CDP connection and the
+/// HTTP accept thread. Clone is cheap (one `Arc` bump); all mutation goes
+/// through a short std mutex that never spans an await.
+#[derive(Clone, Default)]
+pub struct TargetRegistry {
+    inner: Arc<Mutex<RegistryState>>,
+}
+
+impl TargetRegistry {
+    /// Claim the next globally-unique page id (`page-1`, `page-2`, ...).
+    pub fn next_page_id(&self) -> u64 {
+        let mut state = self
+            .inner
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        state.next_page_id = state.next_page_id.saturating_add(1);
+        state.next_page_id
+    }
+
+    /// Insert or refresh a target. Replacing by `target_id` keeps the original
+    /// creation position while updating the url/title after navigation.
+    pub fn upsert(&self, info: TargetInfo) {
+        let mut state = self
+            .inner
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        if let Some(existing) = state.targets.iter_mut().find(|t| t.target_id == info.target_id) {
+            *existing = info;
+        } else {
+            state.targets.push(info);
+        }
+    }
+
+    /// Remove the given targets (page closed, context disposed, or the owning
+    /// connection went away).
+    pub fn remove_pages(&self, target_ids: &[String]) {
+        if target_ids.is_empty() {
+            return;
+        }
+        let mut state = self
+            .inner
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        state.targets.retain(|t| !target_ids.contains(&t.target_id));
+    }
+
+    /// Snapshot of every live target, in creation order.
+    pub fn all(&self) -> Vec<TargetInfo> {
+        self.inner
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .targets
+            .clone()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn ids_are_unique_across_shared_registry_views() {
+        let registry = TargetRegistry::default();
+        assert_eq!(registry.next_page_id(), 1);
+        assert_eq!(registry.next_page_id(), 2);
+        assert_eq!(registry.next_page_id(), 3);
+    }
+
+    #[test]
+    fn upsert_refreshes_in_place_and_all_returns_snapshot() {
+        let registry = TargetRegistry::default();
+        registry.upsert(TargetInfo {
+            target_id: "page-1".into(),
+            title: String::new(),
+            url: "about:blank".into(),
+            browser_context_id: "default".into(),
+        });
+        registry.upsert(TargetInfo {
+            target_id: "page-2".into(),
+            title: String::new(),
+            url: "about:blank".into(),
+            browser_context_id: "default".into(),
+        });
+
+        // Refresh page-1 after navigation; it must keep its creation slot.
+        registry.upsert(TargetInfo {
+            target_id: "page-1".into(),
+            title: "Example".into(),
+            url: "https://example.com/".into(),
+            browser_context_id: "default".into(),
+        });
+
+        let all = registry.all();
+        assert_eq!(all.len(), 2);
+        assert_eq!(all[0].target_id, "page-1");
+        assert_eq!(all[0].url, "https://example.com/");
+        assert_eq!(all[1].target_id, "page-2");
+
+        registry.remove_pages(&["page-1".to_string()]);
+        let all = registry.all();
+        assert_eq!(all.len(), 1);
+        assert_eq!(all[0].target_id, "page-2");
+    }
+}

--- a/crates/obscura-cdp/src/server.rs
+++ b/crates/obscura-cdp/src/server.rs
@@ -842,9 +842,19 @@ async fn cdp_processor(
         match msg {
             ServerMessage::NewConnection { reply_tx } => {
                 connection_reply_tx = Some(reply_tx.clone());
+                // Issue #543: a browser-level client that connects and immediately
+                // calls Target.getTargets must see the existing page targets (the
+                // CDP spec makes targets globally visible). Without this, a fresh
+                // connection's CdpContext has an empty `pages` registry and
+                // getTargets returns [], which breaks puppeteer/playwright-style
+                // clients before they can call Target.createTarget/attachToTarget.
+                // Mirror the interception path below, which already creates a
+                // page + session per new connection.
+                let pid = ctx.create_page();
+                let sid = format!("{pid}-session");
+                ctx.sessions.insert(sid.clone(), pid.clone());
                 let _ = reply_tx.send(
-                    json!({"__init": true})
-                        .to_string(),
+                    json!({"__init": true, "pageId": pid, "sessionId": sid}).to_string(),
                 );
             }
             ServerMessage::Cdp(cdp_msg) => {
@@ -1726,6 +1736,76 @@ mod tests {
                     .unwrap();
                     if value["id"] == 3 {
                         assert_eq!(value["result"]["result"]["value"], "yes");
+                        break;
+                    }
+                }
+
+                drop(server_tx);
+                tokio::time::timeout(std::time::Duration::from_secs(2), processor)
+                    .await
+                    .expect("processor shutdown timeout")
+                    .expect("processor task");
+            })
+            .await;
+    }
+
+    // Issue #543: a browser-level client that connects and immediately calls
+    // Target.getTargets must see the existing page targets. A fresh connection
+    // used to start with an empty pages registry (pages only appeared after a
+    // session-scoped event like Target.createTarget), so getTargets returned
+    // [] and puppeteer/playwright-style clients broke before driving any page.
+    #[tokio::test(flavor = "current_thread")]
+    async fn fresh_connection_sees_page_targets_in_get_targets() {
+        tokio::task::LocalSet::new()
+            .run_until(async {
+                let (server_tx, server_rx) = tokio::sync::mpsc::unbounded_channel();
+                let (reply_tx, mut reply_rx) = tokio::sync::mpsc::unbounded_channel();
+                let shutdown = std::sync::Arc::new(tokio::sync::Notify::new());
+                let default_context = crate::dispatch::CdpContext::new().default_context;
+                let processor = tokio::task::spawn_local(super::cdp_processor(
+                    server_rx,
+                    default_context,
+                    shutdown,
+                ));
+
+                server_tx
+                    .send(super::ServerMessage::NewConnection {
+                        reply_tx: reply_tx.clone(),
+                    })
+                    .unwrap();
+                let init = reply_rx.recv().await.expect("processor init");
+                assert!(init.contains("__init"));
+
+                let send = |value: serde_json::Value| {
+                    server_tx
+                        .send(super::ServerMessage::Cdp(super::CdpMessage {
+                            text: value.to_string(),
+                            reply_tx: reply_tx.clone(),
+                        }))
+                        .unwrap();
+                };
+                send(json!({"id": 1, "method": "Target.getTargets", "params": {}}));
+
+                loop {
+                    let value: serde_json::Value = serde_json::from_str(
+                        &tokio::time::timeout(
+                            std::time::Duration::from_secs(2),
+                            reply_rx.recv(),
+                        )
+                        .await
+                        .expect("getTargets response timeout")
+                        .expect("getTargets response channel"),
+                    )
+                    .unwrap();
+                    if value["id"] == 1 {
+                        let targets = value["result"]["targetInfos"]
+                            .as_array()
+                            .expect("targetInfos must be an array");
+                        assert!(
+                            !targets.is_empty(),
+                            "getTargets must list the connection's page target"
+                        );
+                        assert_eq!(targets[0]["type"], "page");
                         break;
                     }
                 }

--- a/crates/obscura-cdp/src/server.rs
+++ b/crates/obscura-cdp/src/server.rs
@@ -12,6 +12,7 @@ use tokio_tungstenite::tungstenite::Message;
 use tracing::{error, info, warn};
 
 use crate::dispatch::{self, CdpContext};
+use crate::registry::TargetRegistry;
 
 // PR #36 comment 4341743194: the deferral queue in `process_with_interception`
 // must be bounded so a stalled navigation cannot OOM the process. When the cap
@@ -198,6 +199,12 @@ pub async fn start_with_serve_options_and_limit(
 
     let (ws_tx, mut ws_rx) = mpsc::channel::<std::net::TcpStream>(MAX_PENDING_WS_HANDOFFS);
 
+    // Process-wide page target registry (issue #544). Every connection shares
+    // this one so Target.getTargets on any WebSocket and /json/list on the
+    // HTTP accept thread see the same live pages; page ids minted from it are
+    // unique across the whole server.
+    let target_registry = TargetRegistry::default();
+
     // Ctrl-C / graceful shutdown coordination.
     let shutdown_flag = Arc::new(AtomicBool::new(false));
     let shutdown_notify = Arc::new(Notify::new());
@@ -206,6 +213,7 @@ pub async fn start_with_serve_options_and_limit(
     // handles HTTP endpoints (/json/version, /json, /json/protocol) with
     // blocking I/O so they never contend with the LocalSet's V8 work.
     let accept_flag = shutdown_flag.clone();
+    let http_registry = target_registry.clone();
     std::thread::Builder::new()
         .name("obscura-cdp-accept".into())
         .spawn(move || {
@@ -215,7 +223,7 @@ pub async fn start_with_serve_options_and_limit(
                 }
                 match stream {
                     Ok(stream) => {
-                        if let Err(e) = accept_dispatch(stream, port, &ws_tx) {
+                        if let Err(e) = accept_dispatch(stream, port, &ws_tx, &http_registry) {
                             if !format!("{}", e).contains("close") {
                                 error!("Accept dispatch error: {}", e);
                             }
@@ -351,6 +359,7 @@ pub async fn start_with_serve_options_and_limit(
             persistence_lock.clone(),
             shutdown_notify.clone(),
             live_connections.clone(),
+            target_registry.clone(),
         );
     }
 
@@ -439,6 +448,7 @@ fn run_connection(
     persistence_lock: Arc<std::sync::Mutex<()>>,
     shutdown_notify: Arc<Notify>,
     live_connections: Arc<AtomicUsize>,
+    target_registry: TargetRegistry,
 ) {
     // Releases the slot reserved by the accept loop when the thread unwinds,
     // however it exits — clean close, error return, or panic. A plain
@@ -485,6 +495,7 @@ fn run_connection(
                     msg_rx,
                     default_context,
                     shutdown_notify,
+                    target_registry,
                 ));
                 if let Err(e) = handle_connection_ws(tokio_stream, msg_tx).await {
                     error!("WebSocket connection error: {}", e);
@@ -591,6 +602,7 @@ fn accept_dispatch(
     stream: std::net::TcpStream,
     port: u16,
     ws_tx: &mpsc::Sender<std::net::TcpStream>,
+    target_registry: &TargetRegistry,
 ) -> anyhow::Result<()> {
     let mut buf = [0u8; WS_PEEK_BUF];
     let n = stream.peek(&mut buf)?;
@@ -611,7 +623,7 @@ fn accept_dispatch(
         };
 
         if let Some(ep) = endpoint {
-            return handle_http_json_blocking(stream, port, ep);
+            return handle_http_json_blocking(stream, port, ep, target_registry);
         }
         // Fall through: GET request that isn't a /json endpoint → treat as
         // WebSocket upgrade (Chromium DevTools clients issue GET with
@@ -640,6 +652,7 @@ fn handle_http_json_blocking(
     mut stream: std::net::TcpStream,
     port: u16,
     endpoint: &str,
+    target_registry: &TargetRegistry,
 ) -> anyhow::Result<()> {
     use std::io::{Read, Write};
 
@@ -655,15 +668,30 @@ fn handle_http_json_blocking(
             "WebKit-Version": "537.36",
             "webSocketDebuggerUrl": format!("ws://127.0.0.1:{}/devtools/browser", port),
         }))?,
-        "list" => serde_json::to_string_pretty(&json!([{
-            "description": "",
-            "devtoolsFrontendUrl": "",
-            "id": "page-1",
-            "title": "",
-            "type": "page",
-            "url": "about:blank",
-            "webSocketDebuggerUrl": format!("ws://127.0.0.1:{}/devtools/page/page-1", port),
-        }]))?,
+        // The list must mirror the live target registry (issue #544), not a
+        // hardcoded synthetic about:blank page. Every page any connection has
+        // created or navigated shows up here with its current url/title.
+        "list" => {
+            let list: Vec<serde_json::Value> = target_registry
+                .all()
+                .into_iter()
+                .map(|target| {
+                    json!({
+                        "description": "",
+                        "devtoolsFrontendUrl": "",
+                        "id": target.target_id,
+                        "title": target.title,
+                        "type": "page",
+                        "url": target.url,
+                        "webSocketDebuggerUrl": format!(
+                            "ws://127.0.0.1:{}/devtools/page/{}",
+                            port, target.target_id
+                        ),
+                    })
+                })
+                .collect();
+            serde_json::to_string_pretty(&list)?
+        }
         "protocol" => {
             serde_json::to_string_pretty(&json!({ "version": { "major": "1", "minor": "3" } }))?
         }
@@ -690,8 +718,9 @@ async fn cdp_processor(
     mut rx: mpsc::UnboundedReceiver<ServerMessage>,
     default_context: Arc<obscura_browser::BrowserContext>,
     shutdown_notify: Arc<Notify>,
+    target_registry: TargetRegistry,
 ) {
-    let mut ctx = CdpContext::new_with_shared_context(default_context);
+    let mut ctx = CdpContext::new_with_shared_context_and_registry(default_context, target_registry);
     let (itx, irx) = mpsc::unbounded_channel::<obscura_js::ops::InterceptedRequest>();
     ctx.intercept_tx = Some(itx);
     let mut intercept_rx: Option<mpsc::UnboundedReceiver<obscura_js::ops::InterceptedRequest>> = Some(irx);
@@ -1350,6 +1379,10 @@ async fn process_with_interception(
     let reached_network_idle = page.lifecycle.is_network_idle();
 
     ctx.pages.push(page);
+    // Navigation changed the page's url/title: refresh its global target
+    // entry so every connection's getTargets and /json/list see the new
+    // document, not the stale about:blank snapshot.
+    ctx.sync_registry();
 
     #[cfg(feature = "render")]
     let navigation_succeeded = navigate_result.is_ok();
@@ -1632,11 +1665,12 @@ mod tests {
                 let (server_tx, server_rx) = tokio::sync::mpsc::unbounded_channel();
                 let (reply_tx, mut reply_rx) = tokio::sync::mpsc::unbounded_channel();
                 let shutdown = std::sync::Arc::new(tokio::sync::Notify::new());
-                let default_context = crate::dispatch::CdpContext::new().default_context;
+                let default_context = crate::dispatch::CdpContext::new().default_context.clone();
                 let processor = tokio::task::spawn_local(super::cdp_processor(
                     server_rx,
                     default_context,
                     shutdown,
+                    crate::registry::TargetRegistry::default(),
                 ));
 
                 server_tx
@@ -1761,11 +1795,12 @@ mod tests {
                 let (server_tx, server_rx) = tokio::sync::mpsc::unbounded_channel();
                 let (reply_tx, mut reply_rx) = tokio::sync::mpsc::unbounded_channel();
                 let shutdown = std::sync::Arc::new(tokio::sync::Notify::new());
-                let default_context = crate::dispatch::CdpContext::new().default_context;
+                let default_context = crate::dispatch::CdpContext::new().default_context.clone();
                 let processor = tokio::task::spawn_local(super::cdp_processor(
                     server_rx,
                     default_context,
                     shutdown,
+                    crate::registry::TargetRegistry::default(),
                 ));
 
                 server_tx


### PR DESCRIPTION
fix(cdp): global target registry — targets visible & attachable across connections (#570)

Per-connection target lookup made Target.getTargets list only pages owned
by the caller, so a page created on one connection was invisible to others
and attachToTarget failed with "Target not found" (Hermes repro). Pages are
thread-confined (thread-per-connection #430) so their V8 isolates cannot be
shared; instead mirror their metadata in a process-wide registry.

- registry.rs: TargetRegistry — global page-id counter, upsert/remove/all
- createPage/createTarget register the page; Drop unregisters a dead
  connection's pages; navigation syncs url/title into the registry
- getTargets returns every live target with attached=false for remote ones
- attachToTarget/closeTarget resolve through the registry (browser-global,
  matching Chrome), sessions stay connection-local
- /json/list mirrors the registry instead of a hardcoded about:blank page
