### PR TITLE
fix(cdp): deliver connection refusal response

### DIFF
--- a/crates/obscura-cdp/src/server.rs
+++ b/crates/obscura-cdp/src/server.rs
@@ -569,12 +569,31 @@ fn merge_cookie_delta(
 /// Best-effort: the socket is going away either way, so a failed write just
 /// means the client sees a reset instead of the 503.
 fn refuse_connection(stream: std::net::TcpStream) {
-    use std::io::Write;
+    use std::io::{Read, Write};
     let mut stream = stream;
     let _ = stream.set_nonblocking(false);
+
+    // The accept thread only peeked at the WebSocket handshake. Consume its
+    // bounded HTTP header before closing: Windows resets a socket closed with
+    // unread receive data, which can discard the queued 503 response.
+    let _ = stream.set_read_timeout(Some(std::time::Duration::from_millis(100)));
+    let mut request = [0u8; HTTP_PEEK_BUF];
+    let mut received = 0;
+    while received < request.len() {
+        match stream.read(&mut request[received..]) {
+            Ok(0) => break,
+            Ok(n) => {
+                received += n;
+                if request[..received].windows(4).any(|end| end == b"\r\n\r\n") {
+                    break;
+                }
+            }
+            Err(_) => break,
+        }
+    }
     let _ = stream.write_all(CONNECTION_LIMIT_RESPONSE.as_bytes());
     let _ = stream.flush();
-    let _ = stream.shutdown(std::net::Shutdown::Both);
+    let _ = stream.shutdown(std::net::Shutdown::Write);
 }
 
 const HTTP_PEEK_BUF: usize = 4096;


### PR DESCRIPTION
## Summary

- drain the bounded WebSocket request header before sending a capacity refusal
- shut down only the socket write side after flushing the 503 response
- keep the refusal path bounded with a 100 ms read timeout and the existing 4096-byte header limit

Fixes #604.

## Why

The accept thread peeks at the handshake. On Windows, closing a socket with those receive bytes still unread sends a reset. The client can lose the queued 503 response and fail with `ConnectionReset` instead of reading `X-Obscura-Reason: max-connections`.

## Verification

- Current `origin/main` at `6fa87e1`: `max_connections_refuses_then_recovers` fails with Windows error 10054.
- Patched branch: the same focused test passed 3 consecutive runs.
- Render tests: 1397/1397 passed, 4 skipped.
- No-render `obscura-cdp` tests: 115/115 passed, 3 skipped.
- All four release builds passed: render, render with stealth, no-render, and no-render with stealth.
- Obstacle course: 33/33 with the pending `obscura-benchmark` intersection fixture fix from h4ckf0r0day/obscura-benchmark#3, a deterministic 1px card height, and the manifest timezone set to the Windows host value. Unmodified benchmark inputs fail on current `main` for those two fixture assumptions, outside this socket change.

`git diff --check` passes.