### PR TITLE
fix(js): preserve Function.toString native shape

### DIFF
--- a/crates/obscura-js/js/bootstrap.js
+++ b/crates/obscura-js/js/bootstrap.js
@@ -132,17 +132,22 @@ const _nativeFns = new Set();
 // or functions whose `.name` does not match the real builtin.
 const _nativeStr = new Map();
 const _origToString = Function.prototype.toString;
-Function.prototype.toString = function toString() {
-  if (_nativeStr.has(this)) { return _nativeStr.get(this); }
-  if (_nativeFns.has(this)) {
-    return `function ${this.name || ''}() { [native code] }`;
-  }
-  return _origToString.call(this);
-};
+// Method syntax matches the native function's non-constructible shape and
+// does not add an own `prototype` property.
+const _functionToString = {
+  toString() {
+    if (_nativeStr.has(this)) { return _nativeStr.get(this); }
+    if (_nativeFns.has(this)) {
+      return `function ${this.name || ''}() { [native code] }`;
+    }
+    return _origToString.call(this);
+  },
+}.toString;
+Function.prototype.toString = _functionToString;
 function _markNative(fn) { if (typeof fn === 'function') _nativeFns.add(fn); return fn; }
 // Mark a function with an exact native-code toString (used for accessors).
 function _markNativeAs(fn, str) { if (typeof fn === 'function') _nativeStr.set(fn, str); return fn; }
-_nativeFns.add(Function.prototype.toString);
+_nativeFns.add(_functionToString);
 
 // unusualWindowProperties: obscura's internal globals are made non-enumerable
 // (see _preHideInternals and __obscura_init), which hides them from

--- a/crates/obscura-js/src/runtime.rs
+++ b/crates/obscura-js/src/runtime.rs
@@ -2738,6 +2738,40 @@ mod tests {
     }
 
     #[test]
+    fn function_to_string_has_native_function_shape() {
+        let mut rt = setup_runtime("<html><body></body></html>");
+
+        assert_eq!(
+            rt.evaluate(
+                r#"(() => {
+                    const fn = Function.prototype.toString;
+                    let constructible = true;
+                    try {
+                        Reflect.construct(function () {}, [], fn);
+                    } catch (error) {
+                        constructible = false;
+                    }
+                    return {
+                        source: fn.toString(),
+                        name: fn.name,
+                        length: fn.length,
+                        hasOwnPrototype: Object.prototype.hasOwnProperty.call(fn, "prototype"),
+                        constructible,
+                    };
+                })()"#,
+            )
+            .unwrap(),
+            serde_json::json!({
+                "source": "function toString() { [native code] }",
+                "name": "toString",
+                "length": 0,
+                "hasOwnPrototype": false,
+                "constructible": false,
+            })
+        );
+    }
+
+    #[test]
     fn iframe_content_window_exposes_realm_globals() {
         let mut rt = setup_runtime("<html><body></body></html>");
 


### PR DESCRIPTION
## Summary

- install the `Function.prototype.toString` override with object-method syntax
- preserve the native source, name, length, prototype ownership, and constructor shape
- add regression coverage for the full observable shape

The native `Function.prototype.toString` function is not constructible and has no own `prototype`. The former ordinary-function override exposed both properties even though its returned source looked native.

Fixes #603

## Verification

- `cargo nextest run --release --features render -p obscura-js function_to_string_has_native_function_shape`
- no-render `obscura-js`: 281/281 passed
- full render workspace: 1397/1398 passed, 4 skipped
  - only `max_connections_refuses_then_recovers` failed; it also fails on the unchanged Windows baseline and is tracked by #604 with a fix in #605
- release CLI builds passed for `render`, `render,stealth`, no default features, and no default features plus `stealth`
- direct CLI probe confirmed `name: "toString"`, `length: 0`, no own `prototype`, and non-constructibility
- obstacle course: 33/33 with benchmark PR h4ckf0r0day/obscura-benchmark#3 and the fixture normalization recorded there