### PR TITLE
fix(js): coerce Location navigation values

### DIFF
--- a/crates/obscura-js/js/bootstrap.js
+++ b/crates/obscura-js/js/bootstrap.js
@@ -5904,6 +5904,7 @@ globalThis.self = globalThis;
 
 globalThis.document = null;
 function _resolveUrl(url) {
+  url = String(url);
   if (!url) return url;
   if (url.startsWith('http://') || url.startsWith('https://') || url.startsWith('about:')) return url;
   try { return new URL(url, _domParse("document_url") || "about:blank").href; } catch(e) { return url; }

--- a/crates/obscura-js/src/runtime.rs
+++ b/crates/obscura-js/src/runtime.rs
@@ -12640,6 +12640,39 @@ mod tests {
     }
 
     #[test]
+    fn test_location_navigation_coerces_url_objects() {
+        let mut rt = setup_runtime("<html><body></body></html>");
+        let hrefs = rt
+            .evaluate(
+                r#"(() => {
+                    location.href = new URL('/from-href', location.href);
+                    const href = location.href;
+                    location.assign(new URL('/from-assign', location.href));
+                    const assigned = location.href;
+                    location.replace(new URL('/from-replace', location.href));
+                    return [href, assigned, location.href];
+                })()"#,
+            )
+            .unwrap();
+        assert_eq!(
+            hrefs,
+            serde_json::json!([
+                "http://example.com/from-href",
+                "http://example.com/from-assign",
+                "http://example.com/from-replace"
+            ])
+        );
+        assert_eq!(
+            rt.take_pending_navigation(),
+            Some((
+                "http://example.com/from-replace".to_string(),
+                "GET".to_string(),
+                "".to_string()
+            ))
+        );
+    }
+
+    #[test]
     fn test_submit_button_click_handler_can_prevent_default_and_navigate() {
         let mut rt =
             setup_runtime(r#"<form><button type="submit" id="submit">Submit</button></form>"#);


### PR DESCRIPTION
## Summary

- Coerce all Location navigation values through `String` in the shared URL resolver.
- Cover `location.href`, `location.assign()`, and `location.replace()` with URL object regression tests.
- Keep the behavior in one shared path.

Fixes #612

## Validation

- Baseline focused regression failed by returning `null` instead of the three URL values.
- `cargo nextest run --release --features render -p obscura-js`: 367/367 passed.
- `cargo nextest run --release --no-default-features -p obscura-js`: 281/281 passed.
- `cargo nextest run --release --features render --no-fail-fast`: 1397/1398 passed. The only failure is the known Windows refusal case in #604, fixed by #605.
- Release builds passed for `render`, `render,stealth`, no default features, and no default features with `stealth`.
- Direct CLI probe returned the expected URL after each of `href`, `assign`, and `replace`.
- Obstacle course: 33/33 with the benchmark input normalization disclosed at https://github.com/h4ckf0r0day/obscura-benchmark/pull/3#issuecomment-5241675014.