### PR TITLE
fix(cdp): implement Storage.clearCookies

### DIFF
--- a/crates/obscura-cdp/src/dispatch.rs
+++ b/crates/obscura-cdp/src/dispatch.rs
@@ -405,6 +405,7 @@ fn is_v8_free_method(method: &str) -> bool {
             | "IO.close"
             | "Storage.getCookies"
             | "Storage.setCookies"
+            | "Storage.clearCookies"
             | "Storage.deleteCookies"
     )
 }

--- a/crates/obscura-cdp/src/domains/storage.rs
+++ b/crates/obscura-cdp/src/domains/storage.rs
@@ -40,6 +40,10 @@ pub async fn handle(
             }
             Ok(json!({}))
         }
+        "clearCookies" => {
+            cookie_jar_for(ctx, params, session_id)?.clear();
+            Ok(json!({}))
+        }
         "deleteCookies" => {
             if let Some(filter) = parse_delete_cookies_params(params) {
                 cookie_jar_for(ctx, params, session_id)?.delete_cookies_filtered(
@@ -51,5 +55,70 @@ pub async fn handle(
             Ok(json!({}))
         }
         _ => Ok(json!({})),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use obscura_net::CookieInfo;
+
+    fn sample_cookie(value: &str) -> CookieInfo {
+        CookieInfo {
+            name: "sid".to_string(),
+            value: value.to_string(),
+            domain: "example.com".to_string(),
+            path: "/".to_string(),
+            secure: false,
+            http_only: false,
+            same_site: String::new(),
+            expires: None,
+        }
+    }
+
+    #[tokio::test]
+    async fn clear_cookies_is_scoped_to_browser_context() {
+        let mut ctx = CdpContext::new();
+        let browser_context_id = ctx.create_browser_context();
+        ctx.browser_context(&browser_context_id)
+            .unwrap()
+            .cookie_jar
+            .set_cookies_from_cdp(vec![sample_cookie("isolated")]);
+        ctx.default_context
+            .cookie_jar
+            .set_cookies_from_cdp(vec![sample_cookie("default")]);
+
+        handle(
+            "clearCookies",
+            &json!({ "browserContextId": browser_context_id }),
+            &mut ctx,
+            &None,
+        )
+        .await
+        .unwrap();
+
+        assert!(ctx
+            .browser_context(&browser_context_id)
+            .unwrap()
+            .cookie_jar
+            .get_all_cookies()
+            .is_empty());
+        let default = ctx.default_context.cookie_jar.get_all_cookies();
+        assert_eq!(default.len(), 1);
+        assert_eq!(default[0].value, "default");
+    }
+
+    #[tokio::test]
+    async fn clear_cookies_without_context_clears_default_context() {
+        let mut ctx = CdpContext::new();
+        ctx.default_context
+            .cookie_jar
+            .set_cookies_from_cdp(vec![sample_cookie("default")]);
+
+        handle("clearCookies", &json!({}), &mut ctx, &None)
+            .await
+            .unwrap();
+
+        assert!(ctx.default_context.cookie_jar.get_all_cookies().is_empty());
     }
 }


### PR DESCRIPTION
## Summary

- Implement `Storage.clearCookies` with the existing browser-context cookie-jar resolver.
- Keep the default, session, and explicit browser-context scope rules shared with the other Storage cookie methods.
- Mark the Rust-only command as V8-free.
- Add tests for explicit-context isolation and the default-context fallback.

Fixes #614

## Validation

- The focused regression failed on the baseline because the isolated cookie remained after `Storage.clearCookies`.
- Both new focused tests pass.
- `cargo nextest run --release --features render -p obscura-cdp`: 147/148 passed. The only failure is the known Windows refusal case in #604, fixed by #605.
- `cargo nextest run --release --no-default-features -p obscura-cdp`: 116/117 passed, with the same known #604 failure.
- `cargo nextest run --release --features render --no-fail-fast`: 1398/1399 passed, with the same known #604 failure.
- Release builds passed for `render`, `render,stealth`, no default features, and no default features with `stealth`.
- Obstacle course: 33/33 with the benchmark input normalization disclosed at https://github.com/h4ckf0r0day/obscura-benchmark/pull/3#issuecomment-5241675014.