### PR TITLE
fix(js): bind computed style methods passed through to the declaration

### DIFF
--- a/crates/obscura-js/js/bootstrap.js
+++ b/crates/obscura-js/js/bootstrap.js
@@ -7805,7 +7805,15 @@ globalThis.getComputedStyle = (el) => {
               || prop.includes('-'))) {
         return lookup(prop);
       }
-      if (prop in target) return target[prop];
+      if (prop in target) {
+        const fromTarget = target[prop];
+        // Bind methods that pass through (setProperty, removeProperty) to the
+        // declaration. Called through this proxy, `this` would otherwise be
+        // the proxy itself, where the declaration's own fields (_loaded,
+        // _owner) miss the style proxy's has trap and read as "" from the CSS
+        // lookup, so _pull() crashes on ''.getAttribute (issue #635).
+        return typeof fromTarget === 'function' ? fromTarget.bind(target) : fromTarget;
+      }
       if (typeof prop === 'string') return lookup(prop);
       return undefined;
     },

--- a/crates/obscura/tests/computed_style_methods.rs
+++ b/crates/obscura/tests/computed_style_methods.rs
@@ -1,0 +1,98 @@
+// Regression for issue #635: methods on the object returned by
+// getComputedStyle() must not throw. The computed proxy used to hand back
+// CSSStyleDeclaration methods unbound, so they ran _pull() with `this` bound
+// to the proxy, where the declaration's own fields (_loaded, _owner) miss and
+// fall through to the CSS-name lookup as "". The result was
+// "TypeError: this._owner.getAttribute is not a function" on every method
+// call. jQuery's curCSS reads computed.getPropertyValue(name), so every
+// $().css() read and .show() failed on real sites.
+
+use std::io::{Read, Write};
+
+use obscura::Browser;
+
+fn spawn_server() -> String {
+    let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+    let addr = listener.local_addr().unwrap();
+    std::thread::spawn(move || {
+        for incoming in listener.incoming() {
+            let Ok(mut stream) = incoming else {
+                continue;
+            };
+            std::thread::spawn(move || {
+                let mut request = [0u8; 2048];
+                let _ = stream.read(&mut request);
+                let body = r#"<!doctype html><html><head><title>fixture</title></head><body>
+<div id="inline" style="color: red">inline-styled</div>
+<div id="plain">plain</div>
+</body></html>"#;
+                let response = format!(
+                    "HTTP/1.1 200 OK\r\nContent-Type: text/html\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+                    body.len(),
+                    body,
+                );
+                let _ = stream.write_all(response.as_bytes());
+                let _ = stream.shutdown(std::net::Shutdown::Both);
+            });
+        }
+    });
+    format!("http://{}", addr)
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn computed_style_methods_do_not_throw() {
+    std::env::set_var("OBSCURA_ALLOW_PRIVATE_NETWORK", "1");
+    let base = spawn_server();
+
+    let browser = Browser::new().unwrap();
+    let mut page = browser.new_page().await.unwrap();
+    page.goto(&base).await.unwrap();
+
+    let probes = page.evaluate(
+        r#"(function () {
+            function attempt(fn) {
+                try { return String(fn()); } catch (e) { return 'threw: ' + e.message; }
+            }
+            var inline = document.getElementById('inline');
+            var plain = document.getElementById('plain');
+            return {
+                inline_color: attempt(function () { return getComputedStyle(inline).getPropertyValue('color'); }),
+                default_display: attempt(function () { return getComputedStyle(plain).getPropertyValue('display'); }),
+                item: attempt(function () { return getComputedStyle(inline).item(0); }),
+                length: attempt(function () { return getComputedStyle(inline).length; }),
+                css_text: attempt(function () { return getComputedStyle(inline).cssText; }),
+                set_property: attempt(function () { getComputedStyle(inline).setProperty('color', 'blue'); return 'ok'; }),
+                remove_property: attempt(function () { return getComputedStyle(inline).removeProperty('color'); }),
+            };
+        })()"#,
+    );
+
+    let get = |key: &str| {
+        probes[key]
+            .as_str()
+            .unwrap_or_else(|| panic!("probe {key} missing in {probes}"))
+            .to_string()
+    };
+
+    // The jQuery curCSS path: inline value first, engine default as fallback.
+    assert_eq!(get("inline_color"), "red");
+    assert_eq!(get("default_display"), "block");
+
+    // No method reachable through the computed proxy may hit the unbound-this
+    // crash, whatever else it returns.
+    for key in [
+        "inline_color",
+        "default_display",
+        "item",
+        "length",
+        "css_text",
+        "set_property",
+        "remove_property",
+    ] {
+        let value = get(key);
+        assert!(
+            !value.contains("_owner") && !value.contains("is not a function"),
+            "computed style {key} hit the unbound-this crash: {value}"
+        );
+    }
+}


### PR DESCRIPTION
Fixes #635.

`getComputedStyle` wraps the element's live style proxy, and its `get` trap handed pass-through methods back unbound. Called through the computed object, `setProperty`/`removeProperty` then ran `_pull()` with `this` bound to the wrapper, where the declaration's own fields (`_loaded`, `_owner`) miss the style proxy's `has` trap and read as `""` from the CSS lookup, so the call threw `TypeError: this._owner.getAttribute is not a function`.

On current main the `getPropertyValue`/`item`/`length`/`cssText` names already have computed fallbacks ahead of the passthrough (since the geometry/computed-styles work), which fixed the jQuery `.css()`/`.show()` symptom described in the issue for main. This PR closes the remaining hole by binding whatever still falls through to the declaration, and adds a regression test covering every method reachable through the computed proxy so the v0.1.11 failure mode cannot come back.

Test plan:

- `cargo nextest run -p obscura -E 'test(computed_style_methods)'`: fails on main at `set_property` with the `_owner` TypeError, passes with the fix.
- `cargo nextest run -p obscura -p obscura-cdp -p obscura-cli -p obscura-mcp`: 196 passed, 3 skipped.
- Obstacle course: 32/33 with and without this change; the failing `observer-intersection` stage fails identically on unpatched main (verified by stashing the fix and rebuilding), so it is pre-existing and unrelated.