### PR TITLE
fix(js): HTMLSelectElement parity: type, change on assignment, selectedIndex

### DIFF
--- a/crates/obscura-js/js/bootstrap.js
+++ b/crates/obscura-js/js/bootstrap.js
@@ -3572,17 +3572,18 @@ class Element extends Node {
     }
     if (tag === 'select') {
       // Set selected on matching option, clear on others. Puppeteer's
-      // page.select(selector, value) round-trips through this setter.
+      // page.select(selector, value) round-trips through this setter and
+      // dispatches its own input/change events in-page afterwards, like a
+      // real browser: a programmatic value assignment never fires change
+      // itself. Dispatching here fed pages that assign inside a change
+      // handler back into that handler in an infinite loop.
       const wanted = String(v);
       const opts = this.querySelectorAll('option');
-      let matched = false;
       for (let i = 0; i < opts.length; i++) {
         const attrV = opts[i].getAttribute('value');
         const optVal = attrV !== null ? attrV : opts[i].textContent;
-        if (optVal === wanted) { opts[i].selected = true; matched = true; }
-        else { opts[i].selected = false; }
+        opts[i].selected = optVal === wanted;
       }
-      if (matched) try { this.dispatchEvent(new Event('change', { bubbles: true })); } catch (e) {}
       return;
     }
     _formValues[this._nid] = String(v);
@@ -3703,7 +3704,15 @@ class Element extends Node {
   }
   get disabled() { return this.hasAttribute("disabled"); }
   set disabled(v) { if (v) this.setAttribute("disabled", ""); else this.removeAttribute("disabled"); }
-  get type() { return this.getAttribute("type") || (this.localName === "input" ? "text" : ""); }
+  get type() {
+    // select and textarea report fixed IDL types, not the content attribute.
+    // jQuery's select valHook branches on type === "select-one" to decide
+    // scalar vs array .val(); "" here made every single select read as an
+    // array, so value comparisons against strings never matched.
+    if (this.localName === "select") return this.hasAttribute("multiple") ? "select-multiple" : "select-one";
+    if (this.localName === "textarea") return "textarea";
+    return this.getAttribute("type") || (this.localName === "input" ? "text" : "");
+  }
   set type(v) { this.setAttribute("type", v); }
   get name() { return this.getAttribute("name") || ""; }
   set name(v) { this.setAttribute("name", v); }
@@ -3878,7 +3887,9 @@ class Element extends Node {
     for (let i = 0; i < opts.length; i++) {
       if (opts[i].selected || opts[i].hasAttribute('selected')) return i;
     }
-    return opts.length ? 0 : -1;
+    // Only a single select implicitly selects its first option; a multiple
+    // select with nothing chosen idles at -1 like a real browser.
+    return opts.length && !this.hasAttribute('multiple') ? 0 : -1;
   }
   set selectedIndex(v) {
     const opts = this.options;

--- a/crates/obscura/tests/select_semantics.rs
+++ b/crates/obscura/tests/select_semantics.rs
@@ -1,0 +1,101 @@
+// Select-element parity needed by jQuery and WooCommerce variation forms:
+//
+// - A single select with no explicit `selected` attribute implicitly selects
+//   its first option, so selectedIndex is 0, not -1 (jQuery reads selects
+//   through selectedIndex; -1 made $(select).val() return null).
+// - select.type is the fixed IDL string "select-one"/"select-multiple"
+//   (jQuery's valHook branches on it; "" made single selects read as arrays).
+// - Programmatic value assignment must not fire change. Dispatching it fed
+//   pages that assign inside a change handler back into that handler forever
+//   (WooCommerce's variation form hit the stack limit).
+
+use std::io::{Read, Write};
+
+use obscura::Browser;
+
+fn spawn_server() -> String {
+    let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+    let addr = listener.local_addr().unwrap();
+    std::thread::spawn(move || {
+        for incoming in listener.incoming() {
+            let Ok(mut stream) = incoming else {
+                continue;
+            };
+            std::thread::spawn(move || {
+                let mut request = [0u8; 2048];
+                let _ = stream.read(&mut request);
+                let body = r#"<!doctype html><html><head><title>fixture</title></head><body>
+<select id="single"><option value="a">A</option><option value="b">B</option></select>
+<select id="multi" multiple><option value="x">X</option></select>
+<select id="empty"></select>
+</body></html>"#;
+                let response = format!(
+                    "HTTP/1.1 200 OK\r\nContent-Type: text/html\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+                    body.len(),
+                    body,
+                );
+                let _ = stream.write_all(response.as_bytes());
+                let _ = stream.shutdown(std::net::Shutdown::Both);
+            });
+        }
+    });
+    format!("http://{}", addr)
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn select_defaults_match_browser_semantics() {
+    std::env::set_var("OBSCURA_ALLOW_PRIVATE_NETWORK", "1");
+    let base = spawn_server();
+
+    let browser = Browser::new().unwrap();
+    let mut page = browser.new_page().await.unwrap();
+    page.goto(&base).await.unwrap();
+
+    let probes = page.evaluate(
+        r#"(function () {
+            var single = document.getElementById('single');
+            var multi = document.getElementById('multi');
+            var empty = document.getElementById('empty');
+            var changes = 0;
+            single.addEventListener('change', function () { changes++; });
+            single.value = 'b';
+            return {
+                single_index: single.selectedIndex,
+                single_value_after_set: single.value,
+                multi_index: multi.selectedIndex,
+                empty_index: empty.selectedIndex,
+                single_type: single.type,
+                multi_type: multi.type,
+                changes_after_assignment: changes,
+            };
+        })()"#,
+    );
+
+    assert_eq!(probes["single_value_after_set"], "b");
+    assert_eq!(probes["single_index"], 1);
+    assert_eq!(probes["multi_index"], -1);
+    assert_eq!(probes["empty_index"], -1);
+    assert_eq!(probes["single_type"], "select-one");
+    assert_eq!(probes["multi_type"], "select-multiple");
+    assert_eq!(probes["changes_after_assignment"], 0);
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn select_without_explicit_selection_defaults_to_first_option() {
+    std::env::set_var("OBSCURA_ALLOW_PRIVATE_NETWORK", "1");
+    let base = spawn_server();
+
+    let browser = Browser::new().unwrap();
+    let mut page = browser.new_page().await.unwrap();
+    page.goto(&base).await.unwrap();
+
+    let probes = page.evaluate(
+        r#"(function () {
+            var single = document.getElementById('single');
+            return { index: single.selectedIndex, value: single.value };
+        })()"#,
+    );
+
+    assert_eq!(probes["index"], 0);
+    assert_eq!(probes["value"], "a");
+}


### PR DESCRIPTION
Fixes #638. Follow-up to #635/#636: three HTMLSelectElement deviations from the spec that break code reading or writing selects through the standard IDL surface, and that can drive event-handler recursion on real pages.

- `select.type` returned `""` instead of the fixed IDL string `"select-one"`/`"select-multiple"`. Libraries branch on it to decide scalar vs array value handling (jQuery's select valHook is the common case), so a single select read back as an array (`["a"]` instead of `"a"`) and string comparisons against the value never matched. `textarea` now reports `"textarea"`, the same fixed-string contract.
- Programmatic value assignment on a select dispatched `change`. Real browsers reserve `change` for user interaction; a page that assigns a select value inside a change handler re-enters that handler, and with state that never converges this recurses to `RangeError: Maximum call stack size exceeded`. Puppeteer's `page.select` dispatches its own input/change in-page after setting values, so nothing relied on the setter doing it.
- `selectedIndex` returned 0 for a `multiple` select with nothing chosen; the implicit first-option selection only applies to single selects.

Test plan:

- New `crates/obscura/tests/select_semantics.rs` covers all three (type strings, no change on assignment, implicit selection single vs multiple vs empty). The type and change assertions fail on main, pass with the fix.
- `cargo nextest run -p obscura -p obscura-cdp -p obscura-cli -p obscura-mcp`: 197 passed, 3 skipped.
- Obstacle course: unchanged vs unpatched main (the `observer-intersection` failure is pre-existing, see #636's test plan).