### PR TITLE
fix(net): canonicalize the cookie domain on every jar key

### DIFF
--- a/crates/obscura-mcp/src/lib.rs
+++ b/crates/obscura-mcp/src/lib.rs
@@ -1300,7 +1300,7 @@ fn tool_get_cookies(args: &Value, state: &BrowserState) -> Result<String, String
     let domain_filter = args.get("domain").and_then(Value::as_str);
     let cookies = state.context.cookie_jar.get_all_cookies();
     let lines: Vec<String> = cookies.iter()
-        .filter(|c| domain_filter.is_none_or(|d| c.domain == d || c.domain.trim_start_matches('.') == d))
+        .filter(|c| domain_filter.is_none_or(|d| c.domain == obscura_net::canonical_domain(d)))
         .map(|c| serde_json::to_string(&json!({
             "name": c.name,
             "value": c.value,

--- a/crates/obscura-net/src/cookies.rs
+++ b/crates/obscura-net/src/cookies.rs
@@ -16,6 +16,14 @@ fn normalize_same_site(value: &str) -> String {
     .to_string()
 }
 
+/// The jar key for a domain. RFC 6265 4.1.2.3 ignores a leading dot, and hosts are
+/// case-insensitive, so both spellings have to collapse before they reach the map.
+/// Not intended for `domain_matches`, which compares without allocating on the
+/// per-request path.
+pub fn canonical_domain(domain: &str) -> String {
+    domain.trim().trim_start_matches('.').to_lowercase()
+}
+
 pub struct CookieJar {
     /// domain -> (name, path) -> entry. RFC 6265 §5.3 identifies a cookie by
     /// (name, domain, path); the outer map scopes by domain and the inner key
@@ -70,7 +78,7 @@ impl CookieJar {
                 if let Some((key, val)) = attr.split_once('=') {
                     match key.trim().to_lowercase().as_str() {
                         "domain" => {
-                            domain_attr = Some(val.trim().trim_start_matches('.').to_lowercase());
+                            domain_attr = Some(canonical_domain(val));
                         }
                         "path" => {
                             path = val.trim().to_string();
@@ -219,20 +227,16 @@ impl CookieJar {
             .unwrap_or_default()
             .as_secs() as i64;
         for cookie in cookies {
+            // RFC 6265 4.1.2.3: the leading dot is ignored. The Set-Cookie path already strips
+            // it, but this code did not, which is why one cookie became two entries.
+            let domain = canonical_domain(&cookie.domain);
             if cookie.expires.is_some_and(|expires| {
                 expires == 0 || (expires > 0 && expires <= now)
             }) {
-                let domains_to_try = [
-                    cookie.domain.clone(),
-                    format!(".{}", cookie.domain.trim_start_matches('.')),
-                    cookie.domain.trim_start_matches('.').to_string(),
-                ];
-                for domain in &domains_to_try {
-                    if let Some(domain_cookies) = jar.get_mut(domain) {
-                        domain_cookies.retain(|_key, entry| {
-                            entry.name != cookie.name || entry.path != cookie.path
-                        });
-                    }
+                if let Some(domain_cookies) = jar.get_mut(&domain) {
+                    domain_cookies.retain(|_key, entry| {
+                        entry.name != cookie.name || entry.path != cookie.path
+                    });
                 }
                 continue;
             }
@@ -246,7 +250,7 @@ impl CookieJar {
                 name: cookie.name.clone(),
                 value: cookie.value,
                 path: cookie.path.clone(),
-                domain: cookie.domain.clone(),
+                domain: domain.clone(),
                 // CDP/persisted import is trusted; honor the explicit domain as
                 // domain-scoped (matches the prior behavior).
                 host_only: false,
@@ -255,7 +259,7 @@ impl CookieJar {
                 expires,
                 same_site,
             };
-            jar.entry(cookie.domain).or_default().insert((cookie.name, cookie.path), entry);
+            jar.entry(domain).or_default().insert((cookie.name, cookie.path), entry);
         }
     }
 
@@ -322,7 +326,7 @@ impl CookieJar {
                 if let Some((key, val)) = attr.split_once('=') {
                     match key.trim().to_lowercase().as_str() {
                         "domain" => {
-                            domain_attr = Some(val.trim().trim_start_matches('.').to_lowercase());
+                            domain_attr = Some(canonical_domain(val));
                         }
                         "path" => {
                             path = val.trim().to_string();
@@ -400,17 +404,8 @@ impl CookieJar {
             for domain_cookies in cookies.values_mut() {
                 domain_cookies.retain(|_k, e| e.name != name);
             }
-        } else {
-            let domains_to_try = [
-                domain.to_string(),
-                format!(".{}", domain.trim_start_matches('.')),
-                domain.trim_start_matches('.').to_string(),
-            ];
-            for d in &domains_to_try {
-                if let Some(domain_cookies) = cookies.get_mut(d.as_str()) {
-                    domain_cookies.retain(|_k, e| e.name != name);
-                }
-            }
+        } else if let Some(domain_cookies) = cookies.get_mut(canonical_domain(domain).as_str()) {
+            domain_cookies.retain(|_k, e| e.name != name);
         }
     }
 
@@ -424,17 +419,8 @@ impl CookieJar {
             for domain_cookies in cookies.values_mut() {
                 domain_cookies.retain(|_k, e| !(e.name == name && matches_path(&e.path)));
             }
-        } else {
-            let domains_to_try = [
-                domain.to_string(),
-                format!(".{}", domain.trim_start_matches('.')),
-                domain.trim_start_matches('.').to_string(),
-            ];
-            for d in &domains_to_try {
-                if let Some(domain_cookies) = cookies.get_mut(d.as_str()) {
-                    domain_cookies.retain(|_k, e| !(e.name == name && matches_path(&e.path)));
-                }
-            }
+        } else if let Some(domain_cookies) = cookies.get_mut(canonical_domain(domain).as_str()) {
+            domain_cookies.retain(|_k, e| !(e.name == name && matches_path(&e.path)));
         }
     }
 
@@ -575,13 +561,13 @@ fn parse_http_date(s: &str) -> Result<u64, ()> {
 /// blocks the reported cross-domain attack, and single-label suffixes (com,
 /// local) are rejected.
 fn resolve_cookie_domain(origin_host: &str, domain_attr: Option<&str>) -> Option<(String, bool)> {
-    let origin = origin_host.trim().trim_start_matches('.').to_lowercase();
+    let origin = canonical_domain(origin_host);
     if origin.is_empty() {
         return None;
     }
     let dom = match domain_attr {
         None => return Some((origin, true)),
-        Some(raw) => raw.trim().trim_start_matches('.').to_lowercase(),
+        Some(raw) => canonical_domain(raw),
     };
     if dom.is_empty() || dom == origin {
         return Some((origin, true));
@@ -886,6 +872,97 @@ mod tests {
         let cookies = jar.get_all_cookies();
         assert_eq!(cookies.len(), 1);
         assert_eq!(cookies[0].expires, None);
+    }
+
+    fn cdp(name: &str, value: &str, domain: &str, path: &str) -> CookieInfo {
+        CookieInfo {
+            name: name.to_string(),
+            value: value.to_string(),
+            domain: domain.to_string(),
+            path: path.to_string(),
+            secure: false,
+            http_only: false,
+            same_site: String::new(),
+            expires: None,
+        }
+    }
+
+    fn marker(jar: &CookieJar) -> Vec<CookieInfo> {
+        jar.get_all_cookies().into_iter().filter(|c| c.name == "marker").collect()
+    }
+
+    #[test]
+    fn test_cdp_domain_leading_dot_is_not_a_separate_cookie() {
+        // The two entrances disagreed: CDP retained the dot, while Set-Cookie stripped it.
+        let jar = CookieJar::new();
+        let url = Url::parse("https://app.example.com/").unwrap();
+
+        jar.set_cookies_from_cdp(vec![cdp("marker", "stale", ".example.com", "/")]);
+        jar.set_cookie("marker=fresh; Domain=example.com; Path=/", &url);
+
+        assert_eq!(marker(&jar).len(), 1, "one cookie, one entry, got: {:?}", marker(&jar));
+        let header = jar.get_cookie_header(&url);
+        assert_eq!(header.matches("marker=").count(), 1, "header: {header:?}");
+        assert!(header.contains("marker=fresh"), "newer value must win: {header:?}");
+    }
+
+    #[test]
+    fn test_cdp_stored_domain_field_carries_no_dot() {
+        // The dotted spelling comes LAST. That is why an implementation which only
+        // canonicalizes the map key and leaves `entry.domain` raw also fails here.
+        let jar = CookieJar::new();
+        jar.set_cookies_from_cdp(vec![cdp("marker", "one", "example.com", "/")]);
+        jar.set_cookies_from_cdp(vec![cdp("marker", "two", ".EXAMPLE.com", "/")]);
+
+        let all = marker(&jar);
+        assert_eq!(all.len(), 1, "both spellings collapse, got: {all:?}");
+        assert_eq!(all[0].domain, "example.com", "entry.domain is canonical, got: {:?}", all[0].domain);
+        assert_eq!(all[0].value, "two", "newer value must win");
+    }
+
+    #[test]
+    fn test_cdp_domain_leading_dot_repairs_a_persisted_store() {
+        // load_from_file() imports through here, so an old store must not resurrect the
+        // duplicate.
+        let jar = CookieJar::new();
+        jar.set_cookies_from_cdp(vec![
+            cdp("marker", "one", ".example.com", "/"),
+            cdp("marker", "two", "example.com", "/"),
+        ]);
+        assert_eq!(marker(&jar).len(), 1, "got: {:?}", marker(&jar));
+    }
+
+    #[test]
+    fn test_cdp_zero_expiry_deletes_across_domain_spellings() {
+        // The insert canonicalizes the key, so every delete path has to canonicalize its
+        // lookup too. Otherwise the cookie becomes unreachable and keeps going out.
+        for (stored, deleted) in [
+            ("Example.COM", "Example.COM"),
+            (".example.com", "example.com"),
+            ("example.com", ".EXAMPLE.com"),
+        ] {
+            let jar = CookieJar::new();
+            jar.set_cookies_from_cdp(vec![cdp("marker", "current", stored, "/")]);
+            let mut gone = cdp("marker", "", deleted, "/");
+            gone.expires = Some(0);
+            jar.set_cookies_from_cdp(vec![gone]);
+            assert!(marker(&jar).is_empty(), "stored {stored:?}, deleted {deleted:?}: {:?}", marker(&jar));
+        }
+    }
+
+    #[test]
+    fn test_delete_cookie_canonicalizes_its_lookup() {
+        for spelling in ["Example.COM", ".example.com", "example.com"] {
+            let jar = CookieJar::new();
+            jar.set_cookies_from_cdp(vec![cdp("marker", "current", "Example.COM", "/")]);
+            jar.delete_cookie("marker", spelling);
+            assert!(marker(&jar).is_empty(), "delete_cookie({spelling:?}): {:?}", marker(&jar));
+
+            let jar = CookieJar::new();
+            jar.set_cookies_from_cdp(vec![cdp("marker", "current", "Example.COM", "/")]);
+            jar.delete_cookies_filtered("marker", spelling, Some("/"));
+            assert!(marker(&jar).is_empty(), "delete_cookies_filtered({spelling:?}): {:?}", marker(&jar));
+        }
     }
 
     #[test]

--- a/crates/obscura-net/src/lib.rs
+++ b/crates/obscura-net/src/lib.rs
@@ -12,7 +12,7 @@ pub use client::{
     ObscuraNetError, RequestCallback, RequestCredentials, RequestInfo, RequestMode,
     ResourceRequest, ResourceType, Response, ResponseCallback, SsrfGuardResolver,
 };
-pub use cookies::{default_cookie_path, CookieInfo, CookieJar};
+pub use cookies::{canonical_domain, default_cookie_path, CookieInfo, CookieJar};
 pub use encoding::{
     decode_non_html, decode_response, decode_response_with_name, decode_with_label, label_name,
     url_encode_query,


### PR DESCRIPTION
Fixes #648

## What changed

`Network.setCookies` retained the leading dot and the letter case, while the `Set-Cookie` path stripped the dot. The same cookie, when set via both entrances, resulted in two jar entries, and both were sent out in a single request. RFC 6265 4.1.2.3 ignores the dot, and hosts are case-insensitive. A helper therefore now constructs every jar key: the CDP import, the `Set-Cookie` path, and the JS path, both deletion paths, and the MCP domain filter. This also eliminates three copies of a search across three different spellings, which existed solely to mask the inconsistency.

`domain_matches` retains its comparison without allocation. It sits on the per-request path and ignores dot and case anyway.

`load_from_file` imports via `set_cookies_from_cdp`, so a persisted store with dotted domains is repaired on load.

## Validation

```
cargo nextest run --release --features render --no-fail-fast                  1411 passed
cargo nextest run --release --features render,stealth --no-fail-fast     1413/1414 passed
cargo nextest run --release --no-default-features -p obscura-net -p obscura-mcp  99 passed
cargo build --release -p obscura-cli --bins --features render                   clean
cargo build --release -p obscura-cli --bins --features render,stealth           clean
cargo build --release -p obscura-cli --bins --no-default-features               clean
obstacle course, --runs 1 --warmup 0                                            32/33
```

The stealth run is included because `wreq_client.rs` uses the same cookie jar and calls `set_cookie`. It therefore exercises the changed path.

Five tests in `cookies.rs` cover the defect. Each was tested against an intentionally broken version:

- Storing the raw domain in `entry.domain` causes `test_cdp_stored_domain_field_carries_no_dot` to fail
- Failing to canonicalize one of the deletion paths causes `test_cdp_zero_expiry_deletes_across_domain_spellings` and `test_delete_cookie_canonicalizes_its_lookup` to fail

Two failures also occur on `main` and are not caused by this change:

- The obstacle course stage `observer-intersection` (`expected 'io:50', got ''`). The remaining 32 pass.
- `wreq_client::tests::stealth_client_decodes_gzip_response`. Its fixture listens on 127.0.0.1, and the SSRF guard blocks this unless `OBSCURA_ALLOW_PRIVATE_NETWORK` is set. If it is set, `client::ssrf_tests::validate_url_blocks_unspecified_and_allows_public` fails instead, because it requires that `0.0.0.0` be rejected. Both were measured against `main` at 94374e6.

## Rendering

Not applicable.

## Performance

`get_cookie_header` and `domain_matches`, the per-request path, remain unaffected. The change adds one allocation per cookie on import and one per delete call. Median latency of the obstacle course: 3034.2 ms with the change, 3030.5 ms on `main`, inside the noise floor.

## Checklist

- [x] The change is focused and does not remove existing behavior without justification.
- [x] Tests cover the failure or feature.
- [x] Existing tests pass, including render and no-render configurations when affected.
- [x] I checked for CPU, latency, and memory regressions.
- [x] Public API or user-facing behavior changes are documented.
