### PR TITLE
fix(js): make Document.createEvent reject unknown interface names

### DIFF
--- a/crates/obscura-js/js/bootstrap.js
+++ b/crates/obscura-js/js/bootstrap.js
@@ -4904,15 +4904,11 @@ class Document extends Node {
   // Legacy DOM Level 2 event factory. Spec returns an event of the requested
   // class with an empty type until init*Event() is called. We previously
   // returned a generic Event for every type, which broke libraries that call
-  // createEvent('CustomEvent').initCustomEvent(...) — see issue #41.
+  // createEvent('CustomEvent').initCustomEvent(...), see issue #41. The four
+  // legacy aliases Event/Events/HTMLEvents/SVGEvents map to a plain Event;
+  // unknown names throw NotSupportedError (issue #610).
   createEvent(type) {
     const normalized = String(type || '').toLowerCase();
-    if (normalized === 'promiserejectionevent') {
-      throw new DOMException(
-        "The provided event type ('PromiseRejectionEvent') is invalid",
-        'NotSupportedError'
-      );
-    }
     const map = {
       'customevent': CustomEvent, 'customevents': CustomEvent,
       'mouseevent': MouseEvent,   'mouseevents': MouseEvent,
@@ -4928,8 +4924,16 @@ class Document extends Node {
       'animationevent': AnimationEvent,
       'transitionevent': TransitionEvent,
       'storageevent': StorageEvent,
+      'event': Event, 'events': Event,
+      'htmlevents': Event, 'svgevents': Event,
     };
-    const Cls = map[normalized] || Event;
+    const Cls = map[normalized];
+    if (!Cls) {
+      throw new DOMException(
+        `The provided event type ('${type}') is invalid`,
+        'NotSupportedError'
+      );
+    }
     return new Cls('');
   }
   createRange() { return new Range(); }

--- a/crates/obscura-js/src/runtime.rs
+++ b/crates/obscura-js/src/runtime.rs
@@ -13984,12 +13984,42 @@ mod tests {
     }
 
     #[test]
-    fn test_create_event_unknown_type_returns_event() {
+    fn test_create_event_unknown_type_throws_not_supported() {
         let mut rt = setup_runtime("<html><body></body></html>");
-        let kind = rt
-            .evaluate("document.createEvent('NotARealType') instanceof Event")
+        let result = rt
+            .evaluate(
+                r#"(() => {
+                    try {
+                        document.createEvent('NotARealType');
+                        return null;
+                    } catch (error) {
+                        return [error.name, error instanceof DOMException];
+                    }
+                })()"#,
+            )
             .unwrap();
-        assert_eq!(kind, serde_json::json!(true));
+        assert_eq!(
+            result,
+            serde_json::json!(["NotSupportedError", true])
+        );
+    }
+
+    #[test]
+    fn test_create_event_legacy_aliases_return_event() {
+        let mut rt = setup_runtime("<html><body></body></html>");
+        let result = rt
+            .evaluate(
+                r#"(() => {
+                    return [
+                        document.createEvent('Event') instanceof Event,
+                        document.createEvent('Events') instanceof Event,
+                        document.createEvent('HTMLEvents') instanceof Event,
+                        document.createEvent('SVGEvents') instanceof Event
+                    ];
+                })()"#,
+            )
+            .unwrap();
+        assert_eq!(result, serde_json::json!([true, true, true, true]));
     }
 
     #[test]


### PR DESCRIPTION
Unknown interface names passed to Document.createEvent now throw a DOMException named NotSupportedError instead of silently returning a generic Event. The four legacy aliases Event, Events, HTMLEvents and SVGEvents map to a plain Event.

Fixes #610.

Verified with `cargo nextest run -p obscura-js`: 283/283 passing, including the updated unknown-type test and new legacy-alias coverage.