### PR TITLE
fix(net): enable emulation compression for stealth requests

### DIFF
--- a/crates/obscura-net/Cargo.toml
+++ b/crates/obscura-net/Cargo.toml
@@ -24,7 +24,7 @@ futures-util = { version = "0.3", optional = true }
 # Emulation builder reshuffled). A caret requirement let a fresh resolve pull a
 # newer, incompatible rc and broke `cargo build --features stealth` (issue #234).
 # Pin exact versions so the build always resolves to the API wreq_client.rs targets.
-wreq-util = { version = "=3.0.0-rc.12", optional = true }
+wreq-util = { version = "=3.0.0-rc.12", optional = true, features = ["emulation-compression"] }
 
 [dev-dependencies]
 socket2 = "0.6"


### PR DESCRIPTION
## Summary

- enable wreq-util emulation-compression for the pinned stealth transport dependency

Source fork commit: 4f9dd01.

## Validation

- the local release check started but exceeded the five-minute tool window during dependency compilation; no compiler error was returned before the timeout.