### PR TITLE
fix(cdp): report same-document SPA routes after clicks

### DIFF
--- a/crates/obscura-browser/src/fork_virtual_url.rs
+++ b/crates/obscura-browser/src/fork_virtual_url.rs
@@ -1,0 +1,43 @@
+//! Fork-only: adopt a URL the page routed to itself.
+//!
+//! A single page app answers a click by calling `history.pushState` and
+//! rendering the next view in place. `bootstrap.js` tracks that in
+//! `__virtualUrl` so `location.href` reads correctly, but nothing on the Rust
+//! side ever looked at it, so the page had moved on while `page.url()` still
+//! reported the old document. To a CDP client that is a click that did nothing,
+//! and `tools/ab/clicklocal.mjs` reports it as `spa route: FAILED`.
+//!
+//! Ported from fork commit `d7dca7a`. Kept out of `page.rs` so an upstream
+//! rewrite of that file does not touch it; Rust allows an inherent impl in any
+//! module of the defining crate, so the call site still reads
+//! `self.sync_virtual_url()`.
+
+use url::Url;
+
+use crate::page::Page;
+
+impl Page {
+    /// Adopt a URL the page routed to itself, without fetching anything.
+    ///
+    /// Returns whether the URL changed.
+    pub fn sync_virtual_url(&mut self) -> bool {
+        let Some(js) = self.js.as_mut() else {
+            return false;
+        };
+        let Ok(virtual_url) = js.evaluate("globalThis.__virtualUrl || ''") else {
+            return false;
+        };
+        let Some(virtual_url) = virtual_url.as_str().filter(|url| !url.is_empty()) else {
+            return false;
+        };
+        let Ok(parsed) = Url::parse(virtual_url) else {
+            return false;
+        };
+        if self.url.as_ref() == Some(&parsed) {
+            return false;
+        }
+        self.url = Some(parsed);
+        self.push_history(self.url_string());
+        true
+    }
+}

--- a/crates/obscura-browser/src/lib.rs
+++ b/crates/obscura-browser/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod context;
+mod fork_virtual_url;
 pub mod lifecycle;
 pub mod page;
 #[cfg(feature = "render")]

--- a/crates/obscura-browser/src/page.rs
+++ b/crates/obscura-browser/src/page.rs
@@ -3682,7 +3682,9 @@ impl Page {
             self.push_history(self.url_string());
             Ok(true)
         } else {
-            Ok(false)
+            // Fork: a page that routed itself through history has still
+            // navigated. See fork_virtual_url.rs.
+            Ok(self.sync_virtual_url())
         }
     }
 

--- a/crates/obscura-cdp/src/domains/input.rs
+++ b/crates/obscura-cdp/src/domains/input.rs
@@ -207,7 +207,32 @@ pub async fn handle(
                         shift_key = shift_key,
                     );
                     page.evaluate(&code);
-                    page.process_pending_navigation().await.map_err(|e| e.to_string())?;
+                    let moved = page
+                        .process_pending_navigation()
+                        .await
+                        .map_err(|e| e.to_string())?;
+                    // Fork: a single page app answers a click by routing itself,
+                    // with no document fetch. The client still has to be told the
+                    // frame moved, or the click looks like it did nothing.
+                    if moved {
+                        let url = page.url_string();
+                        let frame_id = page.frame_id.clone();
+                        ctx.pending_events.push(crate::types::CdpEvent {
+                            method: "Page.frameNavigated".into(),
+                            params: json!({
+                                "frame": {
+                                    "id": frame_id,
+                                    "url": url,
+                                    "domainAndRegistry": "",
+                                    "securityOrigin": "",
+                                    "mimeType": "text/html",
+                                    "adFrameStatus": { "adFrameType": "none" },
+                                },
+                                "type": "Navigation",
+                            }),
+                            session_id: Some(session_id.clone().unwrap_or_default()),
+                        });
+                    }
                 }
             } else if event_type == "mouseWheel" {
                 let delta_x = params.get("deltaX").and_then(|v| v.as_f64()).unwrap_or(0.0);


### PR DESCRIPTION
## Summary

- sync the virtual URL into the Rust page URL after click-driven history changes
- emit Page.frameNavigated for same-document route changes
- keep normal navigation handling unchanged

Source fork commit: 20d8b87.

## Validation

- cargo check --release -p obscura-cdp --features render passed on the clean origin/main-based branch.