### PR TITLE
fix(js): use the stealth transport for ES modules

### DIFF
--- a/crates/obscura-js/src/module_loader.rs
+++ b/crates/obscura-js/src/module_loader.rs
@@ -224,12 +224,28 @@ impl ModuleLoader for ObscuraModuleLoader {
                     .http_client
                     .clone()
                     .ok_or_else(|| "No http_client wired to module loader".to_string())?;
-                Ok((client, state.callbacks.clone()))
+                // Fork: in stealth mode an ES module must be fetched over the
+                // same transport as the document. Upstream sends it through the
+                // plain reqwest client, so a `type="module"` script arrives with
+                // a different TLS fingerprint and none of the browser identity
+                // headers, while the HTML that referenced it came over wreq.
+                // That cross-transport mismatch is trivially detectable.
+                #[cfg(feature = "stealth")]
+                let stealth = state.stealth_client.clone();
+                #[cfg(not(feature = "stealth"))]
+                let stealth: Option<std::sync::Arc<()>> = None;
+                Ok((client, stealth, state.callbacks.clone()))
             })(),
             None => self
                 .standalone_client
                 .clone()
-                .map(|client| (client, None))
+                .map(|client| {
+                    #[cfg(feature = "stealth")]
+                    let stealth = None;
+                    #[cfg(not(feature = "stealth"))]
+                    let stealth: Option<std::sync::Arc<()>> = None;
+                    (client, stealth, None)
+                })
                 .ok_or_else(|| "No network context wired to module loader".to_string()),
         };
 
@@ -245,17 +261,43 @@ impl ModuleLoader for ObscuraModuleLoader {
             );
 
             match page_network {
-                Ok((client, callbacks)) => {
+                Ok((client, stealth, callbacks)) => {
                     let requested = ModuleSpecifier::parse(&url)
                         .map_err(|e| io_err(format!("Invalid module URL {}: {}", url, e)))?;
-                    let resp = client
-                        .fetch_resource_with_callbacks(
-                            &requested,
-                            obscura_net::ResourceRequest::module_script(&document_url, &referrer),
-                            callbacks.as_deref(),
-                        )
-                        .await
-                        .map_err(|e| io_err(format!("Failed to fetch module {}: {}", url, e)))?;
+                    let request =
+                        obscura_net::ResourceRequest::module_script(&document_url, &referrer);
+                    #[cfg(feature = "stealth")]
+                    let resp = match stealth {
+                        Some(stealth) => stealth
+                            .fetch_resource_with_callbacks(
+                                &requested,
+                                request,
+                                callbacks.as_deref(),
+                            )
+                            .await,
+                        None => {
+                            client
+                                .fetch_resource_with_callbacks(
+                                    &requested,
+                                    request,
+                                    callbacks.as_deref(),
+                                )
+                                .await
+                        }
+                    }
+                    .map_err(|e| io_err(format!("Failed to fetch module {}: {}", url, e)))?;
+                    #[cfg(not(feature = "stealth"))]
+                    let resp = {
+                        let _ = &stealth;
+                        client
+                            .fetch_resource_with_callbacks(
+                                &requested,
+                                request,
+                                callbacks.as_deref(),
+                            )
+                            .await
+                            .map_err(|e| io_err(format!("Failed to fetch module {}: {}", url, e)))?
+                    };
                     if !(200..=299).contains(&resp.status) {
                         return Err(io_err(format!(
                             "Module {} returned HTTP {}",


### PR DESCRIPTION
## Summary

- load ES modules through the page stealth client when stealth mode is enabled
- preserve the existing non-stealth loader path
- keep module fetching aligned with the page transport and profile

Source fork commit: fa23762.

## Validation

- the Rust change was reviewed against the existing module loader paths
- the local release check reached the V8 build but exceeded the tool window without a compiler error; CI should provide the full build result.