### PR TITLE
fix(js): resolve relative URLs against the document base URL

### DIFF
--- a/crates/obscura-js/js/bootstrap.js
+++ b/crates/obscura-js/js/bootstrap.js
@@ -1920,20 +1920,7 @@ class Node {
   get ownerDocument() { return globalThis.document; }
   // https://dom.spec.whatwg.org/#dom-node-baseuri
   get baseURI() {
-    try {
-      const doc = globalThis.document;
-      const docUrl = (doc && doc.URL) || "";
-      const baseEl = (doc && doc.querySelector) ? doc.querySelector("base[href]") : null;
-      if (baseEl) {
-        const href = baseEl.getAttribute("href");
-        if (href) {
-          return docUrl ? new URL(href, docUrl).href : href;
-        }
-      }
-      return docUrl;
-    } catch (e) {
-      return "";
-    }
+    try { return _documentBase(); } catch (e) { return ""; }
   }
   get textContent() { return _domParse("text_content", this._nid) ?? ""; }
   set textContent(v) {
@@ -2492,10 +2479,25 @@ function _applyDocQueryEncoding(u) {
   return u;
 }
 
+// The base for relative URLs. <base href> overrides the document URL, so an app in a sub-path
+// requests "chunk-A.js" under its current route and gets 404.
+// https://html.spec.whatwg.org/multipage/urls-and-fetching.html#document-base-url
+// Returns "" when there is no document, so each call site keeps its own fallback.
+function _documentBase() {
+  // history.pushState moves the document URL without reaching the Rust side. Then the base must
+  // be built here, or every relative URL resolves against the pre-routing address.
+  const virtual = globalThis.__virtualUrl;
+  if (virtual) {
+    const raw = _domParse("document_base_href");
+    if (!raw) return virtual;
+    try { return new URL(raw, virtual).href; } catch (e) { return virtual; }
+  }
+  return _domParse("document_base_url") || _domParse("document_url") || "";
+}
 // HTMLHyperlinkElementUtils helpers (the <a>/<area> URL-decomposition members).
 // The element's href attribute is parsed against the document base URL via the
 // WHATWG url op; component getters read it, setters rewrite the href attribute.
-function _anchorBase() { return _domParse("document_url") || "about:blank"; }
+function _anchorBase() { return _documentBase() || "about:blank"; }
 function _elemHrefURL(el) {
   const raw = el.getAttribute('href');
   if (raw === null || raw === undefined) return null;
@@ -3834,6 +3836,15 @@ class Element extends Node {
       const r = _urlResolveOp(raw, _anchorBase());
       return r !== null ? r : raw;
     }
+    if (ln === 'base') {
+      // https://html.spec.whatwg.org/multipage/semantics.html#dom-base-href
+      // Against the fallback base URL, not the document base URL: a base element is not affected
+      // by other base elements or itself. Applications read this to determine their own base.
+      const raw = this.getAttribute('href');
+      if (raw === null) return '';
+      const r = _urlResolveOp(raw, _domParse("document_url") || "about:blank");
+      return r !== null ? r : raw;
+    }
     return this.getAttribute("href") || "";
   }
   set href(v) { this.setAttribute("href", v); }
@@ -3881,7 +3892,7 @@ class Element extends Node {
     // value (issue #255). getAttribute("src") still returns the literal.
     const v = this.getAttribute("src");
     if (!v) return "";
-    try { return new URL(v, globalThis.location?.href || "about:blank").href; }
+    try { return new URL(v, _documentBase() || "about:blank").href; }
     catch (e) { return v; }
   }
   set src(v) {
@@ -3980,8 +3991,9 @@ class Element extends Node {
     return this._iframeWin;
   }
   get action() {
+    // A missing action falls back to the document URL, a present one resolves against the base.
     const action = this.getAttribute("action") || _domParse("document_url") || "";
-    try { return new URL(action, _domParse("document_url") || "about:blank").href; } catch(e) { return action; }
+    try { return new URL(action, _documentBase() || "about:blank").href; } catch(e) { return action; }
   }
   set action(v) { this.setAttribute("action", v); }
   get method() { return this.getAttribute("method") || "get"; }
@@ -6108,7 +6120,7 @@ function _resolveUrl(url) {
   url = String(url);
   if (!url) return url;
   if (url.startsWith('http://') || url.startsWith('https://') || url.startsWith('about:')) return url;
-  try { return new URL(url, _domParse("document_url") || "about:blank").href; } catch(e) { return url; }
+  try { return new URL(url, _documentBase() || "about:blank").href; } catch(e) { return url; }
 }
 // `__virtualUrl` is set by `history.pushState`/`replaceState` (and cleared by
 // any real navigation). When set, `location.href` and friends read it instead

--- a/crates/obscura-js/src/ops.rs
+++ b/crates/obscura-js/src/ops.rs
@@ -172,6 +172,10 @@ pub struct ObscuraState {
     /// completions use this to discard bytes and lifecycle results belonging
     /// to a navigation that has already been replaced.
     pub document_generation: u64,
+    /// Cached document base URL. Computing it walks the tree and runs the selector engine, and
+    /// the JS layer asks for it on every relative URL, including the URL parts of `<a>`.
+    /// Interior mutability so the read path keeps its shared borrow.
+    pub base_url_cache: RefCell<Option<BaseUrlCache>>,
     /// Final image/font-aware layout shared by CSSOM geometry and screenshots.
     /// DOM/style/viewport changes clear this value but retain resource bytes.
     #[cfg(feature = "render")]
@@ -311,6 +315,7 @@ impl ObscuraState {
             page_in_flight: Arc::new(std::sync::atomic::AtomicU32::new(0)),
             activity_generation: 0,
             document_generation: 0,
+            base_url_cache: RefCell::new(None),
             #[cfg(feature = "render")]
             prepared_render: None,
             #[cfg(feature = "render")]
@@ -1297,6 +1302,18 @@ fn op_dom_inner(shared: SharedState, cmd: String, arg1: String, arg2: String) ->
             serde_json::to_string(&title).unwrap_or("\"\"".into())
         }
         "document_url" => serde_json::to_string(&gs.url).unwrap_or("\"\"".into()),
+        // The base for relative URLs. It differs from document_url exactly when the page carries
+        // a <base href>, and that is the point: HTML resolves against the base, not the document.
+        "document_base_url" => serde_json::to_string(
+            &document_base_url_memoized(&gs).unwrap_or_else(|| gs.url.clone()),
+        )
+        .unwrap_or("\"\"".into()),
+        // The unresolved attribute. After history.pushState only JS knows the URL, so only JS
+        // can resolve a relative base against it.
+        "document_base_href" => {
+            serde_json::to_string(&document_base_href_memoized(&gs).unwrap_or_default())
+                .unwrap_or("\"\"".into())
+        }
         "document_referrer" => serde_json::to_string(&gs.referrer).unwrap_or("\"\"".into()),
         "document_encoding" => serde_json::to_string(&gs.encoding).unwrap_or("\"UTF-8\"".into()),
         "document_element" => {
@@ -4601,7 +4618,8 @@ fn op_waapi_control(
     changed
 }
 
-#[cfg(feature = "render")]
+// Not tied to `render`: the JS layer resolves every relative URL through here, in all build
+// variants.
 pub(crate) fn document_base_url(state: &ObscuraState) -> Option<String> {
     let document_url = url::Url::parse(&state.url).ok()?;
     let base_href = state.dom.as_ref().and_then(|dom| {
@@ -4614,9 +4632,72 @@ pub(crate) fn document_base_url(state: &ObscuraState) -> Option<String> {
             })
     });
     match base_href {
-        Some(href) => document_url.join(&href).ok().map(|url| url.to_string()),
+        // https://html.spec.whatwg.org/multipage/semantics.html#set-the-frozen-base-url
+        // A data: or javascript: base falls back to the document URL. Accepting it would instead
+        // make every later relative resolution fail.
+        Some(href) => match document_url.join(&href) {
+            Ok(base) if base.scheme() != "data" && base.scheme() != "javascript" => {
+                Some(base.to_string())
+            }
+            _ => Some(document_url.to_string()),
+        },
         None => Some(document_url.to_string()),
     }
+}
+
+/// The raw `href` attribute of the first `<base href>`, unresolved. The JS layer needs it after
+/// `history.pushState`: the document URL has moved, only JS knows the new one, so only JS can
+/// resolve a relative base against it.
+fn document_base_href(state: &ObscuraState) -> Option<String> {
+    state.dom.as_ref().and_then(|dom| {
+        dom.query_selector("base[href]")
+            .ok()
+            .flatten()
+            .and_then(|id| {
+                dom.get_node(id)
+                    .and_then(|node| node.get_attribute("href").map(str::to_string))
+            })
+    })
+}
+
+/// What the cached values were computed from. If any of the three changes, they are recomputed.
+pub struct BaseUrlCache {
+    activity_generation: u64,
+    document_generation: u64,
+    url: String,
+    resolved: Option<String>,
+    raw_href: Option<String>,
+}
+
+/// Both base values behind a cache. Uncached, each one walks the tree and runs the selector
+/// engine, which would make `a.href` an O(nodes) read.
+fn base_values_memoized(state: &ObscuraState) -> (Option<String>, Option<String>) {
+    if let Some(cached) = state.base_url_cache.borrow().as_ref() {
+        if cached.activity_generation == state.activity_generation
+            && cached.document_generation == state.document_generation
+            && cached.url == state.url
+        {
+            return (cached.resolved.clone(), cached.raw_href.clone());
+        }
+    }
+    let resolved = document_base_url(state);
+    let raw_href = document_base_href(state);
+    *state.base_url_cache.borrow_mut() = Some(BaseUrlCache {
+        activity_generation: state.activity_generation,
+        document_generation: state.document_generation,
+        url: state.url.clone(),
+        resolved: resolved.clone(),
+        raw_href: raw_href.clone(),
+    });
+    (resolved, raw_href)
+}
+
+pub(crate) fn document_base_url_memoized(state: &ObscuraState) -> Option<String> {
+    base_values_memoized(state).0
+}
+
+pub(crate) fn document_base_href_memoized(state: &ObscuraState) -> Option<String> {
+    base_values_memoized(state).1
 }
 
 #[cfg(feature = "render")]

--- a/crates/obscura-js/src/runtime.rs
+++ b/crates/obscura-js/src/runtime.rs
@@ -13962,6 +13962,320 @@ mod tests {
         );
     }
 
+    /// Document URL two levels deep, base one level deep and the origin root on neither of the
+    /// two. The three possible bases land on three different paths, and one assert keeps them
+    /// apart:
+    ///   document base URL  ->  /app/data/x.json   (the spec)
+    ///   document URL       ->  /deep/data/x.json  (the bug)
+    ///   origin root        ->  /data/x.json       (a base "/" would hide this one)
+    fn setup_runtime_at_deep_url(html: &str) -> ObscuraJsRuntime {
+        let dom = parse_html(html);
+        let mut rt = ObscuraJsRuntime::new();
+        rt.set_dom(dom);
+        rt.set_url("http://example.com/deep/page");
+        rt.run_page_init();
+        rt
+    }
+
+    const BASE_HREF_PAGE: &str = r#"<html><head><base href="/app/"></head><body>
+            <a id="link" href="data/x.json"></a>
+            <form id="form" action="submit"></form>
+            <script id="script" src="chunk.js"></script>
+        </body></html>"#;
+
+    #[test]
+    fn base_href_governs_dom_url_reflection() {
+        let mut rt = setup_runtime_at_deep_url(BASE_HREF_PAGE);
+
+        // One evaluate, one assert: a bundle of assert_eq! aborts at the first failure and
+        // reports one broken path while hiding the others.
+        let seen = rt
+            .evaluate(
+                r#"return [
+                    document.baseURI,
+                    document.getElementById('link').href,
+                    document.getElementById('form').action,
+                    document.getElementById('script').src,
+                ]"#,
+            )
+            .unwrap();
+        assert_eq!(
+            seen.as_array().unwrap(),
+            &vec![
+                serde_json::json!("http://example.com/app/"),
+                serde_json::json!("http://example.com/app/data/x.json"),
+                serde_json::json!("http://example.com/app/submit"),
+                serde_json::json!("http://example.com/app/chunk.js"),
+            ]
+        );
+    }
+
+    #[test]
+    fn a_relative_location_assignment_follows_the_base() {
+        // _resolveUrl serves location.href=, assign, replace and window.location=. Of the six
+        // call sites it has the largest external effect, so it gets its own test.
+        let mut rt = setup_runtime_at_deep_url(BASE_HREF_PAGE);
+        rt.evaluate("location.href = 'users/42'").unwrap();
+
+        let landed = rt.evaluate("location.href").unwrap();
+        assert_eq!(landed.as_str().unwrap(), "http://example.com/app/users/42");
+    }
+
+    #[test]
+    fn without_base_href_resolution_stays_on_the_document_url() {
+        let mut rt = setup_runtime_at_deep_url(
+            r#"<html><head></head><body>
+                <a id="link" href="data/x.json"></a>
+                <form id="form" action="submit"></form>
+                <script id="script" src="chunk.js"></script>
+            </body></html>"#,
+        );
+
+        // Every call site, not just the anchor: a site that resolves to the origin root instead
+        // of the document URL slips through on a page without a base only when nobody is looking.
+        let seen = rt
+            .evaluate(
+                r#"return [
+                    document.baseURI,
+                    document.getElementById('link').href,
+                    document.getElementById('form').action,
+                    document.getElementById('script').src,
+                ]"#,
+            )
+            .unwrap();
+        assert_eq!(
+            seen.as_array().unwrap(),
+            &vec![
+                serde_json::json!("http://example.com/deep/page"),
+                serde_json::json!("http://example.com/deep/data/x.json"),
+                serde_json::json!("http://example.com/deep/submit"),
+                serde_json::json!("http://example.com/deep/chunk.js"),
+            ]
+        );
+    }
+
+    #[test]
+    fn base_element_href_reflects_the_resolved_url() {
+        // Resolved against the fallback base URL, i.e. the document URL and not /app/.
+        let mut rt = setup_runtime_at_deep_url(BASE_HREF_PAGE);
+        let href = rt.evaluate("document.querySelector('base').href").unwrap();
+        assert_eq!(href.as_str().unwrap(), "http://example.com/app/");
+
+        let mut relative = setup_runtime_at_deep_url(
+            r#"<html><head><base href="assets/"></head><body></body></html>"#,
+        );
+        let href = relative
+            .evaluate("document.querySelector('base').href")
+            .unwrap();
+        assert_eq!(href.as_str().unwrap(), "http://example.com/deep/assets/");
+    }
+
+    #[test]
+    fn the_first_base_with_an_href_wins() {
+        // Tree order, and a <base> without href does not count.
+        let mut rt = setup_runtime_at_deep_url(
+            r#"<html><head><base><base href="/a/"><base href="/b/"></head><body>
+                <a id="link" href="x.json"></a>
+            </body></html>"#,
+        );
+        let link = rt
+            .evaluate("document.getElementById('link').href")
+            .unwrap();
+        assert_eq!(link.as_str().unwrap(), "http://example.com/a/x.json");
+    }
+
+    #[test]
+    fn an_empty_base_href_resolves_to_the_document_url() {
+        let mut rt = setup_runtime_at_deep_url(
+            r#"<html><head><base href=""></head><body>
+                <a id="link" href="x.json"></a>
+            </body></html>"#,
+        );
+        let link = rt
+            .evaluate("document.getElementById('link').href")
+            .unwrap();
+        assert_eq!(link.as_str().unwrap(), "http://example.com/deep/x.json");
+    }
+
+    #[test]
+    fn a_cross_origin_base_moves_the_target_but_not_the_page_origin() {
+        let mut rt = setup_runtime_at_deep_url(
+            r#"<html><head><base href="https://cdn.example.net/v2/"></head><body>
+                <a id="link" href="x.json"></a>
+            </body></html>"#,
+        );
+        let seen = rt
+            .evaluate("return [document.getElementById('link').href, location.origin]")
+            .unwrap();
+        assert_eq!(
+            seen.as_array().unwrap(),
+            &vec![
+                serde_json::json!("https://cdn.example.net/v2/x.json"),
+                serde_json::json!("http://example.com"),
+            ]
+        );
+    }
+
+    #[test]
+    fn base_href_rejects_a_data_url_base() {
+        // https://html.spec.whatwg.org/multipage/semantics.html#set-the-frozen-base-url
+        // Accepting it would make every later relative resolution fail instead of falling back.
+        let mut rt = setup_runtime_at_deep_url(
+            r#"<html><head><base href="data:text/html,x"></head><body>
+                <a id="link" href="data/x.json"></a>
+            </body></html>"#,
+        );
+
+        let base_uri = rt.evaluate("document.baseURI").unwrap();
+        assert_eq!(base_uri.as_str().unwrap(), "http://example.com/deep/page");
+
+        let link = rt
+            .evaluate("document.getElementById('link').href")
+            .unwrap();
+        assert_eq!(link.as_str().unwrap(), "http://example.com/deep/data/x.json");
+    }
+
+    #[test]
+    fn base_resolution_follows_the_url_set_by_push_state() {
+        // pushState changes the document URL, and without <base> that very URL is the base.
+        let mut rt = setup_runtime_at_deep_url(
+            r#"<html><head></head><body><a id="link" href="x.json"></a></body></html>"#,
+        );
+        rt.evaluate("history.pushState({}, '', '/other/route')").unwrap();
+
+        let link = rt
+            .evaluate("document.getElementById('link').href")
+            .unwrap();
+        assert_eq!(link.as_str().unwrap(), "http://example.com/other/x.json");
+    }
+
+    #[test]
+    fn a_relative_base_href_resolves_against_the_push_state_url() {
+        let mut rt = setup_runtime_at_deep_url(
+            r#"<html><head><base href="assets/"></head><body>
+                <a id="link" href="x.json"></a>
+            </body></html>"#,
+        );
+        rt.evaluate("history.pushState({}, '', '/other/route')").unwrap();
+
+        let link = rt
+            .evaluate("document.getElementById('link').href")
+            .unwrap();
+        assert_eq!(link.as_str().unwrap(), "http://example.com/other/assets/x.json");
+    }
+
+    /// Guards the cache in `document_base_url_memoized`. Without it, each of these reads walked
+    /// the tree and ran the selector engine, and `a.href` went from a field read to O(nodes).
+    /// The bound is deliberately loose: it should catch the regression, not watch the allocator.
+    #[test]
+    fn anchor_href_reads_do_not_scale_with_document_size() {
+        let mut body = String::from(r#"<html><head></head><body><a id="link" href="x.json"></a>"#);
+        for i in 0..4000 {
+            body.push_str(&format!("<div id=\"n{i}\"><span>text</span></div>"));
+        }
+        body.push_str("</body></html>");
+        let mut rt = setup_runtime_at_deep_url(&body);
+
+        let elapsed = rt
+            .evaluate(
+                r#"
+                const link = document.getElementById('link');
+                const started = Date.now();
+                for (let i = 0; i < 2000; i++) { link.href; }
+                return Date.now() - started;
+                "#,
+            )
+            .unwrap();
+        let ms = elapsed.as_f64().expect("elapsed ms");
+        assert!(
+            ms < 500.0,
+            "2000 a.href reads on a document with 12000 nodes took {ms} ms, the base query is not cached"
+        );
+    }
+
+    #[test]
+    fn the_base_memo_still_sees_a_base_element_added_later() {
+        let mut rt = setup_runtime_at_deep_url(
+            r#"<html><head></head><body><a id="link" href="x.json"></a></body></html>"#,
+        );
+        let before = rt
+            .evaluate("document.getElementById('link').href")
+            .unwrap();
+        assert_eq!(before.as_str().unwrap(), "http://example.com/deep/x.json");
+
+        rt.evaluate(
+            r#"
+            const base = document.createElement('base');
+            base.setAttribute('href', '/');
+            document.head.appendChild(base);
+            "#,
+        )
+        .unwrap();
+
+        let after = rt
+            .evaluate("document.getElementById('link').href")
+            .unwrap();
+        assert_eq!(after.as_str().unwrap(), "http://example.com/x.json");
+    }
+
+    #[test]
+    fn the_base_memo_notices_a_changed_href_attribute() {
+        let mut rt = setup_runtime_at_deep_url(BASE_HREF_PAGE);
+        let before = rt
+            .evaluate("document.getElementById('link').href")
+            .unwrap();
+        assert_eq!(before.as_str().unwrap(), "http://example.com/app/data/x.json");
+
+        rt.evaluate("document.querySelector('base').setAttribute('href', '/other/')")
+            .unwrap();
+
+        let after = rt
+            .evaluate("document.getElementById('link').href")
+            .unwrap();
+        assert_eq!(after.as_str().unwrap(), "http://example.com/other/data/x.json");
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn base_href_governs_fetch_and_xhr_targets() {
+        let mut rt = setup_runtime_at_deep_url(BASE_HREF_PAGE);
+        let result = rt
+            .call_function_on_for_cdp(
+                r#"async () => {
+                const originalFetchOp = Deno.core.ops.op_fetch_url;
+                const seen = [];
+                try {
+                    Deno.core.ops.op_fetch_url = (url) => {
+                        seen.push(url);
+                        return JSON.stringify({ status: 200, headers: {}, body: "{}", url });
+                    };
+                    await fetch("data/x.json");
+                    const xhr = new XMLHttpRequest();
+                    xhr.open("GET", "data/y.json");
+                    xhr.send();
+                    await new Promise((r) => setTimeout(r, 0));
+                    return seen;
+                } finally {
+                    Deno.core.ops.op_fetch_url = originalFetchOp;
+                }
+            }"#,
+                None,
+                &[],
+                true,
+                true,
+            )
+            .await
+            .unwrap();
+
+        let value = result.value.expect("captured URLs");
+        let seen = value.as_array().expect("captured URLs");
+        // The XHR entry cannot isolate its own layer: send() passes the already absolute URL on
+        // to fetch, so fetch takes over the resolution if it is removed from send, and the assert
+        // still holds. It pins the result, not the layer.
+        assert_eq!(seen.len(), 2, "one fetch, one XHR");
+        assert_eq!(seen[0].as_str().unwrap(), "http://example.com/app/data/x.json");
+        assert_eq!(seen[1].as_str().unwrap(), "http://example.com/app/data/y.json");
+    }
+
     #[tokio::test(flavor = "current_thread")]
     async fn test_fetch_url_input_decodes_binary_body_base64() {
         let mut rt = setup_runtime("<html><body></body></html>");


### PR DESCRIPTION
Fixes #658

## What changed

`#242` fixed the same class for `<script src>`, and `document_base_url()` in `crates/obscura-js/src/ops.rs` has resolved per spec since then. It was behind `#[cfg(feature = "render")]` and not accessible to the JS layer, so every relative URL there kept resolving against the document URL.

This change enables the existing function, passes its result to JS through the `_domParse` dispatcher, and routes five call sites through a helper `_documentBase()`: `Node.baseURI`, `_anchorBase()` (covers `<a>` and `<area>` including all URL components), the form's `action`, `_resolveUrl()`, and the general `src` reflection. There is no second implementation of the rule.

`fetch` and `XMLHttpRequest.send` no longer need their own intervention. #687 switched both to `_resolveUrl(url)`, and this PR switches exactly that function to `_documentBase()`. The base correction thus reaches both places. Before the rebase onto #687 they were two more call sites.

Three further changes come along, each from a review finding:

`HTMLBaseElement.href` now returns the resolved address instead of the raw attribute. It resolves against the fallback base URL, that is, against the document URL. A `<base>` element is affected neither by other base elements nor by itself.

A `data:` or `javascript:` base is discarded, and the document URL takes its place. Without this check, every later relative resolution fails silently in the `catch` branch instead of falling back to the fallback base URL.

`history.pushState` moves the document URL without reaching the Rust side. If a virtual URL is set, the base is therefore computed in JS. For this, the dispatcher additionally exposes the raw `href` attribute.

The resolution sits in a cache, see Performance.

The render path remains untouched. `ensure_prepared_render` and the four other callers keep calling `document_base_url()` directly, without a cache. The call is rare there, and the change would gain nothing.

## Validation

```
cargo nextest run --release --features render --no-fail-fast                          1499 passed, 4 skipped
cargo nextest run --release --features render,stealth --no-fail-fast                  1503 passed, 1 failed, 4 skipped
cargo nextest run --release --no-default-features -p obscura-js                       332 passed
cargo check -p obscura-js --no-default-features                                       clean
cargo check -p obscura-js --features render,stealth                                   clean
cargo build --release -p obscura-cli --bins --features render                         clean
cargo build --release -p obscura-cli --bins --features render,stealth                 clean
cargo build --release -p obscura-cli --bins --no-default-features                     clean
cargo build --release -p obscura-cli --bins --no-default-features --features stealth  clean
```

14 new tests in `crates/obscura-js/src/runtime.rs`. Each was checked against a deliberately broken version, not only against the healthy one.

The first version of these tests had no teeth. It used `<base href="/">` on a document under `/deep/page`, and that is exactly the origin root. Resolution against the base and resolution against the origin root then yielded the same value, and four mutations survived. The base is now `/app/`, which puts the three candidates on three different paths:

```
document base URL  ->  /app/data/x.json    (intended)
document URL       ->  /deep/data/x.json   (the defect)
origin root        ->  /data/x.json        (indistinguishable with <base href="/">)
```

Mutation run against the current tests:

```
base always resolves to the origin root       caught
Element.src back to location.href             caught
cache disabled                                caught
cache invalidation disabled                   caught
_resolveUrl back to the document URL          caught
resolution removed from fetch                 caught
resolution removed from XMLHttpRequest.send   SURVIVES
```

The rebase onto #687 has overtaken the table in two places. `fetch` and `XMLHttpRequest.send` no longer resolve on their own, they call `_resolveUrl`. The two rows that mutated the removed code have therefore been replaced rather than carried forward.

Each mutation was measured against both guards together, `obscura-js` with the fourteen tests of this PR and `obscura` with `fetch_relative_url_resolution.rs` from #687. A mutation counts as caught as soon as one of the two suite runs goes red. That is a narrower scope than the full suite run with which the remaining rows were measured.

One mutation survives, and that is a finding about the test coverage, not a flaw. `XMLHttpRequest.send` passes the already absolute URL on to `fetch`, and `fetch` resolves anyway. Removing the resolution from `send` does not change the result. This layer cannot be isolated from the outside, and a comment in the test says so, so that the mere existence of a test does not hide the gap.

Ever since #687 was merged, one question comes before all others: does this PR still contribute anything after #687 already fixed the resolution in `fetch` and `XHR`? The mutation probe answers it. If you turn `_resolveUrl` back from the document base URL to the document URL, the fourteen tests of this PR catch that, while the guard from #687 stays green, 25 of 25. It measures without `<base href>` and cannot see the difference. The two guards cover different cases and do not replace each other.

Covered special forms: multiple `<base>` elements (the first with `href` wins), `<base>` without `href`, `<base href="">`, a foreign origin as the base, a relative base, a `data:` base, a `<base>` inserted after the fact by a script, and an `href` changed after the fact.

The one failure in the stealth configuration is `obscura-net wreq_client::tests::stealth_client_decodes_gzip_response`. It fails on `2810cb4` in the same way. Measured with the same command on both revisions, narrowly scoped to the crate containing the test: `cargo nextest run --release --features stealth -p obscura-net --no-fail-fast` yields 92 tests on both sides, of which 91 passed and one failed. No regression. This PR does not touch `crates/obscura-net`, its diff spans three files, all in `obscura-js`. The same test already appeared in the validation of this PR from 2026-08-14, at that time on a different base.

The Obstacle Course ran interleaved on both revisions, from the same companion repo at the commit that the CI pins it to, and with the same parameters as there. Both revisions reach 32 of 33 stages. The same stage fails on both sides, `observer-intersection` with `expected 'io:50', got ''`. This is the state of `main` and tracked as #671, not a regression from this change. The comparison used the project's `scripts/ci/compare_obstacle.py` instead of a custom evaluator, and the script reports neither a lost nor a gained stage.

## Rendering

Not applicable. No layout, no paint, no output changed. The render path still calls `document_base_url()` directly.

## Performance

The first cut of this change was a serious regression, and it is the reason for the cache.

`document_base_url()` runs `query_selector("base[href]")`. This allocates a vector of all nodes and runs the selector engine against every element. In the render path this has no consequences, because the call is rare. On the JS side, by contrast, the function sits on the hottest getters: `a.href` and, below it, `protocol`, `host`, `hostname`, `port`, `pathname`, `search`, `hash`, and `origin`, plus `Element.src`. Before, the base was a field read there.

The worst case is also the most common one. Without `<base href>`, the scan runs to the end and returns nothing.

Measured with the same probe on both revisions, in the release build. The probe hooks a test into `runtime.rs` that reads `a.href` in a loop, measures both revisions with it, and is removed afterwards. It does not attach to anything that exists on only one of the two revisions.

This measurement was taken against `main` at `94374e6`, the base of this PR before the rebase. The rebase onto #687 did not touch the measured path: `_anchorBase()`, the getters of `a.href`, and the cache are unchanged. The numbers in the validation section, by contrast, all come from the current revision.

```
10,000 reads of a.href on a document of roughly 12,000 nodes, two runs each:

main                        26 ms     21 ms
this PR                     19 ms     28 ms
this PR without the cache 2572 ms   3476 ms
```

The first two lines of the measurement overlap across the runs. The cache is therefore indistinguishable from `main`. The third line is the same change without it and is there only so that the first two can be read.

The cache lives in `ObscuraState` and holds the resolution and the raw attribute. Its key is `activity_generation`, `document_generation`, and the document URL. A `<base>` inserted or changed later therefore reaches it, and two tests pin down exactly that. Both fail if the key check is removed.

## Checklist

- [x] The change is focused and does not remove existing behavior without justification.
- [x] Tests cover the failure or feature.
- [x] Existing tests pass, including render and no-render configurations when affected.
- [x] I checked for CPU, latency, and memory regressions.
- [x] Public API or user-facing behavior changes are documented.

