### PR TITLE
fetch follows twenty redirects, as the Fetch standard requires

### DIFF
--- a/crates/obscura-js/src/ops.rs
+++ b/crates/obscura-js/src/ops.rs
@@ -1928,8 +1928,17 @@ fn fetch_timeout() -> std::time::Duration {
 }
 
 /// Cap on the number of redirect hops op_fetch_url will follow.
-/// Matches reqwest's default policy of 10.
-const FETCH_REDIRECT_LIMIT: usize = 10;
+///
+/// The Fetch standard fixes the number at 20. HTTP-redirect fetch returns
+/// a network error as soon as a request's redirect count *reaches* 20,
+/// and only increments it afterwards. So the twentieth hop must still
+/// succeed and the twenty-first must fail:
+/// https://fetch.spec.whatwg.org/#http-redirect-fetch
+///
+/// The reqwest default of 10 does not apply here. The redirects are
+/// followed by hand in this file, one hop per loop iteration, so that
+/// each hop can be checked against the SSRF rules again.
+const FETCH_REDIRECT_LIMIT: usize = 20;
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 enum FetchCredentials {

--- a/crates/obscura-js/src/runtime.rs
+++ b/crates/obscura-js/src/runtime.rs
@@ -13630,6 +13630,114 @@ mod tests {
             })
         );
     }
+    /// Serves a redirect chain across `connections` consecutive
+    /// requests: `/hop/N` replies with 302 to `/hop/N-1`, `/hop/0` is the
+    /// target. To a path the fixture cannot read it replies with 400
+    /// instead of the target. A broken fixture thereby fails the test
+    /// instead of letting it pass.
+    fn redirect_chain_runtime(connections: usize) -> ObscuraJsRuntime {
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+        let address = listener.local_addr().unwrap();
+        std::thread::spawn(move || {
+            use std::io::{Read as _, Write as _};
+
+            for _ in 0..connections {
+                let Ok((mut stream, _)) = listener.accept() else {
+                    return;
+                };
+                let mut buffer = [0u8; 2048];
+                let read = stream.read(&mut buffer).unwrap_or(0);
+                let hop = String::from_utf8_lossy(&buffer[..read])
+                    .split_whitespace()
+                    .nth(1)
+                    .and_then(|path| path.strip_prefix("/hop/"))
+                    .and_then(|hop| hop.parse::<usize>().ok());
+                let response = match hop {
+                    Some(0) => {
+                        let body = "arrived";
+                        format!(
+                            "HTTP/1.1 200 OK\r\nContent-Type: text/plain\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{body}",
+                            body.len(),
+                        )
+                    }
+                    Some(hop) => format!(
+                        "HTTP/1.1 302 Found\r\nLocation: /hop/{}\r\nContent-Length: 0\r\nConnection: close\r\n\r\n",
+                        hop - 1,
+                    ),
+                    None => {
+                        let body = "unparsed";
+                        format!(
+                            "HTTP/1.1 400 Bad Request\r\nContent-Type: text/plain\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{body}",
+                            body.len(),
+                        )
+                    }
+                };
+                let _ = stream.write_all(response.as_bytes());
+            }
+        });
+
+        let origin = format!("http://{address}");
+        let mut rt = ObscuraJsRuntime::new();
+        rt.set_dom(parse_html("<html><body></body></html>"));
+        rt.set_url(&format!("{origin}/page"));
+        rt.set_http_client(std::sync::Arc::new(
+            obscura_net::ObscuraHttpClient::with_full_options(
+                std::sync::Arc::new(obscura_net::CookieJar::new()),
+                None,
+                true,
+            ),
+        ));
+        rt.run_page_init();
+        rt
+    }
+
+    /// HTTP-redirect fetch returns a network error as soon as the
+    /// redirect count *reaches* 20, and only increments it afterwards. So
+    /// the twentieth hop must still succeed:
+    /// https://fetch.spec.whatwg.org/#http-redirect-fetch
+    /// WPT covers the same pair in `fetch/api/redirect/redirect-count.any.js`.
+    #[tokio::test(flavor = "current_thread")]
+    async fn fetch_follows_the_twentieth_redirect() {
+        let mut rt = redirect_chain_runtime(21);
+        let result = rt
+            .call_function_on_for_cdp(
+                r#"async () => (await fetch("/hop/20")).text()"#,
+                None,
+                &[],
+                true,
+                true,
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(result.value.unwrap(), serde_json::json!("arrived"));
+    }
+
+    /// The other end of the same pair: the twenty-first redirect must
+    /// fail. `fetch` reports a rejected result as a `TypeError`.
+    #[tokio::test(flavor = "current_thread")]
+    async fn fetch_rejects_the_twenty_first_redirect() {
+        let mut rt = redirect_chain_runtime(21);
+        let result = rt
+            .call_function_on_for_cdp(
+                r#"async () => {
+                    try {
+                        const response = await fetch("/hop/21");
+                        return "resolved " + (await response.text());
+                    } catch (error) {
+                        return error instanceof TypeError ? "rejected" : "other";
+                    }
+                }"#,
+                None,
+                &[],
+                true,
+                true,
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(result.value.unwrap(), serde_json::json!("rejected"));
+    }
 
     #[tokio::test(flavor = "current_thread")]
     async fn dynamic_linked_stylesheet_enters_the_live_dom_with_imports_rebased() {


### PR DESCRIPTION
## What this is about

`FETCH_REDIRECT_LIMIT` was 10. With that, `fetch` and `XMLHttpRequest` gave up after half the redirects the standard allows.

The Fetch spec fixes the number. HTTP-redirect fetch checks in step 7 and only increments afterwards:

> 7. If request's redirect count is 20, then return a network error.
> 8. Increase request's redirect count by 1.

https://fetch.spec.whatwg.org/#http-redirect-fetch

So the twentieth hop must still succeed, the twenty-first must fail. The existing comparison `redirects_followed > FETCH_REDIRECT_LIMIT` hits this limit exactly with the value 20. The comparison does not change.

The previous comment justified the 10 with the reqwest default. That does not apply here: the redirects are followed by hand in this file, one hop per loop iteration, so that each hop is checked against the SSRF rules again.

## What changes

One line in `crates/obscura-js/src/ops.rs`, plus the comment. Both call paths read the same constant, `op_fetch_url` and `stealth_fetch_all`.

## Tests

Two new tests in `crates/obscura-js/src/runtime.rs` against a local redirect chain. They cover both ends of the same pair that WPT covers in `fetch/api/redirect/redirect-count.any.js`: twenty hops arrive, twenty-one are rejected.

The fixture's server answers a path it cannot read with 400 instead of the target. A broken fixture thereby fails the test instead of letting it pass.

Three mutations, each caught by exactly the test that means it:

| Mutation | caught by |
|---|---|
| limit back to 10 | twenty hops arrive |
| limit to 21 | twenty-one are rejected |
| comparison `>` becomes `>=` | twenty hops arrive |

`cargo nextest run --features render -p obscura-js` runs green with 370 tests, three times in a row.

## What this PR does not touch

`page.rs:2386` carries a second limit with the value 10 and a similar name. It counts something else, namely client-initiated navigations. It is the subject of its own pull request, because it concerns a different crate and does not depend on this one.

Part of #664.
