### PR TITLE
The limit for client-initiated navigations becomes adjustable and is named after what it counts

### DIFF
--- a/crates/obscura-browser/src/page.rs
+++ b/crates/obscura-browser/src/page.rs
@@ -264,6 +264,8 @@ pub struct Page {
     /// 50-second navigation is not silently cut off by the process default.
     /// Pages without an override retain the environment-configurable default.
     navigation_timeout: Option<std::time::Duration>,
+    /// Optional per-page cap. Pages without a value keep the default.
+    navigation_chain_limit: Option<usize>,
     /// Navigation history for Page.getNavigationHistory / navigateToHistoryEntry.
     /// Entries are URLs in visit order; `history_index` is the current position.
     /// Pushed on every successful navigation; truncated on goBack -> new nav.
@@ -310,6 +312,10 @@ fn max_live_frames() -> usize {
         .unwrap_or(64)
 }
 
+/// The first navigation counts. The low default stops a page that resets
+/// `location` on every load.
+const DEFAULT_NAVIGATION_CHAIN_LIMIT: usize = 10;
+
 fn default_navigation_timeout() -> std::time::Duration {
     navigation_timeout_from_env_value(std::env::var("OBSCURA_NAV_TIMEOUT_MS").ok().as_deref())
 }
@@ -319,6 +325,19 @@ fn navigation_timeout_from_env_value(value: Option<&str>) -> std::time::Duration
         .and_then(|value| value.parse().ok())
         .unwrap_or(DEFAULT_NAVIGATION_TIMEOUT_MS);
     std::time::Duration::from_millis(milliseconds)
+}
+
+fn default_navigation_chain_limit() -> usize {
+    navigation_chain_limit_from_env_value(std::env::var("OBSCURA_NAV_CHAIN_LIMIT").ok().as_deref())
+}
+
+fn navigation_chain_limit_from_env_value(value: Option<&str>) -> usize {
+    // Only an unreadable value falls back to the default, so
+    // `OBSCURA_NAV_CHAIN_LIMIT=0` and `set_navigation_chain_limit(0)` agree.
+    value
+        .and_then(|value| value.parse::<usize>().ok())
+        .map(|limit| limit.max(1))
+        .unwrap_or(DEFAULT_NAVIGATION_CHAIN_LIMIT)
 }
 
 fn duration_millis_u64(duration: std::time::Duration) -> u64 {
@@ -921,6 +940,7 @@ impl Page {
             encoding: "UTF-8".to_string(),
             document_timeline_origin: std::time::Instant::now(),
             navigation_timeout: None,
+            navigation_chain_limit: None,
             history: Vec::new(),
             history_index: 0,
             network_events: Vec::new(),
@@ -950,6 +970,18 @@ impl Page {
     pub fn navigation_timeout(&self) -> std::time::Duration {
         self.navigation_timeout
             .unwrap_or_else(default_navigation_timeout)
+    }
+
+    /// Takes precedence over `OBSCURA_NAV_CHAIN_LIMIT`. A limit of 0 is
+    /// raised to 1, which would otherwise report success having loaded
+    /// nothing.
+    pub fn set_navigation_chain_limit(&mut self, limit: usize) {
+        self.navigation_chain_limit = Some(limit.max(1));
+    }
+
+    pub fn navigation_chain_limit(&self) -> usize {
+        self.navigation_chain_limit
+            .unwrap_or_else(default_navigation_chain_limit)
     }
 
     fn should_block_url(&self, url: &str) -> bool {
@@ -2732,8 +2764,8 @@ impl Page {
         let mut current_method = method.to_string();
         let mut current_body = body.to_string();
         let mut document_referrer = initial_referrer.to_string();
-        const REDIRECT_LIMIT: usize = 10;
-        for chain in 0..REDIRECT_LIMIT {
+        let chain_limit = self.navigation_chain_limit();
+        for chain in 0..chain_limit {
             self.navigate_single(
                 &current_url,
                 wait_until,
@@ -2775,12 +2807,12 @@ impl Page {
                 current_url = next_url;
                 current_method = next_method;
                 current_body = next_body;
-                if chain + 1 == REDIRECT_LIMIT {
+                if chain + 1 == chain_limit {
                     // Hit the cap and the page still wants to keep
                     // chaining. Surface that as an error instead of
                     // returning Ok(()) so callers can distinguish a
-                    // successful load from a redirect storm.
-                    return Err(PageError::TooManyRedirects(REDIRECT_LIMIT));
+                    // successful load from a navigation storm.
+                    return Err(PageError::TooManyClientNavigations(chain_limit));
                 }
                 continue;
             }
@@ -4146,9 +4178,11 @@ fn url_matches_cdp_pattern(pattern: &str, url: &str) -> bool {
 mod tests {
     use super::{
         css_resource_urls, linked_stylesheet_requests, materialize_linked_stylesheet_script,
-        materialize_stylesheet_graph, navigation_referrer, navigation_timeout_from_env_value,
-        parse_import_url, rebase_css_urls, script_response_is_executable, split_css_imports,
-        truncate_on_char_boundary, url_matches_cdp_pattern, LoadedStylesheet, StylesheetImport,
+        materialize_stylesheet_graph, navigation_chain_limit_from_env_value, navigation_referrer,
+        navigation_timeout_from_env_value, parse_import_url, rebase_css_urls,
+        script_response_is_executable, split_css_imports, truncate_on_char_boundary,
+        url_matches_cdp_pattern, LoadedStylesheet, StylesheetImport,
+        DEFAULT_NAVIGATION_CHAIN_LIMIT,
     };
     #[cfg(feature = "render")]
     use super::remaining_settle_resource_warmup_ms;
@@ -4173,6 +4207,25 @@ mod tests {
             navigation_timeout_from_env_value(Some("42000")),
             std::time::Duration::from_secs(42)
         );
+    }
+
+    #[test]
+    fn navigation_chain_limit_environment_default_remains_ten() {
+        assert_eq!(navigation_chain_limit_from_env_value(None), 10);
+        assert_eq!(
+            navigation_chain_limit_from_env_value(Some("not-a-limit")),
+            10
+        );
+    }
+
+    #[test]
+    fn navigation_chain_limit_environment_override_remains_available() {
+        assert_eq!(navigation_chain_limit_from_env_value(Some("25")), 25);
+    }
+
+    #[test]
+    fn navigation_chain_limit_raises_a_zero_that_would_load_nothing() {
+        assert_eq!(navigation_chain_limit_from_env_value(Some("0")), 1);
     }
 
     #[test]
@@ -4394,6 +4447,161 @@ mod tests {
             observed,
             serde_json::json!([format!("http://{address}/final"), source])
         );
+    }
+
+    /// `/hop/N` sets `location.href = "/hop/N-1"`, `/hop/0` is the target.
+    /// An unreadable path gets a 404, so a broken fixture fails the test.
+    fn client_navigation_chain_address(name: &str, connections: usize) -> std::net::SocketAddr {
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+        let address = listener.local_addr().unwrap();
+        let name = name.to_string();
+        std::thread::spawn(move || {
+            use std::io::{Read as _, Write as _};
+
+            for _ in 0..connections {
+                let Ok((mut stream, _)) = listener.accept() else {
+                    return;
+                };
+                let mut buffer = [0u8; 2048];
+                let length = stream.read(&mut buffer).unwrap_or(0);
+                let hop = String::from_utf8_lossy(&buffer[..length])
+                    .lines()
+                    .next()
+                    .and_then(|line| line.split_ascii_whitespace().nth(1))
+                    .and_then(|path| path.strip_prefix("/hop/"))
+                    .and_then(|hop| hop.parse::<usize>().ok());
+                let response = match hop {
+                    Some(0) => {
+                        let body = format!("<!doctype html><title>{name}</title>");
+                        format!(
+                            "HTTP/1.1 200 OK\r\nContent-Type: text/html\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{body}",
+                            body.len(),
+                        )
+                    }
+                    Some(hop) => {
+                        let body = format!("<script>location.href='/hop/{}'</script>", hop - 1);
+                        format!(
+                            "HTTP/1.1 200 OK\r\nContent-Type: text/html\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{body}",
+                            body.len(),
+                        )
+                    }
+                    None => {
+                        "HTTP/1.1 404 Not Found\r\nContent-Length: 0\r\nConnection: close\r\n\r\n"
+                            .to_string()
+                    }
+                };
+                let _ = stream.write_all(response.as_bytes());
+            }
+        });
+        address
+    }
+
+    /// Without a limit set the getter reaches its fallback to the environment.
+    fn page_without_chain_limit(name: &str) -> super::Page {
+        let context = std::sync::Arc::new(crate::BrowserContext::with_storage_and_network(
+            name.to_string(),
+            None,
+            false,
+            None,
+            None,
+            true,
+        ));
+        super::Page::new(name.to_string(), context)
+    }
+
+    /// The only place where the name of the environment variable is checked
+    /// as a string, and the variable is the only way to raise the limit at
+    /// runtime. Without this test a typo in the name would stay green.
+    #[test]
+    fn navigation_chain_limit_reads_the_environment_variable_by_name() {
+        std::env::set_var("OBSCURA_NAV_CHAIN_LIMIT", "17");
+
+        let page = page_without_chain_limit("chain-from-environment");
+
+        assert_eq!(page.navigation_chain_limit(), 17);
+    }
+
+    #[test]
+    fn a_per_page_navigation_chain_limit_wins_over_the_environment() {
+        std::env::set_var("OBSCURA_NAV_CHAIN_LIMIT", "17");
+
+        let mut page = page_without_chain_limit("chain-per-page-wins");
+        page.set_navigation_chain_limit(4);
+
+        assert_eq!(page.navigation_chain_limit(), 4);
+    }
+
+    /// The limit is always set explicitly, never inherited. Otherwise anyone
+    /// running the suite with `OBSCURA_NAV_CHAIN_LIMIT` set would see these
+    /// tests fail through no fault of the code.
+    fn chain_page(name: &str, limit: usize) -> super::Page {
+        let context = std::sync::Arc::new(crate::BrowserContext::with_storage_and_network(
+            name.to_string(),
+            None,
+            false,
+            None,
+            None,
+            true,
+        ));
+        let mut page = super::Page::new(name.to_string(), context);
+        page.set_navigation_chain_limit(limit);
+        page
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn navigation_chain_default_allows_nine_client_navigations() {
+        let address = client_navigation_chain_address("arrived", 10);
+        let mut page = chain_page("chain-within-default", DEFAULT_NAVIGATION_CHAIN_LIMIT);
+
+        page.navigate(&format!("http://{address}/hop/9"))
+            .await
+            .unwrap();
+
+        assert_eq!(page.url_string(), format!("http://{address}/hop/0"));
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn navigation_chain_beyond_the_default_reports_client_navigations() {
+        let address = client_navigation_chain_address("arrived", 10);
+        let mut page = chain_page("chain-beyond-default", DEFAULT_NAVIGATION_CHAIN_LIMIT);
+
+        let error = page
+            .navigate(&format!("http://{address}/hop/10"))
+            .await
+            .expect_err("a chain past the limit must not report success");
+
+        assert!(
+            matches!(error, super::PageError::TooManyClientNavigations(10)),
+            "unexpected error: {error:?}"
+        );
+        assert_eq!(
+            error.to_string(),
+            "Too many client-initiated navigations, the chain reached its limit of 10 documents"
+        );
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn raised_navigation_chain_limit_reaches_a_longer_chain() {
+        let address = client_navigation_chain_address("arrived", 12);
+        let mut page = chain_page("chain-raised", 12);
+
+        page.navigate(&format!("http://{address}/hop/11"))
+            .await
+            .unwrap();
+
+        assert_eq!(page.url_string(), format!("http://{address}/hop/0"));
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn a_zero_navigation_chain_limit_still_loads_the_initial_document() {
+        let address = client_navigation_chain_address("arrived", 1);
+        let mut page = chain_page("chain-zero", 0);
+
+        page.navigate(&format!("http://{address}/hop/0"))
+            .await
+            .unwrap();
+
+        assert_eq!(page.url_string(), format!("http://{address}/hop/0"));
     }
 
     #[tokio::test(flavor = "current_thread")]
@@ -6724,8 +6932,11 @@ pub enum PageError {
     #[error("Parse error: {0}")]
     ParseError(String),
 
-    #[error("Too many redirects (limit {0})")]
-    TooManyRedirects(usize),
+    /// A page kept triggering its own navigations until the chain's limit
+    /// was exhausted. HTTP 3xx redirects are followed one layer down, in
+    /// obscura-net, and report `ObscuraNetError::TooManyRedirects`.
+    #[error("Too many client-initiated navigations, the chain reached its limit of {0} documents")]
+    TooManyClientNavigations(usize),
 }
 
 impl From<ObscuraNetError> for PageError {

--- a/docs/Environment-variables.md
+++ b/docs/Environment-variables.md
@@ -22,6 +22,18 @@ Hard ceiling on a single navigation. Default 30000 (30 seconds). Applies to `Pag
 OBSCURA_NAV_TIMEOUT_MS=60000 obscura serve
 ```
 
+### `OBSCURA_NAV_CHAIN_LIMIT`
+
+How many documents a navigation chain may load, the first navigation included. Default 10, which allows the requested document and nine navigations the page itself triggers via `location` assignments or form submissions. Raise the value for an endpoint that chains longer for good reasons, such as an SSO handover across several providers. The low default is what stops a page that resets `location` on every load.
+
+A zero is raised to 1. This loads the requested document. If the page wants to chain further afterwards, the call reports an error, as at any other limit. A value the engine does not read as a number is replaced by the default. This also applies to a negative value and to a value with a trailing space.
+
+The time budget is not tied to this limit. A longer chain usually also needs a higher `OBSCURA_NAV_TIMEOUT_MS`, because its default of 30 seconds applies to the whole chain and not to the individual document.
+
+```bash
+OBSCURA_NAV_CHAIN_LIMIT=20 obscura serve
+```
+
 ### `OBSCURA_SCRIPT_DEADLINE_MS`
 
 Soft deadline for the complete page script-execution phase, including classic scripts and ES modules. Default 30000 (30 seconds). Raise it for a heavy SPA whose initial module is responsible for mounting an otherwise empty document. The engine also uses this value as a hard V8 watchdog budget, with a one-second grace period, so a synchronous script cannot run forever.


### PR DESCRIPTION
## What changed

The loop in `navigate_with_wait_post_inner` limits how many documents a navigation chain may load. It counts navigations that the page itself triggers after each load, that is assignments to `location`, its methods `assign`, `replace` and `reload`, and form submissions. In CDP terms these fall under `Page.ClientNavigationReason`. obscura does not report these reasons, the reference just places the matter for the reader.

HTTP 3xx redirects never reach this loop. They are followed one layer lower, in `obscura-net`, with their own limit and their own error.

Two things were wrong here.

**The name pointed at the wrong layer.** The message read `Too many redirects (limit 10)`. A chain of client-initiated navigations thus read like a redirect storm. The name cost time. I investigated an abort in an SAP login chain and measured the redirect chain, because the message spoke of redirects. The cause lay one layer higher, in a JavaScript loop. On top of that, the name was given twice. `ObscuraNetError::TooManyRedirects` means real HTTP redirects. After this change, "Too many redirects" in the whole tree means only that.

**The limit could not be raised.** `const REDIRECT_LIMIT: usize = 10` sat inside the function. No CDP parameter, no environment variable, no setter. The low default is correct and stays. It stops a page that reassigns `location` on every load. What was wrong was only that an endpoint that chains longer for good reason remained unreachable.

The limit therefore gets the shape that `navigation_timeout` already has: a field per page, a setter, a getter, and a fallback to the environment.

```
page.set_navigation_chain_limit(20)   programmatically, takes precedence
OBSCURA_NAV_CHAIN_LIMIT=20            in operation
neither of the two set               unchanged default of 10
```

The number means how many documents a chain may load, the first one included. The default of 10 therefore permits the requested document plus nine client-initiated navigations beyond it. That is exactly the previous behavior.

**The message names this unit explicitly**, because the number is now something an operator acts on. If only `limit 10` stood next to the word "navigations", one would read ten permitted navigations and set the limit to eleven when eleven navigations are needed. Twelve are needed, because the number counts documents and the first document is not a navigation.

A zero is raised to 1 on both paths. A zero would let the loop run without a single round, the page would report success and would have loaded nothing. Only an unreadable value from the environment falls back to the default. `OBSCURA_NAV_CHAIN_LIMIT=0` and `set_navigation_chain_limit(0)` therefore mean the same thing: load the first document and do not chain further.

The new switch is documented in `docs/Environment-variables.md` next to its twin `OBSCURA_NAV_TIMEOUT_MS`.

Deliberately not included are a CDP parameter on `Page.navigate` and a dedicated switch on the CLI. `navigation_timeout` has no CDP parameter either. On the CLI, by contrast, it is set along the way, `obscura fetch --timeout` calls `set_navigation_timeout`. No existing option carries that meaning for the chain limit, so a switch would be new. The environment variable covers operation, and a non-standardized parameter on a CDP command would be the larger intervention.

**On the scope.** The rename changes a public variant of `PageError` and with it the string that a CDP client sees. `domains/page.rs` passes the error through via `map_err(|e| e.to_string())`. That exact string is the subject of the change. Outside of `page.rs` no production code reads the variant or the text, checked across the whole tree. Inside, the test that asserts the message reads it.

Part of #664.

## Validation

Rebased onto `e391f66`, measured on 2026-08-23. Every row comes from a release run.

| Command | Result |
|---|---|
| `cargo nextest run --release --features render -p obscura-browser` | 75 of 75 |
| `cargo nextest run --release --features render --no-fail-fast` | 1494 of 1494, 4 skipped |
| `cargo nextest run --release --no-default-features -p obscura-browser` | 60 of 60 |
| `cargo build --release -p obscura-cli --bins --features render` | clean, 1m20s |
| `cargo build --release -p obscura-cli --bins --features render,stealth` | clean, 1m26s |
| `cargo build --release -p obscura-cli --bins --no-default-features` | clean, 57.91s |
| `cargo build --release -p obscura-cli --bins --no-default-features --features stealth` | clean, 57.55s |

The change touches shared code, which is why the run without `render` is in the table too. A build of the no-render variant does not prove this, it does not compile the test code at all.

Nine new tests in `crates/obscura-browser/src/page.rs`. Three test the pure function that evaluates a value from the environment, following the pattern of the tests for `navigation_timeout`. Four drive a real chain against a local server whose pages set `location.href`. Two set the environment variable themselves.

**The last two are the only place where the name `OBSCURA_NAV_CHAIN_LIMIT` is checked as a string.** Without them a typo in the name would go unnoticed and the suite would stay green, and the variable is the only way to raise the limit in operation. The second additionally asserts that the per-page value beats the environment.

**The four chain tests, by contrast, always set their limit themselves.** If they inherited it, the page would read `OBSCURA_NAV_CHAIN_LIMIT` from the process environment, and whoever runs the suite with exactly the switch this change introduces would see it fail through no fault of the code. Measured without the variable set and with `OBSCURA_NAV_CHAIN_LIMIT` at 20, 3, 0, and an unreadable value, that is five runs: all stay green, nine of nine each time.

Eleven mutations, each caught, and each of the nine tests falls under at least one. Measured in release with `--no-fail-fast`, so that per mutation every catching test becomes visible and not just the first.

| Mutation | caught by |
|---|---|
| The loop uses the constant again | `raised_navigation_chain_limit_reaches_a_longer_chain` |
| The default of 10 becomes 11 | `navigation_chain_limit_environment_default_remains_ten`, `navigation_chain_beyond_the_default_reports_client_navigations` |
| The environment evaluation no longer raises a 0 to 1 | `navigation_chain_limit_raises_a_zero_that_would_load_nothing` |
| The setter no longer raises a 0 to 1 | `a_zero_navigation_chain_limit_still_loads_the_initial_document` |
| The old error text returns | `navigation_chain_beyond_the_default_reports_client_navigations` |
| The message omits the unit again | `navigation_chain_beyond_the_default_reports_client_navigations` |
| The environment variable name gets a typo | `navigation_chain_limit_reads_the_environment_variable_by_name`, measured with `OBSCURA_NAV_CHAIN_LIMIT=17` |
| The per-page value loses against the environment | `a_per_page_navigation_chain_limit_wins_over_the_environment`, `raised_navigation_chain_limit_reaches_a_longer_chain` |
| A readable value from the environment is discarded in favor of the default | `navigation_chain_limit_environment_override_remains_available`, `navigation_chain_limit_raises_a_zero_that_would_load_nothing`, `navigation_chain_limit_reads_the_environment_variable_by_name` |
| The loop runs one document short | `a_zero_navigation_chain_limit_still_loads_the_initial_document`, `navigation_chain_beyond_the_default_reports_client_navigations`, `navigation_chain_default_allows_nine_client_navigations`, `raised_navigation_chain_limit_reaches_a_longer_chain` |
| The fixture inherits the environment again | `navigation_chain_beyond_the_default_reports_client_navigations`, measured with `OBSCURA_NAV_CHAIN_LIMIT=20` |

The five runs without mutation from the paragraph above are at the same time the baseline of this probe.

## Rendering

Not applicable. The change affects the course of a navigation and an error variant. It touches neither layout nor paint, screenshots, screencast, or PDF.

## Performance

The change sits in `navigate_with_wait_post_inner` and therefore on the navigation path. `No expected impact` is therefore not permissible, and measurements were taken.

Added to that is exactly one call to `std::env::var` per navigation chain. The line `let chain_limit = self.navigation_chain_limit();` stands before the loop, not inside it. If a caller sets the limit per page, this call is omitted too.

Measured interleaved, both sides from the same release build, against the same local server, with the same viewport, the same settle policy, and the same output path (`--wait 0 --dump text`). Two workloads: a single navigation and a chain of nine client-initiated navigations. The order of the two binaries alternates per pass, so that machine drift does not systematically favor one side.

Six repetitions of 50 interleaved run pairs each per workload, that is 300 runs per side and workload.

| Workload | Base median | Candidate median | Difference of medians across six repetitions |
|---|---|---|---|
| single navigation | 20.9 to 33.0 ms | 20.4 to 31.4 ms | -4.7 to +3.3 percent |
| chain of nine client-initiated navigations | 96.0 to 132.6 ms | 94.8 to 132.9 ms | -4.0 to +0.3 percent |

The sign of the wall-clock difference flips between repetitions, which is the signature of noise. The spread within a single repetition is many times larger than the difference between the sides. In repetition 1 the individual runs of the base for the simple navigation ranged from 18.4 to 25.6 ms, while the medians of both sides were 0.5 ms apart. Memory is at 35 to 42 MB on both sides, the largest measured difference of the medians is 0.8 percent.

**What this measurement can and cannot do.** It compares the wall clock of whole processes with a median of 21 to 33 ms. The added call costs microseconds and is thus two orders of magnitude below what such a measurement resolves. It rules out a regression above roughly two percent. It does not support a smaller claim, and the change does not make one.

Both sides come from the same build with `--features render`, the candidate from the state of this branch, md5 `2b1649eb4cb4c644735f8f678087a53f`.

Obstacle Course from `obscura-benchmark` at `6ebac82`, the state the CI pins to, with `--runs 1 --warmup 0` against both binaries:

| State | Result |
|---|---|
| `e391f66` (base) | 32 of 33 |
| this branch | 32 of 33 |

Comparing the passed versus failed column shows no deviation across all 33 stages. The one failing stage is called `observer-intersection` on both sides with the same message `expected 'io:50', got ''`. It therefore fails independently of this change. The run thus misses the gate from `CONTRIBUTING.md`, which requires 33 of 33. The stage also fails identically on headless Chrome, and the CI does not catch it. Reported as #671.

## Checklist

- [x] The change is focused and does not remove existing behavior without justification.
- [x] Tests cover the failure or feature.
- [x] Existing tests pass, including render and no-render configurations when affected.
- [x] I checked for CPU, latency, and memory regressions.
- [x] Public API or user-facing behavior changes are documented.