### PR TITLE
The frame wrappers borrow the page, otherwise main does not build

### DIFF
--- a/crates/obscura/src/page.rs
+++ b/crates/obscura/src/page.rs
@@ -52,13 +52,13 @@ impl Page {
 
     /// URLs of the page's child frames, in creation order.
     pub fn frame_urls(&self) -> Vec<String> {
-        self.inner.frame_urls()
+        self.inner.borrow().frame_urls()
     }
 
     /// Execute JS inside one of the page's child frames. Each frame is its own
     /// realm with its own document, so this is the only way to observe one.
     pub fn evaluate_in_frame(&mut self, index: usize, expression: &str) -> Result<Value, String> {
-        self.inner.evaluate_in_frame(index, expression)
+        self.inner.borrow_mut().evaluate_in_frame(index, expression)
     }
 
     /// Get page HTML content.


### PR DESCRIPTION
## What this is about

`main` currently does not build. Two lines in `crates/obscura/src/page.rs` call methods directly on `self.inner`, which is now a `RefCell<Page>`:

```
error[E0599]: no method named `frame_urls` found for struct `RefCell<T>`
    --> crates/obscura/src/page.rs:55:20
error[E0599]: no method named `evaluate_in_frame` found for struct `RefCell<T>`
    --> crates/obscura/src/page.rs:61:20
```

Reproduced on `8ceac62` with a fresh checkout and no further changes: `cargo check -p obscura --features render` produces exactly these two errors.

## How it came to this

It is a conflict between two changes that were each correct on their own. One pull request introduced the wrappers `frame_urls` and `evaluate_in_frame`, another turned `Page.inner` into a `RefCell`. Both ran green against the `main` of their time. Only together do they break, and the merge itself cannot see it, because no textual conflict arises.

The neighbor shows how it was meant. `evaluate` directly above already borrows:

```rust
self.inner.borrow_mut().evaluate(expression)
```

The two frame wrappers were simply overlooked in the move to `RefCell`.

## The fix

Two lines, exactly the ones rustc suggests. `frame_urls` reads, so `borrow()`. `evaluate_in_frame` takes `&mut self`, so `borrow_mut()`.

## Tests

No new ones. `crates/obscura/tests/child_frame_scripts.rs` already uses both methods in 14 places. The file just would not build as long as the library does not build.

After the fix:

| Run | Result |
|---|---|
| `cargo nextest run --features render -p obscura` | 22 tests green |
| `cargo nextest run --features render --workspace` | 1439 tests green |
| `cargo build -p obscura-cli --bins --no-default-features` | error-free |
| `cargo check --workspace --features render,stealth` | error-free |

## A remark, not a demand

This breakage was invisible because the checks have only run on pull requests since `0caa646`. As a result, `main` itself is never built, and the next contributor is the first to notice a conflict that only arises on merge. That is exactly how I ran into it: a red light on my own pull request, which touches two files in a different crate.

Whether a change to the CI follows from this is your decision. I only mention it because otherwise the next merge of this kind will again go unnoticed until someone from the outside runs into it.