### PR TITLE
fix(net): apply the SSRF DNS guard to the stealth client

### DIFF
--- a/crates/obscura-net/src/client.rs
+++ b/crates/obscura-net/src/client.rs
@@ -599,15 +599,19 @@ pub fn is_forbidden_ip(ip: IpAddr) -> bool {
     }
 }
 
-/// reqwest DNS resolver that performs the lookup and then rejects the whole
-/// request if ANY resolved address is in the SSRF deny-set. This closes the
-/// DNS-rebinding bypass a host-string check alone cannot: a public name that
-/// resolves to 127.0.0.1 / 169.254.169.254 / an RFC1918 address is blocked at
-/// connect time, using the very addresses reqwest will dial. When private
-/// access is permitted (`--allow-private-network` or
-/// `OBSCURA_ALLOW_PRIVATE_NETWORK`) the lookup passes through unfiltered.
+/// DNS resolver that performs the lookup and then rejects the whole request if
+/// ANY resolved address is in the SSRF deny-set. This closes the DNS-rebinding
+/// bypass a host-string check alone cannot: a public name that resolves to
+/// 127.0.0.1 / 169.254.169.254 / an RFC1918 address is blocked at connect time,
+/// using the very addresses the client will dial. When private access is
+/// permitted (`--allow-private-network` or `OBSCURA_ALLOW_PRIVATE_NETWORK`) the
+/// lookup passes through unfiltered.
+///
+/// Implemented for both transports: `reqwest::dns::Resolve` just below, and
+/// `wreq::dns::Resolve` in `wreq_client.rs`, so `--stealth` never trades the
+/// guard away for a better TLS fingerprint.
 pub struct SsrfGuardResolver {
-    allow_private: bool,
+    pub(crate) allow_private: bool,
 }
 
 impl SsrfGuardResolver {

--- a/crates/obscura-net/src/wreq_client.rs
+++ b/crates/obscura-net/src/wreq_client.rs
@@ -19,10 +19,43 @@ use crate::cookies::CookieJar;
 #[cfg(feature = "stealth")]
 use crate::client::{
     CallbackRegistry, InFlightGuard, ObscuraNetError, RequestInfo, RequestMode,
-    ResourceRequest, Response, cors_required, fetch_file_url, redirect_taints_origin,
-    request_fetch_site, request_referrer, response_too_large, serialized_request_origin,
-    validate_cors_response, validate_request_mode, validate_url,
+    ResourceRequest, Response, SsrfGuardResolver, cors_required, env_allows_private_network,
+    fetch_file_url, is_forbidden_ip, redirect_taints_origin, request_fetch_site,
+    request_referrer, response_too_large, serialized_request_origin, validate_cors_response,
+    validate_request_mode, validate_url,
 };
+
+/// The wreq half of [`SsrfGuardResolver`]. `validate_url` only inspects the
+/// host *string*, so on its own it lets a public name that resolves inward
+/// straight through — the reqwest client closes that with a `dns_resolver`, and
+/// until this impl existed the stealth client did not, which made `--stealth` a
+/// downgrade in protection rather than only a change of fingerprint. The
+/// deny-set is shared, so the two transports cannot drift apart.
+#[cfg(feature = "stealth")]
+impl wreq::dns::Resolve for SsrfGuardResolver {
+    fn resolve(&self, name: wreq::dns::Name) -> wreq::dns::Resolving {
+        let allow = self.allow_private || env_allows_private_network();
+        let host = name.as_str().to_string();
+        Box::pin(async move {
+            let addrs: Vec<std::net::SocketAddr> = tokio::net::lookup_host((host.as_str(), 0))
+                .await
+                .map_err(|e| -> Box<dyn Error + Send + Sync> { Box::new(e) })?
+                .collect();
+            if !allow {
+                if let Some(bad) = addrs.iter().find(|sa| is_forbidden_ip(sa.ip())) {
+                    return Err(format!(
+                        "SSRF blocked: '{}' resolves to forbidden address {}",
+                        host,
+                        bad.ip()
+                    )
+                    .into());
+                }
+            }
+            let iter: wreq::dns::Addrs = Box::new(addrs.into_iter());
+            Ok(iter)
+        })
+    }
+}
 
 #[cfg(feature = "stealth")]
 pub const STEALTH_USER_AGENT: &str =
@@ -160,6 +193,10 @@ impl StealthHttpClient {
         let mut builder = wreq::Client::builder()
             .emulation(emulation_opts)
             .timeout(Duration::from_secs(30))
+            // SSRF guard: reject hostnames that resolve to a private/loopback IP.
+            // `false` mirrors the `validate_url(url, false)` calls below; the
+            // resolver still honours OBSCURA_ALLOW_PRIVATE_NETWORK on its own.
+            .dns_resolver(Arc::new(SsrfGuardResolver::new(false)))
             .redirect(wreq::redirect::Policy::none());
 
         // Honor SSL_CERT_FILE / SSL_CERT_DIR in the stealth client too.
@@ -487,8 +524,32 @@ mod tests {
     use url::Url;
 
     use super::{StealthHttpClient, send_get_with_connection_reset_retry};
-    use crate::client::ObscuraNetError;
+    use crate::client::{ObscuraNetError, SsrfGuardResolver};
     use crate::cookies::CookieJar;
+    use wreq::dns::{Name, Resolve};
+
+    // Mirrors client::ssrf_tests::resolver_blocks_hostname_that_resolves_to_loopback.
+    // Both transports must agree: a host-string check alone cannot see that a
+    // public name points inward, so the stealth client needs the same resolver.
+    #[tokio::test]
+    async fn stealth_resolver_blocks_hostname_that_resolves_to_loopback() {
+        let resolver = SsrfGuardResolver::new(false);
+        let res = resolver.resolve(Name::from("localtest.me")).await;
+        assert!(res.is_err(), "localtest.me -> 127.0.0.1 must be blocked");
+    }
+
+    #[tokio::test]
+    async fn stealth_resolver_does_not_block_public_host() {
+        // Tolerate a no-network sandbox: only an actual SSRF rejection fails.
+        let resolver = SsrfGuardResolver::new(false);
+        match resolver.resolve(Name::from("example.com")).await {
+            Ok(_) => {}
+            Err(e) => assert!(
+                !e.to_string().contains("SSRF blocked"),
+                "example.com wrongly SSRF-blocked: {e}"
+            ),
+        }
+    }
 
     const PLAIN_BODY: &str = "<!DOCTYPE html><html><body><p id=\"mark\">gzip ok</p></body></html>";
 


### PR DESCRIPTION
## Problem

`ObscuraHttpClient` installs `SsrfGuardResolver` as its `dns_resolver`, so a public name resolving to a loopback / RFC1918 / metadata address is rejected at connect time, using the very addresses the client will dial.

`StealthHttpClient` has no such hook. Its only protection is `validate_url`, which for a `Host::Domain` compares the host **string** against `localhost` spellings and never resolves. DNS rebinding therefore passes on the stealth path — the path users select precisely when they expect hostile sites.

## Evidence

A loopback listener on `127.0.0.1:8099`, and a page on a public origin running `fetch('http://127.0.0.1.nip.io:8099/secret.txt')`:

| build | result | internal server log |
|---|---|---|
| without `stealth` | `error sending request` — resolver refused the dial | *(empty)* |
| with `stealth` | `CORS error: ... Access-Control-Allow-Origin ''` | `"GET /secret.txt HTTP/1.1" 200` |
| with `stealth` + this patch | `error sending request for uri ...: client error (Connect)` | *(empty)* |

The CORS error in row 2 is not a defence: it only hides the body from the page. The request landed, so any side-effecting internal endpoint is reachable.

## Fix

`wreq::dns` mirrors `reqwest::dns` (`Name`, `Addrs`, `Resolving`, `Resolve`), so this is a second impl on the **same** `SsrfGuardResolver` — one deny-set, no way for the two transports to drift apart — plus the `dns_resolver` call on the wreq builder.

`SsrfGuardResolver::new(false)` matches the `validate_url(url, false)` calls already in `wreq_client.rs`; `OBSCURA_ALLOW_PRIVATE_NETWORK` is still honoured inside the resolver, so the documented escape hatch is unchanged.

## Tests

Two tests mirroring the reqwest-side ones. `cargo test -p obscura-net --features stealth` goes from 82 to 84 passing.

The two failures in that run (`configured_roots_trust_a_private_ca_via_ssl_cert_file` and `stealth_client_decodes_gzip_response`, both `127.0.0.1` fixtures rejected by `validate_url`) fail identically on unpatched `main` — they are pre-existing and untouched by this change.

I deliberately did not run `cargo fmt`: it reformats the whole crate here, which suggests my rustfmt defaults differ from yours. The diff is hand-formatted to match the surrounding style — happy to adjust to whatever your setup produces.

🤖 Generated with [Claude Code](https://claude.com/claude-code)