### PR TITLE
fix(cdp): bind page-scoped connections so bare commands resolve

### DIFF
--- a/crates/obscura-cdp/src/dispatch.rs
+++ b/crates/obscura-cdp/src/dispatch.rs
@@ -40,6 +40,14 @@ pub(crate) struct ScreencastState {
 pub struct CdpContext {
     pub pages: Vec<Page>,
     pub sessions: HashMap<String, String>, // session_id -> page_id
+    /// The page this connection is bound to, set only for a page-scoped
+    /// connection (a client that connects straight to `/devtools/page/{id}` and
+    /// sends commands WITHOUT a `sessionId`, the way the `webSocketDebuggerUrl`
+    /// advertised by `/json` implies). `get_session_page(None)` falls back to
+    /// this id. None for browser-scoped connections, so `None`-session
+    /// commands keep routing to nothing there (the browser flow always carries
+    /// an explicit session id from `Target.createTarget`/`attachToTarget`).
+    pub default_page_id: Option<String>,
     /// Current document loader per page. Navigation events and later
     /// script-initiated Network events must share this id; inventing a loader
     /// for each fetch breaks DevTools request grouping.
@@ -109,6 +117,19 @@ pub struct CdpContext {
     pub v8_lock: Arc<tokio::sync::Mutex<()>>,
 }
 
+/// Whether a `page/{id}` path segment is a safe target id to use verbatim.
+/// Obscura's own ids look like `page-1`; accept that shape plus a short
+/// alphanumeric/dash id so a client that connects to `/devtools/page/page-1`
+/// maps onto the right page rather than a counter surprise. Anything odd
+/// (slashes, spaces, control chars) is treated as opaque and the context's
+/// counter id is used instead.
+fn is_plausible_page_id(id: &str) -> bool {
+    !id.is_empty()
+        && id
+            .chars()
+            .all(|c| c.is_ascii_alphanumeric() || c == '-')
+}
+
 impl CdpContext {
     pub fn new() -> Self {
         Self::new_with_options(None, false)
@@ -163,6 +184,7 @@ impl CdpContext {
         CdpContext {
             pages: Vec::new(),
             sessions: HashMap::new(),
+            default_page_id: None,
             current_loader_ids: HashMap::new(),
             announced_frames: HashMap::new(),
             pending_events: Vec::new(),
@@ -311,6 +333,40 @@ impl CdpContext {
             }
         }
         self.sessions.retain(|_, v| v != id);
+        if self.default_page_id.as_deref() == Some(id) {
+            self.default_page_id = None;
+        }
+    }
+
+    /// Bind a page-scoped connection to a fresh page so that commands sent
+    /// without a `sessionId` route to it. `page-scoped` is the id from the
+    /// `/devtools/page/{id}` path; it is used as the page id when it is a
+    /// plausible target name, otherwise the context's counter id is kept.
+    pub fn attach_scoped_page(&mut self, page_scoped: &str) -> String {
+        let page_id = if is_plausible_page_id(page_scoped) {
+            self.claim_scoped_page_id(page_scoped)
+        } else {
+            self.create_page()
+        };
+        self.default_page_id = Some(page_id.clone());
+        page_id
+    }
+
+    fn claim_scoped_page_id(&mut self, id: &str) -> String {
+        // Reserve the counter past the claimed id so later `create_page`
+        // calls on this connection do not collide with it.
+        let numeric = id
+            .strip_prefix("page-")
+            .and_then(|n| n.parse::<u32>().ok());
+        if let Some(n) = numeric {
+            self.page_counter = self.page_counter.max(n);
+        }
+        let mut page = Page::new(id.to_string(), self.default_context.clone());
+        page.navigate_blank();
+        self.pages.push(page);
+        self.current_loader_ids
+            .insert(id.to_string(), format!("loader-blank-{id}"));
+        id.to_string()
     }
 
     #[cfg(feature = "render")]
@@ -320,16 +376,23 @@ impl CdpContext {
         self.next_screencast_session_id
     }
 
+    /// Resolve the page a command routes to. Commands on a browser-scoped
+    /// connection carry an explicit session id; commands on a page-scoped
+    /// connection carry none and route to the page the connection is bound to.
+    fn resolve_page_id(&self, session_id: &Option<String>) -> Option<String> {
+        if let Some(sid) = session_id {
+            return self.sessions.get(sid).cloned();
+        }
+        self.default_page_id.clone()
+    }
+
     pub fn get_session_page(&self, session_id: &Option<String>) -> Option<&Page> {
-        let page_id = session_id.as_ref().and_then(|sid| self.sessions.get(sid))?;
-        self.get_page(page_id)
+        self.resolve_page_id(session_id)
+            .and_then(|page_id| self.get_page(&page_id))
     }
 
     pub fn get_session_page_mut(&mut self, session_id: &Option<String>) -> Option<&mut Page> {
-        let page_id = session_id
-            .as_ref()
-            .and_then(|sid| self.sessions.get(sid))
-            .cloned()?;
+        let page_id = self.resolve_page_id(session_id)?;
 
         let target_has_js = self.pages.iter().any(|p| p.id == page_id && p.has_js());
 
@@ -877,5 +940,75 @@ mod tests {
         let resp = dispatch(&outer, &mut ctx).await;
         let err = resp.error.expect("malformed inner messages must error");
         assert_eq!(err.code, -32700);
+    }
+
+    // Issue #680: a client that connects straight to the page-scoped URL that
+    // `/json` advertises (`/devtools/page/page-1`) sends CDP commands WITHOUT a
+    // sessionId. The processor binds such a connection to a fresh page via
+    // attach_scoped_page so those bare commands route there instead of failing
+    // with "No page".
+    #[tokio::test]
+    async fn attach_scoped_page_routes_none_session_commands() {
+        let mut ctx = CdpContext::new();
+        let none: Option<String> = None;
+
+        // Before the binding, a None-session command resolves to no page.
+        assert!(ctx.get_session_page(&none).is_none());
+
+        let page_id = ctx.attach_scoped_page("page-1");
+        assert_eq!(page_id, "page-1");
+
+        // A None-session command now routes to the bound page, mutably too.
+        let page = ctx
+            .get_session_page(&none)
+            .expect("scoped connection must resolve a page for bare commands");
+        assert_eq!(page.id, "page-1");
+        assert!(
+            ctx.get_session_page_mut(&none).is_some(),
+            "mutable resolution must agree with the immutable one"
+        );
+    }
+
+    #[tokio::test]
+    async fn attach_scoped_page_claims_a_matching_target_id() {
+        // The advertised URL id is used verbatim so Target.getTargets and any
+        // id-referencing client see the page the client connected to, and the
+        // counter is advanced so a later create_page does not collide with it.
+        let mut ctx = CdpContext::new();
+        ctx.attach_scoped_page("page-1");
+        assert_eq!(ctx.create_page(), "page-2");
+    }
+
+    #[tokio::test]
+    async fn attach_scoped_page_falls_back_to_counter_for_opaque_id() {
+        // A path segment that is not a clean target id is treated as opaque:
+        // the context's counter id is used and the scoped page still binds.
+        let mut ctx = CdpContext::new();
+        let none: Option<String> = None;
+        let page_id = ctx.attach_scoped_page("not a clean id");
+        assert_eq!(page_id, "page-1");
+        assert!(ctx.get_session_page(&none).is_some());
+    }
+
+    #[tokio::test]
+    async fn browser_scoped_context_keeps_none_session_unrouted() {
+        // A browser-scoped connection never calls attach_scoped_page; its
+        // None-session commands must keep resolving to nothing so that
+        // browser-level handlers are unaffected by the scoped-page fallback.
+        let mut ctx = CdpContext::new();
+        let none: Option<String> = None;
+        let _ = ctx.create_page();
+        assert!(ctx.get_session_page(&none).is_none());
+        assert!(ctx.get_session_page_mut(&none).is_none());
+    }
+
+    #[tokio::test]
+    async fn remove_scoped_page_clears_default_binding() {
+        let mut ctx = CdpContext::new();
+        let none: Option<String> = None;
+        let page_id = ctx.attach_scoped_page("page-1");
+        assert!(ctx.get_session_page(&none).is_some());
+        ctx.remove_page(&page_id);
+        assert!(ctx.get_session_page(&none).is_none());
     }
 }

--- a/crates/obscura-cdp/src/server.rs
+++ b/crates/obscura-cdp/src/server.rs
@@ -196,7 +196,10 @@ pub async fn start_with_serve_options_and_limit(
         info!("file:// navigation enabled (--allow-file-access). Do not expose this port to untrusted networks.");
     }
 
-    let (ws_tx, mut ws_rx) = mpsc::channel::<std::net::TcpStream>(MAX_PENDING_WS_HANDOFFS);
+    // Each handed-off connection carries the page-scoped id if the client
+    // connected to a `/devtools/page/{id}` URL (else None for browser-scoped).
+    let (ws_tx, mut ws_rx) =
+        mpsc::channel::<(std::net::TcpStream, Option<String>)>(MAX_PENDING_WS_HANDOFFS);
 
     // Ctrl-C / graceful shutdown coordination.
     let shutdown_flag = Arc::new(AtomicBool::new(false));
@@ -308,12 +311,12 @@ pub async fn start_with_serve_options_and_limit(
     // Accept loop: hand each WebSocket connection to its own OS thread so its
     // pages' isolates live on a dedicated thread.
     loop {
-        let stream = tokio::select! {
-            stream = ws_rx.recv() => stream,
+        let handoff = tokio::select! {
+            s = ws_rx.recv() => s,
             _ = shutdown_notify.notified() => None,
         };
-        let stream = match stream {
-            Some(s) => s,
+        let (stream, page_scoped) = match handoff {
+            Some((stream, page_scoped)) => (stream, page_scoped),
             None => break,
         };
         // Nagle off + nonblocking on the std socket before it moves to the
@@ -346,6 +349,7 @@ pub async fn start_with_serve_options_and_limit(
         }
         run_connection(
             stream,
+            page_scoped,
             shared_ctx.clone(),
             persistence_ctx.clone(),
             persistence_lock.clone(),
@@ -434,6 +438,7 @@ fn cap_malloc_arenas() {
 /// plumbing is needed.
 fn run_connection(
     std_stream: std::net::TcpStream,
+    page_scoped: Option<String>,
     context_template: Arc<obscura_browser::BrowserContext>,
     persistence_context: Arc<obscura_browser::BrowserContext>,
     persistence_lock: Arc<std::sync::Mutex<()>>,
@@ -485,6 +490,7 @@ fn run_connection(
                     msg_rx,
                     default_context,
                     shutdown_notify,
+                    page_scoped,
                 ));
                 if let Err(e) = handle_connection_ws(tokio_stream, msg_tx).await {
                     error!("WebSocket connection error: {}", e);
@@ -609,11 +615,14 @@ const WS_PEEK_BUF: usize = 4;
 fn accept_dispatch(
     stream: std::net::TcpStream,
     port: u16,
-    ws_tx: &mpsc::Sender<std::net::TcpStream>,
+    ws_tx: &mpsc::Sender<(std::net::TcpStream, Option<String>)>,
 ) -> anyhow::Result<()> {
     let mut buf = [0u8; WS_PEEK_BUF];
     let n = stream.peek(&mut buf)?;
 
+    // Page-scoped target id if the client connected to a `/devtools/page/{id}`
+    // WebSocket; None for browser-scoped (`/devtools/browser`) connections.
+    let mut page_scoped: Option<String> = None;
     if n >= 4 && &buf == b"GET " {
         let mut peek_buf = [0u8; HTTP_PEEK_BUF];
         let n = stream.peek(&mut peek_buf)?;
@@ -632,9 +641,10 @@ fn accept_dispatch(
         if let Some(ep) = endpoint {
             return handle_http_json_blocking(stream, port, ep);
         }
-        // Fall through: GET request that isn't a /json endpoint → treat as
-        // WebSocket upgrade (Chromium DevTools clients issue GET with
-        // Upgrade: websocket).
+        // A GET that isn't a /json endpoint is a WebSocket upgrade. If the
+        // client connected to a page-scoped URL, capture the target id so the
+        // processor can bind a page for its sessionId-less commands.
+        page_scoped = parse_page_scoped_target(&line);
     }
 
     // Try to hand off the WS stream to the LocalSet. If the bounded channel
@@ -644,7 +654,7 @@ fn accept_dispatch(
     // dropped `stream` closes itself; the client will see ECONNRESET and
     // can retry.
     ws_tx
-        .try_send(stream)
+        .try_send((stream, page_scoped))
         .map_err(|e| match e {
             mpsc::error::TrySendError::Full(_) => {
                 warn!("WS handoff channel full ({}); dropping new WebSocket connection", MAX_PENDING_WS_HANDOFFS);
@@ -652,6 +662,25 @@ fn accept_dispatch(
             }
             mpsc::error::TrySendError::Closed(_) => anyhow::anyhow!("accept channel closed"),
         })
+}
+
+/// Extract the `{id}` from a `/devtools/page/{id}` WebSocket request line, e.g.
+/// `"GET /devtools/page/page-1 HTTP/1.1"` → `"page-1"`. Returns None for the
+/// browser-scoped path (`/devtools/browser`) and any other route, so those
+/// connections keep the current browser-level behavior.
+fn parse_page_scoped_target(request_line: &str) -> Option<String> {
+    let path = request_line
+        .split_whitespace()
+        .nth(1)?
+        .split('?')
+        .next()?;
+    let rest = path.strip_prefix("/devtools/page/")?;
+    let id = rest.trim_end_matches('/');
+    if id.is_empty() {
+        None
+    } else {
+        Some(id.to_string())
+    }
 }
 
 /// Serve an HTTP `/json/*` endpoint with blocking I/O on the accept thread.
@@ -709,6 +738,10 @@ async fn cdp_processor(
     mut rx: mpsc::UnboundedReceiver<ServerMessage>,
     default_context: Arc<obscura_browser::BrowserContext>,
     shutdown_notify: Arc<Notify>,
+    // Page-scoped connections (a client that connected straight to
+    // `/devtools/page/{id}`) pass the target id here; None for browser-scoped.
+    // Consumed once on NewConnection (via `.take()`), so it is mutable.
+    mut page_scoped: Option<String>,
 ) {
     let mut ctx = CdpContext::new_with_shared_context(default_context);
     let (itx, irx) = mpsc::unbounded_channel::<obscura_js::ops::InterceptedRequest>();
@@ -861,6 +894,13 @@ async fn cdp_processor(
 
         match msg {
             ServerMessage::NewConnection { reply_tx } => {
+                // A client that connects straight to `/devtools/page/{id}` (the
+                // URL `/json` advertises) has no sessionId to send. Bind this
+                // connection to a fresh page so its bare commands route there
+                // instead of failing with "No page" (#680).
+                if let Some(page_id) = page_scoped.take() {
+                    ctx.attach_scoped_page(&page_id);
+                }
                 connection_reply_tx = Some(reply_tx.clone());
                 let _ = reply_tx.send(
                     json!({"__init": true})
@@ -1615,6 +1655,7 @@ async fn handle_connection_ws(
 mod tests {
     use super::{
         handle_fetch_resolution, is_navigate_method, merge_cookie_delta, parse_cdp_headers,
+        parse_page_scoped_target,
     };
     #[cfg(feature = "render")]
     use super::{pump_and_forward_screencast_frames, pump_live_page_event_loop};
@@ -1647,6 +1688,7 @@ mod tests {
                     server_rx,
                     default_context,
                     shutdown,
+                    None,
                 ));
 
                 server_tx
@@ -1757,6 +1799,113 @@ mod tests {
                     .expect("processor task");
             })
             .await;
+    }
+
+    // Issue #680 end-to-end: a client that connects to the page-scoped URL that
+    // `/json` advertises sends `Runtime.evaluate` with no sessionId. The
+    // processor must bind that connection to a page so the bare command
+    // resolves instead of coming back as
+    // {"error":{"code":-32601,"message":"No page"}}.
+    #[tokio::test(flavor = "current_thread")]
+    async fn page_scoped_connection_evaluate_without_session_id() {
+        tokio::task::LocalSet::new()
+            .run_until(async {
+                let (server_tx, server_rx) = tokio::sync::mpsc::unbounded_channel();
+                let (reply_tx, mut reply_rx) = tokio::sync::mpsc::unbounded_channel();
+                let shutdown = std::sync::Arc::new(tokio::sync::Notify::new());
+                let default_context = crate::dispatch::CdpContext::new().default_context;
+                let processor = tokio::task::spawn_local(super::cdp_processor(
+                    server_rx,
+                    default_context,
+                    shutdown,
+                    Some("page-1".to_string()),
+                ));
+
+                server_tx
+                    .send(super::ServerMessage::NewConnection {
+                        reply_tx: reply_tx.clone(),
+                    })
+                    .unwrap();
+                let init = reply_rx.recv().await.expect("processor init");
+                assert!(init.contains("__init"));
+
+                // The decisive repro step: a bare `Runtime.evaluate` with no
+                // sessionId, exactly as a raw client sending the URL from
+                // `/json` would.
+                let send = |value: serde_json::Value| {
+                    server_tx
+                        .send(super::ServerMessage::Cdp(super::CdpMessage {
+                            text: value.to_string(),
+                            reply_tx: reply_tx.clone(),
+                        }))
+                        .unwrap();
+                };
+                send(json!({
+                    "id": 1,
+                    "method": "Runtime.evaluate",
+                    "params": {
+                        "expression": "document.title",
+                        "returnByValue": true,
+                    },
+                }));
+
+                let response = loop {
+                    let value: serde_json::Value = serde_json::from_str(
+                        &tokio::time::timeout(
+                            std::time::Duration::from_secs(5),
+                            reply_rx.recv(),
+                        )
+                        .await
+                        .expect("evaluate response timeout")
+                        .expect("evaluate response channel"),
+                    )
+                    .unwrap();
+                    if value["id"] == 1 {
+                        break value;
+                    }
+                };
+
+                assert!(
+                    response.get("error").is_none(),
+                    "a bare Runtime.evaluate on a page-scoped connection must not \
+                     error (got: {response})"
+                );
+                assert!(
+                    response.get("result").is_some(),
+                    "a bare Runtime.evaluate must return a result (got: {response})"
+                );
+
+                drop(server_tx);
+                tokio::time::timeout(std::time::Duration::from_secs(2), processor)
+                    .await
+                    .expect("processor shutdown timeout")
+                    .expect("processor task");
+            })
+            .await;
+    }
+
+    #[test]
+    fn parse_page_scoped_target_extracts_page_id() {
+        assert_eq!(
+            parse_page_scoped_target("GET /devtools/page/page-1 HTTP/1.1"),
+            Some("page-1".to_string()),
+        );
+        // Trailing slashes and query strings are tolerated.
+        assert_eq!(
+            parse_page_scoped_target("GET /devtools/page/page-2/?a=1 HTTP/1.1"),
+            Some("page-2".to_string()),
+        );
+    }
+
+    #[test]
+    fn parse_page_scoped_target_rejects_non_page_paths() {
+        // The browser-scoped path and an empty page path must stay
+        // browser-scoped so they keep the current behavior.
+        assert_eq!(
+            parse_page_scoped_target("GET /devtools/browser HTTP/1.1"),
+            None,
+        );
+        assert_eq!(parse_page_scoped_target("GET /devtools/page/ HTTP/1.1"), None);
     }
 
     #[test]


### PR DESCRIPTION
## What changed

A client that connects to the page-scoped WebSocket URL that `/json` advertises
(`/devtools/page/{id}`) sends CDP commands with no `sessionId`. The server never
read the WS request path, so `get_session_page(None)` resolved to nothing and
every page-domain command came back as `{"error":{"code":-32601,"message":"No page"}}`.
The browser-scoped flow (Puppeteer/Playwright) was unaffected: it connects to
`/devtools/browser`, calls `Target.createTarget`/`attachToTarget`, and carries
the returned `sessionId` in every command.

- `accept_dispatch` peeks the WS request line and, for a `/devtools/page/{id}`
  upgrade, captures the target id (`parse_page_scoped_target`); the handoff
  channel now carries `(TcpStream, Option<String>)`.
- The processor binds a page-scoped connection to a fresh page on
  `NewConnection` (`CdpContext::attach_scoped_page`), reusing the URL id when it
  is a plausible target name so the page matches what `/json` advertised.
- `get_session_page` / `get_session_page_mut` fall back to that bound page when a
  command carries no `sessionId` (`resolve_page_id`); `remove_page` clears the
  binding.

Browser-scoped connections leave `default_page_id` unset, so the
`Target.createTarget` / `attachToTarget` path is unchanged.

Fixes #680.

## Validation

On the PR branch (`origin/main` + this commit):

- `cargo nextest run --release --features render -p obscura-cdp` → 163 passed, 3 skipped.
- `cargo nextest run --release -p obscura-cdp` (no render) → 132 passed, 3 skipped.
- New regression tests: `attach_scoped_page_routes_none_session_commands`,
  `attach_scoped_page_claims_a_matching_target_id`,
  `attach_scoped_page_falls_back_to_counter_for_opaque_id`,
  `browser_scoped_context_keeps_none_session_unrouted`,
  `remove_scoped_page_clears_default_binding`, `parse_page_scoped_target_*`, and the
  end-to-end `page_scoped_connection_evaluate_without_session_id`.
- Manual: `obscura serve`, connect to the `webSocketDebuggerUrl` from `GET /json`
  (`ws://127.0.0.1:<port>/devtools/page/page-1`), send `Runtime.evaluate` with no
  `sessionId` → returns a result (was `"No page"`). Confirmed the browser-scoped
  flow (`Target.createTarget` then `Runtime.evaluate` with the returned `sessionId`)
  still returns correctly.

## Rendering

Not applicable.

## Performance

Connect-time only: one extra `stream.peek` (up to 4 KiB) and a small path parse in
`accept_dispatch` per new WebSocket connection, and one page created at
`NewConnection` for page-scoped connections. Per command, `resolve_page_id` adds a
branch and an `Option<String>` clone when the command has no `sessionId`; commands
that carry a session id (the browser-scoped path) resolve exactly as before. No
layout, paint, or memory growth. No hot-path before/after benchmark because the
change is routing, not a render or fetch path.

## Checklist

- [x] The change is focused and does not remove existing behavior without justification.
- [x] Tests cover the failure or feature.
- [x] Existing tests pass, including render and no-render configurations when affected.
- [x] I checked for CPU, latency, and memory regressions.
- [x] Public API or user-facing behavior changes are documented.
