### PR TITLE
fix(render): give textarea an intrinsic control box and its own interface

### DIFF
--- a/crates/obscura-js/js/bootstrap.js
+++ b/crates/obscura-js/js/bootstrap.js
@@ -6049,6 +6049,7 @@ function _elementClassFor(nid) {
     if (globalThis.SVGElement) return globalThis.SVGElement;
   }
   if (tag === "FORM" && globalThis.HTMLFormElement) return globalThis.HTMLFormElement;
+  if (tag === "TEXTAREA" && globalThis.HTMLTextAreaElement) return globalThis.HTMLTextAreaElement;
   if (tag === "IMG") return HTMLImageElement;
   if (tag === "CANVAS" && globalThis.HTMLCanvasElement) return globalThis.HTMLCanvasElement;
   if (tag === "AUDIO") return HTMLAudioElement;
@@ -6068,6 +6069,7 @@ function _elementClassForKnownName(namespace, qualifiedName) {
   if (namespace === "http://www.w3.org/1999/xhtml") {
     const tag = localName.toUpperCase();
     if (tag === "FORM" && globalThis.HTMLFormElement) return globalThis.HTMLFormElement;
+    if (tag === "TEXTAREA" && globalThis.HTMLTextAreaElement) return globalThis.HTMLTextAreaElement;
     if (tag === "IMG") return HTMLImageElement;
     if (tag === "CANVAS" && globalThis.HTMLCanvasElement) return globalThis.HTMLCanvasElement;
     if (tag === "AUDIO") return HTMLAudioElement;
@@ -11019,7 +11021,23 @@ globalThis.HTMLFormElement = class HTMLFormElement extends Element {
   reset() { for (const f of this.elements) { if ('value' in f) f.value = ''; } }
 };
 globalThis.HTMLSelectElement = Element;
-globalThis.HTMLTextAreaElement = Element;
+globalThis.HTMLTextAreaElement = class HTMLTextAreaElement extends Element {
+  // `rows`/`cols` reflect the content attributes and drive the control's
+  // intrinsic box (the renderer sizes a textarea from them). The attributes
+  // are limited to positive non-zero numbers; anything else falls back to the
+  // HTML defaults (rows=2, cols=20), which is what an unsized <textarea>
+  // measures against. (#685)
+  get rows() {
+    const v = parseInt(this.getAttribute('rows'), 10);
+    return Number.isFinite(v) && v > 0 ? v : 2;
+  }
+  set rows(v) { this.setAttribute('rows', String(v)); }
+  get cols() {
+    const v = parseInt(this.getAttribute('cols'), 10);
+    return Number.isFinite(v) && v > 0 ? v : 20;
+  }
+  set cols(v) { this.setAttribute('cols', String(v)); }
+};
 globalThis.HTMLLabelElement = Element;
 globalThis.HTMLTableElement = Element;
 globalThis.HTMLIFrameElement = Element;

--- a/crates/obscura-render/src/dom.rs
+++ b/crates/obscura-render/src/dom.rs
@@ -5780,7 +5780,7 @@ fn layout_dom_once(
             .filter_map(|(&id, style)| {
                 let node = tree.get_node(id)?;
                 let element = node.as_element()?;
-                matches!(element.local.as_ref(), "input" | "select").then(|| {
+                matches!(element.local.as_ref(), "input" | "select" | "textarea").then(|| {
                     (
                         id,
                         (
@@ -5914,26 +5914,54 @@ fn layout_dom_once(
                 let intrinsic_width = label_width + horizontal_edges;
                 let intrinsic_height =
                     crate::inline::used_line_height(style).max(1.0) * rows + vertical_edges;
-                let (stretch_inline, stretch_block) = native_control_grid_stretch
-                    .get(&id)
-                    .copied()
-                    .unwrap_or_default();
-                if style.width == crate::Dimension::Auto && !stretch_inline {
-                    style.width =
-                        crate::Dimension::Px(if style.box_sizing == crate::BoxSizing::ContentBox {
-                            label_width
-                        } else {
-                            intrinsic_width
-                        });
-                }
-                if style.height == crate::Dimension::Auto && !stretch_block {
-                    style.height =
-                        crate::Dimension::Px(if style.box_sizing == crate::BoxSizing::ContentBox {
-                            (intrinsic_height - vertical_edges).max(0.0)
-                        } else {
-                            intrinsic_height
-                        });
-                }
+                assign_native_control_size(
+                    style,
+                    native_control_grid_stretch.get(&id).copied().unwrap_or_default(),
+                    intrinsic_width,
+                    intrinsic_height,
+                    horizontal_edges,
+                    vertical_edges,
+                );
+                continue;
+            }
+            if element.local.as_ref() == "textarea" {
+                // A native textarea's intrinsic border box comes from the
+                // rows/cols content attributes (HTML defaults 2 and 20), not
+                // from its text content: an empty textarea is still a
+                // visible, clickable control (Chromium cols=20 rows=2 ->
+                // 168x36, rows=8 -> 126 tall). Per-column width is the
+                // fixed-pitch average advance calibrated to Chromium's
+                // control metrics; per-row height is the normal line height.
+                let rows = node
+                    .get_attribute("rows")
+                    .and_then(|value| value.trim().parse::<usize>().ok())
+                    .filter(|&value| value > 0)
+                    .unwrap_or(2) as f32;
+                let cols = node
+                    .get_attribute("cols")
+                    .and_then(|value| value.trim().parse::<usize>().ok())
+                    .filter(|&value| value > 0)
+                    .unwrap_or(20) as f32;
+                let font_size = style.font_size.unwrap_or(13.333_333).max(1.0);
+                let horizontal_edges = style.padding.left
+                    + style.padding.right
+                    + style.border.left
+                    + style.border.right;
+                let vertical_edges = style.padding.top
+                    + style.padding.bottom
+                    + style.border.top
+                    + style.border.bottom;
+                let intrinsic_width = cols * font_size * 0.6075 + horizontal_edges;
+                let intrinsic_height =
+                    crate::inline::used_line_height(style).max(1.0) * rows + vertical_edges;
+                assign_native_control_size(
+                    style,
+                    native_control_grid_stretch.get(&id).copied().unwrap_or_default(),
+                    intrinsic_width,
+                    intrinsic_height,
+                    horizontal_edges,
+                    vertical_edges,
+                );
                 continue;
             }
             if element.local.as_ref() != "input" {
@@ -5950,10 +5978,6 @@ fn layout_dom_once(
             }
 
             let font_size = style.font_size.unwrap_or(13.333_333).max(1.0);
-            let (stretch_inline, stretch_block) = native_control_grid_stretch
-                .get(&id)
-                .copied()
-                .unwrap_or_default();
             let horizontal_edges =
                 style.padding.left + style.padding.right + style.border.left + style.border.right;
             let vertical_edges =
@@ -5993,22 +6017,14 @@ fn layout_dom_once(
                     )
                 }
             };
-            if style.width == crate::Dimension::Auto && !stretch_inline {
-                let declared_width = if style.box_sizing == crate::BoxSizing::ContentBox {
-                    (intrinsic_width - horizontal_edges).max(0.0)
-                } else {
-                    intrinsic_width
-                };
-                style.width = crate::Dimension::Px(declared_width);
-            }
-            if style.height == crate::Dimension::Auto && !stretch_block {
-                let declared_height = if style.box_sizing == crate::BoxSizing::ContentBox {
-                    (intrinsic_height - vertical_edges).max(0.0)
-                } else {
-                    intrinsic_height
-                };
-                style.height = crate::Dimension::Px(declared_height);
-            }
+            assign_native_control_size(
+                style,
+                native_control_grid_stretch.get(&id).copied().unwrap_or_default(),
+                intrinsic_width,
+                intrinsic_height,
+                horizontal_edges,
+                vertical_edges,
+            );
         }
 
         resolve_grid_areas(tree, root_id, &mut styles);
@@ -11394,6 +11410,39 @@ enum ContainerAutoInlineSize {
 enum ContainerAutoBlockSize {
     Intrinsic,
     StretchedGridItem,
+}
+
+/// Assign a native control's intrinsic border-box size to its auto axes.
+/// The intrinsic figures are border boxes (Chromium's control metrics), so
+/// a content-box control receives the content part. An authored width or
+/// height keeps winning, as does a grid axis that stretches the item:
+/// only an untouched auto axis adopts the intrinsic value.
+fn assign_native_control_size(
+    style: &mut crate::LayoutStyle,
+    stretched_grid_item: (bool, bool),
+    intrinsic_width: f32,
+    intrinsic_height: f32,
+    horizontal_edges: f32,
+    vertical_edges: f32,
+) {
+    let (stretch_inline, stretch_block) = stretched_grid_item;
+    let content_box = style.box_sizing == crate::BoxSizing::ContentBox;
+    if style.width == crate::Dimension::Auto && !stretch_inline {
+        let declared = if content_box {
+            (intrinsic_width - horizontal_edges).max(0.0)
+        } else {
+            intrinsic_width
+        };
+        style.width = crate::Dimension::Px(declared);
+    }
+    if style.height == crate::Dimension::Auto && !stretch_block {
+        let declared = if content_box {
+            (intrinsic_height - vertical_edges).max(0.0)
+        } else {
+            intrinsic_height
+        };
+        style.height = crate::Dimension::Px(declared);
+    }
 }
 
 /// Classify how an auto inline-size is resolved. Stretched grid items need
@@ -20279,5 +20328,48 @@ mod tests {
         let width = |id| laid.rects[&tree.get_element_by_id(id).unwrap()].width;
 
         assert!(width("keep") > width("normal"));
+    }
+
+    #[test]
+    fn textarea_intrinsic_box_comes_from_rows_and_cols() {
+        // #685: an empty textarea must keep a real control box instead of
+        // laying out as a plain block. Chromium calibrates cols=20/rows=2 to
+        // a 168x36 border box with one 15px control line per row.
+        let tree = parse_html(
+            r#"<style>html, body { margin: 0 }</style>
+            <div><textarea id="plain"></textarea></div>
+            <div><textarea id="rows8" rows="8"></textarea></div>
+            <div><textarea id="cssheight" style="height: 36px"></textarea></div>
+            <div><textarea id="invalid-rows" rows="0"></textarea></div>"#,
+        );
+        let laid = layout_dom(&tree, (1280.0, 720.0));
+        let rect = |id: &str| laid.rects[&tree.get_element_by_id(id).unwrap()];
+
+        let plain = rect("plain");
+        assert!((plain.width - 168.0).abs() < 0.5, "{}", plain.width);
+        assert!((plain.height - 36.0).abs() < 0.5, "{}", plain.height);
+
+        let rows8 = rect("rows8");
+        assert!((rows8.width - 168.0).abs() < 0.5);
+        assert!((rows8.height - 126.0).abs() < 0.5, "{}", rows8.height);
+
+        // Author height wins over the rows-derived intrinsic height, and the
+        // control is border-box, so 36px stays the border-box height.
+        let cssheight = rect("cssheight");
+        assert!(
+            (cssheight.height - 36.0).abs() < 0.5,
+            "{}",
+            cssheight.height
+        );
+
+        // rows/cols are limited to positive numbers; anything else falls
+        // back to the HTML defaults (rows=2).
+        let invalid = rect("invalid-rows");
+        assert!((invalid.height - 36.0).abs() < 0.5, "{}", invalid.height);
+
+        // The control is an atomic inline-block, not a stretched block.
+        let style = &laid.styles[&tree.get_element_by_id("plain").unwrap()];
+        assert_eq!(style.display, crate::Display::Inline);
+        assert!(style.is_inline_block);
     }
 }

--- a/crates/obscura-render/src/style.rs
+++ b/crates/obscura-render/src/style.rs
@@ -243,6 +243,38 @@ pub fn ua_style(tag: &str) -> LayoutStyle {
         style.border_model.colors = crate::Sides::all(Some([118, 118, 118, 255]));
         style.border_color = Some([118, 118, 118, 255]);
         style.background_color = Some([255, 255, 255, 255]);
+    } else if tag == "textarea" {
+        // A native textarea is an atomic inline-block control whose
+        // intrinsic box comes from rows/cols (resolved in dom.rs once the
+        // attributes are readable), not from its text content. Unlike the
+        // other controls it keeps its content in the tree (the value is the
+        // text child), laid out inside the sized box; line breaks in the
+        // value must survive, hence pre-wrap. Chromium defaults the control
+        // to the fixed-pitch face and to border-box sizing.
+        style.display = Display::Inline;
+        style.is_inline_block = true;
+        style.font_size = Some(13.333_333);
+        style.font_family = Some("monospace".to_string());
+        style.line_height = Some(crate::LineHeight::Normal);
+        style.white_space = Some(crate::WhiteSpace::PreWrap);
+        style.box_sizing = crate::BoxSizing::BorderBox;
+        style.padding = Edges {
+            top: 2.0,
+            right: 2.0,
+            bottom: 2.0,
+            left: 2.0,
+        };
+        style.border = Edges {
+            top: 1.0,
+            right: 1.0,
+            bottom: 1.0,
+            left: 1.0,
+        };
+        style.border_model.specified_widths = crate::Sides::all(1.0);
+        style.border_model.styles = crate::Sides::all(crate::BorderStyle::Solid);
+        style.border_model.colors = crate::Sides::all(Some([118, 118, 118, 255]));
+        style.border_color = Some([118, 118, 118, 255]);
+        style.background_color = Some([255, 255, 255, 255]);
     } else if matches!(tag, "table" | "tbody" | "thead" | "tfoot") {
         style.display = Display::Flex;
         style.internal_flex_container = true;

--- a/crates/obscura/tests/textarea_semantics.rs
+++ b/crates/obscura/tests/textarea_semantics.rs
@@ -1,0 +1,121 @@
+// Textarea parity from #685: the element kept its parser handling and value
+// semantics but had no interface of its own and no control geometry, so it
+// laid out as a plain block (full containing-block width, zero height when
+// empty). Playwright resolves that zero-height box to `hidden`, and
+// wait_for_selector/click/fill then burn their full timeout. Both halves are
+// covered here:
+//
+// - DOM: rows/cols reflect their attributes with the HTML defaults (2/20),
+//   type is the fixed string "textarea", and the wrapper is a real
+//   HTMLTextAreaElement (constructor.name, instanceof) instead of Element.
+// - Layout: an empty textarea keeps an intrinsic box from rows/cols
+//   (Chromium: cols=20 rows=2 -> 168x36, rows=8 -> 126 tall), is
+//   inline-block, and an authored height still wins.
+
+use std::io::{Read, Write};
+
+use obscura::Browser;
+
+fn spawn_server() -> String {
+    let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+    let addr = listener.local_addr().unwrap();
+    std::thread::spawn(move || {
+        for incoming in listener.incoming() {
+            let Ok(mut stream) = incoming else {
+                continue;
+            };
+            std::thread::spawn(move || {
+                let mut request = [0u8; 2048];
+                let _ = stream.read(&mut request);
+                let body = r#"<!doctype html><html><head><title>fixture</title></head><body>
+<textarea id="t"></textarea>
+<textarea id="r" rows="8"></textarea>
+<textarea id="c" style="height:36px"></textarea>
+</body></html>"#;
+                let response = format!(
+                    "HTTP/1.1 200 OK\r\nContent-Type: text/html\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+                    body.len(),
+                    body,
+                );
+                let _ = stream.write_all(response.as_bytes());
+                let _ = stream.shutdown(std::net::Shutdown::Both);
+            });
+        }
+    });
+    format!("http://{}", addr)
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn textarea_idl_matches_browser_semantics() {
+    std::env::set_var("OBSCURA_ALLOW_PRIVATE_NETWORK", "1");
+    let base = spawn_server();
+
+    let browser = Browser::new().unwrap();
+    let mut page = browser.new_page().await.unwrap();
+    page.goto(&base).await.unwrap();
+
+    let probes = page.evaluate(
+        r#"(function () {
+            var t = document.getElementById('t');
+            return {
+                rows_default: t.rows,
+                cols_default: t.cols,
+                type: t.type,
+                ctor: t.constructor.name,
+                is_textarea: t instanceof HTMLTextAreaElement,
+                is_element: t instanceof Element,
+                rows_reflect: (t.rows = 5, t.getAttribute('rows')),
+                rows_after_set: t.rows,
+                rows_invalid: (t.setAttribute('rows', '0'), t.rows),
+            };
+        })()"#,
+    );
+
+    assert_eq!(probes["rows_default"], 2);
+    assert_eq!(probes["cols_default"], 20);
+    assert_eq!(probes["type"], "textarea");
+    assert_eq!(probes["ctor"], "HTMLTextAreaElement");
+    assert_eq!(probes["is_textarea"], true);
+    assert_eq!(probes["is_element"], true);
+    assert_eq!(probes["rows_reflect"], "5");
+    assert_eq!(probes["rows_after_set"], 5);
+    // rows/cols are limited to positive numbers; anything else reads back
+    // as the default.
+    assert_eq!(probes["rows_invalid"], 2);
+}
+
+#[cfg(feature = "render")]
+#[tokio::test(flavor = "current_thread")]
+async fn textarea_gets_intrinsic_control_box() {
+    std::env::set_var("OBSCURA_ALLOW_PRIVATE_NETWORK", "1");
+    let base = spawn_server();
+
+    let browser = Browser::new().unwrap();
+    let mut page = browser.new_page().await.unwrap();
+    page.goto(&base).await.unwrap();
+
+    let probes = page.evaluate(
+        r#"(function () {
+            var box = function (id) {
+                var r = document.getElementById(id).getBoundingClientRect();
+                return r.width.toFixed(0) + 'x' + r.height.toFixed(0);
+            };
+            var t = document.getElementById('t');
+            return {
+                empty: box('t'),
+                rows8: box('r'),
+                css_height: box('c'),
+                display: getComputedStyle(t).display,
+                value_roundtrip: (t.value = 'hi', t.value),
+            };
+        })()"#,
+    );
+
+    // Chromium reference: an empty cols=20 rows=2 control is 168x36; each
+    // extra row adds one 15px control line; authored height wins.
+    assert_eq!(probes["empty"], "168x36");
+    assert_eq!(probes["rows8"], "168x126");
+    assert_eq!(probes["css_height"], "168x36");
+    assert_eq!(probes["display"], "inline-block");
+    assert_eq!(probes["value_roundtrip"], "hi");
+}

--- a/render-repros/checks.json
+++ b/render-repros/checks.json
@@ -105,7 +105,9 @@
     {"name": "standards author dimensions use content box", "color": "#e8590c", "x": 808, "y": 0, "width": 20, "height": 30},
     {"name": "checkbox uses native intrinsic border box and margins", "color": "#7048e8", "x": 20, "y": 100, "width": 20, "height": 13},
     {"name": "range uses native intrinsic border box and margins", "color": "#c2255c", "x": 333, "y": 100, "width": 20, "height": 16},
-    {"name": "hidden input consumes no flex geometry", "color": "#2b8a3e", "x": 500, "y": 100, "width": 20, "height": 20}
+    {"name": "hidden input consumes no flex geometry", "color": "#2b8a3e", "x": 500, "y": 100, "width": 20, "height": 20},
+    {"name": "textarea intrinsic box comes from rows and cols", "color": "#f08c00", "x": 168, "y": 200, "width": 20, "height": 36},
+    {"name": "rows attribute scales the textarea intrinsic height", "color": "#e64980", "x": 518, "y": 200, "width": 20, "height": 126}
   ],
   "form-control-quirks": [
     {"name": "quirks form keeps legacy one-em bottom margin", "color": "#087f5b", "x": 0, "y": 37, "width": 100, "height": 20},

--- a/render-repros/form-control-geometry.html
+++ b/render-repros/form-control-geometry.html
@@ -21,6 +21,8 @@
     .checkbox-row { left: 0; top: 100px; }
     .range-row { left: 200px; top: 100px; }
     .hidden-row { left: 500px; top: 100px; }
+    .textarea-row { left: 0; top: 200px; }
+    .textarea-rows8-row { left: 350px; top: 200px; }
     .marker { width: 20px; }
     .form-marker { width: 100px; height: 20px; background: #087f5b; }
     .text-marker { height: 21px; background: #1971c2; }
@@ -28,6 +30,8 @@
     .checkbox-marker { height: 13px; background: #7048e8; }
     .range-marker { height: 16px; background: #c2255c; }
     .hidden-marker { height: 20px; background: #2b8a3e; }
+    .textarea-marker { height: 36px; background: #f08c00; }
+    .textarea-rows8-marker { height: 126px; background: #e64980; }
   </style>
 </head>
 <body>
@@ -43,5 +47,7 @@
   <div class="row checkbox-row"><input type="checkbox"><div class="marker checkbox-marker"></div></div>
   <div class="row range-row"><input type="range"><div class="marker range-marker"></div></div>
   <div class="row hidden-row"><input type="hidden"><div class="marker hidden-marker"></div></div>
+  <div class="row textarea-row"><textarea></textarea><div class="marker textarea-marker"></div></div>
+  <div class="row textarea-rows8-row"><textarea rows="8"></textarea><div class="marker textarea-rows8-marker"></div></div>
 </body>
 </html>


### PR DESCRIPTION
## What changed

Fixes #685. A `<textarea>` was parsed and its `value` worked, but it had no entry in the native-control UA styles or the intrinsic-sizing pass, and its JS interface was an alias of `Element`. It therefore laid out as a plain block: full containing-block width (1264px in a 1280 viewport) and zero height when empty, `display:block`, `constructor.name === "Element"`, `rows`/`cols` undefined. Playwright resolves that zero-height box to `hidden`, so `wait_for_selector(state="visible")`, `click()`, and `fill()` each burn their full timeout.

- `style.rs`: textarea UA branch matching its sibling controls. Atomic inline-block, fixed-pitch 13.333px face, 2px padding, 1px #767676 border, white background, border-box sizing, pre-wrap value text (line breaks in the value survive).
- `dom.rs`: intrinsic border box from the `rows`/`cols` content attributes (HTML defaults 2 and 20, non-positive values fall back to them), calibrated to Chromium's control metrics. Author width/height and a stretched grid axis keep winning; the control joined the existing `native_control_grid_stretch` map.
- `bootstrap.js`: `HTMLTextAreaElement` becomes a real `Element` subclass with reflecting `rows`/`cols`, registered in both wrapper-resolution paths (parsed nodes and `createElement`/`createElementNS`). `type` already reported `"textarea"` since #639.
- Cleanup rider: adding the third copy of the native-control auto-size clamp (select, input, textarea) prompted extracting `assign_native_control_size` and pointing all three branches at it. Behavior-identical; covered by the existing select/input suites.
- `render-repros`: `form-control-geometry` gains two textarea marker rows plus checks.json entries, verified identical in obscura and Chromium.

Issue repro (`obscura fetch "data:text/html,<textarea>..." --stealth --eval ...`, default fetch viewport 1280x720, DPR 1), before and after:

| probe | main | this PR | headless Chrome |
|---|---|---|---|
| empty textarea | 1264x0 | 168x36 | 168x36 |
| `rows=8` | 1264x0 | 168x126 | 168x126 |
| `style=height:36px` | 1264x36 | 168x36 | 168x36 |
| computed display | block | inline-block | inline-block |
| `constructor.name` | Element | HTMLTextAreaElement | HTMLTextAreaElement |
| `rows` / `cols` / `type` | undefined / undefined / "" | 2 / 20 / "textarea" | 2 / 20 / "textarea" |

## Validation

- New `crates/obscura/tests/textarea_semantics.rs`: IDL contract (rows/cols defaults and reflection, type, constructor.name, instanceof) runs in every configuration; geometry assertions (168x36, 168x126, authored height wins, display inline-block, value round-trip) are gated on `render`. New unit test `textarea_intrinsic_box_comes_from_rows_and_cols` in `obscura-render` (styles + rects, invalid rows falls back to the default).
- `cargo test -p obscura-render --features paint`: 469 + 112 passed.
- `cargo test -p obscura --features render --test textarea_semantics --test select_semantics`: 4 passed.
- `cargo test -p obscura --test textarea_semantics` (no-render): 1 passed.
- `cargo nextest run -p obscura --features render -p obscura-cdp -p obscura-mcp -p obscura-render --features paint`: 774 passed, 4 skipped.
- Corpus: captured `form-control-geometry` with local Chromium 145.0.7632.6 and with this branch. Both new markers land identically in both engines (x=168 y=200 20x36; x=518 y=200 20x126). One pre-existing entry, "text input size attribute sets intrinsic inline width", records x=503 and this machine's Chromium 145 renders x=506 even with the unmodified fixture, so that single Chromium-side check drifts locally regardless of this change.
- `python render-repros/test_check.py`, `python render-repros/test_paired_corpus.py`: OK.

## Rendering

Layout change. Corpus pair at 900x1000, DPR 1, `--wait 2` (regenerate with `render-repros/run.sh`): before this PR the empty textarea occupies the full row width at zero height and the rows=8 control collapses, after it each textarea holds a 168px-wide control box (36px and 126px tall). The full-canvas pair metrics for the fixture after the change: rgb_mae=0.001172. The numbers table above carries the before/after for the issue repro; I could not attach PNGs through the API, the `run.sh` pair reproduces them.

## Performance

The sizing pass runs one extra tag check per element and, for textarea elements only, two attribute parses and an O(1) intrinsic computation; the refactor replaced three copies of the clamp with one function without adding work. No allocations beyond the attribute reads. No expected measurable impact.

## Checklist

- [x] The change is focused and does not remove existing behavior without justification.
- [x] Tests cover the failure or feature.
- [x] Existing tests pass, including render and no-render configurations when affected.
- [x] I checked for CPU, latency, and memory regressions.
- [x] Public API or user-facing behavior changes are documented.
