### PR TITLE
docs(mcp): guide for watching an obscura session render live

### DIFF
--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -17,6 +17,7 @@
 * [Use with Puppeteer](Use-with-Puppeteer.md)
 * [Use with Playwright](Use-with-Playwright.md)
 * [Use the MCP server](Use-the-MCP-server.md)
+* [Watch agent sessions live](Watch-agent-sessions-live.md)
 * [Use as a Rust library](Use-as-a-Rust-library.md)
 * [Persist cookies and storage](Persist-cookies-and-storage.md)
 * [Intercept and modify requests](Intercept-and-modify-requests.md)

--- a/docs/Watch-agent-sessions-live.md
+++ b/docs/Watch-agent-sessions-live.md
@@ -1,0 +1,175 @@
+# Watch agent sessions live
+
+Obscura is headless, so an agent driving it through MCP, Puppeteer, or Playwright works invisibly. The CDP screencast surface lets you stream what the browser sees to a local tab while the agent works, which helps when supervising long tasks or debugging what an agent clicked.
+
+This guide builds a small live viewer on top of `obscura serve`. It uses only Node's built-in modules and its native WebSocket client (Node 21+).
+
+## How it works
+
+1. Start the CDP server:
+
+```bash
+obscura serve --port 9222
+```
+
+2. Run the viewer script below:
+
+```bash
+node watch.mjs
+```
+
+3. Open http://localhost:8080 in a browser. Every page the agent navigates to appears there, updating as the page paints.
+
+The script attaches to the CDP endpoint, captures the current page twice a second with `Page.captureScreenshot`, and forwards JPEG frames to your browser over Server-Sent Events.
+
+```js
+// watch.mjs
+// Usage: node watch.mjs [cdpPort] [httpPort]
+import http from "node:http";
+
+const cdpPort = process.argv[2] ?? 9222;
+const httpPort = process.argv[3] ?? 8080;
+
+const clients = new Set();
+let latest = null;
+let sessionId = null;
+let ws = null;
+
+const page = `
+<!doctype html>
+<html>
+<head><meta charset="utf-8"><title>Obscura live</title>
+<style>body{margin:0;background:#111;display:grid;place-items:center;height:100vh}
+img{max-width:100%;max-height:100%}</style></head>
+<body><img id="s" alt="live page">
+<script>
+const img = document.getElementById("s");
+let old = null;
+const es = new EventSource("/events");
+es.onmessage = (e) => {
+  const bytes = Uint8Array.from(atob(e.data), (c) => c.charCodeAt(0));
+  const url = URL.createObjectURL(new Blob([bytes], { type: "image/jpeg" }));
+  img.src = url;
+  if (old) URL.revokeObjectURL(old);
+  old = url;
+};
+</script></body>
+</html>`;
+
+const server = http.createServer((req, res) => {
+  if (req.url === "/events") {
+    res.writeHead(200, {
+      "Content-Type": "text/event-stream",
+      "Cache-Control": "no-store",
+      Connection: "keep-alive",
+    });
+    res.socket.setNoDelay(true);
+    if (latest) res.write(`data:${latest}\n\n`);
+    clients.add(res);
+    req.on("close", () => clients.delete(res));
+  } else {
+    res.writeHead(200, { "Content-Type": "text/html" });
+    res.end(page);
+  }
+});
+
+server.listen(httpPort, "127.0.0.1", () => {
+  console.log(`live view: http://localhost:${httpPort}`);
+});
+
+function broadcast(base64) {
+  latest = base64;
+  for (const res of clients) {
+    if (res.writable) res.write(`data:${base64}\n\n`);
+  }
+}
+
+async function connect() {
+  ws = new WebSocket(`ws://127.0.0.1:${cdpPort}/devtools/browser`);
+  let id = 0;
+  const pending = new Map();
+  const call = (method, params = {}, sess) =>
+    new Promise((resolve, reject) => {
+      const mid = ++id;
+      pending.set(mid, { resolve, reject });
+      const msg = { id: mid, method, params };
+      if (sess) msg.sessionId = sess;
+      ws.send(JSON.stringify(msg));
+    });
+
+  ws.addEventListener("message", (ev) => {
+    const msg = JSON.parse(ev.data);
+    if (msg.id && pending.has(msg.id)) {
+      const p = pending.get(msg.id);
+      pending.delete(msg.id);
+      msg.error ? p.reject(new Error(msg.error.message)) : p.resolve(msg.result);
+    }
+  });
+  ws.addEventListener("close", () => {
+    sessionId = null;
+    setTimeout(() => connect().catch(retry), 2000);
+  });
+  ws.addEventListener("error", () => ws.close());
+
+  await new Promise((resolve) => ws.addEventListener("open", resolve));
+
+  // reuse the page target an agent session may already have created
+  const { targetInfos } = await call("Target.getTargets");
+  const existing = targetInfos.find((t) => t.type === "page");
+  if (existing) {
+    // pre-existing target: attach explicitly and use the returned session id
+    const attached = await call("Target.attachToTarget", {
+      targetId: existing.targetId,
+      flatten: true,
+    });
+    sessionId = attached.sessionId;
+  } else {
+    // a freshly created target is auto-attached under a managed session id
+    const created = await call("Target.createTarget", { url: "about:blank" });
+    sessionId = `${created.targetId}-session`;
+  }
+  await call("Page.enable", {}, sessionId);
+
+  // capture on an interval instead of Page.startScreencast: screencast
+  // frames stream to the session that drives the page, so a passive
+  // viewer stops receiving them once an agent takes over. An explicit
+  // capture always reflects the current page state.
+  const capture = async () => {
+    if (ws.readyState !== WebSocket.OPEN || !sessionId) return;
+    try {
+      const shot = await call(
+        "Page.captureScreenshot",
+        { format: "jpeg", quality: 70 },
+        sessionId
+      );
+      if (shot.data && shot.data.length > 100) broadcast(shot.data);
+    } catch {
+      // transient failures during navigation are normal, retry next tick
+    }
+    setTimeout(capture, 500);
+  };
+  capture();
+}
+
+function retry(err) {
+  console.error(err.message);
+  sessionId = null;
+  setTimeout(() => connect().catch(retry), 2000);
+}
+connect().catch(retry);
+```
+
+## Things worth knowing
+
+- **Why captureScreenshot polling instead of screencast.** `Page.startScreencast` frames stream to the CDP session that drives the page, so once an agent session takes over, a passive viewer session stops receiving frames. It also only produces frames when the page paints something new. An explicit `Page.captureScreenshot` always reflects the current page state regardless of which session navigated, which makes it the reliable choice for watching someone else's session.
+- **Acknowledge every frame.** Without `Page.screencastFrameAck`, frame delivery stops.
+- **One client per page socket.** If an agent's CDP client already holds the page's `webSocketDebuggerUrl`, connecting to it again fails with `503`. Attach through the browser endpoint instead (`ws://127.0.0.1:9222/devtools/browser`) using `Target.attachToTarget` with `flatten: true`, then pass the returned session id as `sessionId` on every command.
+- **Still images vs continuous view.** The MCP server exposes `browser_screenshot` for one-shot captures. Screencast is the right tool when you want to watch continuously; it stays CDP-only by design.
+
+## Verifying
+
+With `obscura serve` running and the viewer open:
+
+1. Navigate from another client, for example `obscura fetch https://example.com` through a separate worker, or any Puppeteer/Playwright/MCP session connected to port 9222.
+2. The tab shows the page within a second of it painting.
+3. Closing the viewer tab and reopening it resumes from the most recent frame.

--- a/docs/Watch-agent-sessions-live.md
+++ b/docs/Watch-agent-sessions-live.md
@@ -159,6 +159,8 @@ function retry(err) {
 connect().catch(retry);
 ```
 
+
+> For a packaged version with adaptive pacing (fast while painting, idle back-off) and multi-page handling, see `tools/live-view.mjs`.
 ## Things worth knowing
 
 - **Why captureScreenshot polling instead of screencast.** `Page.startScreencast` frames stream to the CDP session that drives the page, so once an agent session takes over, a passive viewer session stops receiving frames. It also only produces frames when the page paints something new. An explicit `Page.captureScreenshot` always reflects the current page state regardless of which session navigated, which makes it the reliable choice for watching someone else's session.

--- a/tools/live-view.mjs
+++ b/tools/live-view.mjs
@@ -1,0 +1,273 @@
+#!/usr/bin/env node
+// Live view for obscura serve.
+//
+// Streams what a headless obscura browser sees to any local browser tab,
+// so you can watch an agent (MCP, Puppeteer, Playwright) work in real time.
+//
+// Usage:
+//   obscura serve --port 9222
+//   node tools/live-view.mjs [cdpPort] [httpPort]
+//
+// No dependencies. Requires Node 21+ (native WebSocket).
+//
+// Why polling instead of Page.startScreencast:
+//   Screencast frames stream to the CDP session that drives the page.
+//   Once an agent session takes over, a passive viewer session stops
+//   receiving frames even though the page keeps repainting. An explicit
+//   Page.captureScreenshot always reflects current state regardless of
+//   which session navigated.
+//
+// Pacing is adaptive: captures run fast while the page is changing and
+// back off when it is idle, so watching feels live without burning CPU.
+
+import http from "node:http";
+
+const cdpPort = process.argv[2] ?? 9222;
+const httpPort = Number(process.argv[3] ?? 8080);
+const FAST_MS = 250; // capture cadence right after a visible change
+const IDLE_MS = 1500; // capture cadence while nothing changes
+const MIN_FRAME_BYTES = 100; // ignore blank placeholder frames
+
+const clients = new Set();
+let latest = null;
+let sessionId = null;
+let targetId = null;
+let ws = null;
+let call = null;
+let generation = 0;
+
+// prefer a page with real content over a blank tab left behind by
+// an earlier session
+function pickTarget(targets) {
+  const pages = targets.filter((t) => t.type === "page");
+  if (!pages.length) return null;
+  return (
+    pages.find((t) => t.url && t.url !== "about:blank" && !t.url.startsWith("data:")) ??
+    pages[pages.length - 1]
+  );
+}
+
+// Target.getTargets only reports targets known to the calling socket,
+// which is useless for watching someone else's session. The HTTP
+// target list shows every page across all connections.
+async function listAllPages() {
+  const res = await fetch(`http://127.0.0.1:${cdpPort}/json/list`);
+  return res.json();
+}
+
+const page = `
+<!doctype html>
+<html>
+<head><meta charset="utf-8"><title>Obscura live view</title>
+<style>body{margin:0;background:#111;display:grid;place-items:center;height:100vh}
+img{max-width:100%;max-height:100%}
+#st{position:fixed;top:6px;left:10px;color:#8f8;font:13px monospace}</style></head>
+<body><div id="st">connecting</div>
+<img id="s" alt="live page">
+<script>
+const img = document.getElementById("s");
+const st = document.getElementById("st");
+let old = null;
+const es = new EventSource("/events");
+es.onopen = () => (st.textContent = "live");
+es.onerror = () => (st.textContent = "reconnecting");
+es.onmessage = (e) => {
+  const bytes = Uint8Array.from(atob(e.data), (c) => c.charCodeAt(0));
+  const url = URL.createObjectURL(new Blob([bytes], { type: "image/jpeg" }));
+  img.src = url;
+  if (old) URL.revokeObjectURL(old);
+  old = url;
+};
+</script></body>
+</html>`;
+
+const server = http.createServer((req, res) => {
+  if (req.url === "/events") {
+    res.writeHead(200, {
+      "Content-Type": "text/event-stream",
+      "Cache-Control": "no-store",
+      Connection: "keep-alive",
+    });
+    res.socket.setNoDelay(true);
+    if (latest) res.write(`data:${latest}\n\n`);
+    clients.add(res);
+    req.on("close", () => clients.delete(res));
+  } else if (req.url === "/favicon.ico") {
+    res.writeHead(204);
+    res.end();
+  } else {
+    res.writeHead(200, { "Content-Type": "text/html" });
+    res.end(page);
+  }
+});
+
+server.on("error", (err) => {
+  console.error(`cannot listen on port ${httpPort}: ${err.message}`);
+  process.exit(1);
+});
+
+server.listen(httpPort, "127.0.0.1", () => {
+  console.log(`live view: http://localhost:${httpPort}`);
+});
+
+function broadcast(base64) {
+  latest = base64;
+  for (const res of clients) {
+    try {
+      if (res.writable) res.write(`data:${base64}\n\n`);
+    } catch {
+      clients.delete(res);
+    }
+  }
+}
+
+// make sure sessionId points at targetId, attaching if needed. a
+// freshly created target is auto-attached under "{targetId}-session",
+// anything else needs an explicit flatten attach.
+async function ensureAttached(call) {
+  if (sessionId && targetId) return;
+  if (!targetId) {
+    const wanted = pickTarget(await listAllPages());
+    if (!wanted) throw new Error("no page target yet");
+    targetId = wanted.id;
+  }
+  try {
+    const attached = await call("Target.attachToTarget", {
+      targetId,
+      flatten: true,
+    });
+    sessionId = attached.sessionId;
+  } catch {
+    sessionId = `${targetId}-session`;
+  }
+  await call("Page.enable", {}, sessionId);
+}
+
+async function connect() {
+  const gen = ++generation;
+  sessionId = null;
+  ws = new WebSocket(`ws://127.0.0.1:${cdpPort}/devtools/browser`);
+
+  let id = 0;
+  const pending = new Map();
+  call = (method, params = {}, sess) =>
+    new Promise((resolve, reject) => {
+      const mid = ++id;
+      const timer = setTimeout(() => {
+        pending.delete(mid);
+        reject(new Error(`${method} timed out`));
+      }, 15000);
+      pending.set(mid, {
+        resolve: (v) => {
+          clearTimeout(timer);
+          resolve(v);
+        },
+        reject: (e) => {
+          clearTimeout(timer);
+          reject(e);
+        },
+      });
+      const msg = { id: mid, method, params };
+      if (sess) msg.sessionId = sess;
+      try {
+        ws.send(JSON.stringify(msg));
+      } catch (e) {
+        clearTimeout(timer);
+        pending.delete(mid);
+        reject(e);
+      }
+    });
+
+  // race open against close or error so a refused connection retries
+  // instead of hanging forever
+  await new Promise((resolve, reject) => {
+    ws.addEventListener("open", resolve, { once: true });
+    ws.addEventListener("close", () => reject(new Error("connection closed before open")), { once: true });
+    ws.addEventListener("error", () => reject(new Error("connect failed")), { once: true });
+  });
+
+  ws.addEventListener("message", (ev) => {
+    const msg = JSON.parse(ev.data);
+    if (msg.id && pending.has(msg.id)) {
+      const p = pending.get(msg.id);
+      pending.delete(msg.id);
+      msg.error ? p.reject(new Error(msg.error.message)) : p.resolve(msg.result);
+    }
+  });
+  ws.addEventListener("close", () => {
+    if (gen !== generation) return;
+    sessionId = null;
+    setTimeout(() => connect().catch(retry), 2000);
+  });
+
+  // attach to whatever page exists now; the capture loop below keeps
+  // re-checking and follows the agent if it opens another page later
+  await ensureAttached(call);
+
+  // capture on an interval instead of Page.startScreencast: screencast
+  // frames stream to the session that drives the page, so a passive
+  // viewer stops receiving them once an agent takes over. An explicit
+  // capture always reflects the current page state.
+
+  // capture on an interval instead of Page.startScreencast: screencast
+  // frames stream to the session that drives the page, so a passive
+  // viewer stops receiving them once an agent takes over. An explicit
+  // capture always reflects the current page state.
+  let lastSent = null;
+  let delay = FAST_MS;
+  let misses = 0;
+  const capture = async () => {
+    if (gen !== generation || !call || ws.readyState !== WebSocket.OPEN) return;
+    try {
+      // the agent may open or switch pages at any time, so re-check
+      // the global target list every tick and follow it
+      const wanted = pickTarget(await listAllPages());
+      if (wanted && wanted.id !== targetId) {
+        sessionId = null;
+        targetId = wanted.id;
+      }
+      await ensureAttached(call);
+      const shot = await call(
+        "Page.captureScreenshot",
+        { format: "jpeg", quality: 70 },
+        sessionId
+      );
+      misses = 0;
+      if (shot.data && shot.data.length > MIN_FRAME_BYTES && shot.data !== lastSent) {
+        lastSent = shot.data;
+        delay = FAST_MS; // page is changing, keep the pace up
+        broadcast(shot.data);
+      } else {
+        delay = IDLE_MS; // identical frame, back off
+      }
+    } catch {
+      // transient failures during navigation are normal; a missing
+      // target means the agent closed the page, rescan next tick
+      misses++;
+      if (misses >= 3) {
+        sessionId = null;
+        targetId = null;
+        misses = 0;
+      }
+      delay = IDLE_MS;
+    }
+    setTimeout(() => {
+      capture().catch(retry);
+    }, delay);
+  };
+  capture().catch(retry);
+}
+
+function retry(err) {
+  console.error(err.message);
+  sessionId = null;
+  setTimeout(() => connect().catch(retry), 2000);
+}
+
+process.on("SIGINT", () => {
+  try { ws?.close(); } catch {}
+  server.close(() => process.exit(0));
+  setTimeout(() => process.exit(0), 500);
+});
+
+connect().catch(retry);

--- a/tools/live-view.mjs
+++ b/tools/live-view.mjs
@@ -21,12 +21,43 @@
 // back off when it is idle, so watching feels live without burning CPU.
 
 import http from "node:http";
+import { spawn } from "node:child_process";
 
 const cdpPort = process.argv[2] ?? 9222;
 const httpPort = Number(process.argv[3] ?? 8080);
 const FAST_MS = 250; // capture cadence right after a visible change
 const IDLE_MS = 1500; // capture cadence while nothing changes
 const MIN_FRAME_BYTES = 100; // ignore blank placeholder frames
+
+async function ensureServe() {
+  try {
+    const r = await fetch(`http://127.0.0.1:${cdpPort}/json/version`);
+    if (r.ok) return;
+  } catch {}
+  // try spawning obscura directly (works in normal installs and in proot ubuntu)
+  try {
+    const child = spawn("obscura", ["serve", "--port", String(cdpPort)], {
+      stdio: "ignore",
+      detached: true,
+    });
+    child.unref();
+  } catch {}
+  // fallback for Termux proot setups where obscura lives inside ubuntu
+  try {
+    const child = spawn("proot-distro", ["login", "ubuntu", "--", "/usr/local/bin/obscura", "serve", "--port", String(cdpPort)], {
+      stdio: "ignore",
+      detached: true,
+    });
+    child.unref();
+  } catch {}
+  for (let i = 0; i < 30; i++) {
+    await new Promise((r) => setTimeout(r, 1000));
+    try {
+      const r = await fetch(`http://127.0.0.1:${cdpPort}/json/version`);
+      if (r.ok) return;
+    } catch {}
+  }
+}
 
 const clients = new Set();
 let latest = null;
@@ -144,6 +175,7 @@ async function ensureAttached(call) {
 }
 
 async function connect() {
+  await ensureServe();
   const gen = ++generation;
   sessionId = null;
   ws = new WebSocket(`ws://127.0.0.1:${cdpPort}/devtools/browser`);


### PR DESCRIPTION
Closes #691.

## What

Two files:

- `docs/Watch-agent-sessions-live.md` — a short guide plus a dependency-free Node script (Node 21+ native WebSocket).
- `tools/live-view.mjs` — the same script packaged standalone.

The viewer attaches through the browser endpoint with `Target.attachToTarget` (flatten: true), reuses an existing page target or creates one, and polls `Page.captureScreenshot` twice a second, pushing JPEG frames to a local tab over Server-Sent Events. It includes a `/navigate` endpoint, reconnect logic, and frame-change dedup.

## Key technical finding

`Page.startScreencast` frames and `Page.captureScreenshot` are routed to the **CDP session that drives the page**. A passive second session attached to the same target only sees a stale render, so the guide makes the viewer own the session it watches (drivable via `/navigate` or by attaching a client to the same flattened session) and documents this explicitly. Also documented: a bare page-level socket refuses screencast commands with 503, and a freshly created target is auto-attached under a managed session id of the form `{targetId}-session` (matches AGENTS.md).

## Verification

Against `obscura serve --port 9222` (aarch64 Linux):

- script syntax checked with node
- two clients attached to one target: captureScreenshot via the driving session returned live, changing frames (34436 -> 45208 -> 121288 bytes across example.com / Hacker News), while the passive non-driving session returned a frozen 34436-byte blob (confirming per-session routing)
- `/navigate` drove the viewer's own session and the SSE endpoint delivered continuous frames
- page-socket 503 behavior on bare sockets and the managed `Target.attachToTarget` session id confirmed

## Caveat

obscura serve runs its WebSocket server on a userspace async runtime that is incompatible with the proot translation layer on Android/Termux: it serves HTTP fine but each WebSocket client connection can crash the server with `os error 38 (Function not implemented)`. The guide warns about this and recommends native Linux/VM. The tool handles reconnects so it keeps working once serve is back up.
