### PR TITLE
docs: document --allow-private-network for localhost/LAN testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,6 +244,22 @@ obscura fetch https://example.com --screenshot page.png
 
 # The screenshot flag also has a short form
 obscura fetch https://example.com -s page.png
+
+### Testing against localhost / LAN dev servers
+
+Obscura blocks fetches to private/internal IPs by default (SSRF protection).
+To point it at a local dev server, pass `--allow-private-network` (or set
+`OBSCURA_ALLOW_PRIVATE_NETWORK=1`):
+
+```bash
+obscura fetch http://127.0.0.1:3000 --allow-private-network --dump text
+
+# Works on any subcommand, e.g. the CDP server for local Puppeteer/Playwright:
+obscura serve --port 9222 --allow-private-network
+```
+
+See [docs/Environment-variables.md](docs/Environment-variables.md) for the
+full allow/deny rules (DNS-resolution-time checks included).
 ```
 
 ## Rendering


### PR DESCRIPTION
Closes #695.

## What

Adds a **Testing against localhost / LAN dev servers** subsection to the README Quick Start, documenting:

- `--allow-private-network` per-invocation flag
- `OBSCURA_ALLOW_PRIVATE_NETWORK=1` env equivalent
- usage on subcommands (`fetch`, `serve`)
- pointer to `docs/Environment-variables.md` for the full allow/deny rules

## Why

The SSRF block on private IPs is a great default, but the escape hatch was only discoverable via `--help`. Anyone pointing Obscura at a local dev server hits this with no hint that an override exists:

```
Error: Failed to navigate to http://127.0.0.1:3000/: Network error:
Access to private/internal IP address 127.0.0.1 is not allowed
```

(Real-world case: using Obscura to E2E-test a self-hosted PWA served on `127.0.0.1:3000`.)

Docs-only change — no code paths touched.