### PR TITLE
fix(cli): await promise-returning --eval expressions

### DIFF
--- a/crates/obscura-cli/src/worker.rs
+++ b/crates/obscura-cli/src/worker.rs
@@ -106,7 +106,22 @@ async fn main() {
                 }
             }
             WorkerCommand::Evaluate { expression } => {
-                let result = page.evaluate(&expression);
+                // Await promise-returning expressions so async IIFEs resolve
+                // before serialization. Previously the sync path serialized an
+                // unresolved Promise as `{}`, making single-invocation flows
+                // that call async app APIs impossible (issue #693). A 30s cap
+                // matches the CDP await timeout so a never-settling promise
+                // cannot hang the worker.
+                let result = match page
+                    .evaluate_for_cdp_with_timeout(&expression, true, true, 30_000)
+                    .await
+                {
+                    Ok(info) => match info.value {
+                        Some(v) => v,
+                        None => serde_json::Value::String(info.description),
+                    },
+                    Err(_) => serde_json::Value::Null,
+                };
                 WorkerResponse::success(result)
             }
             WorkerCommand::Title => {


### PR DESCRIPTION
Fixes #693.

## Problem

`obscura fetch --eval <expr>` used the synchronous `Page::evaluate` path, which serializes an unresolved Promise as `{}`. Any async IIFE printed `{}` instead of its result:

```bash
obscura fetch URL --eval "(async () => { const r = await fetch('/api'); return JSON.stringify({ok: r.ok}); })()"
# → {}
```

This makes single-invocation E2E flows impossible without a CDP client — e.g. "call the app's own async login helper, then inspect localStorage".

## Fix

Route `WorkerCommand::Evaluate` through `Page::evaluate_for_cdp_with_timeout(expression, return_by_value=true, await_promise=true)` with the same 30s cap the CDP path uses:

- resolved promises serialize their actual value (`v8_to_json` → `info_from_json`)
- plain values behave exactly as before
- a never-settling promise cannot hang the worker (30s cap)

The JS runtime has implemented this await path for CDP clients all along — the CLI simply wasn't using it.

## Testing

Not built locally (aarch64 phone; V8 from source is out of reach) — relying on this repo's PR CI to validate the build across all four feature configs. Behavior verified by reading the runtime paths: `evaluate_for_cdp_with_timeout` with `await_promise && return_by_value` returns via `info_from_json(&json_val)`, so non-promise expressions keep byte-identical output through the same `info_from_json` helper the old sync path used.