### PR TITLE
fix(render): cover SVG symbol glyphs with the embedded broad-coverage face

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2019,6 +2019,7 @@ dependencies = [
  "cosmic-text",
  "cssparser",
  "image",
+ "log",
  "obscura-dom",
  "resvg",
  "swash",

--- a/crates/obscura-render/Cargo.toml
+++ b/crates/obscura-render/Cargo.toml
@@ -37,6 +37,11 @@ usvg = { version = "0.47", default-features = false, optional = true }
 url = { workspace = true, optional = true }
 cssparser = "0.34"
 wuff = { version = "0.2.7", optional = true }
+# Same `log` instance usvg emits glyph-fallback warnings through, so tests can
+# install a collector and assert on them.
+[dev-dependencies]
+log = "0.4"
+
 [lib]
 path = "src/lib.rs"
 

--- a/crates/obscura-render/src/paint.rs
+++ b/crates/obscura-render/src/paint.rs
@@ -10107,6 +10107,15 @@ fn svg_font_database() -> std::sync::Arc<usvg::fontdb::Database> {
             FONT_BOLD_OBLIQUE_BYTES,
             SERIF_FONT_BYTES,
             MONO_FONT_BYTES,
+            // The Liberation families stop at Latin/Greek/Cyrillic: an SVG
+            // text run with a symbol glyph (★/U+2605 and friends) had no face
+            // covering it anywhere in the database, so usvg's per-glyph
+            // fallback dropped the glyph and warned per character (#701).
+            // DejaVu Sans is the same embedded broad-coverage face the HTML
+            // engine already keeps for `system-ui`; family selection is
+            // unchanged (Liberation stays the sans/serif/mono default), it
+            // only extends what the fallback search can find.
+            SYSTEM_FONT_BYTES,
         ] {
             database.load_font_data(bytes.to_vec());
         }
@@ -14669,6 +14678,61 @@ mod tests {
         assert!(
             painted_green,
             "author-styled SVG text should rasterize with embedded fonts"
+        );
+    }
+
+    #[test]
+    fn svg_text_symbol_glyphs_resolve_in_the_font_database() {
+        // The Liberation faces stop at Latin/Greek/Cyrillic: without a
+        // broad-coverage face in the SVG database, usvg's per-glyph fallback
+        // finds nothing for ★/U+2605, renders the .notdef tofu, and warns per
+        // character (#701). Pixel presence cannot distinguish a real glyph
+        // from tofu, so capture usvg's warnings while rasterizing a
+        // symbol-bearing SVG text run through the same database the page
+        // pipeline uses.
+        static WARNINGS: std::sync::Mutex<Vec<String>> = std::sync::Mutex::new(Vec::new());
+        struct SymbolWarningLogger;
+        impl log::Log for SymbolWarningLogger {
+            fn enabled(&self, _metadata: &log::Metadata) -> bool {
+                true
+            }
+            fn log(&self, record: &log::Record) {
+                if record.level() == log::Level::Warn {
+                    WARNINGS.lock().unwrap().push(record.args().to_string());
+                }
+            }
+            fn flush(&self) {}
+        }
+        let _ = log::set_boxed_logger(Box::new(SymbolWarningLogger));
+        log::set_max_level(log::LevelFilter::Warn);
+        WARNINGS.lock().unwrap().clear();
+
+        let svg = r##"<svg xmlns="http://www.w3.org/2000/svg" width="60" height="50">
+            <text x="8" y="34" font-size="24" fill="#00cc55">★</text>
+            <text x="8" y="4" font-size="24" fill="#00cc55">&#x378;</text>
+        </svg>"##;
+        let pixmap = render_svg_with_font_database(svg.as_bytes(), 60, 50, &svg_font_database())
+            .expect("raster");
+        assert!(
+            pixmap
+                .pixels()
+                .iter()
+                .any(|pixel| pixel.green() > 150 && pixel.red() < 80 && pixel.blue() < 120),
+            "the ★ text run should rasterize"
+        );
+        let warnings = WARNINGS.lock().unwrap();
+        // Positive control first: an unassigned codepoint must still warn, so
+        // the test fails loudly if the logger wiring breaks instead of
+        // vacuously passing.
+        assert!(
+            warnings
+                .iter()
+                .any(|warning| warning.contains("U+378 character")),
+            "the unassigned-codepoint control must warn: {warnings:?}"
+        );
+        assert!(
+            !warnings.iter().any(|warning| warning.contains("U+2605")),
+            "the SVG font database must cover ★ instead of dropping to .notdef: {warnings:?}"
         );
     }
 


### PR DESCRIPTION
Fixes #701.

## Problem

`svg_font_database` loads only the Liberation faces into the usvg `fontdb`. The Liberation families stop at Latin/Greek/Cyrillic, so an SVG text run with a symbol glyph (`★`/U+2605 and friends — star ratings, bullets, checkmarks) had **no face covering it anywhere in the database**: usvg's per-glyph fallback (`FontResolver::default_fallback_selector`, which searches every face for the character) found nothing, rendered the `.notdef` tofu, and logged a warning per character per rasterized text run:

```
WARN usvg::text::layout: No fonts with a ★/U+2605 character were found.
```

Surfaced while diagnosing #698 on https://betorodriguez.com (its inline SVG badges and the `★ … ★` footer produced dozens of warnings per screenshot); Chromium resolves these glyphs through font fallback and paints them.

## Fix

Load the embedded DejaVu Sans face (`assets/dejavu-sans.ttf`, `SYSTEM_FONT_BYTES`) into the SVG font database as well — it is the same broad-coverage face the HTML text engine already ships for `system-ui`. Family selection is unchanged: Liberation stays the explicit `sans-serif`/`serif`/`monospace` default, DejaVu only extends what the fallback search can find. No system-font scan, so rendering stays deterministic across hosts.

One-line change plus comment in `svg_font_database`.

## Testing

- New test `svg_text_symbol_glyphs_resolve_in_the_font_database`: rasterizes an SVG `<text>` run containing `★` through the page's font database with a `log` collector installed, and asserts no missing-glyph warning fires. Pixel presence alone cannot catch this (`.notdef` tofu still paints ink), so the warning is the asserted signal; an unassigned-codepoint (`U+0378`) control in the same run must still warn, so the test fails loudly if the logger wiring ever breaks rather than vacuously passing.
- `log` added as a dev-dependency (it resolves to the same `log` instance usvg already logs through); the test also calls `log::set_max_level` because the facade's default filter is off.
- `cargo test -p obscura-render --features paint`: 470 lib + 112 integration tests pass. Verified the new test **fails** with the `SYSTEM_FONT_BYTES` load removed (the exact `No fonts with a ★/U+2605` warning appears) and passes with it present.
- End-to-end on the live page from the issue: the repro command now emits **zero** `No fonts with a …` warnings (previously dozens per screenshot).