### PR TITLE
fix(js): preserve Request headers and binary bodies

### DIFF
--- a/crates/obscura-browser/tests/binary_fetch_body.rs
+++ b/crates/obscura-browser/tests/binary_fetch_body.rs
@@ -1,0 +1,143 @@
+use std::io::{Read, Write};
+use std::sync::{mpsc, Arc};
+use std::time::Duration;
+
+use obscura_browser::{BrowserContext, Page};
+
+const BINARY_BODY: [u8; 4] = [0, 128, 255, 16];
+
+fn spawn_echo_server() -> (String, mpsc::Receiver<Vec<u8>>) {
+    let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+    let address = listener.local_addr().unwrap();
+    let (body_tx, body_rx) = mpsc::channel();
+
+    std::thread::spawn(move || {
+        for incoming in listener.incoming() {
+            let Ok(mut stream) = incoming else {
+                continue;
+            };
+            let body_tx = body_tx.clone();
+            std::thread::spawn(move || {
+                let mut request = Vec::new();
+                let mut chunk = [0u8; 2048];
+                let header_end = loop {
+                    let read = stream.read(&mut chunk).unwrap();
+                    if read == 0 {
+                        return;
+                    }
+                    request.extend_from_slice(&chunk[..read]);
+                    if let Some(end) = request.windows(4).position(|bytes| bytes == b"\r\n\r\n") {
+                        break end + 4;
+                    }
+                };
+
+                let (path, content_length) = {
+                    let headers = std::str::from_utf8(&request[..header_end]).unwrap();
+                    let path = headers.split_whitespace().nth(1).unwrap_or("/").to_string();
+                    let content_length = headers
+                        .lines()
+                        .find_map(|line| {
+                            let (name, value) = line.split_once(':')?;
+                            name.eq_ignore_ascii_case("content-length")
+                                .then(|| value.trim().parse::<usize>().unwrap())
+                        })
+                        .unwrap_or(0);
+                    (path, content_length)
+                };
+                while request.len() < header_end + content_length {
+                    let read = stream.read(&mut chunk).unwrap();
+                    if read == 0 {
+                        break;
+                    }
+                    request.extend_from_slice(&chunk[..read]);
+                }
+
+                if path == "/binary" {
+                    body_tx
+                        .send(request[header_end..header_end + content_length].to_vec())
+                        .unwrap();
+                }
+
+                let (content_type, body) = if path == "/binary" {
+                    ("text/plain", "ok")
+                } else {
+                    (
+                        "text/html",
+                        "<!doctype html><html><body>binary fetch fixture</body></html>",
+                    )
+                };
+                write!(
+                    stream,
+                    "HTTP/1.1 200 OK\r\nContent-Type: {content_type}\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{body}",
+                    body.len()
+                )
+                .unwrap();
+            });
+        }
+    });
+
+    (format!("http://{address}"), body_rx)
+}
+
+async fn assert_binary_fetch_body(stealth: bool) {
+    std::env::set_var("OBSCURA_ALLOW_PRIVATE_NETWORK", "1");
+    let (base_url, body_rx) = spawn_echo_server();
+    let context = Arc::new(BrowserContext::with_storage_and_network(
+        "binary-fetch".to_string(),
+        None,
+        stealth,
+        None,
+        None,
+        true,
+    ));
+    let mut page = Page::new("binary-fetch-page".to_string(), context);
+    page.navigate(&base_url).await.unwrap();
+
+    page.evaluate(
+        r#"
+        (function() {
+            document.body.setAttribute('data-binary-fetch', 'pending');
+            fetch('/binary', {
+                method: 'POST',
+                headers: { 'content-type': 'application/octet-stream' },
+                body: new Uint8Array([0, 128, 255, 16]),
+            })
+                .then(function(response) {
+                    if (!response.ok) throw new Error('HTTP ' + response.status);
+                    document.body.setAttribute('data-binary-fetch', 'done');
+                })
+                .catch(function(error) {
+                    document.body.setAttribute('data-binary-fetch', 'error: ' + String(error));
+                });
+        })()
+        "#,
+    );
+
+    for _ in 0..20 {
+        page.settle(100).await;
+        let status = page.evaluate("document.body.getAttribute('data-binary-fetch')");
+        if status != serde_json::json!("pending") {
+            break;
+        }
+    }
+
+    assert_eq!(
+        page.evaluate("document.body.getAttribute('data-binary-fetch')"),
+        serde_json::json!("done")
+    );
+    assert_eq!(
+        body_rx.recv_timeout(Duration::from_secs(2)).unwrap(),
+        BINARY_BODY
+    );
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn fetch_preserves_binary_request_body() {
+    assert_binary_fetch_body(false).await;
+}
+
+#[cfg(feature = "stealth")]
+#[tokio::test(flavor = "current_thread")]
+async fn stealth_fetch_preserves_binary_request_body() {
+    assert_binary_fetch_body(true).await;
+}

--- a/crates/obscura-js/js/bootstrap.js
+++ b/crates/obscura-js/js/bootstrap.js
@@ -6715,21 +6715,21 @@ function _formDataToMultipart(fd) {
 
 // Coerce a fetch()/XHR body into the bytes op_fetch_url expects, attaching a
 // Content-Type header for body types that need one (FormData, URLSearchParams).
-function _serializeBody(initBody, headers) {
+function _serializeBody(initBody, headers, synthesizeContentType = true) {
   if (initBody == null || initBody === '') return new Uint8Array(0);
   if (initBody instanceof FormData) {
     const mp = _formDataToMultipart(initBody);
-    headers['Content-Type'] = 'multipart/form-data; boundary=' + mp.boundary;
+    if (synthesizeContentType) headers['Content-Type'] = 'multipart/form-data; boundary=' + mp.boundary;
     return mp.body;
   }
   if (initBody instanceof URLSearchParams) {
-    if (!Object.keys(headers).some(k => k.toLowerCase() === 'content-type')) {
+    if (synthesizeContentType && !Object.keys(headers).some(k => k.toLowerCase() === 'content-type')) {
       headers['Content-Type'] = 'application/x-www-form-urlencoded;charset=UTF-8';
     }
     return new TextEncoder().encode(initBody.toString());
   }
   if (typeof Blob !== 'undefined' && initBody instanceof Blob) {
-    if (initBody.type && !Object.keys(headers).some(k => k.toLowerCase() === 'content-type')) {
+    if (synthesizeContentType && initBody.type && !Object.keys(headers).some(k => k.toLowerCase() === 'content-type')) {
       headers['Content-Type'] = initBody.type;
     }
     return _bodyToUint8Array(initBody);
@@ -6745,26 +6745,29 @@ function _serializeBody(initBody, headers) {
 
 globalThis.fetch = async (input, init = {}) => {
   init = init || {};
+  const request = input instanceof Request ? input : null;
   let url = typeof input === "string"
     ? input
-    : (input instanceof Request
-      ? input.url
+    : (request
+      ? request.url
       : ((typeof URL === 'function' && input instanceof URL) ? input.href : (input?.url || input?.href || String(input || ""))));
   // Always resolve: the URL parser, not a "://" substring search, decides
   // whether the input is absolute. _resolveUrl leaves absolute URLs
   // unchanged and keeps unparseable input as-is.
   url = _resolveUrl(url);
-  const method = init.method || (input instanceof Request ? input.method : "GET");
-  let _h = init.headers instanceof Headers ? Object.fromEntries(init.headers.entries()) : (init.headers || {});
+  const method = init.method || (request ? request.method : "GET");
+  const headers = init.headers !== undefined ? init.headers : (request ? request.headers : undefined);
+  let _h = headers instanceof Headers ? Object.fromEntries(headers.entries()) : (headers || {});
+  const inheritsRequestBody = init.body === undefined && request !== null;
   const initBody = init.body !== undefined
     ? init.body
-    : (input instanceof Request ? input.body : undefined);
-  const body = _serializeBody(initBody, _h);
+    : (request ? request.body : undefined);
+  const body = _serializeBody(initBody, _h, !(inheritsRequestBody && init.headers !== undefined));
   const hdrs = JSON.stringify(_h);
-  const fetchMode = init.mode || (input instanceof Request ? input.mode : "cors");
+  const fetchMode = init.mode || (request ? request.mode : "cors");
   const fetchCredentials = init.credentials !== undefined
     ? String(init.credentials)
-    : (input instanceof Request ? input.credentials : "same-origin");
+    : (request ? request.credentials : "same-origin");
   if (fetchCredentials !== "omit" && fetchCredentials !== "same-origin" && fetchCredentials !== "include") {
     throw new TypeError("Failed to execute 'fetch': '" + fetchCredentials + "' is not a valid RequestCredentials value");
   }

--- a/crates/obscura-js/js/bootstrap.js
+++ b/crates/obscura-js/js/bootstrap.js
@@ -325,7 +325,7 @@ async function __fetchDynClassicScript(task) {
     body = _decodeDataScriptUrl(task.url);
   } else {
     const raw = await Deno.core.ops.op_fetch_url(
-      task.url, "GET", "{}", "", task.pageOrigin, "no-cors", "same-origin"
+      task.url, "GET", "{}", new Uint8Array(0), task.pageOrigin, "no-cors", "same-origin"
     );
     const parsed = JSON.parse(raw);
     // The HTML script-fetch algorithm treats an unsuccessful HTTP response
@@ -551,7 +551,7 @@ async function _fetchLinkedCss(url, pageOrigin, depth = 0, seen = new Set()) {
   if (depth > 4 || seen.has(url)) return "";
   seen.add(url);
   const raw = await Deno.core.ops.op_fetch_url(
-    url, "GET", "{}", "", pageOrigin, "no-cors", "same-origin"
+    url, "GET", "{}", new Uint8Array(0), pageOrigin, "no-cors", "same-origin"
   );
   const parsed = JSON.parse(raw);
   if (parsed.blocked || parsed.status >= 400 || parsed.status === 0) {
@@ -6682,28 +6682,41 @@ function _formDataToMultipart(fd) {
   const chars = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';
   let bnd = '----WebKitFormBoundary';
   for (let i = 0; i < 16; i++) bnd += chars[Math.floor(Math.random() * chars.length)];
-  let out = '';
+  const encoder = new TextEncoder();
+  const chunks = [];
+  let length = 0;
+  const append = (chunk) => {
+    const bytes = typeof chunk === 'string' ? encoder.encode(chunk) : _bodyToUint8Array(chunk);
+    chunks.push(bytes);
+    length += bytes.byteLength;
+  };
   const entries = fd._d || [];
   for (let i = 0; i < entries.length; i++) {
     const k = entries[i][0], v = entries[i][1];
-    out += '--' + bnd + '\r\n';
+    append('--' + bnd + '\r\n');
     if (v != null && typeof v === 'object' && v._bytes != null) {
-      out += 'Content-Disposition: form-data; name="' + k + '"; filename="' + (v.name || 'blob') + '"\r\n';
-      out += 'Content-Type: ' + (v.type || 'application/octet-stream') + '\r\n\r\n';
-      try { out += new TextDecoder().decode(v._bytes); } catch (e) {}
-      out += '\r\n';
+      append('Content-Disposition: form-data; name="' + k + '"; filename="' + (v.name || 'blob') + '"\r\n');
+      append('Content-Type: ' + (v.type || 'application/octet-stream') + '\r\n\r\n');
+      append(v._bytes);
+      append('\r\n');
     } else {
-      out += 'Content-Disposition: form-data; name="' + k + '"\r\n\r\n' + String(v) + '\r\n';
+      append('Content-Disposition: form-data; name="' + k + '"\r\n\r\n' + String(v) + '\r\n');
     }
   }
-  out += '--' + bnd + '--\r\n';
+  append('--' + bnd + '--\r\n');
+  const out = new Uint8Array(length);
+  let offset = 0;
+  for (const chunk of chunks) {
+    out.set(chunk, offset);
+    offset += chunk.byteLength;
+  }
   return { boundary: bnd, body: out };
 }
 
-// Coerce a fetch()/XHR body into the string op_fetch_url expects, attaching a
+// Coerce a fetch()/XHR body into the bytes op_fetch_url expects, attaching a
 // Content-Type header for body types that need one (FormData, URLSearchParams).
 function _serializeBody(initBody, headers) {
-  if (initBody == null || initBody === '') return '';
+  if (initBody == null || initBody === '') return new Uint8Array(0);
   if (initBody instanceof FormData) {
     const mp = _formDataToMultipart(initBody);
     headers['Content-Type'] = 'multipart/form-data; boundary=' + mp.boundary;
@@ -6713,25 +6726,21 @@ function _serializeBody(initBody, headers) {
     if (!Object.keys(headers).some(k => k.toLowerCase() === 'content-type')) {
       headers['Content-Type'] = 'application/x-www-form-urlencoded;charset=UTF-8';
     }
-    return initBody.toString();
+    return new TextEncoder().encode(initBody.toString());
   }
   if (typeof Blob !== 'undefined' && initBody instanceof Blob) {
     if (initBody.type && !Object.keys(headers).some(k => k.toLowerCase() === 'content-type')) {
       headers['Content-Type'] = initBody.type;
     }
-    return _bytesToBinaryString(_bodyToUint8Array(initBody));
+    return _bodyToUint8Array(initBody);
   }
   if (typeof ArrayBuffer !== 'undefined' && initBody instanceof ArrayBuffer) {
-    const bytes = new Uint8Array(initBody);
-    let s = ''; for (let i = 0; i < bytes.length; i++) s += String.fromCharCode(bytes[i]);
-    return s;
+    return new Uint8Array(initBody);
   }
   if (typeof ArrayBuffer !== 'undefined' && ArrayBuffer.isView(initBody) && initBody.buffer instanceof ArrayBuffer) {
-    const bytes = new Uint8Array(initBody.buffer, initBody.byteOffset, initBody.byteLength);
-    let s = ''; for (let i = 0; i < bytes.length; i++) s += String.fromCharCode(bytes[i]);
-    return s;
+    return new Uint8Array(initBody.buffer, initBody.byteOffset, initBody.byteLength);
   }
-  return typeof initBody === 'string' ? initBody : String(initBody);
+  return new TextEncoder().encode(typeof initBody === 'string' ? initBody : String(initBody));
 }
 
 globalThis.fetch = async (input, init = {}) => {
@@ -6747,7 +6756,10 @@ globalThis.fetch = async (input, init = {}) => {
   url = _resolveUrl(url);
   const method = init.method || (input instanceof Request ? input.method : "GET");
   let _h = init.headers instanceof Headers ? Object.fromEntries(init.headers.entries()) : (init.headers || {});
-  const body = _serializeBody(init.body, _h);
+  const initBody = init.body !== undefined
+    ? init.body
+    : (input instanceof Request ? input.body : undefined);
+  const body = _serializeBody(initBody, _h);
   const hdrs = JSON.stringify(_h);
   const fetchMode = init.mode || (input instanceof Request ? input.mode : "cors");
   const fetchCredentials = init.credentials !== undefined

--- a/crates/obscura-js/src/ops.rs
+++ b/crates/obscura-js/src/ops.rs
@@ -6,7 +6,6 @@ use std::sync::Arc;
 use base64::{engine::general_purpose::STANDARD as BASE64, Engine as _};
 use deno_core::op2;
 use deno_core::Extension;
-#[cfg(feature = "render")]
 use deno_core::JsBuffer;
 use deno_core::v8;
 use deno_core::OpState;
@@ -2160,11 +2159,12 @@ async fn op_fetch_url(
     #[string] url: String,
     #[string] method: String,
     #[string] headers_json: String,
-    #[string] body: String,
+    #[buffer] body: JsBuffer,
     #[string] origin: String,
     #[string] mode: String,
     #[string] credentials: String,
 ) -> Result<String, deno_error::JsErrorBox> {
+    let body = body.to_vec();
     tracing::debug!(
         "op_fetch_url called: {} {} (intercept check pending)",
         method,
@@ -2257,7 +2257,7 @@ async fn op_fetch_url(
     let mut override_url: Option<String> = None;
     let mut override_method: Option<String> = None;
     let mut override_headers: Option<HashMap<String, String>> = None;
-    let mut override_body: Option<String> = None;
+    let mut override_body: Option<Vec<u8>> = None;
 
     if let Some((tx, request_id)) = intercept_tx {
         let custom_headers: HashMap<String, String> =
@@ -2307,7 +2307,7 @@ async fn op_fetch_url(
                     override_url = url;
                     override_method = method;
                     override_headers = headers;
-                    override_body = body;
+                    override_body = body.map(String::into_bytes);
                     tracing::debug!(
                         "Interception: continue (overrides url={} method={} headers={} body={})",
                         override_url.is_some(),
@@ -2760,7 +2760,7 @@ async fn stealth_fetch_all(
     url: String,
     method: String,
     custom_headers: HashMap<String, String>,
-    body: String,
+    body: Vec<u8>,
     page_origin: String,
     mode: String,
     credentials: FetchCredentials,

--- a/crates/obscura-js/src/runtime.rs
+++ b/crates/obscura-js/src/runtime.rs
@@ -14091,6 +14091,8 @@ mod tests {
                             (url, method, headers, body) => {
                                 calls.push({
                                     path: new URL(url).pathname,
+                                    method,
+                                    headers: JSON.parse(headers),
                                     isUint8Array: body instanceof Uint8Array,
                                     bytes: Array.from(
                                         body instanceof Uint8Array
@@ -14121,10 +14123,27 @@ mod tests {
                             body: backing.subarray(1, 5),
                         });
 
-                        await fetch(new Request("/request", {
+                        const request = new Request("/request", {
                             method: "POST",
+                            headers: {
+                                authorization: "Bearer test-token",
+                                "x-request-source": "request",
+                            },
                             body: new Uint8Array(sentinel),
-                        }));
+                        });
+                        await fetch(request);
+                        await fetch(request, {
+                            headers: { "x-init-override": "yes" },
+                        });
+
+                        await fetch(new Request("/request-params-object", {
+                            method: "POST",
+                            body: new URLSearchParams({ a: "b" }),
+                        }), { headers: {} });
+                        await fetch(new Request("/request-params-headers", {
+                            method: "POST",
+                            body: new URLSearchParams({ a: "b" }),
+                        }), { headers: new Headers() });
 
                         return calls;
                     } finally {
@@ -14142,10 +14161,13 @@ mod tests {
         assert_eq!(
             result.value.unwrap(),
             serde_json::json!([
-                { "path": "/blob", "isUint8Array": true, "bytes": [0, 128, 255, 16] },
-                { "path": "/array-buffer", "isUint8Array": true, "bytes": [0, 128, 255, 16] },
-                { "path": "/typed-array-view", "isUint8Array": true, "bytes": [0, 128, 255, 16] },
-                { "path": "/request", "isUint8Array": true, "bytes": [0, 128, 255, 16] },
+                { "path": "/blob", "method": "POST", "headers": {}, "isUint8Array": true, "bytes": [0, 128, 255, 16] },
+                { "path": "/array-buffer", "method": "POST", "headers": {}, "isUint8Array": true, "bytes": [0, 128, 255, 16] },
+                { "path": "/typed-array-view", "method": "POST", "headers": {}, "isUint8Array": true, "bytes": [0, 128, 255, 16] },
+                { "path": "/request", "method": "POST", "headers": { "authorization": "Bearer test-token", "x-request-source": "request" }, "isUint8Array": true, "bytes": [0, 128, 255, 16] },
+                { "path": "/request", "method": "POST", "headers": { "x-init-override": "yes" }, "isUint8Array": true, "bytes": [0, 128, 255, 16] },
+                { "path": "/request-params-object", "method": "POST", "headers": {}, "isUint8Array": true, "bytes": [97, 61, 98] },
+                { "path": "/request-params-headers", "method": "POST", "headers": {}, "isUint8Array": true, "bytes": [97, 61, 98] },
             ])
         );
     }

--- a/crates/obscura-js/src/runtime.rs
+++ b/crates/obscura-js/src/runtime.rs
@@ -14077,6 +14077,207 @@ mod tests {
             })
         );
     }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn fetch_preserves_binary_body_sources_at_the_op_boundary() {
+        let mut rt = setup_runtime("<html><body></body></html>");
+        let result = rt
+            .call_function_on_for_cdp(
+                r#"async () => {
+                    const originalFetchOp = Deno.core.ops.op_fetch_url;
+                    const calls = [];
+                    try {
+                        Deno.core.ops.op_fetch_url =
+                            (url, method, headers, body) => {
+                                calls.push({
+                                    path: new URL(url).pathname,
+                                    isUint8Array: body instanceof Uint8Array,
+                                    bytes: Array.from(
+                                        body instanceof Uint8Array
+                                            ? body
+                                            : new TextEncoder().encode(body),
+                                    ),
+                                });
+                                return JSON.stringify({
+                                    status: 200,
+                                    headers: {},
+                                    body: "ok",
+                                    url,
+                                });
+                            };
+
+                        const sentinel = [0, 128, 255, 16];
+                        await fetch("/blob", {
+                            method: "POST",
+                            body: new Blob([new Uint8Array(sentinel)]),
+                        });
+
+                        const arrayBuffer = new Uint8Array(sentinel).buffer;
+                        await fetch("/array-buffer", { method: "POST", body: arrayBuffer });
+
+                        const backing = new Uint8Array([9, ...sentinel, 8]);
+                        await fetch("/typed-array-view", {
+                            method: "POST",
+                            body: backing.subarray(1, 5),
+                        });
+
+                        await fetch(new Request("/request", {
+                            method: "POST",
+                            body: new Uint8Array(sentinel),
+                        }));
+
+                        return calls;
+                    } finally {
+                        Deno.core.ops.op_fetch_url = originalFetchOp;
+                    }
+                }"#,
+                None,
+                &[],
+                true,
+                true,
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(
+            result.value.unwrap(),
+            serde_json::json!([
+                { "path": "/blob", "isUint8Array": true, "bytes": [0, 128, 255, 16] },
+                { "path": "/array-buffer", "isUint8Array": true, "bytes": [0, 128, 255, 16] },
+                { "path": "/typed-array-view", "isUint8Array": true, "bytes": [0, 128, 255, 16] },
+                { "path": "/request", "isUint8Array": true, "bytes": [0, 128, 255, 16] },
+            ])
+        );
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn fetch_form_urlencoded_and_xhr_bodies_reach_the_op_as_bytes() {
+        let mut rt = setup_runtime("<html><body></body></html>");
+        let result = rt
+            .call_function_on_for_cdp(
+                r#"async () => {
+                    const originalFetchOp = Deno.core.ops.op_fetch_url;
+                    const calls = [];
+                    const includesBytes = (bytes, needle) => {
+                        outer: for (let i = 0; i <= bytes.length - needle.length; i++) {
+                            for (let j = 0; j < needle.length; j++) {
+                                if (bytes[i + j] !== needle[j]) continue outer;
+                            }
+                            return true;
+                        }
+                        return false;
+                    };
+                    try {
+                        Deno.core.ops.op_fetch_url =
+                            (url, method, headers, body) => {
+                                const bytes = Array.from(
+                                    body instanceof Uint8Array
+                                        ? body
+                                        : new TextEncoder().encode(body),
+                                );
+                                calls.push({
+                                    path: new URL(url).pathname,
+                                    headers: JSON.parse(headers),
+                                    isUint8Array: body instanceof Uint8Array,
+                                    bytes,
+                                    hasRawSentinel: includesBytes(bytes, [0, 128, 255, 16]),
+                                });
+                                return JSON.stringify({
+                                    status: 200,
+                                    headers: {},
+                                    body: "ok",
+                                    url,
+                                });
+                            };
+
+                        const form = new FormData();
+                        form.append("note", "snow \u96ea");
+                        form.append(
+                            "upload",
+                            new File([new Uint8Array([0, 128, 255, 16])], "sentinel.bin", {
+                                type: "application/octet-stream",
+                            }),
+                        );
+                        await fetch("/form-data", { method: "POST", body: form });
+
+                        const params = new URLSearchParams();
+                        params.append("greeting", "\u96ea space&");
+                        await fetch("/url-search-params", { method: "POST", body: params });
+
+                        await new Promise((resolve, reject) => {
+                            const xhr = new XMLHttpRequest();
+                            xhr.open("POST", "/xhr-typed-array");
+                            xhr.onload = resolve;
+                            xhr.onerror = reject;
+                            const backing = new Uint8Array([9, 0, 128, 255, 16, 8]);
+                            xhr.send(backing.subarray(1, 5));
+                        });
+
+                        const formCall = calls.find(call => call.path === "/form-data");
+                        const paramsCall = calls.find(call => call.path === "/url-search-params");
+                        const xhrCall = calls.find(call => call.path === "/xhr-typed-array");
+                        return {
+                            formData: {
+                                isUint8Array: formCall.isUint8Array,
+                                contentType: Object.entries(formCall.headers)
+                                    .find(([name]) => name.toLowerCase() === "content-type")[1]
+                                    .startsWith("multipart/form-data; boundary=----WebKitFormBoundary"),
+                                hasText: includesBytes(
+                                    formCall.bytes,
+                                    Array.from(new TextEncoder().encode("snow \u96ea")),
+                                ),
+                                hasFilename: includesBytes(
+                                    formCall.bytes,
+                                    Array.from(new TextEncoder().encode('filename="sentinel.bin"')),
+                                ),
+                                hasRawSentinel: formCall.hasRawSentinel,
+                            },
+                            urlSearchParams: {
+                                isUint8Array: paramsCall.isUint8Array,
+                                contentType: Object.entries(paramsCall.headers)
+                                    .find(([name]) => name.toLowerCase() === "content-type")[1],
+                                bytes: paramsCall.bytes,
+                            },
+                            xhr: {
+                                isUint8Array: xhrCall.isUint8Array,
+                                bytes: xhrCall.bytes,
+                            },
+                        };
+                    } finally {
+                        Deno.core.ops.op_fetch_url = originalFetchOp;
+                    }
+                }"#,
+                None,
+                &[],
+                true,
+                true,
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(
+            result.value.unwrap(),
+            serde_json::json!({
+                "formData": {
+                    "isUint8Array": true,
+                    "contentType": true,
+                    "hasText": true,
+                    "hasFilename": true,
+                    "hasRawSentinel": true,
+                },
+                "urlSearchParams": {
+                    "isUint8Array": true,
+                    "contentType": "application/x-www-form-urlencoded;charset=UTF-8",
+                    "bytes": "greeting=%E9%9B%AA+space%26".as_bytes(),
+                },
+                "xhr": {
+                    "isUint8Array": true,
+                    "bytes": [0, 128, 255, 16],
+                },
+            })
+        );
+    }
+
     /// Serves a redirect chain across `connections` consecutive
     /// requests: `/hop/N` replies with 302 to `/hop/N-1`, `/hop/0` is the
     /// target. To a path the fixture cannot read it replies with 400

--- a/crates/obscura-net/src/wreq_client.rs
+++ b/crates/obscura-net/src/wreq_client.rs
@@ -433,7 +433,7 @@ impl StealthHttpClient {
         method: &str,
         url: &Url,
         headers: &HashMap<String, String>,
-        body: &str,
+        body: &[u8],
         send_cookies: bool,
         store_cookies: bool,
     ) -> Result<Response, ObscuraNetError> {
@@ -468,7 +468,7 @@ impl StealthHttpClient {
             req = req.header(k.as_str(), v.as_str());
         }
         if !body.is_empty() {
-            req = req.body(body.to_string());
+            req = req.body(body.to_vec());
         }
 
         let in_flight = InFlightGuard::new(&self.in_flight);
@@ -631,7 +631,7 @@ mod tests {
                 "POST",
                 &url,
                 &std::collections::HashMap::new(),
-                "payload",
+                b"payload",
                 false,
                 false,
             )


### PR DESCRIPTION
## What changed

Obscura version or commit: main (f449e6fb3183138eb3e80f11fe44af31cefe0fae)

- serialize JavaScript request bodies as Uint8Array instead of binary strings
- preserve Blob, ArrayBuffer, typed-array view bounds, Request bodies, and binary files in FormData
- preserve headers from an existing Request unless RequestInit explicitly supplies replacement headers
- pass request bytes unchanged through the normal reqwest transport and the stealth wreq transport
- keep the existing public InterceptResolution string API compatible in this focused fix

This fixes fetch(Request) losing authentication or account headers and preserves binary request bodies without text coercion.

This is the first part of #716. The byte-native public interception API is split into a follow-up PR because it is a breaking change.

## Validation

- cargo nextest run --release -p obscura-js (406 passed)
- focused JavaScript regressions covering Blob, ArrayBuffer, sliced views, Request headers and bodies, FormData, URLSearchParams, and XHR
- cargo nextest run --release -p obscura-browser --test binary_fetch_body
- cargo check --release --features render,stealth -p obscura-js
- cargo nextest run --release --features stealth -p obscura-net stealth_post_does_not_retry_connection_reset
- node --check crates/obscura-js/js/bootstrap.js
- git diff --check

## Rendering

Not applicable.

## Performance

The request-body path passes byte buffers directly instead of expanding binary data into JavaScript/Rust strings. Request headers are enumerated once. No additional network round trips are introduced.

## Checklist

- [x] The change is focused and does not remove existing behavior without justification.
- [x] Tests cover the failure.
- [x] Existing tests pass for the directly affected crates, including the stealth transport.
- [x] I checked the changed path for unnecessary copying and byte expansion.
- [x] Public API compatibility is preserved in this PR.