### PR TITLE
fix(js)!: preserve byte-native interception bodies

### DIFF
--- a/crates/obscura-cdp/src/server.rs
+++ b/crates/obscura-cdp/src/server.rs
@@ -3,6 +3,7 @@ use std::net::SocketAddr;
 use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use std::sync::Arc;
 
+use base64::Engine as _;
 use futures_util::{SinkExt, StreamExt};
 use serde_json::json;
 use tokio::net::TcpStream;
@@ -1106,10 +1107,31 @@ fn handle_fetch_resolution(
         let request_id = req.params.get("requestId").and_then(|v| v.as_str()).unwrap_or("");
         tracing::info!("INTERCEPTION resolution: {} for {}, paused_count={}", method, request_id, intercepted_paused.len());
 
-        if let Some(resolver) = intercepted_paused.remove(request_id) {
-            tracing::info!("INTERCEPTION resolved: {}", request_id);
-            let resolution = match method {
-                "Fetch.continueRequest" => obscura_js::ops::InterceptResolution::Continue {
+        if !intercepted_paused.contains_key(request_id) {
+            return false;
+        }
+
+        let resolution = match method {
+            "Fetch.continueRequest" => {
+                let body = match req.params.get("postData") {
+                    Some(value) => match value.as_str().map(decode_base64) {
+                        Some(Ok(body)) => Some(body),
+                        _ => {
+                            let resp = crate::types::CdpResponse::error(
+                                req.id,
+                                -32602,
+                                "Invalid base64 postData".to_string(),
+                                req.session_id,
+                            );
+                            if let Ok(json) = serde_json::to_string(&resp) {
+                                let _ = reply_tx.send(json);
+                            }
+                            return true;
+                        }
+                    },
+                    None => None,
+                };
+                obscura_js::ops::InterceptResolution::Continue {
                     // Honor the client's overrides (Playwright route.continue,
                     // Puppeteer request.continue). op_fetch_url applies each and
                     // re-validates a rewritten URL through the SSRF gate. Leaving
@@ -1117,26 +1139,44 @@ fn handle_fetch_resolution(
                     url: req.params.get("url").and_then(|v| v.as_str()).map(|s| s.to_string()),
                     method: req.params.get("method").and_then(|v| v.as_str()).map(|s| s.to_string()),
                     headers: parse_cdp_headers(&req.params),
-                    body: req.params.get("postData").and_then(|v| v.as_str()).map(|s| s.to_string()),
-                },
-                "Fetch.fulfillRequest" => {
-                    let status = req.params.get("responseCode").and_then(|v| v.as_u64()).unwrap_or(200) as u16;
-                    let raw_body = req.params.get("body").and_then(|v| v.as_str()).unwrap_or("");
-                    let body = decode_base64(raw_body);
-                    let headers = req.params.get("responseHeaders")
-                        .and_then(|v| v.as_array())
-                        .map(|arr| arr.iter().filter_map(|h| {
-                            Some((h.get("name")?.as_str()?.to_string(), h.get("value")?.as_str()?.to_string()))
-                        }).collect())
-                        .unwrap_or_default();
-                    obscura_js::ops::InterceptResolution::Fulfill { status, headers, body }
+                    body,
                 }
-                "Fetch.failRequest" => {
-                    let reason = req.params.get("errorReason").and_then(|v| v.as_str()).unwrap_or("Failed").to_string();
-                    obscura_js::ops::InterceptResolution::Fail { reason }
-                }
-                _ => return false,
-            };
+            }
+            "Fetch.fulfillRequest" => {
+                let status = req.params.get("responseCode").and_then(|v| v.as_u64()).unwrap_or(200) as u16;
+                let raw_body = req.params.get("body").and_then(|v| v.as_str()).unwrap_or("");
+                let body = match decode_base64(raw_body) {
+                    Ok(body) => body,
+                    Err(_) => {
+                        let resp = crate::types::CdpResponse::error(
+                            req.id,
+                            -32602,
+                            "Invalid base64 body".to_string(),
+                            req.session_id,
+                        );
+                        if let Ok(json) = serde_json::to_string(&resp) {
+                            let _ = reply_tx.send(json);
+                        }
+                        return true;
+                    }
+                };
+                let headers = req.params.get("responseHeaders")
+                    .and_then(|v| v.as_array())
+                    .map(|arr| arr.iter().filter_map(|h| {
+                        Some((h.get("name")?.as_str()?.to_string(), h.get("value")?.as_str()?.to_string()))
+                    }).collect())
+                    .unwrap_or_default();
+                obscura_js::ops::InterceptResolution::Fulfill { status, headers, body }
+            }
+            "Fetch.failRequest" => {
+                let reason = req.params.get("errorReason").and_then(|v| v.as_str()).unwrap_or("Failed").to_string();
+                obscura_js::ops::InterceptResolution::Fail { reason }
+            }
+            _ => return false,
+        };
+
+        if let Some(resolver) = intercepted_paused.remove(request_id) {
+            tracing::info!("INTERCEPTION resolved: {}", request_id);
             let _ = resolver.send(resolution);
             let resp = crate::types::CdpResponse::success(req.id, json!({}), req.session_id);
             if let Ok(json) = serde_json::to_string(&resp) {
@@ -1459,31 +1499,8 @@ async fn process_cdp_message(
     }
 }
 
-fn decode_base64(input: &str) -> String {
-    fn val(c: u8) -> Option<u8> {
-        match c {
-            b'A'..=b'Z' => Some(c - b'A'),
-            b'a'..=b'z' => Some(c - b'a' + 26),
-            b'0'..=b'9' => Some(c - b'0' + 52),
-            b'+' => Some(62),
-            b'/' => Some(63),
-            _ => None,
-        }
-    }
-    let bytes: Vec<u8> = input.bytes().filter_map(val).collect();
-    let mut out = Vec::with_capacity(bytes.len() * 3 / 4);
-    for chunk in bytes.chunks(4) {
-        let b = [
-            chunk.first().copied().unwrap_or(0),
-            chunk.get(1).copied().unwrap_or(0),
-            chunk.get(2).copied().unwrap_or(0),
-            chunk.get(3).copied().unwrap_or(0),
-        ];
-        out.push((b[0] << 2) | (b[1] >> 4));
-        if chunk.len() > 2 { out.push((b[1] << 4) | (b[2] >> 2)); }
-        if chunk.len() > 3 { out.push((b[2] << 6) | b[3]); }
-    }
-    String::from_utf8_lossy(&out).to_string()
+fn decode_base64(input: &str) -> Result<Vec<u8>, base64::DecodeError> {
+    base64::engine::general_purpose::STANDARD.decode(input)
 }
 
 fn fast_path_response(text: &str) -> Option<String> {
@@ -1824,26 +1841,72 @@ mod tests {
     }
 
     #[test]
-    fn fetch_resolution_is_handled_once_by_the_outer_processor() {
+    fn continue_resolution_preserves_non_utf8_body_and_replies_once() {
+        let expected = [0, 255, 128, 195, 40];
         let (resolution_tx, mut resolution_rx) = tokio::sync::oneshot::channel();
         let mut paused = HashMap::from([("request-1".to_string(), resolution_tx)]);
         let (reply_tx, mut reply_rx) = tokio::sync::mpsc::unbounded_channel::<String>();
         let mut ctx = crate::dispatch::CdpContext::new();
 
         assert!(handle_fetch_resolution(
-            r#"{"id":17,"method":"Fetch.continueRequest","params":{"requestId":"request-1"}}"#,
+            r#"{"id":17,"method":"Fetch.continueRequest","params":{"requestId":"request-1","postData":"AP+Awyg="}}"#,
             &mut ctx,
             &reply_tx,
             &mut paused,
         ));
-        assert!(matches!(
-            resolution_rx.try_recv(),
-            Ok(obscura_js::ops::InterceptResolution::Continue { .. })
-        ));
+        let resolution = resolution_rx.try_recv().expect("continue resolution");
+        let obscura_js::ops::InterceptResolution::Continue { body, .. } = resolution else {
+            panic!("expected continue resolution");
+        };
+        assert_eq!(body, Some(expected.to_vec()));
         let response: serde_json::Value =
             serde_json::from_str(&reply_rx.try_recv().expect("one command response")).unwrap();
         assert_eq!(response["id"], 17);
         assert!(reply_rx.try_recv().is_err(), "must not emit a duplicate response");
+    }
+
+    #[test]
+    fn fulfill_resolution_preserves_non_utf8_body_bytes() {
+        let expected = [0, 255, 128, 195, 40];
+        let (resolution_tx, mut resolution_rx) = tokio::sync::oneshot::channel();
+        let mut paused = HashMap::from([("binary-response".to_string(), resolution_tx)]);
+        let (reply_tx, _reply_rx) = tokio::sync::mpsc::unbounded_channel::<String>();
+        let mut ctx = crate::dispatch::CdpContext::new();
+
+        assert!(handle_fetch_resolution(
+            r#"{"id":18,"method":"Fetch.fulfillRequest","params":{"requestId":"binary-response","responseCode":200,"body":"AP+Awyg="}}"#,
+            &mut ctx,
+            &reply_tx,
+            &mut paused,
+        ));
+
+        let resolution = resolution_rx.try_recv().expect("fulfill resolution");
+        let obscura_js::ops::InterceptResolution::Fulfill { body, .. } = resolution else {
+            panic!("expected fulfill resolution");
+        };
+        assert_eq!(body, expected);
+    }
+
+    #[test]
+    fn invalid_base64_does_not_resolve_the_paused_request() {
+        let (resolution_tx, mut resolution_rx) = tokio::sync::oneshot::channel();
+        let mut paused = HashMap::from([("invalid-body".to_string(), resolution_tx)]);
+        let (reply_tx, mut reply_rx) = tokio::sync::mpsc::unbounded_channel::<String>();
+        let mut ctx = crate::dispatch::CdpContext::new();
+
+        assert!(handle_fetch_resolution(
+            r#"{"id":19,"method":"Fetch.continueRequest","params":{"requestId":"invalid-body","postData":"not base64"}}"#,
+            &mut ctx,
+            &reply_tx,
+            &mut paused,
+        ));
+
+        assert!(resolution_rx.try_recv().is_err());
+        assert!(paused.contains_key("invalid-body"));
+        let response: serde_json::Value =
+            serde_json::from_str(&reply_rx.try_recv().expect("invalid params response")).unwrap();
+        assert_eq!(response["id"], 19);
+        assert_eq!(response["error"]["code"], -32602);
     }
 
     #[cfg(feature = "render")]

--- a/crates/obscura-js/src/ops.rs
+++ b/crates/obscura-js/src/ops.rs
@@ -38,12 +38,12 @@ pub enum InterceptResolution {
         url: Option<String>,
         method: Option<String>,
         headers: Option<HashMap<String, String>>,
-        body: Option<String>,
+        body: Option<Vec<u8>>,
     },
     Fulfill {
         status: u16,
         headers: HashMap<String, String>,
-        body: String,
+        body: Vec<u8>,
     },
     Fail {
         reason: String,
@@ -2279,9 +2279,11 @@ async fn op_fetch_url(
                     body: b,
                 }) => {
                     let resp_headers: HashMap<String, String> = h;
+                    let resp_body = String::from_utf8_lossy(&b).into_owned();
                     return Ok(serde_json::json!({
                         "status": status,
-                        "body": b,
+                        "body": resp_body,
+                        "bodyBase64": BASE64.encode(&b),
                         "url": url,
                         "headers": resp_headers,
                     })
@@ -2307,7 +2309,7 @@ async fn op_fetch_url(
                     override_url = url;
                     override_method = method;
                     override_headers = headers;
-                    override_body = body.map(String::into_bytes);
+                    override_body = body;
                     tracing::debug!(
                         "Interception: continue (overrides url={} method={} headers={} body={})",
                         override_url.is_some(),

--- a/crates/obscura/tests/interception.rs
+++ b/crates/obscura/tests/interception.rs
@@ -4,7 +4,8 @@
 
 use std::io::{Read, Write};
 use std::sync::atomic::{AtomicU32, Ordering};
-use std::sync::{Arc, Mutex};
+use std::sync::{mpsc, Arc, Mutex};
+use std::time::Duration;
 
 use obscura::{Browser, InterceptResolution, ResourceType};
 
@@ -41,6 +42,70 @@ fn spawn_echo_server() -> String {
         }
     });
     format!("http://{}", addr)
+}
+
+fn spawn_binary_server() -> (String, mpsc::Receiver<Vec<u8>>) {
+    let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+    let addr = listener.local_addr().unwrap();
+    let (body_tx, body_rx) = mpsc::channel();
+    std::thread::spawn(move || {
+        for incoming in listener.incoming() {
+            let mut stream = match incoming {
+                Ok(stream) => stream,
+                Err(_) => continue,
+            };
+            let mut request = Vec::new();
+            let mut chunk = [0u8; 2048];
+            let header_end = loop {
+                let read = stream.read(&mut chunk).unwrap_or(0);
+                if read == 0 {
+                    break None;
+                }
+                request.extend_from_slice(&chunk[..read]);
+                if let Some(pos) = request.windows(4).position(|bytes| bytes == b"\r\n\r\n") {
+                    break Some(pos + 4);
+                }
+            };
+            let Some(header_end) = header_end else {
+                continue;
+            };
+            let headers = String::from_utf8_lossy(&request[..header_end]).into_owned();
+            let content_length = headers
+                .lines()
+                .find_map(|line| {
+                    let (name, value) = line.split_once(':')?;
+                    name.eq_ignore_ascii_case("content-length")
+                        .then(|| value.trim().parse::<usize>().ok())
+                        .flatten()
+                })
+                .unwrap_or(0);
+            while request.len() - header_end < content_length {
+                let read = stream.read(&mut chunk).unwrap_or(0);
+                if read == 0 {
+                    break;
+                }
+                request.extend_from_slice(&chunk[..read]);
+            }
+
+            let path = headers.split_whitespace().nth(1).unwrap_or("/");
+            if path == "/binary" {
+                let end = header_end + content_length.min(request.len() - header_end);
+                let _ = body_tx.send(request[header_end..end].to_vec());
+            }
+            let body = if path == "/" {
+                b"<!doctype html><title>binary interception</title>".as_slice()
+            } else {
+                b"ok".as_slice()
+            };
+            let response = format!(
+                "HTTP/1.1 200 OK\r\nContent-Type: text/html\r\nContent-Length: {}\r\nConnection: close\r\n\r\n",
+                body.len()
+            );
+            let _ = stream.write_all(response.as_bytes());
+            let _ = stream.write_all(body);
+        }
+    });
+    (format!("http://{}", addr), body_rx)
 }
 
 #[tokio::test]
@@ -210,6 +275,110 @@ async fn page_rewrites_request_url_via_interception() {
         body.contains("REWRITTEN"),
         "interception Continue url-rewrite did not take effect; captured: {:?}",
         body
+    );
+}
+
+#[tokio::test]
+async fn page_continue_overrides_post_body_with_non_utf8_bytes() {
+    std::env::set_var("OBSCURA_ALLOW_PRIVATE_NETWORK", "1");
+    let (base, received_body) = spawn_binary_server();
+    let expected: Vec<u8> = vec![0, 255, 128, 195, 40];
+
+    let browser = Browser::new().unwrap();
+    let mut page = browser.new_page().await.unwrap();
+    page.goto(&base).await.unwrap();
+
+    let mut rx = page.enable_interception();
+    let override_body = expected.clone();
+    tokio::spawn(async move {
+        while let Some(req) = rx.recv().await {
+            let body = req.url.ends_with("/binary").then(|| override_body.clone());
+            if req
+                .resolver
+                .send(InterceptResolution::Continue {
+                    url: None,
+                    method: None,
+                    headers: None,
+                    body,
+                })
+                .is_err()
+            {
+                break;
+            }
+        }
+    });
+
+    page.evaluate(
+        "fetch('/binary', { method: 'POST', body: new Uint8Array([1, 2, 3]) })\
+         .then(() => { globalThis.__binaryPostDone = true; })",
+    );
+    for _ in 0..20 {
+        page.settle(100).await;
+        if page.evaluate("globalThis.__binaryPostDone === true") == serde_json::json!(true) {
+            break;
+        }
+    }
+
+    assert_eq!(
+        received_body
+            .recv_timeout(Duration::from_secs(2))
+            .expect("server should receive the overridden POST"),
+        expected
+    );
+}
+
+#[tokio::test]
+async fn page_fulfill_preserves_non_utf8_response_bytes() {
+    std::env::set_var("OBSCURA_ALLOW_PRIVATE_NETWORK", "1");
+    let (base, _received_body) = spawn_binary_server();
+    let expected: Vec<u8> = vec![0, 255, 128, 195, 40];
+
+    let browser = Browser::new().unwrap();
+    let mut page = browser.new_page().await.unwrap();
+    page.goto(&base).await.unwrap();
+
+    let mut rx = page.enable_interception();
+    let fulfilled_body = expected.clone();
+    tokio::spawn(async move {
+        while let Some(req) = rx.recv().await {
+            let resolution = if req.url.ends_with("/fulfilled") {
+                InterceptResolution::Fulfill {
+                    status: 200,
+                    headers: std::collections::HashMap::from([(
+                        "content-type".to_string(),
+                        "application/octet-stream".to_string(),
+                    )]),
+                    body: fulfilled_body.clone(),
+                }
+            } else {
+                InterceptResolution::Continue {
+                    url: None,
+                    method: None,
+                    headers: None,
+                    body: None,
+                }
+            };
+            if req.resolver.send(resolution).is_err() {
+                break;
+            }
+        }
+    });
+
+    page.evaluate(
+        "fetch('/fulfilled')\
+         .then(response => response.arrayBuffer())\
+         .then(body => { globalThis.__fulfilledBytes = Array.from(new Uint8Array(body)); })",
+    );
+    for _ in 0..20 {
+        page.settle(100).await;
+        if page.evaluate("Array.isArray(globalThis.__fulfilledBytes)") == serde_json::json!(true) {
+            break;
+        }
+    }
+
+    assert_eq!(
+        page.evaluate("globalThis.__fulfilledBytes"),
+        serde_json::json!(expected)
     );
 }
 

--- a/docs/Use-as-a-Rust-library.md
+++ b/docs/Use-as-a-Rust-library.md
@@ -106,7 +106,7 @@ tokio::spawn(async move {
             InterceptResolution::Fulfill {
                 status: 200,
                 headers: Default::default(),
-                body: r#"{"newDashboard":true}"#.into(),
+                body: br#"{"newDashboard":true}"#.to_vec(),
             }
         } else {
             // Pass through, or rewrite by setting url/method/headers/body.
@@ -121,6 +121,7 @@ page.settle(2000).await;
 ```
 
 A `Continue` with `url: Some(...)` rewrites the target. The new URL is re-checked against the SSRF / private-network gate, so a rewrite cannot reach an internal address that would otherwise need `--allow-private-network`.
+`Continue.body` and `Fulfill.body` are raw bytes (`Vec<u8>`), so binary request and response bodies are preserved without UTF-8 conversion.
 
 ### Preload scripts
 


### PR DESCRIPTION
## What changed

Based on upstream main at `89964b3ef9b4132f679558e6b6685e086648b955`.

Interception body overrides still used text even after #717 fixed normal request transport. This changes `Continue.body` to `Option<Vec<u8>>` and replaces `Fulfill.body` plus `Fulfill.body_base64` with a single `Vec<u8>`.

CDP request and fulfilled-response bodies are decoded from Base64 before resolving the paused request. Invalid Base64 or a non-string body returns `-32602` and leaves the request available for a corrected command. The JavaScript response retains both its text view and exact `bodyBase64` representation, preserving the upstream #912 fix.

This addresses the interception portion of #716. #717 is already merged; XHR response handling and response-body retention remain separate concerns. No new issue or dependent branch is required.

This is a breaking Rust API change: callers supply raw bytes and no longer provide a separate `body_base64` field.

## Validation

- Release render CDP library and public interception tests: 137 passed.
- No-render check for `obscura-cdp` and `obscura`: passed.
- No-render focused Continue, Fulfill, invalid-input and public interception tests: 5 passed.
- Retained #912 binary fulfilled-response regression: passed.
- Full release render suite: 1,710 passed, 2 failed, 4 skipped. Both failures (`a_miss_created_inside_an_awaited_expression_loads_during_the_wait` and `timers_inside_a_fixed_wait_observe_bytes_that_land_during_it`) reproduce with the same font-width assertions on unmodified main at the baseline above.
- Release CLI build with render: passed.
- Obstacle course: 32/33 passed. The `observer-intersection` stage also fails on unmodified main with the same result (expected `io:50`, received an empty string).
- `git diff --check`: passed.

## Rendering

Not applicable.

## Performance

The wire format is unchanged. Rust interception uses one byte buffer instead of caller-maintained text and Base64 copies. No additional network requests or dependencies are introduced.
