### PR TITLE
fix: forward stealth features through public crates

### DIFF
--- a/crates/obscura-cdp/Cargo.toml
+++ b/crates/obscura-cdp/Cargo.toml
@@ -7,6 +7,7 @@ repository.workspace = true
 
 [features]
 default = []
+stealth = ["obscura-browser/stealth"]
 # Enable Page.captureScreenshot via obscura-render. Propagates render to
 # obscura-browser so Page::screenshot is available.
 render = ["obscura-browser/render", "dep:image", "dep:png"]

--- a/crates/obscura/Cargo.toml
+++ b/crates/obscura/Cargo.toml
@@ -10,6 +10,7 @@ license = "Apache-2.0"
 [features]
 default = ["api"]
 api = ["obscura-browser", "obscura-net", "tokio"]
+stealth = ["api", "obscura-browser/stealth"]
 render = ["api", "obscura-browser/render"]
 
 [dependencies]
@@ -24,3 +25,7 @@ url = "2"
 
 [dev-dependencies]
 tokio = { version = "1", features = ["rt-multi-thread", "macros", "sync", "time"] }
+
+[[example]]
+name = "basic"
+required-features = ["stealth"]

--- a/crates/obscura/tests/stealth_transport.rs
+++ b/crates/obscura/tests/stealth_transport.rs
@@ -1,0 +1,75 @@
+#![cfg(feature = "stealth")]
+
+use std::io::{Read, Write};
+use std::sync::mpsc;
+use std::time::Duration;
+
+use obscura::Browser;
+
+const STEALTH_USER_AGENT: &str = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) \
+AppleWebKit/537.36 (KHTML, like Gecko) Chrome/145.0.0.0 Safari/537.36";
+const ORDINARY_USER_AGENT: &str = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) \
+AppleWebKit/537.36 (KHTML, like Gecko) Chrome/143.0.0.0 Safari/537.36";
+
+fn spawn_server() -> (String, mpsc::Receiver<String>) {
+    let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+    let addr = listener.local_addr().unwrap();
+    let (request_tx, request_rx) = mpsc::sync_channel(1);
+
+    std::thread::spawn(move || {
+        let (mut stream, _) = listener.accept().unwrap();
+        stream
+            .set_read_timeout(Some(Duration::from_secs(5)))
+            .unwrap();
+
+        let mut request = Vec::new();
+        let mut chunk = [0u8; 1024];
+        while !request.windows(4).any(|window| window == b"\r\n\r\n") {
+            let read = stream.read(&mut chunk).unwrap();
+            if read == 0 {
+                break;
+            }
+            request.extend_from_slice(&chunk[..read]);
+        }
+        request_tx
+            .send(String::from_utf8(request).unwrap())
+            .unwrap();
+
+        let body = "<!doctype html><html><body>ok</body></html>";
+        let response = format!(
+            "HTTP/1.1 200 OK\r\nContent-Type: text/html\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+            body.len(),
+            body,
+        );
+        stream.write_all(response.as_bytes()).unwrap();
+    });
+
+    (format!("http://{}", addr), request_rx)
+}
+
+async fn navigate_user_agent(stealth: bool) -> String {
+    let (url, request_rx) = spawn_server();
+
+    let browser = Browser::builder().stealth(stealth).build().unwrap();
+    let mut page = browser.new_page().await.unwrap();
+    page.goto(&url).await.unwrap();
+
+    let request = request_rx.recv_timeout(Duration::from_secs(5)).unwrap();
+    request
+        .lines()
+        .filter_map(|line| line.split_once(':'))
+        .find_map(|(name, value)| {
+            name.eq_ignore_ascii_case("user-agent")
+                .then(|| value.trim().to_string())
+        })
+        .expect("request should include a user-agent header")
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn stealth_transport_requires_compile_time_and_runtime_opt_in() {
+    std::env::set_var("OBSCURA_ALLOW_PRIVATE_NETWORK", "1");
+    std::env::set_var("OBSCURA_PROFILE", "0");
+
+    assert_eq!(navigate_user_agent(true).await, STEALTH_USER_AGENT);
+    assert_eq!(navigate_user_agent(false).await, ORDINARY_USER_AGENT);
+}


### PR DESCRIPTION
## What changed

Fixes #724.

Expose and forward the existing stealth capability through both public entry points:

- obscura now provides a stealth feature that enables its API and forwards to obscura-browser/stealth.
- obscura-cdp now forwards its stealth feature to obscura-browser/stealth.
- The high-level basic example is gated on the stealth feature because it explicitly requests BrowserBuilder::stealth(true).
- A public integration test verifies the resulting network behavior with stealth enabled and disabled at runtime.

Before this change, BrowserBuilder::stealth(true) was available to embedded users, but the public obscura crate offered no way to select the full stealth transport at compile time. The CDP crate had the same missing feature forwarding. This left the runtime option disconnected from the required lower-level capability.

The test observes the actual User-Agent received by a local HTTP server. It covers both compile-time selection and runtime opt-in without asserting internal call order or implementation details.

## Validation

Passed:

- cargo check -p obscura --offline
- cargo check -p obscura --features stealth --offline
- cargo check -p obscura-cdp --offline
- cargo check -p obscura-cdp --features stealth --offline
- cargo nextest run -p obscura --features stealth --test stealth_transport --offline
- rustfmt --edition 2021 --check crates/obscura/tests/stealth_transport.rs
- cargo metadata --no-deps --format-version 1
- git diff --check origin/main...HEAD

The focused integration test passed 1/1. The workspace-wide cargo fmt check still reports existing formatting differences in files outside this change; the added Rust test itself passes rustfmt.

## Rendering

Not applicable.

## Performance

Default builds retain their existing feature set. Enabling stealth intentionally selects the existing stealth transport; there is no new runtime work beyond that established feature behavior.

## Checklist

- [x] The change is focused and does not remove existing behavior without justification.
- [x] Tests cover the failure or feature.
- [x] Default and stealth configurations for both affected public crates compile.
- [x] I checked for CPU, latency, and memory regressions.
- [x] Public API behavior is described in the linked issue and this pull request.
