### PR TITLE
fix(render): give flattened inline wrappers real DOM geometry

### DIFF
--- a/crates/obscura-render/src/dom.rs
+++ b/crates/obscura-render/src/dom.rs
@@ -7088,6 +7088,8 @@ fn layout_dom_once(
         }
     }
 
+    synthesize_flattened_inline_rects(tree, &mut rects, &text_runs, &styles, &mut inline_fragments);
+
     let generated_boxes = ifc_items
         .generated
         .iter()
@@ -7125,6 +7127,158 @@ fn layout_dom_once(
         query_stats,
         cascade_time,
     )
+}
+
+/// Flattened inline wrappers (see `is_flattenable_inline`) own no Taffy box,
+/// so layout records no rect for them. Synthesize their geometry from their
+/// rendered descendants, one fragment per line, so `getBoundingClientRect`,
+/// `getClientRects`, and hit-testing see the wrapper where its content
+/// actually is. Runs after all other geometry is final.
+fn synthesize_flattened_inline_rects(
+    tree: &DomTree,
+    rects: &mut HashMap<NodeId, Rect>,
+    text_runs: &HashMap<NodeId, Vec<(Rect, String)>>,
+    styles: &HashMap<NodeId, crate::LayoutStyle>,
+    inline_fragments: &mut HashMap<NodeId, Vec<Rect>>,
+) {
+    // Iterative so that deeply nested inline wrappers, which a recursive walk
+    // would have to bound by depth, are limited only by a node budget the way
+    // descendants() in tree.rs is.
+    fn gather(
+        tree: &DomTree,
+        id: NodeId,
+        rects: &HashMap<NodeId, Rect>,
+        text_runs: &HashMap<NodeId, Vec<(Rect, String)>>,
+        styles: &HashMap<NodeId, crate::LayoutStyle>,
+        fragments: &HashMap<NodeId, Vec<Rect>>,
+        pieces: &mut Vec<Rect>,
+    ) -> bool {
+        const MAX_VISITED: usize = 100_000;
+        let mut stack = vec![id];
+        let mut visited = 0usize;
+        while let Some(current) = stack.pop() {
+            visited += 1;
+            if visited > MAX_VISITED {
+                return false;
+            }
+            for child in rendered_children(tree, current).into_iter().rev() {
+                let Some(node) = tree.get_node(child) else {
+                    continue;
+                };
+                if matches!(node.data, obscura_dom::tree::NodeData::Text { .. }) {
+                    if let Some(runs) = text_runs.get(&child) {
+                        pieces.extend(runs.iter().map(|(rect, _)| *rect));
+                    }
+                    continue;
+                }
+                // An out-of-flow or floated descendant is not part of the
+                // inline box: including one drags the wrapper's rect out to
+                // wherever the descendant was placed.
+                if let Some(style) = styles.get(&child) {
+                    if style.display == crate::Display::None
+                        || style.float.is_some()
+                        || matches!(style.position, Some(taffy::Position::Absolute))
+                    {
+                        continue;
+                    }
+                }
+                // A wrapper synthesized earlier in this pass contributes its
+                // own line fragments, not the single union rect, so an outer
+                // wrapper spanning several lines keeps them separate.
+                match (fragments.get(&child), rects.get(&child)) {
+                    (Some(child_fragments), _) => pieces.extend(child_fragments.iter().copied()),
+                    (None, Some(rect)) => pieces.push(*rect),
+                    (None, None) => stack.push(child),
+                }
+            }
+        }
+        true
+    }
+
+    // One fragment per line, not per word: getClientRects() exposes these, and
+    // a multi-line inline has one rect per line box.
+    fn merge_into_line_fragments(mut pieces: Vec<Rect>) -> Vec<Rect> {
+        pieces.sort_by(|a, b| a.y.total_cmp(&b.y).then_with(|| a.x.total_cmp(&b.x)));
+        let mut lines: Vec<Rect> = Vec::new();
+        for piece in pieces {
+            match lines.last_mut() {
+                // Word boxes on one line share a baseline but can differ in
+                // height, so overlap is the test, not equality.
+                Some(line)
+                    if piece.y < line.y + line.height && piece.y + piece.height > line.y =>
+                {
+                    let left = line.x.min(piece.x);
+                    let top = line.y.min(piece.y);
+                    let right = (line.x + line.width).max(piece.x + piece.width);
+                    let bottom = (line.y + line.height).max(piece.y + piece.height);
+                    *line = Rect {
+                        x: left,
+                        y: top,
+                        width: (right - left).max(0.0),
+                        height: (bottom - top).max(0.0),
+                    };
+                }
+                _ => lines.push(piece),
+            }
+        }
+        lines
+    }
+    let mut missing: Vec<NodeId> = styles
+        .iter()
+        .filter(|(id, style)| {
+            // A positioned inline is a containing block for absolute
+            // descendants; installing a synthesized rect would change how
+            // those resolve. Leave its geometry to the existing paths.
+            style.ignores_used_box_sizes()
+                && style.position.is_none()
+                && !rects.contains_key(id)
+        })
+        .map(|(&id, _)| id)
+        .collect();
+    // Deepest first, so a nested wrapper is resolved before the wrapper that
+    // contains it and each subtree is walked once. Node ids do not track
+    // ancestry once script has created or reparented nodes, so depth is
+    // measured from the tree. The id is a tie-break to keep the fragment maps
+    // identical across runs (the incremental layout tests compare them).
+    let depth_of = |mut id: NodeId| {
+        let mut depth = 0u32;
+        while let Some(parent) = rendered_parent(tree, id) {
+            depth += 1;
+            if depth > 10_000 {
+                break;
+            }
+            id = parent;
+        }
+        depth
+    };
+    missing.sort_unstable_by_key(|id| (std::cmp::Reverse(depth_of(*id)), id.raw()));
+    for id in missing {
+        let mut pieces = Vec::new();
+        // A walk that ran out of budget has only part of the subtree, and
+        // partial geometry is worse than none.
+        if !gather(tree, id, rects, text_runs, styles, inline_fragments, &mut pieces) {
+            continue;
+        }
+        if pieces.is_empty() {
+            continue;
+        }
+        let pieces = merge_into_line_fragments(pieces);
+        let mut union = pieces[0];
+        for rect in &pieces[1..] {
+            let left = union.x.min(rect.x);
+            let top = union.y.min(rect.y);
+            let right = (union.x + union.width).max(rect.x + rect.width);
+            let bottom = (union.y + union.height).max(rect.y + rect.height);
+            union = Rect {
+                x: left,
+                y: top,
+                width: (right - left).max(0.0),
+                height: (bottom - top).max(0.0),
+            };
+        }
+        rects.insert(id, union);
+        inline_fragments.entry(id).or_insert(pieces);
+    }
 }
 
 /// Convert Taffy's ordinary-inline line surrogate into the element's actual
@@ -9579,6 +9733,7 @@ fn is_flattenable_inline(
         && style.background_image.is_none()
         && style.mask_image.is_none()
         && style.border == crate::Edges::default()
+        && style.padding == crate::Edges::default()
         && style.position.is_none()
         && !style.overflow_hidden
         && style.float.is_none()

--- a/crates/obscura-render/src/dom.rs
+++ b/crates/obscura-render/src/dom.rs
@@ -9894,6 +9894,7 @@ fn is_flattenable_inline(
         && style.mask_image.is_none()
         && style.border == crate::Edges::default()
         && style.padding == crate::Edges::default()
+        && style.margin == crate::Edges::default()
         && style.position.is_none()
         && !style.overflow_hidden
         && style.float.is_none()

--- a/crates/obscura-render/src/dom.rs
+++ b/crates/obscura-render/src/dom.rs
@@ -7248,6 +7248,8 @@ fn layout_dom_once(
         }
     }
 
+    synthesize_flattened_inline_rects(tree, &mut rects, &text_runs, &styles, &mut inline_fragments);
+
     let generated_boxes = ifc_items
         .generated
         .iter()
@@ -7285,6 +7287,158 @@ fn layout_dom_once(
         query_stats,
         cascade_time,
     )
+}
+
+/// Flattened inline wrappers (see `is_flattenable_inline`) own no Taffy box,
+/// so layout records no rect for them. Synthesize their geometry from their
+/// rendered descendants, one fragment per line, so `getBoundingClientRect`,
+/// `getClientRects`, and hit-testing see the wrapper where its content
+/// actually is. Runs after all other geometry is final.
+fn synthesize_flattened_inline_rects(
+    tree: &DomTree,
+    rects: &mut HashMap<NodeId, Rect>,
+    text_runs: &HashMap<NodeId, Vec<(Rect, String)>>,
+    styles: &HashMap<NodeId, crate::LayoutStyle>,
+    inline_fragments: &mut HashMap<NodeId, Vec<Rect>>,
+) {
+    // Iterative so that deeply nested inline wrappers, which a recursive walk
+    // would have to bound by depth, are limited only by a node budget the way
+    // descendants() in tree.rs is.
+    fn gather(
+        tree: &DomTree,
+        id: NodeId,
+        rects: &HashMap<NodeId, Rect>,
+        text_runs: &HashMap<NodeId, Vec<(Rect, String)>>,
+        styles: &HashMap<NodeId, crate::LayoutStyle>,
+        fragments: &HashMap<NodeId, Vec<Rect>>,
+        pieces: &mut Vec<Rect>,
+    ) -> bool {
+        const MAX_VISITED: usize = 100_000;
+        let mut stack = vec![id];
+        let mut visited = 0usize;
+        while let Some(current) = stack.pop() {
+            visited += 1;
+            if visited > MAX_VISITED {
+                return false;
+            }
+            for child in rendered_children(tree, current).into_iter().rev() {
+                let Some(node) = tree.get_node(child) else {
+                    continue;
+                };
+                if matches!(node.data, obscura_dom::tree::NodeData::Text { .. }) {
+                    if let Some(runs) = text_runs.get(&child) {
+                        pieces.extend(runs.iter().map(|(rect, _)| *rect));
+                    }
+                    continue;
+                }
+                // An out-of-flow or floated descendant is not part of the
+                // inline box: including one drags the wrapper's rect out to
+                // wherever the descendant was placed.
+                if let Some(style) = styles.get(&child) {
+                    if style.display == crate::Display::None
+                        || style.float.is_some()
+                        || matches!(style.position, Some(taffy::Position::Absolute))
+                    {
+                        continue;
+                    }
+                }
+                // A wrapper synthesized earlier in this pass contributes its
+                // own line fragments, not the single union rect, so an outer
+                // wrapper spanning several lines keeps them separate.
+                match (fragments.get(&child), rects.get(&child)) {
+                    (Some(child_fragments), _) => pieces.extend(child_fragments.iter().copied()),
+                    (None, Some(rect)) => pieces.push(*rect),
+                    (None, None) => stack.push(child),
+                }
+            }
+        }
+        true
+    }
+
+    // One fragment per line, not per word: getClientRects() exposes these, and
+    // a multi-line inline has one rect per line box.
+    fn merge_into_line_fragments(mut pieces: Vec<Rect>) -> Vec<Rect> {
+        pieces.sort_by(|a, b| a.y.total_cmp(&b.y).then_with(|| a.x.total_cmp(&b.x)));
+        let mut lines: Vec<Rect> = Vec::new();
+        for piece in pieces {
+            match lines.last_mut() {
+                // Word boxes on one line share a baseline but can differ in
+                // height, so overlap is the test, not equality.
+                Some(line)
+                    if piece.y < line.y + line.height && piece.y + piece.height > line.y =>
+                {
+                    let left = line.x.min(piece.x);
+                    let top = line.y.min(piece.y);
+                    let right = (line.x + line.width).max(piece.x + piece.width);
+                    let bottom = (line.y + line.height).max(piece.y + piece.height);
+                    *line = Rect {
+                        x: left,
+                        y: top,
+                        width: (right - left).max(0.0),
+                        height: (bottom - top).max(0.0),
+                    };
+                }
+                _ => lines.push(piece),
+            }
+        }
+        lines
+    }
+    let mut missing: Vec<NodeId> = styles
+        .iter()
+        .filter(|(id, style)| {
+            // A positioned inline is a containing block for absolute
+            // descendants; installing a synthesized rect would change how
+            // those resolve. Leave its geometry to the existing paths.
+            style.ignores_used_box_sizes()
+                && style.position.is_none()
+                && !rects.contains_key(id)
+        })
+        .map(|(&id, _)| id)
+        .collect();
+    // Deepest first, so a nested wrapper is resolved before the wrapper that
+    // contains it and each subtree is walked once. Node ids do not track
+    // ancestry once script has created or reparented nodes, so depth is
+    // measured from the tree. The id is a tie-break to keep the fragment maps
+    // identical across runs (the incremental layout tests compare them).
+    let depth_of = |mut id: NodeId| {
+        let mut depth = 0u32;
+        while let Some(parent) = rendered_parent(tree, id) {
+            depth += 1;
+            if depth > 10_000 {
+                break;
+            }
+            id = parent;
+        }
+        depth
+    };
+    missing.sort_unstable_by_key(|id| (std::cmp::Reverse(depth_of(*id)), id.raw()));
+    for id in missing {
+        let mut pieces = Vec::new();
+        // A walk that ran out of budget has only part of the subtree, and
+        // partial geometry is worse than none.
+        if !gather(tree, id, rects, text_runs, styles, inline_fragments, &mut pieces) {
+            continue;
+        }
+        if pieces.is_empty() {
+            continue;
+        }
+        let pieces = merge_into_line_fragments(pieces);
+        let mut union = pieces[0];
+        for rect in &pieces[1..] {
+            let left = union.x.min(rect.x);
+            let top = union.y.min(rect.y);
+            let right = (union.x + union.width).max(rect.x + rect.width);
+            let bottom = (union.y + union.height).max(rect.y + rect.height);
+            union = Rect {
+                x: left,
+                y: top,
+                width: (right - left).max(0.0),
+                height: (bottom - top).max(0.0),
+            };
+        }
+        rects.insert(id, union);
+        inline_fragments.entry(id).or_insert(pieces);
+    }
 }
 
 /// Convert Taffy's ordinary-inline line surrogate into the element's actual
@@ -9739,6 +9893,7 @@ fn is_flattenable_inline(
         && style.background_image.is_none()
         && style.mask_image.is_none()
         && style.border == crate::Edges::default()
+        && style.padding == crate::Edges::default()
         && style.position.is_none()
         && !style.overflow_hidden
         && style.float.is_none()

--- a/crates/obscura-render/tests/layout_test.rs
+++ b/crates/obscura-render/tests/layout_test.rs
@@ -4471,3 +4471,108 @@ fn grid_ordinary_aspect_ratio_preserves_normal_alignment_provenance() {
     assert_eq!(size("parent-align-stretch"), (400.0, 200.0));
     assert_eq!(size("parent-justify-stretch"), (300.0, 150.0));
 }
+
+#[test]
+fn flattened_inline_wrappers_keep_dom_geometry_next_to_replaced_siblings() {
+    // An inline run holding a replaced sibling takes the mixed-run path, where
+    // the wrapper is spliced into its parent's children and owns no box. It
+    // still needs a rect: automation clicks labels and spans by coordinate.
+    let tree = parse_html(
+        r#"
+        <style>
+          html, body { margin:0; font:16px/17px monospace }
+        </style>
+        <div><label id="with-input">toggle</label><input type="checkbox"></div>
+        <div><span id="with-image">caption</span><img src="x.png" width="10" height="10"></div>
+        <div><span id="plain">alone</span></div>
+        <div style="position:relative">
+          <span id="positioned" style="position:absolute">absolute</span>
+          <input type="checkbox">
+        </div>
+        "#,
+    );
+    let layout = layout_dom(&tree, (400.0, 200.0));
+    let rect = |id| layout.rects[&tree.get_element_by_id(id).unwrap()];
+
+    for id in ["with-input", "with-image"] {
+        let flattened = rect(id);
+        let plain = rect("plain");
+        assert!(
+            flattened.width > 0.0 && flattened.height > 0.0,
+            "{id} must report its content geometry, got {flattened:?}"
+        );
+        // Within a pixel of an ordinary inline: the synthesized union is
+        // derived from text-run boxes, the unflattened rect from the font box.
+        assert!(
+            (flattened.height - plain.height).abs() <= 1.0,
+            "{id} must be one line tall like an ordinary inline: {flattened:?} vs {plain:?}"
+        );
+    }
+
+    // A positioned inline is a containing block for absolute descendants, so
+    // its geometry stays with the paths that resolve those insets.
+    let positioned = rect("positioned");
+    assert!(
+        positioned.width > 0.0,
+        "positioned inline keeps its own layout box: {positioned:?}"
+    );
+}
+
+#[test]
+fn flattened_inline_geometry_excludes_out_of_flow_and_merges_lines() {
+    // The synthesized union must describe the inline box itself: an absolutely
+    // positioned descendant is not part of it, and a wrapped inline exposes one
+    // fragment per line rather than one per word.
+    let tree = parse_html(
+        r#"
+        <style>
+          html, body { margin:0; font:16px/18px monospace }
+        </style>
+        <div style="position:relative">
+          <span id="host">text <span style="position:absolute;left:900px">far</span></span>
+          <input type="checkbox">
+        </div>
+        <div style="width:80px"><span id="wrapped">aaa bbb ccc ddd</span><input type="checkbox"></div>
+        "#,
+    );
+    let layout = layout_dom(&tree, (400.0, 300.0));
+    let host = layout.rects[&tree.get_element_by_id("host").unwrap()];
+    assert!(
+        host.width < 200.0,
+        "an absolute descendant must not stretch the inline box: {host:?}"
+    );
+
+    let wrapped_id = tree.get_element_by_id("wrapped").unwrap();
+    let fragments = &layout.inline_fragments[&wrapped_id];
+    assert!(
+        fragments.len() > 1 && fragments.len() <= 4,
+        "wrapped inline exposes one fragment per line, got {}: {fragments:?}",
+        fragments.len()
+    );
+    for pair in fragments.windows(2) {
+        assert!(
+            pair[1].y >= pair[0].y + pair[0].height - 0.5,
+            "fragments must be one per line, not per word: {fragments:?}"
+        );
+    }
+}
+
+#[test]
+fn deeply_nested_flattened_inline_wrappers_all_keep_geometry() {
+    // The walk is bounded by a node budget rather than by depth, so nesting
+    // far past any plausible recursion limit still resolves every wrapper.
+    let open: String = (0..70).map(|i| format!("<span id=\"d{i}\">")).collect();
+    let close = "</span>".repeat(70);
+    let tree = parse_html(&format!(
+        r#"<style>html, body {{ margin:0; font:16px/18px monospace }}</style>
+        <div>{open}deep{close}<input type="checkbox"></div>"#
+    ));
+    let layout = layout_dom(&tree, (400.0, 200.0));
+    for id in ["d0", "d35", "d69"] {
+        let rect = layout.rects[&tree.get_element_by_id(id).unwrap()];
+        assert!(
+            rect.width > 0.0 && rect.height > 0.0,
+            "{id} must keep geometry at any nesting depth, got {rect:?}"
+        );
+    }
+}

--- a/crates/obscura-render/tests/layout_test.rs
+++ b/crates/obscura-render/tests/layout_test.rs
@@ -4496,3 +4496,108 @@ fn deeply_nested_wrappers_cascade_without_stack_overflow() {
         "the descendant rule must match at depth 400, got {rect:?}"
     );
 }
+
+#[test]
+fn flattened_inline_wrappers_keep_dom_geometry_next_to_replaced_siblings() {
+    // An inline run holding a replaced sibling takes the mixed-run path, where
+    // the wrapper is spliced into its parent's children and owns no box. It
+    // still needs a rect: automation clicks labels and spans by coordinate.
+    let tree = parse_html(
+        r#"
+        <style>
+          html, body { margin:0; font:16px/17px monospace }
+        </style>
+        <div><label id="with-input">toggle</label><input type="checkbox"></div>
+        <div><span id="with-image">caption</span><img src="x.png" width="10" height="10"></div>
+        <div><span id="plain">alone</span></div>
+        <div style="position:relative">
+          <span id="positioned" style="position:absolute">absolute</span>
+          <input type="checkbox">
+        </div>
+        "#,
+    );
+    let layout = layout_dom(&tree, (400.0, 200.0));
+    let rect = |id| layout.rects[&tree.get_element_by_id(id).unwrap()];
+
+    for id in ["with-input", "with-image"] {
+        let flattened = rect(id);
+        let plain = rect("plain");
+        assert!(
+            flattened.width > 0.0 && flattened.height > 0.0,
+            "{id} must report its content geometry, got {flattened:?}"
+        );
+        // Within a pixel of an ordinary inline: the synthesized union is
+        // derived from text-run boxes, the unflattened rect from the font box.
+        assert!(
+            (flattened.height - plain.height).abs() <= 1.0,
+            "{id} must be one line tall like an ordinary inline: {flattened:?} vs {plain:?}"
+        );
+    }
+
+    // A positioned inline is a containing block for absolute descendants, so
+    // its geometry stays with the paths that resolve those insets.
+    let positioned = rect("positioned");
+    assert!(
+        positioned.width > 0.0,
+        "positioned inline keeps its own layout box: {positioned:?}"
+    );
+}
+
+#[test]
+fn flattened_inline_geometry_excludes_out_of_flow_and_merges_lines() {
+    // The synthesized union must describe the inline box itself: an absolutely
+    // positioned descendant is not part of it, and a wrapped inline exposes one
+    // fragment per line rather than one per word.
+    let tree = parse_html(
+        r#"
+        <style>
+          html, body { margin:0; font:16px/18px monospace }
+        </style>
+        <div style="position:relative">
+          <span id="host">text <span style="position:absolute;left:900px">far</span></span>
+          <input type="checkbox">
+        </div>
+        <div style="width:80px"><span id="wrapped">aaa bbb ccc ddd</span><input type="checkbox"></div>
+        "#,
+    );
+    let layout = layout_dom(&tree, (400.0, 300.0));
+    let host = layout.rects[&tree.get_element_by_id("host").unwrap()];
+    assert!(
+        host.width < 200.0,
+        "an absolute descendant must not stretch the inline box: {host:?}"
+    );
+
+    let wrapped_id = tree.get_element_by_id("wrapped").unwrap();
+    let fragments = &layout.inline_fragments[&wrapped_id];
+    assert!(
+        fragments.len() > 1 && fragments.len() <= 4,
+        "wrapped inline exposes one fragment per line, got {}: {fragments:?}",
+        fragments.len()
+    );
+    for pair in fragments.windows(2) {
+        assert!(
+            pair[1].y >= pair[0].y + pair[0].height - 0.5,
+            "fragments must be one per line, not per word: {fragments:?}"
+        );
+    }
+}
+
+#[test]
+fn deeply_nested_flattened_inline_wrappers_all_keep_geometry() {
+    // The walk is bounded by a node budget rather than by depth, so nesting
+    // far past any plausible recursion limit still resolves every wrapper.
+    let open: String = (0..70).map(|i| format!("<span id=\"d{i}\">")).collect();
+    let close = "</span>".repeat(70);
+    let tree = parse_html(&format!(
+        r#"<style>html, body {{ margin:0; font:16px/18px monospace }}</style>
+        <div>{open}deep{close}<input type="checkbox"></div>"#
+    ));
+    let layout = layout_dom(&tree, (400.0, 200.0));
+    for id in ["d0", "d35", "d69"] {
+        let rect = layout.rects[&tree.get_element_by_id(id).unwrap()];
+        assert!(
+            rect.width > 0.0 && rect.height > 0.0,
+            "{id} must keep geometry at any nesting depth, got {rect:?}"
+        );
+    }
+}

--- a/crates/obscura-render/tests/layout_test.rs
+++ b/crates/obscura-render/tests/layout_test.rs
@@ -4601,3 +4601,26 @@ fn deeply_nested_flattened_inline_wrappers_all_keep_geometry() {
         );
     }
 }
+
+#[test]
+fn an_inline_with_horizontal_margin_keeps_its_box_on_the_mixed_run_path() {
+    // Flattening splices the wrapper's children into the parent and drops the
+    // wrapper's own edges with it, so a margined inline used to lay its
+    // following sibling out 50px too far left (Chrome puts the input at 60).
+    // Margin joins border and padding as a reason not to flatten.
+    let tree = parse_html(
+        r#"<style>html, body { margin:0; font:16px/18px monospace }</style>
+        <div><span id="m" style="margin-left:50px">A</span><input id="after"></div>"#,
+    );
+    let layout = layout_dom(&tree, (400.0, 200.0));
+    let wrapper = layout.rects[&tree.get_element_by_id("m").unwrap()];
+    let after = layout.rects[&tree.get_element_by_id("after").unwrap()];
+    assert!(
+        wrapper.x >= 50.0,
+        "the margin must offset the inline itself, got {wrapper:?}"
+    );
+    assert!(
+        after.x >= wrapper.x + wrapper.width,
+        "the following sibling must start after the margined inline, got {after:?} vs {wrapper:?}"
+    );
+}


### PR DESCRIPTION
Fixes #722.

A plain inline wrapper whose run holds a replaced element (`<label>x</label><input>`, `<span>x</span><img>`) fails `try_build_run`, so `build_mixed_block` takes the mixed-run path and `is_flattenable_inline` splices the wrapper's children into the parent's taffy children. The wrapper owns no box, nothing records a rect for it, and `getBoundingClientRect()` returned `0x0`, so Puppeteer/Playwright `handle.click()` failed with "not clickable".

The rect is now synthesized after layout from the wrapper's rendered descendants, grouped per line. Out-of-flow and floated descendants are excluded, since they are not part of the inline box; without that an absolutely positioned child at `left:900px` turned a 28px span into a 918px one. Positioned inlines keep their own box because they are a containing block for absolute descendants. A padded inline now keeps a real box instead of being flattened, matching how a bordered inline is already handled.

The walk is iterative and bounded by a node budget rather than by depth, and wrappers are resolved deepest-first so each subtree is visited once and a nested wrapper contributes its own line fragments rather than a collapsed union.

## Verification

Measured against headless Chrome 145 unless stated.

| probe | Chrome | before | after |
|---|---|---|---|
| `<div><label>toggle</label><input></div>` | 48x17 | 0x0 | 47x18 |
| absolute descendant inside the wrapper | 28px wide | 918px | 30px |
| wrapped inline, `getClientRects()` | 2 | 4 (one per word) | 2 |
| padded inline width | 43px | 27px | 47px |
| 70 nested inline wrappers, outermost | 39x19 | 0x0 | 38x18 |

- `cargo nextest run --release --features render --no-fail-fast`: 1488 run, 1486 passed. The two failures are `intersection_observer_*` tests that fail on unmodified `main` as well, at 2/10 and 3/10 over ten runs each on both trees.
- Obstacle course: 32/33, failing `observer-intersection` identically on `main`.
- All 69 `render-repros` fixtures produce metrics byte-identical to the pre-change build, so nothing repaints differently.
- Interleaved performance, same build and fixtures: 58 vs 55 ms median on a fixture, 1358 vs 1351 ms on a synthetic page with 3000 flattened wrappers. Inside the noise floor.

No `render-repros` fixture is included: the change is DOM geometry and produces no pixel difference, so a screenshot fixture would assert nothing. Coverage is in `layout_test.rs`.

## Known limitations

- An inline wrapping a block child reports one client rect where Chromium reports one per fragment. The bounding box matches.
- An empty inline reports `0x0` where Chromium reports `0x<line height>`, and an inline wrapping only a replaced element gets that element's height rather than the line box's. Both need the inline strut that `synthesize_ordinary_inline_fragments` derives from the text engine.
