### PR TITLE
fix(js): honor the click in progress flag

### DIFF
--- a/crates/obscura-js/js/bootstrap.js
+++ b/crates/obscura-js/js/bootstrap.js
@@ -2576,6 +2576,10 @@ function _htmlAttrName(el, n) {
 // A submit button per the HTML spec: a <button> whose type is submit — the
 // default, including when the type attribute is missing or invalid — or an
 // <input> of type submit/image. Used to validate requestSubmit's submitter.
+// Elements with a click currently dispatching, so a handler cannot re-enter
+// click() on its own element.
+const _clickInProgress = new WeakSet();
+
 function _isSubmitButton(el) {
   if (!el || typeof el.localName !== "string") return false;
   const type = ((el.getAttribute && el.getAttribute("type")) || "").toLowerCase();
@@ -3436,30 +3440,42 @@ class Element extends Node {
     return cache[name];
   }
   click() {
-    const cancelled = !this.dispatchEvent(new MouseEvent("click", {bubbles: true, cancelable: true}));
-    if (!cancelled) {
-      const link = this.tagName === 'A' ? this : (this.closest ? this.closest('a[href]') : null);
-      if (link) {
-        const href = link.getAttribute('href');
-        if (href && !href.startsWith('#') && !href.startsWith('javascript:')) {
-          location.assign(href);
-          return;
+    // The HTML click in progress flag. Without it a handler that clicks its own
+    // element re-enters until the stack is exhausted, and dispatchEvent catches
+    // and logs the resulting RangeError rather than propagating it, so the
+    // overflow surfaces only as a console trace.
+    if (_clickInProgress.has(this)) {
+      return;
+    }
+    _clickInProgress.add(this);
+    try {
+      const cancelled = !this.dispatchEvent(new MouseEvent("click", {bubbles: true, cancelable: true}));
+      if (!cancelled) {
+        const link = this.tagName === 'A' ? this : (this.closest ? this.closest('a[href]') : null);
+        if (link) {
+          const href = link.getAttribute('href');
+          if (href && !href.startsWith('#') && !href.startsWith('javascript:')) {
+            location.assign(href);
+            return;
+          }
+        }
+        // Same predicate requestSubmit validates against, so an internal click
+        // can never hand it a submitter it would reject. Also matches the CDP
+        // click path in input.rs, which already treats <input type=image> as a
+        // submit button.
+        if (_isSubmitButton(this)) {
+          const form = this.closest ? this.closest('form') : null;
+          // A real submit-button click fires the cancelable submit event, so use
+          // requestSubmit() (not the plain submit() method, which now bypasses it).
+          if (form && typeof form.requestSubmit === 'function') {
+            form.requestSubmit(this);
+          } else if (form && typeof form.submit === 'function') {
+            form.submit(this);
+          }
         }
       }
-      // Same predicate requestSubmit validates against, so an internal click
-      // can never hand it a submitter it would reject. Also matches the CDP
-      // click path in input.rs, which already treats <input type=image> as a
-      // submit button.
-      if (_isSubmitButton(this)) {
-        const form = this.closest ? this.closest('form') : null;
-        // A real submit-button click fires the cancelable submit event, so use
-        // requestSubmit() (not the plain submit() method, which now bypasses it).
-        if (form && typeof form.requestSubmit === 'function') {
-          form.requestSubmit(this);
-        } else if (form && typeof form.submit === 'function') {
-          form.submit(this);
-        }
-      }
+    } finally {
+      _clickInProgress.delete(this);
     }
   }
   focus() { globalThis.__obscura_focused = this; globalThis.__obscura_click_target = this; }

--- a/crates/obscura-js/js/bootstrap.js
+++ b/crates/obscura-js/js/bootstrap.js
@@ -2753,6 +2753,9 @@ function _labeledControl(label) {
 const _INTERACTIVE = 'a[href],audio[controls],button,details,embed,iframe,'
   + 'img[usemap],input:not([type=hidden]),select,textarea,video[controls]';
 
+// Elements with a click currently dispatching, so a handler cannot re-enter
+// click() on its own element.
+const _clickInProgress = new WeakSet();
 const _forwardingLabels = new WeakSet();
 // Passed to click() only by label activation on behalf of a real input event,
 // so the forwarded control events keep the trustedness of the click that
@@ -3726,85 +3729,96 @@ class Element extends Node {
     if (_isActuallyDisabled(this) && _tag !== 'LABEL') {
       return;
     }
-    let _oldChecked = false, _oldIndeterminate = false, _radioStates = null;
-    if (_checkable) {
-      _oldChecked = !!this.checked;
-      _oldIndeterminate = !!this.indeterminate;
-      if (_type === 'radio') {
-        const _name = this.getAttribute('name') || '';
-        if (_name) {
-          _radioStates = [];
-          const _all = (this.ownerDocument || globalThis.document).querySelectorAll('input');
-          for (let i = 0; i < _all.length; i++) {
-            const r = _all[i];
-            if (((r.getAttribute('type') || '').toLowerCase()) !== 'radio') continue;
-            if ((r.getAttribute('name') || '') !== _name || r.form !== this.form) continue;
-            _radioStates.push([r, !!r.checked]);
-            if (r !== this) r.checked = false;
+    // The HTML click in progress flag, checked after the disabled return and
+    // before pre-click activation so a suppressed re-entrant call cannot
+    // leave a flipped checked state behind.
+    if (_clickInProgress.has(this)) {
+      return;
+    }
+    _clickInProgress.add(this);
+    try {
+      let _oldChecked = false, _oldIndeterminate = false, _radioStates = null;
+      if (_checkable) {
+        _oldChecked = !!this.checked;
+        _oldIndeterminate = !!this.indeterminate;
+        if (_type === 'radio') {
+          const _name = this.getAttribute('name') || '';
+          if (_name) {
+            _radioStates = [];
+            const _all = (this.ownerDocument || globalThis.document).querySelectorAll('input');
+            for (let i = 0; i < _all.length; i++) {
+              const r = _all[i];
+              if (((r.getAttribute('type') || '').toLowerCase()) !== 'radio') continue;
+              if ((r.getAttribute('name') || '') !== _name || r.form !== this.form) continue;
+              _radioStates.push([r, !!r.checked]);
+              if (r !== this) r.checked = false;
+            }
           }
+          this.checked = true;
+        } else {
+          // Legacy-pre-activation behaviour (HTML spec): a checkbox toggles its
+          // checkedness *and* drops indeterminateness. Clearing it here, not on
+          // `change`, is what lets the cancelled-activation path put the old
+          // flag back instead of leaving it stuck off.
+          this.checked = !_oldChecked;
+          this.indeterminate = false;
         }
-        this.checked = true;
-      } else {
-        // Legacy-pre-activation behaviour (HTML spec): a checkbox toggles its
-        // checkedness *and* drops indeterminateness. Clearing it here, not on
-        // `change`, is what lets the cancelled-activation path put the old
-        // flag back instead of leaving it stuck off.
-        this.checked = !_oldChecked;
-        this.indeterminate = false;
       }
-    }
-    const _clickEvent = new MouseEvent("click", {bubbles: true, cancelable: true});
-    if (_trusted) globalThis.__obscura_markTrusted(_clickEvent);
-    const cancelled = !this.dispatchEvent(_clickEvent);
-    if (cancelled) {
-      if (_radioStates) { for (let i = 0; i < _radioStates.length; i++) _radioStates[i][0].checked = _radioStates[i][1]; }
-      else if (_checkable) { this.checked = _oldChecked; this.indeterminate = _oldIndeterminate; }
-      return;
-    }
-    if (_checkable && this.checked !== _oldChecked) {
-      for (const _type of ['input', 'change']) {
-        const _e = new Event(_type, {bubbles: true});
-        if (_trusted) globalThis.__obscura_markTrusted(_e);
-        try { this.dispatchEvent(_e); } catch (e) {}
-      }
-      return;
-    }
-    // Label activation behaviour (HTML spec): activating a label runs a
-    // synthetic click on its labeled control. The re-entrancy guard stops a
-    // control nested inside its own label from bouncing the click back.
-    const _label = _tag === 'LABEL'
-      ? this
-      : (this.closest && !this.matches(_INTERACTIVE) ? this.closest('label') : null);
-    if (_label && !(this.closest && this.closest(_INTERACTIVE) &&
-        _label.contains(this.closest(_INTERACTIVE)))) {
-      const control = _labeledControl(_label);
-      if (control && control !== this && globalThis.__obscura_activateLabel(_label, control)) {
+      const _clickEvent = new MouseEvent("click", {bubbles: true, cancelable: true});
+      if (_trusted) globalThis.__obscura_markTrusted(_clickEvent);
+      const cancelled = !this.dispatchEvent(_clickEvent);
+      if (cancelled) {
+        if (_radioStates) { for (let i = 0; i < _radioStates.length; i++) _radioStates[i][0].checked = _radioStates[i][1]; }
+        else if (_checkable) { this.checked = _oldChecked; this.indeterminate = _oldIndeterminate; }
         return;
       }
-    }
-    if (!cancelled) {
-      const link = this.tagName === 'A' ? this : (this.closest ? this.closest('a[href]') : null);
-      if (link) {
-        const href = link.getAttribute('href');
-        if (href && !href.startsWith('#') && !href.startsWith('javascript:')) {
-          location.assign(href);
+      if (_checkable && this.checked !== _oldChecked) {
+        for (const _type of ['input', 'change']) {
+          const _e = new Event(_type, {bubbles: true});
+          if (_trusted) globalThis.__obscura_markTrusted(_e);
+          try { this.dispatchEvent(_e); } catch (e) {}
+        }
+        return;
+      }
+      // Label activation behaviour (HTML spec): activating a label runs a
+      // synthetic click on its labeled control. The re-entrancy guard stops a
+      // control nested inside its own label from bouncing the click back.
+      const _label = _tag === 'LABEL'
+        ? this
+        : (this.closest && !this.matches(_INTERACTIVE) ? this.closest('label') : null);
+      if (_label && !(this.closest && this.closest(_INTERACTIVE) &&
+          _label.contains(this.closest(_INTERACTIVE)))) {
+        const control = _labeledControl(_label);
+        if (control && control !== this && globalThis.__obscura_activateLabel(_label, control)) {
           return;
         }
       }
-      // Same predicate requestSubmit validates against, so an internal click
-      // can never hand it a submitter it would reject. Also matches the CDP
-      // click path in input.rs, which already treats <input type=image> as a
-      // submit button.
-      if (_isSubmitButton(this)) {
-        const form = this.closest ? this.closest('form') : null;
-        // A real submit-button click fires the cancelable submit event, so use
-        // requestSubmit() (not the plain submit() method, which now bypasses it).
-        if (form && typeof form.requestSubmit === 'function') {
-          form.requestSubmit(this);
-        } else if (form && typeof form.submit === 'function') {
-          form.submit(this);
+      if (!cancelled) {
+        const link = this.tagName === 'A' ? this : (this.closest ? this.closest('a[href]') : null);
+        if (link) {
+          const href = link.getAttribute('href');
+          if (href && !href.startsWith('#') && !href.startsWith('javascript:')) {
+            location.assign(href);
+            return;
+          }
+        }
+        // Same predicate requestSubmit validates against, so an internal click
+        // can never hand it a submitter it would reject. Also matches the CDP
+        // click path in input.rs, which already treats <input type=image> as a
+        // submit button.
+        if (_isSubmitButton(this)) {
+          const form = this.closest ? this.closest('form') : null;
+          // A real submit-button click fires the cancelable submit event, so use
+          // requestSubmit() (not the plain submit() method, which now bypasses it).
+          if (form && typeof form.requestSubmit === 'function') {
+            form.requestSubmit(this);
+          } else if (form && typeof form.submit === 'function') {
+            form.submit(this);
+          }
         }
       }
+    } finally {
+      _clickInProgress.delete(this);
     }
   }
   focus() { globalThis.__obscura_focused = this; globalThis.__obscura_click_target = this; }

--- a/crates/obscura-js/src/runtime.rs
+++ b/crates/obscura-js/src/runtime.rs
@@ -13087,6 +13087,36 @@ mod tests {
     }
 
     #[test]
+    fn test_click_suppresses_reentrant_dispatch() {
+        // The HTML click in progress flag is per element: a handler clicking
+        // its own element is suppressed, a cycle between two elements stops at
+        // the second, and ordinary sequential clicks are untouched.
+        let mut rt = setup_runtime(r#"<button id="a">a</button><button id="b">b</button>"#);
+        let result = rt
+            .evaluate(
+                r#"
+            const a = document.getElementById('a');
+            const b = document.getElementById('b');
+            let self = 0;
+            a.onclick = () => { self++; if (self < 5000) { a.click(); } };
+            a.click();
+            let cycle = 0;
+            a.onclick = () => { cycle++; if (cycle < 5000) { b.click(); } };
+            b.onclick = () => { cycle++; if (cycle < 5000) { a.click(); } };
+            a.click();
+            let plain = 0;
+            a.onclick = () => { plain++; };
+            a.click();
+            a.click();
+            a.click();
+            return [self, cycle, plain];
+        "#,
+            )
+            .unwrap();
+        assert_eq!(result, serde_json::json!([1, 2, 3]));
+    }
+
+    #[test]
     fn test_dispatch_mouse_event_runs_listener() {
         let mut rt = setup_runtime(r#"<button id="go">Go</button>"#);
         let result = rt

--- a/crates/obscura-js/src/runtime.rs
+++ b/crates/obscura-js/src/runtime.rs
@@ -14531,6 +14531,36 @@ mod tests {
     }
 
     #[test]
+    fn test_click_suppresses_reentrant_dispatch() {
+        // The HTML click in progress flag is per element: a handler clicking
+        // its own element is suppressed, a cycle between two elements stops at
+        // the second, and ordinary sequential clicks are untouched.
+        let mut rt = setup_runtime(r#"<button id="a">a</button><button id="b">b</button>"#);
+        let result = rt
+            .evaluate(
+                r#"
+            const a = document.getElementById('a');
+            const b = document.getElementById('b');
+            let self = 0;
+            a.onclick = () => { self++; if (self < 5000) { a.click(); } };
+            a.click();
+            let cycle = 0;
+            a.onclick = () => { cycle++; if (cycle < 5000) { b.click(); } };
+            b.onclick = () => { cycle++; if (cycle < 5000) { a.click(); } };
+            a.click();
+            let plain = 0;
+            a.onclick = () => { plain++; };
+            a.click();
+            a.click();
+            a.click();
+            return [self, cycle, plain];
+        "#,
+            )
+            .unwrap();
+        assert_eq!(result, serde_json::json!([1, 2, 3]));
+    }
+
+    #[test]
     fn test_dispatch_mouse_event_runs_listener() {
         let mut rt = setup_runtime(r#"<button id="go">Go</button>"#);
         let result = rt


### PR DESCRIPTION
Fixes #726.

`HTMLElement.click()` did not implement the HTML click in progress flag, so a handler that clicks its own element re-entered until the V8 stack was exhausted. `dispatchEvent` wraps every listener in `try { ... } catch(e) { console.error(e) }`, so the resulting `RangeError` was logged and did not propagate: the outer `click()` returned normally and the overflow surfaced only as a console trace.

```
obscura fetch 'data:text/html,<button id=x>b</button>' --eval "(function(){ var n=0; var x=document.getElementById('x'); x.onclick=function(){ n++; if(n<5000) x.click(); }; x.click(); return n; })()"
```

Returned `2017` on this host on v0.2.1 and `main`; the depth is stack-size dependent. Chrome returns `1`.

The flag is tracked per element in a closure-private `WeakSet` and cleared in `finally`, so it survives a listener that throws and adds nothing page-observable.

## Verification

| probe | Chrome | before | after |
|---|---|---|---|
| handler clicks its own element | 1 | to stack exhaustion | 1 |
| three sequential clicks | 3 | 3 | 3 |
| cycle: A clicks B clicks A | 2 | to stack exhaustion | 2 |
| flag clears after a listener throws | 2 | 2 | 2 |
| handler clicks a different element | fires both | fires both | fires both |

- `cargo nextest run --release --features render --no-fail-fast`: 1486 run, 1485 passed. The single failure is a timing-sensitive test that also fails on unmodified `main`.
- Obstacle course unchanged at 32/33, failing `observer-intersection` identically on `main`.

## Note on merge order

This is independent of #721 and #722 and applies to `main` on its own. If it merges alongside #721, the flag check must stay after the disabled early return and before pre-click activation, otherwise a suppressed re-entrant call still flips `checked` before it returns. That ordering is not observable on `main` alone, because pre-click activation does not exist yet.
