### PR TITLE
docs: drop the WebGL/GPU renderer claim from the stealth profile section

### DIFF
--- a/docs/Configure-stealth-and-proxies.md
+++ b/docs/Configure-stealth-and-proxies.md
@@ -69,7 +69,7 @@ Default UA matches a recent Chrome on the build platform.
 
 ## Browser profile, timezone, and geolocation
 
-The engine presents one of a built-in pool of realistic browser profiles (a mix of Windows and macOS, recent Chrome versions). Each profile keeps `navigator.platform`, `navigator.userAgentData` (platform and platform version), the UA string, and the WebGL/GPU renderer internally consistent, so the surfaces a site fingerprints agree with each other. Windows profiles report ANGLE Direct3D11 renderers, macOS profiles report ANGLE Metal renderers.
+The engine presents one of a built-in pool of realistic browser profiles (a mix of Windows and macOS, recent Chrome versions). Each profile keeps `navigator.platform`, `navigator.userAgentData` (platform and platform version), and the UA string internally consistent, so the surfaces a site fingerprints agree with each other. There is no GPU renderer among them: `canvas.getContext('webgl')` returns `null`, so a page cannot read a renderer string at all.
 
 A single stable profile is used by default. One IP cycling through different identities is itself a signal, so rotation is opt-in:
 


### PR DESCRIPTION
## What changed

`docs/Configure-stealth-and-proxies.md` promises that each built-in profile keeps "the WebGL/GPU renderer internally consistent", and that Windows profiles report ANGLE Direct3D11 renderers while macOS profiles report ANGLE Metal. There is no renderer to be consistent with: `getContext('webgl')` returns `null`.

Timeline, so the sentence is not misread as a typo:

- 2026-06-10, #288 added the sentence. It was accurate then, against the WebGL shim that existed at the time, and against the profile pool from #268.
- 2026-07-26, `29d0bce` ("render: expose WebGL as unavailable without backend") made `webgl`, `experimental-webgl` and `webgl2` return `null`, deliberately, with an in-source comment: the former shim reported successful shader and program creation while every draw call was a no-op, so feature-detecting pages selected their WebGL path, hid the fallback and painted nothing.
- The doc file was edited again on 2026-08-07 (`cd66198`) and the sentence carried over.

Doc-only change. The rest of the paragraph - `navigator.platform`, `navigator.userAgentData`, the UA string - is unaffected and still holds.

## Validation

On `main` (`f449e6f`) and on the v0.2.0 render+stealth binary, Windows 10 x64:

```
$ obscura fetch "data:text/html,<p>x" \
    --eval "String(document.createElement('canvas').getContext('webgl'))"
null
```

Same result for `experimental-webgl` and `webgl2`, and the same over CDP through Playwright with `--stealth`.

Source check on `main`: `crates/obscura-js/js/bootstrap.js:12493` returns `null` for all three context types. The `gpu` and `gpuVendor` fields are assigned into the fingerprint object at `bootstrap.js:684` and `grep` finds no read of either anywhere in the tree - they are the pool that used to feed the shim. Whether to delete them or to keep them for when a WebGL backend lands is a judgement about direction rather than a doc bug, so this PR does not touch them. Happy to open a follow-up either way.

No code touched, so no test run applies. Markdown renders unchanged apart from the edited sentence.

## Rendering

Not applicable.

## Performance

No expected impact.

## Checklist

- [x] The change is focused and does not remove existing behavior without justification.
- [ ] Tests cover the failure or feature. Doc-only; nothing to test.
- [x] Existing tests pass, including render and no-render configurations when affected. Not affected.
- [x] I checked for CPU, latency, and memory regressions. None; no code path changed.
- [x] Public API or user-facing behavior changes are documented. This is the documentation fix.