### PR TITLE
render: reuse the retained resource cache on the capture fallback

### DIFF
--- a/crates/obscura-browser/src/page.rs
+++ b/crates/obscura-browser/src/page.rs
@@ -3400,6 +3400,22 @@ impl Page {
             .as_ref()
             .map(|js| js.scroll_offset())
             .unwrap_or((0.0, 0.0));
+        // When there IS a runtime, paint against the resource cache it already
+        // holds for this document. Building a fresh one here refetched every
+        // image on every capture, so a caller repeating a screenshot at a
+        // viewport that does not match the prepared key paid the whole network
+        // cost per frame.
+        if let Some(js) = &self.js {
+            if let Some(png) = js.screenshot_unprepared_with_retained_resources(
+                viewport,
+                base_url,
+                scroll,
+                animation_sample.time,
+                self.capture_surface_color(),
+            ) {
+                return Some(png);
+            }
+        }
         self.with_dom(|dom| {
             obscura_js::screenshot_png_scrolled_at_animation_time_with_surface_color(
                 dom,

--- a/crates/obscura-js/src/runtime.rs
+++ b/crates/obscura-js/src/runtime.rs
@@ -1117,6 +1117,41 @@ impl ObscuraJsRuntime {
         )
     }
 
+    /// Paint an unprepared view of the current document against the runtime's
+    /// retained resource cache.
+    ///
+    /// `Page` falls back to a raw-DOM paint when a capture's viewport does not
+    /// match the prepared render key. That fallback used a fresh
+    /// `RenderResourceCache`, so it refetched every image on every call and a
+    /// repeated capture paid the network cost per frame. Reusing the cache the
+    /// runtime already holds for this document keeps the fallback correct while
+    /// fetching each resource once.
+    #[cfg(feature = "render")]
+    pub fn screenshot_unprepared_with_retained_resources(
+        &self,
+        viewport: (f32, f32),
+        base_url: Option<&str>,
+        scroll: (f32, f32),
+        animation_sample_time: obscura_render::AnimationSampleTime,
+        surface_color: [u8; 4],
+    ) -> Option<Vec<u8>> {
+        let mut state = self.state.borrow_mut();
+        let ObscuraState {
+            dom,
+            render_resources,
+            ..
+        } = &mut *state;
+        obscura_render::screenshot_png_scrolled_at_animation_time_with_surface_color_and_resources(
+            dom.as_ref()?,
+            viewport,
+            base_url,
+            scroll,
+            animation_sample_time,
+            surface_color,
+            render_resources,
+        )
+    }
+
     #[cfg(feature = "render")]
     pub fn screenshot_prepared_with_surface_color(
         &self,

--- a/crates/obscura-render/src/lib.rs
+++ b/crates/obscura-render/src/lib.rs
@@ -99,6 +99,7 @@ mod paint;
 pub use paint::{
     image_intrinsic_dimensions, paint_dom, paint_dom_scrolled,
     paint_dom_scrolled_at_animation_time,
+    paint_dom_scrolled_at_animation_time_with_surface_color_and_resources,
     paint_dom_scrolled_at_animation_time_with_surface_color, paint_prepared,
     paint_prepared_region_with_scroll, paint_prepared_region_with_scroll_and_surface_color,
     paint_prepared_region_with_scroll_and_surface_color_and_canvas_surfaces,
@@ -111,6 +112,7 @@ pub use paint::{
     prepare_dom_with_dynamic_fonts_and_stylesheet_cache_for_media_with_animation_state,
     prepare_dom_with_dynamic_fonts_and_stylesheet_cache_with_animation_state,
     screenshot_png, screenshot_png_scrolled, screenshot_png_scrolled_at_animation_time,
+    screenshot_png_scrolled_at_animation_time_with_surface_color_and_resources,
     screenshot_png_scrolled_at_animation_time_with_surface_color,
     prepare_dom_with_retained_attribute_styles, prepare_dom_with_retained_styles,
     prepare_dom_with_retained_styles_at_animation_time,

--- a/crates/obscura-render/src/paint.rs
+++ b/crates/obscura-render/src/paint.rs
@@ -2104,14 +2104,41 @@ pub fn paint_dom_scrolled_at_animation_time_with_surface_color(
     surface_color: [u8; 4],
 ) -> Option<Pixmap> {
     let mut resources = RenderResourceCache::default();
+    paint_dom_scrolled_at_animation_time_with_surface_color_and_resources(
+        tree,
+        viewport,
+        base_url,
+        scroll,
+        animation_sample_time,
+        surface_color,
+        &mut resources,
+    )
+}
+
+/// As [`paint_dom_scrolled_at_animation_time_with_surface_color`], but painting
+/// against a caller-owned resource cache instead of a fresh one.
+///
+/// The default-cache version starts empty, so every image is fetched again on
+/// every call. A caller that already holds a warm cache for this document — a
+/// page repeating a capture, for instance — can pass it here and pay the
+/// network cost once rather than per frame.
+pub fn paint_dom_scrolled_at_animation_time_with_surface_color_and_resources(
+    tree: &DomTree,
+    viewport: (f32, f32),
+    base_url: Option<&str>,
+    scroll: (f32, f32),
+    animation_sample_time: crate::AnimationSampleTime,
+    surface_color: [u8; 4],
+    resources: &mut RenderResourceCache,
+) -> Option<Pixmap> {
     let mut prepared = prepare_dom_at_animation_time(
         tree,
         viewport,
         base_url,
-        &mut resources,
+        resources,
         animation_sample_time,
     )?;
-    paint_prepared_with_surface_color(tree, &mut prepared, &mut resources, scroll, surface_color)
+    paint_prepared_with_surface_color(tree, &mut prepared, resources, scroll, surface_color)
 }
 
 /// Resolve image candidates and web fonts, then create the single final layout
@@ -6265,6 +6292,28 @@ pub fn screenshot_png_scrolled_at_animation_time_with_surface_color(
         scroll,
         animation_sample_time,
         surface_color,
+    )
+    .and_then(|pixmap| pixmap.encode_png().ok())
+}
+
+/// PNG wrapper for [`paint_dom_scrolled_at_animation_time_with_surface_color_and_resources`].
+pub fn screenshot_png_scrolled_at_animation_time_with_surface_color_and_resources(
+    tree: &DomTree,
+    viewport: (f32, f32),
+    base_url: Option<&str>,
+    scroll: (f32, f32),
+    animation_sample_time: crate::AnimationSampleTime,
+    surface_color: [u8; 4],
+    resources: &mut RenderResourceCache,
+) -> Option<Vec<u8>> {
+    paint_dom_scrolled_at_animation_time_with_surface_color_and_resources(
+        tree,
+        viewport,
+        base_url,
+        scroll,
+        animation_sample_time,
+        surface_color,
+        resources,
     )
     .and_then(|pixmap| pixmap.encode_png().ok())
 }


### PR DESCRIPTION
`Page::screenshot` tries the prepared path first, which bails when the requested viewport does
not match the runtime's render key. Since `Page::screenshot` takes `&self` it cannot align the
viewport itself, so the fallback is easy to reach — it is what happens whenever a caller asks
for a size without setting the viewport to match first, with no signal that it happened.

The fallback calls `paint_dom_scrolled_at_animation_time_with_surface_color`, which builds a
fresh `RenderResourceCache`. A fresh cache starts empty, so every image is fetched again on
every capture, and a caller repeating a screenshot pays the whole network cost per frame.

This paints against the cache the runtime already holds for the document instead.

### Measured

An article with 28 images, 1280x800, five consecutive frames:

| | per frame |
|---|---|
| before | 19,565 ms |
| after | 1,240 ms |

What remains is the relayout the fallback does by design; what goes away is refetching the
images. For comparison a capture on the prepared path is 89 ms, so aligning the viewport is
still much better where a caller can — this just stops the fallback being a cliff.

### Shape

- `paint.rs` gains a `..._and_resources` variant; the existing entry point keeps its signature
  and delegates to it with a fresh cache, so nothing changes for current callers.
- `runtime.rs` exposes the retained cache through one method.
- `page.rs` uses it when a JS runtime exists. The no-runtime path is untouched, since there is
  no retained cache to reuse there.

### Testing

- `obscura-render`: 469 + 112 tests pass.
- `render-repros`: 61/61 fixtures, 248/248 assertions, unchanged from before the patch.

### Note

I looked at two other shapes before this one. Having `screenshot` align the viewport needs
`&mut self`, and having the prepared path re-prepare on mismatch rather than returning `None`
is a larger behavioural change — happy to go either way if you would prefer one of those.
