### PR TITLE
fix(js): implement HTMLInputElement.indeterminate

### DIFF
--- a/crates/obscura-cdp/src/domains/input.rs
+++ b/crates/obscura-cdp/src/domains/input.rs
@@ -160,6 +160,7 @@ pub async fn handle(
                             if (globalThis.__obscura_isDisabled(clickTarget)) return;\
                             var checkable = tag === 'INPUT' && (type === 'checkbox' || type === 'radio');\
                             var oldChecked = checkable ? !!clickTarget.checked : false;\
+                            var oldIndeterminate = checkable ? !!clickTarget.indeterminate : false;\
                             var radioStates = null;\
                             if (checkable && type === 'radio') {{\
                                 var radioName = clickTarget.getAttribute('name') || '';\
@@ -176,13 +177,14 @@ pub async fn handle(
                                 clickTarget.checked = true;\
                             }} else if (checkable) {{\
                                 clickTarget.checked = !oldChecked;\
+                                clickTarget.indeterminate = false;\
                             }}\
                             var click = globalThis.__obscura_markTrusted(new MouseEvent('click', {{bubbles:true,cancelable:true,view:globalThis,clientX:{x},clientY:{y},button:0,buttons:0,detail:{click_count},altKey:{alt_key},ctrlKey:{ctrl_key},metaKey:{meta_key},shiftKey:{shift_key}}}));\
                             var cancelled = !clickTarget.dispatchEvent(click);\
                             if (cancelled) {{\
                                 if (radioStates) {{\
                                     for (var rr = 0; rr < radioStates.length; rr++) radioStates[rr][0].checked = radioStates[rr][1];\
-                                }} else if (checkable) clickTarget.checked = oldChecked;\
+                                }} else if (checkable) {{ clickTarget.checked = oldChecked; clickTarget.indeterminate = oldIndeterminate; }}\
                                 return;\
                             }}\
                             if (checkable && clickTarget.checked !== oldChecked) {{\

--- a/crates/obscura-js/js/bootstrap.js
+++ b/crates/obscura-js/js/bootstrap.js
@@ -699,9 +699,11 @@ function _fp(key) { return _getFp()[key]; }
 globalThis._eventRegistry = globalThis._eventRegistry || {};
 globalThis._formValues = globalThis._formValues || {};
 globalThis._formChecked = globalThis._formChecked || {};
+globalThis._formIndeterminate = globalThis._formIndeterminate || {};
 const _eventRegistry = globalThis._eventRegistry;
 const _formValues = globalThis._formValues;
 const _formChecked = globalThis._formChecked;
+const _formIndeterminate = globalThis._formIndeterminate;
 const _domParse = (cmd, a1, a2) => { try { return JSON.parse(_dom(cmd, a1, a2)); } catch { return null; } };
 
 // HTML "ASCII whitespace": U+0009 TAB, U+000A LF, U+000C FF, U+000D CR, U+0020 SPACE.
@@ -3556,9 +3558,10 @@ class Element extends Node {
     if (_isActuallyDisabled(this) && _tag !== 'LABEL') {
       return;
     }
-    let _oldChecked = false, _radioStates = null;
+    let _oldChecked = false, _oldIndeterminate = false, _radioStates = null;
     if (_checkable) {
       _oldChecked = !!this.checked;
+      _oldIndeterminate = !!this.indeterminate;
       if (_type === 'radio') {
         const _name = this.getAttribute('name') || '';
         if (_name) {
@@ -3574,7 +3577,12 @@ class Element extends Node {
         }
         this.checked = true;
       } else {
+        // Legacy-pre-activation behaviour (HTML spec): a checkbox toggles its
+        // checkedness *and* drops indeterminateness. Clearing it here, not on
+        // `change`, is what lets the cancelled-activation path put the old
+        // flag back instead of leaving it stuck off.
         this.checked = !_oldChecked;
+        this.indeterminate = false;
       }
     }
     const _clickEvent = new MouseEvent("click", {bubbles: true, cancelable: true});
@@ -3582,7 +3590,7 @@ class Element extends Node {
     const cancelled = !this.dispatchEvent(_clickEvent);
     if (cancelled) {
       if (_radioStates) { for (let i = 0; i < _radioStates.length; i++) _radioStates[i][0].checked = _radioStates[i][1]; }
-      else if (_checkable) this.checked = _oldChecked;
+      else if (_checkable) { this.checked = _oldChecked; this.indeterminate = _oldIndeterminate; }
       return;
     }
     if (_checkable && this.checked !== _oldChecked) {
@@ -3929,6 +3937,13 @@ class Element extends Node {
     return this.hasAttribute("checked");
   }
   set checked(v) { _formChecked[this._nid] = !!v; }
+  // `indeterminate` is IDL-only: it has no content attribute to reflect, so
+  // the property itself must exist on the prototype for `'indeterminate' in
+  // el` to be true on a freshly created element. It is node-keyed like
+  // `checked` because element wrappers are rebuilt on each lookup, so a
+  // per-instance field would not survive getElementById returning a new one.
+  get indeterminate() { return _formIndeterminate[this._nid] === true; }
+  set indeterminate(v) { _formIndeterminate[this._nid] = !!v; }
   get selected() {
     if (this._selected !== undefined) return this._selected;
     return this.hasAttribute("selected");

--- a/crates/obscura-js/src/runtime.rs
+++ b/crates/obscura-js/src/runtime.rs
@@ -13222,6 +13222,48 @@ mod tests {
     }
 
     #[test]
+    fn test_checkbox_indeterminate_is_idl_only_and_cleared_by_activation() {
+        // `indeterminate` has no content attribute, so it exists only if the
+        // prototype defines it -- `'indeterminate' in el` is the check that
+        // fails when it is missing. Activation clears it as well as toggling
+        // checkedness (HTML legacy-pre-activation behaviour), and a cancelled
+        // click puts both back, so a script-set flag is never left stuck.
+        let mut rt = setup_runtime(
+            r#"<input type="checkbox" id="fresh">
+               <input type="checkbox" id="click">
+               <input type="checkbox" id="cancel">"#,
+        );
+        let result = rt
+            .evaluate(
+                r#"
+            const fresh = document.getElementById('fresh');
+            const present = 'indeterminate' in fresh;
+            const initial = fresh.indeterminate;
+            fresh.indeterminate = true;
+            const roundTrip = fresh.indeterminate;
+
+            const clicked = document.getElementById('click');
+            clicked.indeterminate = true;
+            clicked.click();
+
+            const cancelled = document.getElementById('cancel');
+            cancelled.indeterminate = true;
+            cancelled.addEventListener('click', e => e.preventDefault());
+            cancelled.click();
+
+            return [present, initial, roundTrip,
+                    clicked.checked, clicked.indeterminate,
+                    cancelled.checked, cancelled.indeterminate];
+        "#,
+            )
+            .unwrap();
+        assert_eq!(
+            result,
+            serde_json::json!([true, false, true, true, false, false, true])
+        );
+    }
+
+    #[test]
     fn test_disabled_only_applies_to_disableable_elements() {
         // A `disabled` attribute is meaningless on anything that cannot be
         // disabled, and only listed form controls inherit it from a fieldset.


### PR DESCRIPTION
Fixes #732.

## What changed

`indeterminate` was not implemented anywhere in the engine. `grep -r indeterminate crates/` returned nothing: no prototype accessor to back it, `'indeterminate' in checkbox` was `false`, and a script could neither set nor read the flag.

**`crates/obscura-js/js/bootstrap.js`**

* `get`/`set indeterminate` on the element prototype, backed by a node-keyed `_formIndeterminate` store. Node-keyed rather than per-instance for the same reason `checked` is: element wrappers are rebuilt on every lookup, so a field on the instance would not survive `getElementById` handing back a new wrapper. Being on the prototype is also what makes `'indeterminate' in el` true for a freshly created element, which is the check in the issue's repro.
* `Element#click()` clears `indeterminate` in the pre-click step and restores the old value when the click is canceled, alongside the existing `checked` handling.

**`crates/obscura-cdp/src/domains/input.rs`**

The pre-click activation logic is duplicated in the CDP mouse snippet, which is what real dispatched input goes through. Without the same three lines there, `Input.dispatchMouseEvent` on a checkbox would leave the flag stuck even once the property exists. This is the duplication the comment in `bootstrap.js` already points at.

Radio inputs are unaffected: HTML's pre-activation for radio sets checkedness to true and says nothing about indeterminateness, so the restore path there writes back the value it read.

<details>
<summary><b>One correction to the issue, which changes what the fix does</b></summary>

The issue also says an indeterminate checkbox clicked once should report `checked=false`, describing the state as "not flipped on the first click". That is not what HTML specifies. Legacy-pre-activation behavior is:

> If this element's `type` attribute is in the Checkbox state, then set this element's checkedness to its opposite value (i.e. true if it is false, false if it is true) **and** set this element's indeterminateness to false.

Clearing `indeterminate` is an extra step, not a replacement for the toggle. An unchecked indeterminate checkbox reports `checked=true, indeterminate=false` after one click, which is what Chrome and Firefox do, and it is what this PR implements.

I have gone with the spec rather than the linked reference implementation because the spec is the thing the rest of the file follows. If you would rather match the reference, it is two lines in each of the two places, and I will send it as a follow-up rather than hold this one.
</details>

## Validation

New test `test_checkbox_indeterminate_is_idl_only_and_cleared_by_activation` in `crates/obscura-js/src/runtime.rs`, covering the four things that were broken or at risk: `'indeterminate' in el` is true on a fresh element and reads `false`; setting it round-trips; clicking an indeterminate checkbox yields `checked=true, indeterminate=false`; a canceled click (`preventDefault`) restores both.

I ran the four-configuration sequence from CONTRIBUTING rather than only the crate I touched, since this changes shared DOM and CDP code. All six steps in a `rust:latest` container, so the result matches CI rather than my Windows host:

| Step | Result |
| --- | --- |
| `cargo build --release -p obscura-cli --bins --features render` | ok, 1m40s |
| `cargo nextest run --release --features render --no-fail-fast` | **1507 passed**, 4 skipped |
| `cargo build --release -p obscura-cli --bins --no-default-features` | ok |
| `cargo nextest run --release -p obscura --no-fail-fast` | **23 passed** |
| `cargo nextest run --release --workspace --exclude obscura --exclude obscura-render --no-default-features --no-fail-fast` | **758 passed**, 3 skipped |
| `cargo check --release -p obscura-render --no-default-features` | ok |

The focused test, for the log:

```
PASS [0.017s] obscura-js runtime::tests::test_checkbox_indeterminate_is_idl_only_and_cleared_by_activation
```

I have not run `cargo fmt` over the tree, and the diff is the three files the fix needs.

## Rendering

Not applicable. No layout, paint, screenshot, screencast or PDF code is touched, and the render-feature suite above is unchanged at 1507 passing.

## Performance

The two accessors are only reached when a page reads or writes `.indeterminate`, which nothing did before this PR. The cost added to the common path is one object write per activation of a checkable input, next to the `_formChecked` write already there. Nothing is added to layout, paint, or the network path.

## Checklist

- [x] The change is focused and does not remove existing behavior without justification.
- [x] Tests cover the failure or feature.
- [x] Existing tests pass, including render and no-render configurations when affected.
- [x] I checked for CPU, latency, and memory regressions.
- [x] Public API or user-facing behavior changes are documented.
