### PR TITLE
fix(js): pin the ICU default locale to navigator.language

### DIFF
--- a/crates/obscura-js/src/runtime.rs
+++ b/crates/obscura-js/src/runtime.rs
@@ -3214,6 +3214,29 @@ mod tests {
             result,
             serde_json::json!(["en-US", "en-US", "en-US", "en-US", "en-US"])
         );
+
+        // The isolate has now used `Intl`, which is the state that matters:
+        // V8 resolves the default locale once per isolate and caches it, so a
+        // pin that lands after a page has formatted anything silently does
+        // nothing. That is why `pin_default_locale` runs before
+        // `JsRuntime::new` rather than anywhere later. Move the host default a
+        // second time, underneath the warmed isolate, and it must still be
+        // reading its own locale rather than picking the new one up.
+        deno_core::v8::icu::set_default_locale("de-DE");
+        let after_warmup = rt
+            .evaluate(
+                r#"
+            return [
+                Intl.DateTimeFormat().resolvedOptions().locale,
+                Intl.NumberFormat().format(1234.5),
+            ];
+        "#,
+            )
+            .unwrap();
+        // 1,234.5 is en-US grouping. de-DE would say 1.234,5 and fr-FR
+        // 1 234,5, so this asserts formatting behaviour and not just the name
+        // the locale reports for itself.
+        assert_eq!(after_warmup, serde_json::json!(["en-US", "1,234.5"]));
     }
 
     fn setup_runtime(html: &str) -> ObscuraJsRuntime {

--- a/crates/obscura-js/src/runtime.rs
+++ b/crates/obscura-js/src/runtime.rs
@@ -50,6 +50,32 @@ static SNAPSHOT: &[u8] = include_bytes!(env!("OBSCURA_SNAPSHOT_PATH"));
 /// parallel, each isolate on its own thread with no shared lock.
 static ISOLATE_CREATE_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
 
+/// The locale every locale-bearing surface reports.
+///
+/// Kept equal to the `navigator.language` and `navigator.languages` values in
+/// `js/bootstrap.js` and to the `Accept-Language` default in `obscura-net`.
+/// Those two were already pinned; `Intl` was not, so it reported whatever
+/// locale the V8 build happened to carry (#734 measured `en-AU` against a
+/// `navigator.language` of `en-US` on a Windows release build). A page that
+/// reads two of the three surfaces sees a browser disagreeing with itself,
+/// which is exactly the kind of inconsistency identity checks look for.
+const DEFAULT_LOCALE: &str = "en-US";
+
+static ICU_LOCALE_INIT: std::sync::Once = std::sync::Once::new();
+
+/// Pin ICU's default locale once, before the first isolate exists.
+///
+/// `Intl` resolves its default through ICU, not through anything the engine
+/// hands it, so leaving this unset makes the value a property of the build
+/// host rather than of the browser identity Obscura presents. Called under
+/// [`ISOLATE_CREATE_LOCK`] so the write cannot race an isolate being built on
+/// another connection thread.
+fn pin_default_locale() {
+    ICU_LOCALE_INIT.call_once(|| {
+        deno_core::v8::icu::set_default_locale(DEFAULT_LOCALE);
+    });
+}
+
 const DEFAULT_CDP_AWAIT_TIMEOUT_MS: u64 = 30_000;
 const HEAP_LIMIT_RECOVERY_HEADROOM_BYTES: usize = 64 * 1024 * 1024;
 
@@ -304,6 +330,11 @@ impl ObscuraJsRuntime {
             let _create_guard = ISOLATE_CREATE_LOCK
                 .lock()
                 .unwrap_or_else(|poisoned| poisoned.into_inner());
+
+            // Before the isolate, not after: ICU is consulted when a page
+            // first constructs an Intl object, and an isolate built ahead of
+            // this call would answer from the host default.
+            pin_default_locale();
 
             let mut runtime = JsRuntime::new(RuntimeOptions {
                 extensions: vec![build_extension()],
@@ -3147,6 +3178,43 @@ impl Default for ObscuraJsRuntime {
 mod tests {
     use super::*;
     use obscura_dom::parse_html;
+
+    #[test]
+    fn test_intl_default_locale_is_pinned_not_inherited_from_the_host() {
+        // Every locale surface a page can read has to name the same locale.
+        // `Intl` resolves its default through ICU, which nothing in the engine
+        // set, so it reported whatever locale the build carried while
+        // `navigator.language` and the `Accept-Language` header both said
+        // en-US. A page reading two of the three sees a browser disagreeing
+        // with itself.
+        //
+        // The reported host default was en-AU on a Windows build, and a host
+        // default is not reproducible across machines: on a Linux CI runner
+        // ICU already answers en-US, so asserting agreement alone would pass
+        // here whether or not the engine pins anything. Forcing a different
+        // default first is what makes this a regression test rather than a
+        // coincidence, and it is safe because nextest runs each test in its
+        // own process, so this global never reaches a sibling.
+        deno_core::v8::icu::set_default_locale("fr-FR");
+        let mut rt = setup_runtime("<html><body>x</body></html>");
+        let result = rt
+            .evaluate(
+                r#"
+            return [
+                Intl.DateTimeFormat().resolvedOptions().locale,
+                Intl.NumberFormat().resolvedOptions().locale,
+                Intl.Collator().resolvedOptions().locale,
+                navigator.language,
+                navigator.languages[0],
+            ];
+        "#,
+            )
+            .unwrap();
+        assert_eq!(
+            result,
+            serde_json::json!(["en-US", "en-US", "en-US", "en-US", "en-US"])
+        );
+    }
 
     fn setup_runtime(html: &str) -> ObscuraJsRuntime {
         let dom = parse_html(html);


### PR DESCRIPTION
Fixes #734.

## What changed

Three surfaces name a locale, and only two of them were pinned:

* `navigator.language` is `"en-US"` and `navigator.languages` is `["en-US", "en"]`, both hardcoded in `js/bootstrap.js`.
* `obscura-net` sends `Accept-Language: en-US,en;q=0.9`.
* `Intl` resolves its default through ICU, and nothing under `crates/` ever set one. `grep -rn "set_default_locale" crates/` was empty.

So the third value was a property of whichever V8 build you happened to be running, not of the browser identity Obscura presents. The report measured `en-AU` from `Intl` against `en-US` from `navigator.language` on a Windows release build. A page that reads two of the three sees a browser disagreeing with itself, which is the kind of internal inconsistency identity checks look for, so this sits in the stealth priority the README states.

The disagreement being one-sided is what decides the fix: two surfaces are already pinned, one is inherited, so agreeing means pinning the third rather than loosening the other two. That also keeps what scripts read consistent with what actually goes out on the wire.

One constant and one call, in `crates/obscura-js/src/runtime.rs`:

* `DEFAULT_LOCALE` names the value and, in its doc comment, the two other places that have to stay equal to it.
* `pin_default_locale()` calls `v8::icu::set_default_locale` inside a `Once`.

It is called from `with_base_url_and_proxy` **before** `JsRuntime::new`, inside the existing `ISOLATE_CREATE_LOCK` block. Both parts matter: ICU is consulted when a page first constructs an `Intl` object, so an isolate built ahead of the call would answer from the host default, and the lock keeps the write from racing an isolate being constructed on another connection thread. That is the only `JsRuntime::new` site in the crate, so CLI and CDP both go through it.

<details>
<summary><b>A note on the constant, which does not need an answer before merging</b></summary>

`DEFAULT_LOCALE` duplicates a string that also lives in `bootstrap.js` and in `obscura-net`. I kept it that way because threading one constant across a Rust crate boundary and a JS bundle is a larger change than this bug warrants, and the doc comment records the coupling so the next person to change one has a pointer to the others. If you would rather have a single source, tell me where you want it to live and I will send that separately.
</details>

## Validation

The interesting part of this one is that the obvious test does not work.

A test that just asserts the three surfaces agree **passes on `main`, unfixed**, because ICU on a Linux runner already defaults to `en-US`. The reported default was a Windows build's. A host default is not reproducible across machines, so asserting agreement proves nothing about whether the engine pins anything.

`test_intl_default_locale_is_pinned_not_inherited_from_the_host` therefore forces a different default first and asserts the engine still names its own. That is safe because nextest runs each test in its own process, so the global never reaches a sibling test.

Red on this branch with the `pin_default_locale()` call commented out, which is the exact shape of the reported bug, three inherited values next to two pinned ones:

```
assertion `left == right` failed
  left: ["fr-FR", "fr-FR", "fr-FR", "en-US", "en-US"]
 right: ["en-US", "en-US", "en-US", "en-US", "en-US"]
```

Green with the call restored.

@yinnho raised a V8 subtlety on the issue that the test now encodes: V8 resolves the ICU default locale once per isolate and caches it at the first `Intl` use, so a pin landing after a page has formatted anything silently does nothing. Their literal suggestion, format then change the configured language then format again, does not translate directly because Obscura has no runtime language switch. The half that does translate is that the pin has to survive the host default moving underneath a *warmed* isolate, so the test now formats, moves the host default a second time, and formats again in the same isolate.

That second block is load-bearing, and what it reports without the pin is a direct measurement of the caching they described. Host default forced to `fr-FR`, isolate built and warmed, host default then moved to `de-DE`:

```
  left: ["fr-FR", "1 234,5"]
 right: ["en-US", "1,234.5"]
```

The warmed isolate answers **`fr-FR`**, not `de-DE`, and formats with French narrow-no-break-space grouping. It never saw the second change. That is the cache, and it is why `pin_default_locale` runs before `JsRuntime::new` rather than anywhere later. With the pin in place both surfaces read `en-US` and the number formats as `1,234.5`.

Since this changes shared JS-runtime code, I ran the whole four-configuration sequence from CONTRIBUTING rather than only `obscura-js`, in a `rust:latest` container so the result matches CI rather than my Windows host:

| Step | Result |
| --- | --- |
| `cargo build --release -p obscura-cli --bins --features render` | ok |
| `cargo nextest run --release --features render --no-fail-fast` | **1507 passed**, 4 skipped |
| `cargo build --release -p obscura-cli --bins --no-default-features` | ok |
| `cargo nextest run --release -p obscura --no-fail-fast` | **23 passed** |
| `cargo nextest run --release --workspace --exclude obscura --exclude obscura-render --no-default-features --no-fail-fast` | **758 passed**, 3 skipped |
| `cargo check --release -p obscura-render --no-default-features` | ok |

I have not run `cargo fmt` over the tree, per CONTRIBUTING; the added lines are rustfmt-clean on their own.

## Rendering

Not applicable. No layout, paint, screenshot, screencast or PDF code is touched.

## Performance

The call is inside a `std::sync::Once`, on the isolate-construction path, already under `ISOLATE_CREATE_LOCK`. It runs once per process and adds nothing per request, per page, or per script. There is no change to any hot path.

## Checklist

- [x] The change is focused and does not remove existing behavior without justification.
- [x] Tests cover the failure or feature.
- [x] Existing tests pass, including render and no-render configurations when affected.
- [x] I checked for CPU, latency, and memory regressions.
- [x] Public API or user-facing behavior changes are documented.
