### PR TITLE
fix(render): gate the webfont pseudo-content test on paint

### DIFF
--- a/crates/obscura-render/src/dom.rs
+++ b/crates/obscura-render/src/dom.rs
@@ -19678,6 +19678,13 @@ mod tests {
         );
     }
 
+    /// Gated on `paint`: without it `TextEngine::new_with_web_fonts` ignores
+    /// the fonts it is handed, so neither half of this test has anything to
+    /// observe. `word_ifc_items` does not exist to read, and the advance-width
+    /// comparison sees the same fallback face on both sides and finds the two
+    /// widths equal. Gating only the field access would leave an assertion
+    /// that compiles and then fails.
+    #[cfg(feature = "paint")]
     #[test]
     fn generated_pseudo_content_shapes_with_the_loaded_webfont() {
         let tree = parse_html(


### PR DESCRIPTION
Fixes #628.

## What changed

`generated_pseudo_content_shapes_with_the_loaded_webfont` reads `DomLayout::word_ifc_items` from a plain `#[cfg(test)] mod tests`, but that field is declared `#[cfg(feature = "paint")]`. So `cargo check --tests -p obscura-render` on default features stopped before any test ran:

```
crates/obscura-render/src/dom.rs:19710:20: error[E0609]: no field `word_ifc_items` on type `dom::DomLayout`
error: could not compile `obscura-render` (lib test) due to 1 previous error
```

Exactly one error. The line has moved since the report was filed (`:19710`, not `:19581`); same test, same field.

The fix is `#[cfg(feature = "paint")]` on the test, plus a doc comment recording why it is the whole test rather than the one field access. Seven lines.

<details>
<summary><b>Why the whole test, and not just the field access</b></summary>

My first attempt gated only the `word_ifc_items` assertion, on the theory that the advance-width comparison beside it was pure layout and worth keeping alive in a no-render build. It compiles. It also fails:

```
FAIL obscura-render dom::tests::generated_pseudo_content_shapes_with_the_loaded_webfont
```

Without `paint`, `TextEngine::new_with_web_fonts` ignores the fonts it is handed. The build says so itself, in warnings that are easy to read past while chasing the error:

```
warning: associated function `new_with_web_fonts` is never used
warning: fields `data`, `family`, `weight` and `italic` are never read
```

So the "loaded" face is the fallback face, both sides of the `assert_ne!` measure the same font, and the widths are equal. Both halves of the test depend on `paint`, so the test does. Gating only the field would have traded a compile error for a failing test, which is the worse of the two: a compile error stops you, a red test looks like a regression and costs someone an investigation. That reasoning is in the doc comment above the gate so the next person does not repeat the attempt.
</details>

## Validation

```
# 1. the reported failure, default features
cargo check --tests -p obscura-render            -> Finished

# 2. paint still runs the test
cargo nextest run --release -p obscura-render --features paint generated_pseudo_content_shapes
   PASS generated_pseudo_content_shapes_with_the_loaded_webfont

# 3. paint suite unaffected
cargo nextest run --release -p obscura-render --features paint
   583 passed, 1 skipped
```

And the four-configuration sequence from CONTRIBUTING, since this is a feature-gate change, run in a `rust:latest` container:

| Step | Result |
| --- | --- |
| `cargo build --release -p obscura-cli --bins --features render` | ok |
| `cargo nextest run --release --features render --no-fail-fast` | **1506 passed**, 4 skipped (the count on `main`; this PR adds no test) |
| `cargo build --release -p obscura-cli --bins --no-default-features` | ok |
| `cargo nextest run --release -p obscura --no-fail-fast` | **23 passed** |
| `cargo nextest run --release --workspace --exclude obscura --exclude obscura-render --no-default-features --no-fail-fast` | **758 passed**, 3 skipped |
| `cargo check --release -p obscura-render --no-default-features` | ok |

## Rendering

Not applicable in the sense the template means: no fixture is needed and no output changes. The only edit is a `cfg` attribute and a comment on an existing test, and the paint-feature suite that owns the rendering behaviour is unchanged at 583 passing.

## Performance

No expected impact. The change is a test attribute; no code that ships in any binary is touched.

## Something this uncovers, which is deliberately not in this PR

The issue asks for "a whole-workspace test run without `--features render`". This change delivers the compile half, and the run then surfaces something that was invisible while compilation failed first:

```
cargo nextest run --release -p obscura-render --no-fail-fast
399 tests run: 370 passed, 29 failed, 1 skipped
```

29 failures, all one kind: tests that assert real text measurements (`auto_width_*`, `fixed_table_layout_*`, `inline_*`, `canonical_inline_fragments_shape_with_the_loaded_webfont`, and two `layout_test` replaced-element cases). Same root cause as the one above, that font shaping lives behind `paint`, so a no-render build measures text with a stand-in.

**None of this blocks merging.** Your CI's no-render step runs `--workspace --exclude obscura --exclude obscura-render` and then only `cargo check` on `obscura-render`, so those 29 are outside the gate either way; what was inside the gate was the `cargo check`, and this fixes it.

Which direction to take afterwards is a design question, not a bug fix: either those tests get the same gate, or a no-render build needs metrics good enough for them to hold. I would rather land the compile fix and let you pick than hand you 29 gated tests. Happy to open a separate issue with the full list, or to do the work once you have chosen.

## Checklist

- [x] The change is focused and does not remove existing behavior without justification.
- [x] Tests cover the failure or feature.
- [x] Existing tests pass, including render and no-render configurations when affected.
- [x] I checked for CPU, latency, and memory regressions.
- [x] Public API or user-facing behavior changes are documented.
