### PR TITLE
test(browser): cover the load-delaying pump's page-error path

### DIFF
--- a/crates/obscura-browser/src/page.rs
+++ b/crates/obscura-browser/src/page.rs
@@ -5648,6 +5648,73 @@ mod tests {
     }
 
     #[tokio::test(flavor = "current_thread")]
+    async fn load_delaying_script_driver_survives_a_page_script_exception() {
+        // An exception from an async page callback reaches the pump as an
+        // event-loop error, and the pump used to answer it by abandoning every
+        // still-pending load-delaying script. The error is transient: measured
+        // against this runtime, the tick carrying it fails and the following
+        // ticks poll clean, so the pending script below was dropped over a
+        // condition that had already cleared, and dropped silently, since the
+        // script simply never arrives.
+        //
+        // The throw is deferred through a timer so it lands on a pump tick.
+        // Thrown during the installing script's own microtask drain it would
+        // clear the pending-script bookkeeping before the fetch even starts,
+        // which is a different bug from the one under test here.
+        let (base, requests) = spawn_delayed_classic_script_server(
+            std::time::Duration::from_millis(150),
+            "globalThis.__lateDynamicRan = true;",
+        );
+        let mut page = import_map_test_page(
+            "load-delayer-throws",
+            "http://127.0.0.1:9",
+            "<html><head></head><body></body></html>",
+        );
+        page.js
+            .as_mut()
+            .unwrap()
+            .execute_script(
+                "install-load-delayer",
+                &format!(
+                    "globalThis.__documentReadyState__ = 'loading'; \
+                     const script = document.createElement('script'); \
+                     script.src = '{base}/slow-dynamic.js'; \
+                     document.head.appendChild(script); \
+                     setTimeout(() => {{ \
+                         queueMicrotask(() => {{ throw new Error('page script boom'); }}); \
+                     }}, 0);",
+                ),
+            )
+            .unwrap();
+        assert!(page
+            .js
+            .as_mut()
+            .unwrap()
+            .has_pending_load_delaying_scripts());
+
+        let deadline = tokio::time::Instant::now() + std::time::Duration::from_secs(5);
+        let completed =
+            super::Page::drive_load_delaying_scripts(page.js.as_mut().unwrap(), deadline).await;
+
+        assert!(
+            completed,
+            "the throw must not end the pump while a script is still pending"
+        );
+        assert_eq!(
+            requests
+                .recv_timeout(std::time::Duration::from_secs(1))
+                .unwrap(),
+            "/slow-dynamic.js",
+            "the pending script must still be fetched"
+        );
+        assert!(!page
+            .js
+            .as_mut()
+            .unwrap()
+            .has_pending_load_delaying_scripts());
+    }
+
+    #[tokio::test(flavor = "current_thread")]
     async fn post_load_dynamic_script_waits_only_when_caller_requests_settle() {
         let (base, requests) = spawn_delayed_classic_script_server(
             std::time::Duration::from_millis(400),


### PR DESCRIPTION
**Rescoped.** ad29745 fixed #699 upstream while this was open, and your fix is broader than mine was — it covers all four pumps rather than only the load-delaying one, and `is_fatal_event_loop_error` is a better seam than the local error counter I had. I have dropped my implementation entirely and reduced this PR to the one piece your commit did not carry: **a test at the layer where the bug was reported.**

## Why this layer

ad29745 changes `Page::drive_load_delaying_scripts` in `obscura-browser` and adds no test there. The tests that exist do not reach the new branch:

| Test | Layer | Covers the error path? |
|---|---|---|
| `unhandled_rejection_does_not_starve_later_tasks` (yours, ad29745) | `obscura-js`, `run_event_loop_bounded` | yes, but not this pump |
| `load_delaying_script_driver_respects_absolute_deadline` (existing) | `obscura-browser`, this pump | no — deadline path only |

So the `is_fatal_event_loop_error` branch in `page.rs` is currently unguarded, and #699 was reported as *load-delaying scripts going missing*, which is this function.

## Mutation-checked

Reverting your branch to the unconditional bail it replaced:

```rust
Ok(Err(error)) => {
    tracing::warn!("load-delaying dynamic script event loop failed: {error}");
    return false;
}
```

```
FAIL  load_delaying_script_driver_survives_a_page_script_exception
      the throw must not end the pump while a script is still pending
PASS  load_delaying_script_driver_respects_absolute_deadline
```

The deadline test passing under the same mutation is the point: the existing suite does not notice the regression, and this test does. Restored, both pass:

```
2 tests run: 2 passed, 65 skipped
```

`cargo nextest run --release --features render -p obscura-browser load_delaying_script_driver`, Linux container, rustc 1.98.

## The test

A load-delaying classic script is left pending against a 150 ms server while a page callback throws. The throw is deferred through a timer so it lands on a pump tick — thrown during the installing script's own microtask drain it would clear the pending-script bookkeeping before the fetch starts, which is a different path. The assertions are that the pump reports completion, that the pending script was still fetched, and that the pending set drained.

No production code in this PR. `rustfmt --check` is clean across the inserted range (the file carries unrelated pre-existing diffs elsewhere).

Closes nothing on its own — #699 is already fixed by ad29745.
