### PR TITLE
fix(cdp): report a thrown or rejected value through exceptionDetails

### DIFF
--- a/crates/obscura-browser/src/page.rs
+++ b/crates/obscura-browser/src/page.rs
@@ -3650,6 +3650,7 @@ impl Page {
                 Err(e) => {
                     tracing::debug!("evaluate_for_cdp error: {}", e);
                     obscura_js::runtime::RemoteObjectInfo {
+                        thrown: false,
                         js_type: "undefined".into(),
                         subtype: None,
                         class_name: String::new(),
@@ -3662,6 +3663,7 @@ impl Page {
         } else {
             let val = self.evaluate(expression);
             obscura_js::runtime::RemoteObjectInfo {
+                thrown: false,
                 js_type: match &val {
                     serde_json::Value::String(_) => "string".into(),
                     serde_json::Value::Number(_) => "number".into(),
@@ -3695,6 +3697,7 @@ impl Page {
         } else {
             let value = self.evaluate(expression);
             Ok(obscura_js::runtime::RemoteObjectInfo {
+                thrown: false,
                 js_type: match &value {
                     serde_json::Value::String(_) => "string".into(),
                     serde_json::Value::Number(_) => "number".into(),
@@ -3733,6 +3736,7 @@ impl Page {
                 Err(e) => {
                     tracing::debug!("callFunctionOn error: {}", e);
                     obscura_js::runtime::RemoteObjectInfo {
+                        thrown: false,
                         js_type: "undefined".into(),
                         subtype: None,
                         class_name: String::new(),
@@ -3744,6 +3748,7 @@ impl Page {
             }
         } else {
             obscura_js::runtime::RemoteObjectInfo {
+                thrown: false,
                 js_type: "undefined".into(),
                 subtype: None,
                 class_name: String::new(),

--- a/crates/obscura-cdp/src/domains/runtime.rs
+++ b/crates/obscura-cdp/src/domains/runtime.rs
@@ -149,7 +149,7 @@ pub async fn handle(
             };
             emit_post_eval_nav(ctx, session_id).await?;
 
-            Ok(json!({ "result": remote_object_from_info(&info) }))
+            Ok(evaluation_reply(&info))
         }
         "callFunctionOn" => {
             let function_declaration = params
@@ -213,7 +213,7 @@ pub async fn handle(
             };
             emit_post_eval_nav(ctx, session_id).await?;
 
-            Ok(json!({ "result": remote_object_from_info(&info) }))
+            Ok(evaluation_reply(&info))
         }
         "getProperties" => {
             // Puppeteer's $$() flow:
@@ -455,6 +455,33 @@ fn validate_context_id(
     Ok(())
 }
 
+/// Shape one `Runtime.evaluate` or `Runtime.callFunctionOn` reply.
+///
+/// A thrown value, or the value a promise rejected with, is not a protocol
+/// failure: the command succeeds and reports it through `exceptionDetails`,
+/// which is what a client rebuilds the page error from. The value is repeated
+/// in `result` the way Chrome does, so a client that reads only `result` sees
+/// the error object rather than a success that never happened.
+///
+/// `exceptionId` is a fixed 1 because nothing here correlates exceptions
+/// across commands; clients key off the presence of the field, not its id.
+fn evaluation_reply(info: &RemoteObjectInfo) -> Value {
+    let remote = remote_object_from_info(info);
+    if !info.thrown {
+        return json!({ "result": remote });
+    }
+    json!({
+        "result": remote.clone(),
+        "exceptionDetails": {
+            "exceptionId": 1,
+            "text": "Uncaught",
+            "lineNumber": 0,
+            "columnNumber": 0,
+            "exception": remote,
+        }
+    })
+}
+
 fn remote_object_from_info(info: &RemoteObjectInfo) -> Value {
     let mut obj = json!({ "type": info.js_type });
 
@@ -557,6 +584,99 @@ mod tests {
         }
     }
 
+    #[tokio::test(flavor = "current_thread")]
+    async fn evaluate_reports_a_rejection_through_exception_details() {
+        let mut ctx = CdpContext::new();
+        let page_id = ctx.create_page();
+        let session_id = "evaluate-rejection".to_string();
+        ctx.sessions.insert(session_id.clone(), page_id);
+
+        let reply = handle(
+            "evaluate",
+            &json!({
+                "expression": "Promise.reject(new Error('boom'))",
+                "returnByValue": true,
+                "awaitPromise": true,
+                "timeout": 3000,
+            }),
+            &mut ctx,
+            &Some(session_id),
+        )
+        .await
+        .expect("a rejection is answered, not failed at the protocol level");
+
+        let details = reply
+            .get("exceptionDetails")
+            .expect("a thrown value is reported through exceptionDetails");
+        assert_eq!(details["text"], json!("Uncaught"));
+        assert_eq!(details["exception"]["subtype"], json!("error"));
+        assert_eq!(details["exception"]["className"], json!("Error"));
+        assert!(
+            details["exception"]["description"]
+                .as_str()
+                .unwrap_or_default()
+                .contains("boom"),
+            "the description carries the page message: {details}"
+        );
+        // Chrome repeats the exception in `result`, so a client that reads
+        // only that field still sees the error rather than a stale success.
+        assert_eq!(reply["result"], details["exception"]);
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn call_function_on_reports_a_rejection_through_exception_details() {
+        // This is the path Puppeteer's page.evaluate(fn) takes. It used to
+        // answer successfully with `{}` for a rejected Error, so the caller
+        // could not tell a failure from an empty object.
+        let mut ctx = CdpContext::new();
+        let page_id = ctx.create_page();
+        let session_id = "call-rejection".to_string();
+        ctx.sessions.insert(session_id.clone(), page_id);
+
+        let reply = handle(
+            "callFunctionOn",
+            &json!({
+                "functionDeclaration": "() => Promise.reject(new Error('boom'))",
+                "returnByValue": true,
+                "awaitPromise": true,
+                "timeout": 3000,
+            }),
+            &mut ctx,
+            &Some(session_id),
+        )
+        .await
+        .expect("a rejection is answered, not failed at the protocol level");
+
+        let details = reply
+            .get("exceptionDetails")
+            .expect("a rejected call is reported through exceptionDetails");
+        assert_eq!(details["exception"]["subtype"], json!("error"));
+        assert!(reply["result"]["value"].is_null(), "the error must not be serialized by value: {reply}");
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn a_resolved_evaluation_carries_no_exception_details() {
+        let mut ctx = CdpContext::new();
+        let page_id = ctx.create_page();
+        let session_id = "evaluate-resolved".to_string();
+        ctx.sessions.insert(session_id.clone(), page_id);
+
+        let reply = handle(
+            "evaluate",
+            &json!({
+                "expression": "Promise.resolve(2)",
+                "returnByValue": true,
+                "awaitPromise": true,
+                "timeout": 3000,
+            }),
+            &mut ctx,
+            &Some(session_id),
+        )
+        .await
+        .unwrap();
+        assert_eq!(reply["result"]["value"], json!(2.0));
+        assert!(reply.get("exceptionDetails").is_none());
+    }
     #[tokio::test(flavor = "current_thread")]
     async fn evaluate_await_promise_reports_the_requested_timeout() {
         let mut ctx = CdpContext::new();

--- a/crates/obscura-js/src/runtime.rs
+++ b/crates/obscura-js/src/runtime.rs
@@ -1509,33 +1509,40 @@ impl ObscuraJsRuntime {
         await_promise: bool,
         await_timeout_ms: u64,
     ) -> Result<RemoteObjectInfo, String> {
-        if !await_promise && return_by_value {
-            let val = self.evaluate(expression)?;
-            return Ok(Self::info_from_json(&val));
-        }
+        // Every shape of this command now travels the same path. The
+        // by-value sync case used to short-circuit through `evaluate`,
+        // whose wrapper answers an exception with `null` — indistinguishable
+        // from an expression that really evaluated to null (#746).
         self.begin_javascript_task();
 
         self.object_counter += 1;
         let oid = self.make_oid(self.object_counter);
 
-        // Same trailing-semicolon trim as wrap_expression — Playwright's
-        // utility-script eval ends with `})();`, and `({expr})` would
-        // otherwise become `(...;)` which is a parse-time SyntaxError.
-        let cleaned_expr = expression
-            .trim()
-            .trim_end_matches(|c: char| c == ';' || c.is_whitespace());
-
-        // Puppeteer / Playwright bundles end with a `//# sourceURL=...`
-        // line comment. If we put `{expr})` on a single line the comment
-        // swallows the closing paren and our wrapper breaks. A newline
-        // before the `)` terminates any trailing line comment so the
-        // parens close on their own line.
+        // The expression travels as a *string* into an indirect eval rather
+        // than being pasted into a wrapper. Pasting forced two workarounds
+        // that only half worked: a trailing `;` had to be trimmed or
+        // `(expr;)` failed to parse, and a trailing `//# sourceURL=` comment
+        // (Puppeteer and Playwright both append one) would swallow the
+        // closing paren unless it sat on its own line. Neither can happen to
+        // a string literal.
+        //
+        // It also makes statements legal. `Runtime.evaluate` is specified to
+        // take a script, not an expression, so `throw new Error('x')` and
+        // `var x = 1; x * 2` are both valid input; wrapped in parentheses the
+        // first was a parse-time SyntaxError, which is not catchable, and the
+        // second returned the wrapper's own `undefined` instead of the
+        // completion value Chrome reports (#746).
+        //
+        // `(0, eval)` rather than `eval` so the script runs at global scope,
+        // where `var` lands on `globalThis` the way it does in Chrome, and
+        // cannot see this wrapper's `__result`.
+        let source_literal = serde_json::Value::String(expression.to_string());
         let done_counter = self.object_counter;
         let meta_code = if await_promise {
             format!(
                 "(async function() {{\n\
                     try {{\n\
-                        var __result = await (\n{expr}\n);\n\
+                        var __result = await (0, eval)({src});\n\
                         globalThis.__obscura_objects['{oid}'] = __result;\n\
                         globalThis.__obscura_await_meta = {meta_fn};\n\
                         globalThis.__obscura_await_rejected = false;\n\
@@ -1546,23 +1553,38 @@ impl ObscuraJsRuntime {
                     }}\n\
                     globalThis.__obscura_done_{done_counter} = true;\n\
                 }})()",
-                expr = cleaned_expr,
+                src = source_literal,
                 oid = oid,
                 meta_fn = Self::meta_extract_js("__result"),
                 err_meta_fn = Self::meta_extract_js("e"),
                 done_counter = done_counter,
             )
         } else {
+            // The synchronous half writes the same two globals as the await
+            // half above, so one outcome protocol covers both and the reply
+            // builder does not have to care which path produced the value.
+            // Before this, a throw here became `__result = undefined`: the
+            // command answered successfully with `undefined`, so a page error
+            // was indistinguishable from an expression with no value.
             format!(
                 "(function() {{\n\
                     var __result;\n\
-                    try {{ __result = (\n{expr}\n); }} catch(e) {{ __result = undefined; }}\n\
+                    try {{\n\
+                        __result = (0, eval)({src});\n\
+                    }} catch(e) {{\n\
+                        globalThis.__obscura_objects['{oid}'] = e;\n\
+                        globalThis.__obscura_await_meta = {err_meta_fn};\n\
+                        globalThis.__obscura_await_rejected = true;\n\
+                        return globalThis.__obscura_await_meta;\n\
+                    }}\n\
                     globalThis.__obscura_objects['{oid}'] = __result;\n\
+                    globalThis.__obscura_await_rejected = false;\n\
                     return {meta_fn};\n\
                 }})()",
-                expr = cleaned_expr,
+                src = source_literal,
                 oid = oid,
                 meta_fn = Self::meta_extract_js("__result"),
+                err_meta_fn = Self::meta_extract_js("e"),
             )
         };
 
@@ -1603,27 +1625,28 @@ impl ObscuraJsRuntime {
                     preview,
                 );
             }
-            let rejected = self
-                .execute_runtime_script(
-                    "<readRejected>",
-                    "globalThis.__obscura_await_rejected".to_string(),
-                )
-                .map_err(|e| format!("JS error: {}", e))?;
-            if self.v8_to_json(rejected)?.as_bool().unwrap_or(false) {
-                // A rejection is not a protocol failure. CDP answers the
-                // command and puts the rejected value in `exceptionDetails`,
-                // which is what a client rebuilds the page error from, so the
-                // value travels back as a remote object flagged `thrown`.
-                // It is reported by reference even when the caller asked for a
-                // value: `JSON.stringify(new Error("boom"))` is `{}`, so
-                // serializing it would throw the message away.
-                return self.thrown_info(&oid);
-            }
             self.execute_runtime_script("<readMeta>", "globalThis.__obscura_await_meta".to_string())
                 .map_err(|e| format!("JS error: {}", e))?
         } else {
             result
         };
+
+        // Neither a rejection nor a synchronous throw is a protocol failure.
+        // CDP answers the command and puts the value in `exceptionDetails`,
+        // which is what a client rebuilds the page error from, so it travels
+        // back as a remote object flagged `thrown`. It is reported by
+        // reference even when the caller asked for a value:
+        // `JSON.stringify(new Error("boom"))` is `{}`, so serializing it
+        // would throw the message away.
+        let thrown = self
+            .execute_runtime_script(
+                "<readRejected>",
+                "globalThis.__obscura_await_rejected".to_string(),
+            )
+            .map_err(|e| format!("JS error: {}", e))?;
+        if self.v8_to_json(thrown)?.as_bool().unwrap_or(false) {
+            return self.thrown_info(&oid);
+        }
         let meta_str = self.v8_to_json(meta_str)?;
         let meta_json = if let serde_json::Value::String(s) = &meta_str {
             serde_json::from_str(s).unwrap_or(meta_str)
@@ -1635,7 +1658,7 @@ impl ObscuraJsRuntime {
             format!("globalThis.__obscura_objects['{}']", oid),
         );
 
-        if await_promise && return_by_value {
+        if return_by_value {
             let read = self
                 .execute_runtime_script(
                     "<readResult>",
@@ -13790,6 +13813,104 @@ mod tests {
         assert_eq!(resolved.value, Some(serde_json::json!({"code": 42})));
     }
 
+    #[tokio::test(flavor = "current_thread")]
+    async fn a_synchronous_throw_is_reported_instead_of_swallowed() {
+        // The sync wrapper answered a throw with `__result = undefined`, so the
+        // command succeeded and the page error vanished. A client cannot tell
+        // that from an expression that genuinely has no value.
+        let mut rt = setup_runtime("<html><body></body></html>");
+        let info = rt
+            .evaluate_for_cdp("undefined_variable_xyz", false, false)
+            .await
+            .expect("a page error is not a protocol failure");
+        assert!(info.thrown, "a ReferenceError must come back flagged thrown");
+        assert_eq!(info.subtype.as_deref(), Some("error"));
+        assert!(
+            info.description.contains("ReferenceError"),
+            "the description is what a client rebuilds the error from: {:?}",
+            info.description
+        );
+    }
+    
+    #[tokio::test(flavor = "current_thread")]
+    async fn a_synchronous_throw_is_reported_when_a_value_was_asked_for() {
+        // returnByValue took a different route entirely, through `evaluate`,
+        // whose wrapper answers an exception with null. That is the shape a
+        // Puppeteer `page.evaluate` uses most, and it reported success.
+        let mut rt = setup_runtime("<html><body></body></html>");
+        let info = rt
+            .evaluate_for_cdp("undefined_variable_xyz", true, false)
+            .await
+            .expect("a page error is not a protocol failure");
+        assert!(info.thrown, "a ReferenceError must not serialize to null");
+        assert!(info.description.contains("ReferenceError"));
+    }
+    
+    #[tokio::test(flavor = "current_thread")]
+    async fn a_throw_statement_is_run_as_a_script_not_wrapped_in_parentheses() {
+        // `Runtime.evaluate` takes a script. Pasted into `(...)` a throw is a
+        // parse-time SyntaxError, which no catch can see, so the whole command
+        // failed at the protocol level instead of reporting the page's error.
+        let mut rt = setup_runtime("<html><body></body></html>");
+        let info = rt
+            .evaluate_for_cdp("throw new Error('boom')", false, false)
+            .await
+            .expect("a throw statement must be evaluated, not rejected as invalid");
+        assert!(info.thrown);
+        assert!(
+            info.description.contains("boom"),
+            "the thrown error must survive: {:?}",
+            info.description
+        );
+    }
+    
+    #[tokio::test(flavor = "current_thread")]
+    async fn a_statement_bundle_yields_its_completion_value() {
+        // Chrome reports the completion value of the script. The old wrapper
+        // put statement bundles in a function body with no `return`, so every
+        // one of them evaluated to the wrapper's own undefined.
+        let mut rt = setup_runtime("<html><body></body></html>");
+        let info = rt
+            .evaluate_for_cdp("var completion_x = 1; completion_x * 2", true, false)
+            .await
+            .expect("statement bundles are valid input");
+        assert!(!info.thrown);
+        // Compared as a number rather than against a literal: the engine
+        // boxes every number as f64, so `json!(2)` would not match `2.0`.
+        // That spelling is its own defect and does not belong to this test.
+        assert_eq!(
+            info.value.as_ref().and_then(serde_json::Value::as_f64),
+            Some(2.0),
+            "the bundle's completion value, not the wrapper's undefined"
+        );
+    }
+    
+    #[tokio::test(flavor = "current_thread")]
+    async fn a_trailing_semicolon_and_source_url_still_parse() {
+        // Both were handled by hand before: the semicolon had to be trimmed or
+        // `(expr;)` failed to parse, and the sourceURL comment had to be closed
+        // by a newline or it swallowed the wrapper's own paren. Passing the
+        // script as a string removes the class, so these pin that it stays gone.
+        let mut rt = setup_runtime("<html><body></body></html>");
+        let info = rt
+            .evaluate_for_cdp("(() => 7)();", true, false)
+            .await
+            .expect("a trailing semicolon is legal");
+        assert_eq!(
+            info.value.as_ref().and_then(serde_json::Value::as_f64),
+            Some(7.0)
+        );
+    
+        let info = rt
+            .evaluate_for_cdp("(() => 8)()\n//# sourceURL=__puppeteer_evaluation_script__", true, false)
+            .await
+            .expect("a trailing sourceURL comment is legal");
+        assert_eq!(
+            info.value.as_ref().and_then(serde_json::Value::as_f64),
+            Some(8.0)
+        );
+    }
+    
     #[tokio::test(flavor = "current_thread")]
     async fn a_rejection_does_not_leak_into_the_next_call() {
         // `__obscura_await_rejected` is a global, so the success branch has to

--- a/crates/obscura-js/src/runtime.rs
+++ b/crates/obscura-js/src/runtime.rs
@@ -107,6 +107,11 @@ fn with_sync_render_loading_disabled<R>(
 
 #[derive(Debug, Clone)]
 pub struct RemoteObjectInfo {
+    /// True when this object is a value that was thrown or that a promise
+    /// rejected with, rather than the evaluation result. CDP reports those
+    /// through `exceptionDetails` on a successful reply, so the difference
+    /// has to survive the trip out of the runtime.
+    pub thrown: bool,
     pub js_type: String,
     pub subtype: Option<String>,
     pub class_name: String,
@@ -1605,12 +1610,14 @@ impl ObscuraJsRuntime {
                 )
                 .map_err(|e| format!("JS error: {}", e))?;
             if self.v8_to_json(rejected)?.as_bool().unwrap_or(false) {
-                let err = self.execute_runtime_script("<readError>", format!("String(globalThis.__obscura_objects['{0}'] && (globalThis.__obscura_objects['{0}'].message || globalThis.__obscura_objects['{0}']))", oid))
-                    .map_err(|e| format!("JS error: {}", e))?;
-                return Err(format!(
-                    "Promise rejected: {}",
-                    self.v8_to_json(err)?.as_str().unwrap_or("")
-                ));
+                // A rejection is not a protocol failure. CDP answers the
+                // command and puts the rejected value in `exceptionDetails`,
+                // which is what a client rebuilds the page error from, so the
+                // value travels back as a remote object flagged `thrown`.
+                // It is reported by reference even when the caller asked for a
+                // value: `JSON.stringify(new Error("boom"))` is `{}`, so
+                // serializing it would throw the message away.
+                return self.thrown_info(&oid);
             }
             self.execute_runtime_script("<readMeta>", "globalThis.__obscura_await_meta".to_string())
                 .map_err(|e| format!("JS error: {}", e))?
@@ -1690,10 +1697,12 @@ impl ObscuraJsRuntime {
                         __result = await __fn.call(__this, {args});\n\
                         globalThis.__obscura_objects['{oid}'] = __result;\n\
                         globalThis.__obscura_await_meta = {meta_fn};\n\
+                        globalThis.__obscura_await_rejected = false;\n\
                     }} catch(e) {{\n\
                         __result = e;\n\
                         globalThis.__obscura_objects['{oid}'] = e;\n\
                         globalThis.__obscura_await_meta = {err_meta_fn};\n\
+                        globalThis.__obscura_await_rejected = true;\n\
                     }} finally {{\n\
                         globalThis.__obscura_done_{done_counter} = true;\n\
                     }}\n\
@@ -1742,6 +1751,22 @@ impl ObscuraJsRuntime {
                     __dt.as_millis(),
                     preview,
                 );
+            }
+
+            // Same rule as evaluate: a rejected call is answered, not failed,
+            // and the value is never serialized by value. Without this the
+            // wrapper stored the error under the object id a success uses, so
+            // a rejection came back as an ordinary result: an Error as `{}`,
+            // and `Promise.reject({code: 42})` as `{code: 42}`, which is
+            // indistinguishable from resolving with it.
+            let rejected = self
+                .execute_runtime_script(
+                    "<readRejected>",
+                    "globalThis.__obscura_await_rejected".to_string(),
+                )
+                .map_err(|e| format!("JS error: {}", e))?;
+            if self.v8_to_json(rejected)?.as_bool().unwrap_or(false) {
+                return self.thrown_info(&oid);
             }
 
             if return_by_value {
@@ -2935,6 +2960,12 @@ impl ObscuraJsRuntime {
                     cn = 'Function';
                     desc = v.name ? 'function ' + v.name + '()' : 'function()';
                 }}
+                else if (t === 'object' && v instanceof Error) {{
+                    st = 'error';
+                    cn = (v.constructor && v.constructor.name) || 'Error';
+                    desc = (typeof v.stack === 'string' && v.stack) ? v.stack
+                         : (cn + (v.message ? ': ' + v.message : ''));
+                }}
                 else if (t === 'object') {{
                     cn = (v.constructor && v.constructor.name) || 'Object';
                     desc = cn;
@@ -3047,6 +3078,7 @@ impl ObscuraJsRuntime {
     fn info_from_json(value: &serde_json::Value) -> RemoteObjectInfo {
         match value {
             serde_json::Value::Null => RemoteObjectInfo {
+                thrown: false,
                 js_type: "object".into(),
                 subtype: Some("null".into()),
                 class_name: String::new(),
@@ -3055,6 +3087,7 @@ impl ObscuraJsRuntime {
                 value: Some(serde_json::Value::Null),
             },
             serde_json::Value::Bool(b) => RemoteObjectInfo {
+                thrown: false,
                 js_type: "boolean".into(),
                 subtype: None,
                 class_name: String::new(),
@@ -3063,6 +3096,7 @@ impl ObscuraJsRuntime {
                 value: Some(value.clone()),
             },
             serde_json::Value::Number(n) => RemoteObjectInfo {
+                thrown: false,
                 js_type: "number".into(),
                 subtype: None,
                 class_name: String::new(),
@@ -3071,6 +3105,7 @@ impl ObscuraJsRuntime {
                 value: Some(value.clone()),
             },
             serde_json::Value::String(s) => RemoteObjectInfo {
+                thrown: false,
                 js_type: "string".into(),
                 subtype: None,
                 class_name: String::new(),
@@ -3079,6 +3114,7 @@ impl ObscuraJsRuntime {
                 value: Some(value.clone()),
             },
             serde_json::Value::Array(arr) => RemoteObjectInfo {
+                thrown: false,
                 js_type: "object".into(),
                 subtype: Some("array".into()),
                 class_name: "Array".into(),
@@ -3087,6 +3123,7 @@ impl ObscuraJsRuntime {
                 value: Some(value.clone()),
             },
             serde_json::Value::Object(_) => RemoteObjectInfo {
+                thrown: false,
                 js_type: "object".into(),
                 subtype: None,
                 class_name: "Object".into(),
@@ -3095,6 +3132,33 @@ impl ObscuraJsRuntime {
                 value: Some(value.clone()),
             },
         }
+    }
+
+    /// Build the remote object for a value that was thrown, or that a promise
+    /// rejected with.
+    ///
+    /// Both wrappers have already stored the value under `oid` and put its
+    /// metadata in `__obscura_await_meta`, so this reads them back and marks
+    /// the result. The mark is what lets the CDP layer answer the command with
+    /// `exceptionDetails` rather than fail it or, worse, present the value as
+    /// the evaluation result.
+    fn thrown_info(&mut self, oid: &str) -> Result<RemoteObjectInfo, String> {
+        let meta = self
+            .execute_runtime_script("<readMeta>", "globalThis.__obscura_await_meta".to_string())
+            .map_err(|e| format!("JS error: {}", e))?;
+        let meta = self.v8_to_json(meta)?;
+        let meta_json = if let serde_json::Value::String(text) = &meta {
+            serde_json::from_str(text).unwrap_or_else(|_| meta.clone())
+        } else {
+            meta
+        };
+        self.object_store.insert(
+            oid.to_string(),
+            format!("globalThis.__obscura_objects['{}']", oid),
+        );
+        let mut info = Self::info_from_meta(&meta_json, Some(oid.to_string()));
+        info.thrown = true;
+        Ok(info)
     }
 
     fn info_from_meta(meta: &serde_json::Value, object_id: Option<String>) -> RemoteObjectInfo {
@@ -3127,6 +3191,7 @@ impl ObscuraJsRuntime {
         };
 
         RemoteObjectInfo {
+            thrown: false,
             js_type,
             subtype,
             class_name,
@@ -13665,14 +13730,90 @@ mod tests {
         assert_eq!(result.value.unwrap().as_str().unwrap(), "async-ok");
     }
 
+    // This test used to assert that a rejection came back as `Err`. It does
+    // not any more, and the old expectation was the defect: CDP answers the
+    // command and reports the rejected value through `exceptionDetails`, so
+    // failing the command loses the page error rather than delivering it.
     #[tokio::test(flavor = "current_thread")]
     async fn test_evaluate_for_cdp_reports_promise_rejection() {
         let mut rt = setup_runtime("<html><body></body></html>");
-        let err = rt
+        let info = rt
             .evaluate_for_cdp("Promise.reject(new Error('boom'))", true, true)
             .await
-            .unwrap_err();
-        assert!(err.contains("boom"));
+            .expect("a rejection is answered, not failed");
+        assert!(info.thrown, "the rejected value must be marked as thrown");
+        assert_eq!(info.js_type, "object");
+        assert_eq!(info.subtype.as_deref(), Some("error"));
+        assert_eq!(info.class_name, "Error");
+        assert!(
+            info.description.contains("boom"),
+            "the description is what a client rebuilds the error from: {}",
+            info.description
+        );
+        // Reported by reference, never serialized: an Error has no own
+        // enumerable properties, so by value it would be `{}`.
+        assert!(info.value.is_none());
+        assert!(info.object_id.is_some());
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn call_function_on_marks_a_rejection_instead_of_returning_it() {
+        // The reported shape: returnByValue on a rejected call answered
+        // successfully with `{}`, because the wrapper stored the error under
+        // the object id a success uses and nothing said which branch ran.
+        let mut rt = setup_runtime("<html><body></body></html>");
+        let info = rt
+            .call_function_on_for_cdp("() => Promise.reject(new Error('boom'))", None, &[], true, true)
+            .await
+            .expect("a rejection is answered, not failed");
+        assert!(info.thrown, "expected a thrown value, got {:?}", info.value);
+        assert_eq!(info.subtype.as_deref(), Some("error"));
+        assert!(info.description.contains("boom"));
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn call_function_on_separates_a_rejected_object_from_a_resolved_one() {
+        // The sharper half of the same defect: rejecting with a plain object
+        // produced a reply byte-identical to resolving with it, so no client
+        // could tell the two apart.
+        let mut rt = setup_runtime("<html><body></body></html>");
+        let resolved = rt
+            .call_function_on_for_cdp("() => Promise.resolve({code: 42})", None, &[], true, true)
+            .await
+            .unwrap();
+        let rejected = rt
+            .call_function_on_for_cdp("() => Promise.reject({code: 42})", None, &[], true, true)
+            .await
+            .unwrap();
+        assert!(!resolved.thrown);
+        assert!(rejected.thrown);
+        assert_eq!(resolved.value, Some(serde_json::json!({"code": 42})));
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn a_rejection_does_not_leak_into_the_next_call() {
+        // `__obscura_await_rejected` is a global, so the success branch has to
+        // clear it. Without that the first rejection would mark every later
+        // call on the same runtime as thrown.
+        let mut rt = setup_runtime("<html><body></body></html>");
+        let rejected = rt
+            .call_function_on_for_cdp("() => Promise.reject(new Error('first'))", None, &[], true, true)
+            .await
+            .unwrap();
+        assert!(rejected.thrown);
+        let after = rt
+            .call_function_on_for_cdp("() => Promise.resolve(7)", None, &[], true, true)
+            .await
+            .unwrap();
+        assert!(!after.thrown, "a later success was still marked as thrown");
+        assert_eq!(after.value.unwrap().as_f64(), Some(7.0));
+
+        let evaluated = rt
+            .evaluate_for_cdp("Promise.resolve(8)", true, true)
+            .await
+            .unwrap();
+        assert!(!evaluated.thrown);
+        assert_eq!(evaluated.value.unwrap().as_f64(), Some(8.0));
     }
 
     #[tokio::test(flavor = "current_thread")]


### PR DESCRIPTION
## What changed

Fixes #746.

`Runtime.evaluate` and `Runtime.callFunctionOn` could not report that a page threw. Each of the four shapes of the command lost the error a different way:

| input | | before | after |
|---|---|---|---|
| `Promise.reject(new Error('x'))` | `awaitPromise: true` | protocol error | `exceptionDetails` |
| `callFunctionOn` returning a rejection | `awaitPromise: true` | **success, `{}`** | `exceptionDetails` |
| `undefined_variable_xyz` | `awaitPromise: false` | success, `type: "undefined"` | `exceptionDetails` |
| `undefined_variable_xyz` | `returnByValue: true` | **success, `value: null`** | `exceptionDetails` |
| `throw new Error('boom')` | `awaitPromise: false` | protocol error (SyntaxError) | `exceptionDetails` |
| `var x = 1; x * 2` | `returnByValue: true` | success, `value: null` | `2` |

The `callFunctionOn` row is the one that matters most: a rejection was **indistinguishable from a resolution**. `Promise.reject({code: 42})` came back byte-identical to `Promise.resolve({code: 42})`, and an `Error` came back as `{}` because it has no own enumerable properties to serialize. That is the path `page.evaluate(fn)` uses, so `await page.evaluate(() => Promise.reject(new Error('boom')))` resolved to `{}` instead of throwing.

### One outcome protocol

CDP reports a thrown value on a **successful** reply, in `exceptionDetails` — not as a protocol error. So the difference between "this is the result" and "this was thrown" has to survive the trip out of the runtime, which is what the new `thrown` flag on `RemoteObjectInfo` carries.

Every shape now writes the same two globals the await path already wrote (`__obscura_await_meta`, `__obscura_await_rejected`), and the check for them moved out of the `if await_promise` block to cover both. The reply builder no longer has to know which path produced the value. Concretely:

- the `callFunctionOn` wrapper sets the flag on rejection **and clears it on success** — it is a global, so without the reset one rejection marks every later call (`a_rejection_does_not_leak_into_the_next_call`);
- the synchronous branch records the thrown value instead of `catch(e) { __result = undefined; }`;
- `returnByValue: true, awaitPromise: false` no longer short-circuits through `evaluate`, whose wrapper answers an exception with `null`. That was a second, independent implementation of the same swallow, on the shape Puppeteer uses most.

A thrown value is reported **by reference even when the caller asked for a value**: `JSON.stringify(new Error("boom"))` is `{}`, so serializing it would throw away the one thing the client needs.

`meta_extract_js` also grows an `Error` branch. Without it the field would be present and useless: an `Error` reported `className: "Error", description: "Error"` and no `subtype`, where Chrome gives `subtype: "error"` and a description carrying the message and stack.

### The expression is now a string, not pasted source

`Runtime.evaluate` takes a *script*, not an expression. Pasting it into `(...)` made `throw new Error('x')` a parse-time SyntaxError — which no `catch` can see, so the whole command failed — and put statement bundles in a function body with no `return`, so `var x = 1; x * 2` evaluated to the wrapper's own `undefined`.

Passing the script as a JSON string literal into `(0, eval)(…)` fixes both, and deletes two workarounds that existed only to keep the pasted form parseable:

- a trailing `;` had to be trimmed, or `(expr;)` failed to parse;
- a trailing `//# sourceURL=` comment (Puppeteer and Playwright both append one) would swallow the closing paren unless it sat on its own line.

Neither is possible against a string literal. `a_trailing_semicolon_and_source_url_still_parse` pins that the class stays gone. `(0, eval)` rather than `eval` so the script runs at global scope, where `var` lands on `globalThis` as it does in Chrome and cannot see the wrapper's `__result`.

## Validation

```
render     656 tests run: 656 passed, 3 skipped
no-render  521 tests run: 521 passed, 3 skipped
```

across `obscura-js`, `obscura-cdp` and `obscura-browser`. No existing test changed behaviour — the risk I was most concerned about, since every `Runtime.evaluate` caller goes through this path.

New tests:

- `evaluate_reports_a_rejection_through_exception_details`
- `call_function_on_reports_a_rejection_through_exception_details`
- `call_function_on_marks_a_rejection_instead_of_returning_it`
- `call_function_on_separates_a_rejected_object_from_a_resolved_one` — `Promise.reject({code:42})` must not equal `Promise.resolve({code:42})`
- `a_rejection_does_not_leak_into_the_next_call` — the global-reset case
- `a_resolved_evaluation_carries_no_exception_details`
- `a_synchronous_throw_is_reported_instead_of_swallowed`
- `a_synchronous_throw_is_reported_when_a_value_was_asked_for`
- `a_throw_statement_is_run_as_a_script_not_wrapped_in_parentheses`
- `a_statement_bundle_yields_its_completion_value`
- `a_trailing_semicolon_and_source_url_still_parse`

`test_evaluate_for_cdp_reports_promise_rejection` was rewritten: it asserted `unwrap_err()`, which pinned the bug.

## Rendering

Not applicable.

## Performance

No expected impact. The synchronous path costs one extra small script execution to read the outcome flag, on a path that already executes a script per call. Indirect eval replaces string pasting with an equivalent parse.

## Checklist

- [x] The change is focused and does not remove existing behavior without justification.
- [x] Tests cover the failure or feature.
- [x] Existing tests pass, including render and no-render configurations when affected.
- [x] I checked for CPU, latency, and memory regressions.
- [x] Public API or user-facing behavior changes are documented.

## Deliberately not in scope

- **`wrap_expression`** keeps its `catch → null`. Its callers are `evaluate` and `evaluate_with_timeout`, internal helpers a lot of engine code depends on for that contract; #746 is about the CDP surface.
- **The RemoteObject shape for primitives.** While measuring this I found `value` is a JSON string for every primitive on the handle path (`1 + 1` reports `value: "2"`), `undefined` becomes `{type: "object", subtype: "null"}` under `returnByValue`, and integers describe as `"2.0"`. All predate this PR and are unchanged by it; filed separately since they touch every primitive rather than the error path.

Thanks to @yinnho, whose comments on #746 identified the synchronous-path asymmetry and the indirect-eval approach from an engine that already reports this shape.
