### PR TITLE
render: resolve functional flex-basis against the containing block

### DIFF
--- a/crates/obscura-render/src/dom.rs
+++ b/crates/obscura-render/src/dom.rs
@@ -5194,6 +5194,13 @@ fn layout_dom_once(
                 style.max_width = style.max_width.resolve(em_px, root_fs, vw, vh);
                 style.max_height = style.max_height.resolve(em_px, root_fs, vw, vh);
                 style.flex_basis = style.flex_basis.resolve(em_px, root_fs, vw, vh);
+                if let Some(expression) = style.flex_basis_expression.as_deref() {
+                    if let Some(px) = crate::style::resolve_contextual_length(
+                        expression, em_px, root_fs, vw, vh, cb_w,
+                    ) {
+                        style.flex_basis = crate::Dimension::Px(px);
+                    }
+                }
                 if matches!(style.height, crate::Dimension::Percent(_))
                     && !inh.cb_height_definite
                     && !matches!(style.position, Some(taffy::Position::Absolute))

--- a/crates/obscura-render/src/lib.rs
+++ b/crates/obscura-render/src/lib.rs
@@ -1280,6 +1280,12 @@ pub struct LayoutStyle {
     /// is the default. Fixed-basis sidebars/columns (`flex: 0 0 260px`)
     /// collapse to content width without it.
     pub flex_basis: Dimension,
+    /// A functional `flex-basis` (`calc(100% - 314px)`) kept unresolved until
+    /// layout knows the containing block, exactly as `size_expressions` does
+    /// for width. Evaluating it context-free at parse time turns the `100%`
+    /// into 0, yielding a negative-then-clamped basis that pins the item to
+    /// its min-content width and makes a specified `width` look ignored.
+    pub flex_basis_expression: Option<String>,
 
     // CSS Grid. Tracks are stored as taffy sizing functions; `grid_areas` is the
     // parsed `grid-template-areas` matrix (one Vec per row, `.` for a null cell),

--- a/crates/obscura-render/src/style.rs
+++ b/crates/obscura-render/src/style.rs
@@ -1332,6 +1332,7 @@ fn apply_value(style: &mut LayoutStyle, name: &str, value: &str) {
         }
         "flex-basis" => {
             style.flex_basis = dimension_value(value.trim());
+            style.flex_basis_expression = deferred_length_expression(value);
         }
         "flex" => parse_flex_shorthand(style, value),
         "position" => match value {
@@ -8157,28 +8158,27 @@ fn parse_url(value: &str) -> Option<String> {
 /// the shorthand form almost all real-world flexbox CSS actually uses (far
 /// more often than the flex-grow/flex-shrink longhands); leaving it
 /// unhandled silently drops grow/shrink from every rule written this way.
-/// flex-basis is not modeled as a distinct field from width, so a basis
-/// length in the shorthand is parsed (to keep the number-only forms working)
-/// but otherwise not separately applied; auto is a reasonable approximation
-/// for the common case where basis is 0 or unspecified.
 fn parse_flex_shorthand(style: &mut LayoutStyle, value: &str) {
     match value.trim() {
         "none" => {
             style.flex_grow = Some(0.0);
             style.flex_shrink = Some(0.0);
             style.flex_basis = crate::Dimension::Auto;
+            style.flex_basis_expression = None;
             return;
         }
         "auto" => {
             style.flex_grow = Some(1.0);
             style.flex_shrink = Some(1.0);
             style.flex_basis = crate::Dimension::Auto;
+            style.flex_basis_expression = None;
             return;
         }
         "initial" => {
             style.flex_grow = Some(0.0);
             style.flex_shrink = Some(1.0);
             style.flex_basis = crate::Dimension::Auto;
+            style.flex_basis_expression = None;
             return;
         }
         _ => {}
@@ -8188,15 +8188,24 @@ fn parse_flex_shorthand(style: &mut LayoutStyle, value: &str) {
     // (e.g. `flex: 0 0 260px`, the fixed-width sidebar idiom).
     let mut numbers: Vec<f32> = Vec::new();
     let mut basis: Option<crate::Dimension> = None;
-    for tok in value.split_whitespace() {
+    let mut basis_token: Option<String> = None;
+    // Split at paren-depth 0 so a functional basis such as
+    // `flex: 0 0 calc(100% - 314px)` stays one token.
+    for tok in split_top_level(value, ' ')
+        .into_iter()
+        .map(str::trim)
+        .filter(|tok| !tok.is_empty())
+    {
         if let Ok(n) = tok.parse::<f32>() {
             if numbers.len() < 2 {
                 numbers.push(n);
             } else {
                 basis = Some(dimension_value(tok));
+                basis_token = Some(tok.to_string());
             }
         } else {
             basis = Some(dimension_value(tok));
+            basis_token = Some(tok.to_string());
         }
     }
     match numbers.as_slice() {
@@ -8212,6 +8221,10 @@ fn parse_flex_shorthand(style: &mut LayoutStyle, value: &str) {
     }
     // Explicit basis wins; otherwise numbers-only shorthand implies basis 0
     // (per spec `flex: 1` == `1 1 0%`), while a bare basis keeps grow/shrink 1.
+    style.flex_basis_expression = match &basis {
+        Some(_) => basis_token.as_deref().and_then(deferred_length_expression),
+        None => None,
+    };
     style.flex_basis = match basis {
         Some(b) => b,
         None if !numbers.is_empty() => crate::Dimension::Px(0.0),

--- a/crates/obscura-render/tests/layout_test.rs
+++ b/crates/obscura-render/tests/layout_test.rs
@@ -4471,3 +4471,37 @@ fn grid_ordinary_aspect_ratio_preserves_normal_alignment_provenance() {
     assert_eq!(size("parent-align-stretch"), (400.0, 200.0));
     assert_eq!(size("parent-justify-stretch"), (300.0, 150.0));
 }
+
+#[test]
+fn functional_flex_basis_resolves_against_the_containing_block() {
+    // readymembership.com: `.main-nav-holder{flex-basis:calc(100% - 314px)}`.
+    // Evaluating the calc() context-free at parse time turned the 100% into
+    // 0, producing a negative basis that clamped to the item's min-content
+    // width and made the nav stack vertically.
+    let tree = parse_html(
+        r#"
+        <body style="margin:0">
+          <div style="display:flex;width:1200px">
+            <div style="flex:0 0 300px">a</div>
+            <div id="longhand" style="flex-basis:calc(100% - 314px)">nav</div>
+          </div>
+          <div style="display:flex;width:1200px">
+            <div style="flex:0 0 300px">a</div>
+            <div id="shorthand" style="flex:0 0 calc(100% - 314px)">nav</div>
+          </div>
+        </body>
+        "#,
+    );
+    let layout = layout_dom(&tree, (1400.0, 900.0));
+    let rect = |id| layout.rects[&tree.get_element_by_id(id).unwrap()];
+    assert!(
+        (rect("longhand").width - 886.0).abs() < 0.01,
+        "longhand: {:?}",
+        rect("longhand")
+    );
+    assert!(
+        (rect("shorthand").width - 886.0).abs() < 0.01,
+        "shorthand: {:?}",
+        rect("shorthand")
+    );
+}


### PR DESCRIPTION
## What changed

`flex-basis: calc(100% - 314px)` (longhand, or as the third token of `flex:`) was evaluated context-free at parse time through `dimension_value`, so the `100%` became 0 and the basis a negative length that taffy clamped to 0. With a definite zero basis and `flex-grow: 0` the item sat at its min-content width, and any specified `width` was — correctly, per spec — irrelevant. That made the failure look like a dropped `width` declaration (only an inline `style.flexBasis` could move the element), which is how it was first reported in #737 alongside a Wikipedia case that turns out to be a separate table-sizing issue.

`width`/`height`/`min-*`/`max-*` already defer functional expressions in `size_expressions` and resolve them in `layout_dom`'s top-down pass; this gives `flex-basis` the same treatment:

- `LayoutStyle::flex_basis_expression: Option<String>` (lib.rs)
- the `flex-basis` longhand and `flex` shorthand store the expression; keyword forms clear it (style.rs)
- the `flex` shorthand tokenises with `split_top_level(value, ' ')` so `flex: 0 0 calc(100% - 314px)` is one basis token instead of three
- resolved with `resolve_contextual_length` against `inh.cb_width` next to the existing width/height resolution (dom.rs)

Related to #737 (fixes the readymembership.com half of it; the `en.wikipedia.org` infobox there is a table min-content-width problem, not this).

## Validation

- New test `functional_flex_basis_resolves_against_the_containing_block` in `crates/obscura-render/tests/layout_test.rs`: longhand and shorthand `calc()` bases in a 1200px flex row both lay out at 886px (were 26px, the item's min-content width).
- `cargo test -p obscura-render --test layout_test`: 97 passed / 11 failed, the same 11 failures as `main` before this change (font/environment related, unrelated files).
- Live check through an embedding host: `https://readymembership.com/` at 1400×900, `.main-nav-holder` went from 145px (nav stacked vertically over the hero) to 1046px with the nav laid out horizontally. `width: calc(100% - 314px)` on the same item already produced 886px in the fixture before the change, confirming the deferred path is the right one.

## Rendering

Layout only. Fixture, viewport 1400×900, DSF 1:

```html
<div style="display:flex;width:1200px">
  <div style="flex:0 0 300px">a</div>
  <div style="flex-basis:calc(100% - 314px)">nav</div>
</div>
```

Second item before: 26px wide. After: 886px (Chrome: 886px).

## Performance

No expected impact: one extra `Option<String>` per style, populated only when a `flex-basis`/`flex` value contains `(`, and one extra expression evaluation per such node in the existing per-node resolution pass.

## Checklist

- [x] The change is focused and does not remove existing behavior without justification.
- [x] Tests cover the failure or feature.
- [x] Existing tests pass, including render and no-render configurations when affected. (Same pre-existing failure set as `main`.)
- [x] I checked for CPU, latency, and memory regressions.
- [x] Public API or user-facing behavior changes are documented. (New public field on `LayoutStyle`, doc-commented.)
