### PR TITLE
render: let an overflowing inline-block wrap instead of running one line

### DIFF
--- a/crates/obscura-render/src/dom.rs
+++ b/crates/obscura-render/src/dom.rs
@@ -6366,7 +6366,19 @@ fn layout_dom_once(
                         if matches!(width_style, crate::Dimension::Percent(_)) {
                             continue;
                         }
+                        // A shrink-fit inline-block is a `NoWrap` row only as an
+                        // approximation of its max-content line; its min-content
+                        // contribution to the table must still break between
+                        // items, or an inline list of `<li>`s widens the table to
+                        // one long line.
+                        let inline_block_rows =
+                            nowrap_inline_block_rows(&taffy_tree, &id_map, &styles);
                         let min_c = {
+                            set_flex_wrap(
+                                &mut taffy_tree,
+                                &inline_block_rows,
+                                taffy::FlexWrap::Wrap,
+                            );
                             let _ = taffy_tree.compute_layout_with_measure(
                                 tnode,
                                 taffy::Size {
@@ -6374,6 +6386,11 @@ fn layout_dom_once(
                                     height: taffy::AvailableSpace::MaxContent,
                                 },
                                 &mut measure,
+                            );
+                            set_flex_wrap(
+                                &mut taffy_tree,
+                                &inline_block_rows,
+                                taffy::FlexWrap::NoWrap,
                             );
                             taffy_tree
                                 .layout(tnode)
@@ -6477,7 +6494,14 @@ fn layout_dom_once(
                             // as a plain box here).
                             let mut measured: Vec<(usize, usize, f32, f32)> =
                                 Vec::with_capacity(cells.len());
+                            let inline_block_rows =
+                                nowrap_inline_block_rows(&taffy_tree, &id_map, &styles);
                             for (cell, col, span) in &cells {
+                                set_flex_wrap(
+                                    &mut taffy_tree,
+                                    &inline_block_rows,
+                                    taffy::FlexWrap::Wrap,
+                                );
                                 let _ = taffy_tree.compute_layout_with_measure(
                                     *cell,
                                     taffy::Size {
@@ -6485,6 +6509,11 @@ fn layout_dom_once(
                                         height: taffy::AvailableSpace::MaxContent,
                                     },
                                     &mut measure,
+                                );
+                                set_flex_wrap(
+                                    &mut taffy_tree,
+                                    &inline_block_rows,
+                                    taffy::FlexWrap::NoWrap,
                                 );
                                 let cmin = taffy_tree
                                     .layout(*cell)
@@ -6665,6 +6694,10 @@ fn layout_dom_once(
                     let _ =
                         taffy_tree.compute_layout_with_measure(taffy_root, available, &mut measure);
                 }
+                if wrap_overflowing_inline_blocks(&mut taffy_tree, &id_map, &styles) {
+                    let _ =
+                        taffy_tree.compute_layout_with_measure(taffy_root, available, &mut measure);
+                }
                 let _ = resolve_deferred_flex_inline_sizes(
                     tree,
                     &mut taffy_tree,
@@ -6800,6 +6833,9 @@ fn layout_dom_once(
                 }
                 if repair_intrinsic_column_flex_negative_margins(&mut taffy_tree, &id_map, &styles)
                 {
+                    let _ = taffy_tree.compute_layout(taffy_root, available);
+                }
+                if wrap_overflowing_inline_blocks(&mut taffy_tree, &id_map, &styles) {
                     let _ = taffy_tree.compute_layout(taffy_root, available);
                 }
                 let _ = resolve_deferred_flex_inline_sizes(
@@ -8917,6 +8953,84 @@ fn apply_table_cell_block_alignment(
 /// Repair Taffy 0.12's intrinsic main-size calculation for column flexboxes
 /// containing a negative main-axis margin.
 ///
+/// The auto-width inline-blocks the node builder emitted as `NoWrap` flex rows
+/// (its max-content shrink-fit approximation). These are the boxes whose
+/// min-content width must still allow internal line breaks.
+fn nowrap_inline_block_rows(
+    taffy_tree: &TaffyTree<usize>,
+    id_map: &HashMap<taffy::NodeId, NodeId>,
+    styles: &HashMap<NodeId, crate::LayoutStyle>,
+) -> Vec<taffy::NodeId> {
+    id_map
+        .iter()
+        .filter_map(|(&node, &dom_id)| {
+            let style = styles.get(&dom_id)?;
+            if !style.is_inline_block
+                || style.width != crate::Dimension::Auto
+                || style.float.is_some()
+                || matches!(style.position, Some(taffy::Position::Absolute))
+            {
+                return None;
+            }
+            let taffy_style = taffy_tree.style(node).ok()?;
+            (taffy_style.display == taffy::style::Display::Flex
+                && taffy_style.flex_wrap == taffy::FlexWrap::NoWrap)
+                .then_some(node)
+        })
+        .collect()
+}
+
+fn set_flex_wrap(
+    taffy_tree: &mut TaffyTree<usize>,
+    nodes: &[taffy::NodeId],
+    wrap: taffy::FlexWrap,
+) {
+    for node in nodes {
+        if let Ok(current) = taffy_tree.style(*node) {
+            if current.flex_wrap != wrap {
+                let mut updated = current.clone();
+                updated.flex_wrap = wrap;
+                let _ = taffy_tree.set_style(*node, updated);
+            }
+        }
+    }
+}
+
+/// An auto-width inline-block without block children is built as a `NoWrap`
+/// flex row so that a short control shrink-fits to one max-content line (see
+/// the inline-block branch of the node builder). CSS shrink-to-fit is
+/// `min(max-content, available)` though: when that max-content line is wider
+/// than the containing block the inline-block must wrap internally instead of
+/// overflowing — an `<ul>` of inline-block `<li>`s (Wikipedia's `.cslist`)
+/// otherwise runs as one 1000px line and, inside a table, drags the table's
+/// min-content floor far past its specified width. Detect the overflow from the
+/// preliminary layout and switch those rows to `Wrap`; the caller re-runs Taffy.
+fn wrap_overflowing_inline_blocks(
+    taffy_tree: &mut TaffyTree<usize>,
+    id_map: &HashMap<taffy::NodeId, NodeId>,
+    styles: &HashMap<NodeId, crate::LayoutStyle>,
+) -> bool {
+    let repairs: Vec<taffy::NodeId> = nowrap_inline_block_rows(taffy_tree, id_map, styles)
+        .into_iter()
+        .filter(|&node| {
+            let (Some(parent), Ok(layout)) = (taffy_tree.parent(node), taffy_tree.layout(node))
+            else {
+                return false;
+            };
+            let Ok(parent_layout) = taffy_tree.layout(parent) else {
+                return false;
+            };
+            let available = parent_layout.content_box_width();
+            if !available.is_finite() || available <= 0.0 {
+                return false;
+            }
+            layout.size.width + layout.margin.left + layout.margin.right > available + 0.5
+        })
+        .collect();
+    set_flex_wrap(taffy_tree, &repairs, taffy::FlexWrap::Wrap);
+    !repairs.is_empty()
+}
+
 /// In the max-content path Taffy feeds the margin-adjusted contribution into
 /// its flex-fraction calculation. A negative margin on a shrink-disabled item
 /// can therefore subtract the item's entire flex basis (or many multiples of

--- a/crates/obscura-render/tests/layout_test.rs
+++ b/crates/obscura-render/tests/layout_test.rs
@@ -4471,3 +4471,56 @@ fn grid_ordinary_aspect_ratio_preserves_normal_alignment_provenance() {
     assert_eq!(size("parent-align-stretch"), (400.0, 200.0));
     assert_eq!(size("parent-justify-stretch"), (300.0, 150.0));
 }
+
+#[test]
+fn overflowing_inline_block_list_wraps_inside_its_container() {
+    // Wikipedia `.cslist`: an inline-block <ul> of inline-block <li>s. The
+    // shrink-fit `NoWrap` approximation must not let the list run as one
+    // long line past its containing block; in an infobox cell that line
+    // becomes the table's min-content floor and pushes a `width:22em` table
+    // to ~640px.
+    let items: String = [
+        "Alef",
+        "BETA",
+        "CLU",
+        "Cyclone",
+        "Elm",
+        "Erlang",
+        "Haskell",
+        "Hermes",
+        "Limbo",
+        "Newsqueak",
+        "OCaml",
+        "Ruby",
+        "Scheme",
+        "Standard-ML",
+        "Swift",
+        "Idris",
+        "PHP",
+    ]
+    .iter()
+    .map(|w| format!("<li>{w}</li>"))
+    .collect();
+    let tree = parse_html(&format!(
+        r#"
+        <body style="margin:0;width:1000px">
+          <style>
+            ul{{display:inline-block;margin:0;padding:0;list-style:none}}
+            li{{display:inline-block;padding:0 .25em 0 0}}
+            li:after{{content:", "}}
+          </style>
+          <div style="width:352px"><ul id="list">{items}</ul></div>
+        </body>
+        "#
+    ));
+    let layout = layout_dom(&tree, (1280.0, 900.0));
+    let list = layout.rects[&tree.get_element_by_id("list").unwrap()];
+    assert!(
+        list.width <= 352.0 + 0.01,
+        "inline-block list must wrap inside its 352px container: {list:?}"
+    );
+    assert!(
+        list.height > 30.0,
+        "list should occupy several lines: {list:?}"
+    );
+}


### PR DESCRIPTION
## What changed

Fixes #737.

An auto-width inline-block without in-flow block children is built as a `NoWrap` flex row so that a short control shrink-fits to one max-content line (`dom.rs`, inline-block branch of the node builder). CSS shrink-to-fit is `min(max-content, available)` though, and nothing enforced the `available` half: when the max-content line is wider than the containing block the box simply overflowed. Wikipedia's `.cslist` — an `inline-block` `<ul>` of `inline-block` `<li>`s with `::after` commas — ran as one ~1000px line. Inside the infobox `<td>` that line became the table's min-content floor, so the `width:22em` table laid out at 641px instead of 310px and the article text beside the float collapsed to a few characters per line.

Two changes, both in `crates/obscura-render/src/dom.rs`:

- `wrap_overflowing_inline_blocks` — a post-preliminary-layout repair in the same chain as `repair_intrinsic_column_flex_negative_margins`: any such `NoWrap` inline-block whose margin box exceeds its parent's content box is switched to `Wrap`, and Taffy is re-run. Boxes that fit keep their single max-content line, so the two-word-button case the `NoWrap` approximation exists for is unchanged.
- The table sizing pass temporarily switches those inline-blocks to `Wrap` while measuring the table's and each cell's **min-content** width (`nowrap_inline_block_rows` / `set_flex_wrap`), then restores `NoWrap` for the max-content and final passes. Without this the table floor is computed before the repair can run.

## Validation

- New test `overflowing_inline_block_list_wraps_inside_its_container` in `tests/layout_test.rs`: the list stays ≤352px and wraps onto several lines (was 1023px on one line).
- `cargo test -p obscura-render --test layout_test`: same 11 pre-existing failures as `main` on this machine, +1 pass. Note that on this machine `main` already fails `table_width_uses_local_space_and_keeps_width_hints_shrinkable` (a `<table style="width:300px">` lays out at the viewport width in the unit harness), so I could not assert the table half of the fix in the harness; it is validated end-to-end below.
- End-to-end through an embedding host, `https://en.wikipedia.org/wiki/Rust_(programming_language)` at 1280×900: `.infobox` 641px → **310px**. Chrome on the same page/viewport: `309.76px` (`22em` at the infobox's 14.08px computed font-size — the 352px figure in the issue assumed a 16px root). Article text flows normally beside the float.
- Fixture matrix (all now 352px wide, wrapping): inline-block `ul`/`li` with and without `::after`; `inline` `li`; `div`/`span` equivalents; the same list inside a `width:352px` table (was 1000px).

## Rendering

Layout only. Fixture, viewport 1280×900, DSF 1:

```html
<style>ul{display:inline-block;margin:0;padding:0;list-style:none} li{display:inline-block;padding-right:.25em} li:after{content:", "}</style>
<div style="width:352px"><ul><li>Alef</li><li>BETA</li>…17 items…</ul></div>
<table style="width:352px"><tr><td><ul>…same list…</ul></td></tr></table>
```

Before: `ul` 1023×20 (one line, overflowing), table 1000px. After: `ul` 352×74, table 352px.

## Performance

The repair pass is one `id_map` scan plus a style read per node, and triggers a relayout only when an overflowing inline-block exists (previously a mis-rendered page). The table path adds two `set_style` sweeps over the inline-block set per min-content measurement; that set is usually empty or tiny. No hot-path change otherwise.

## Checklist

- [x] The change is focused and does not remove existing behavior without justification.
- [x] Tests cover the failure or feature.
- [x] Existing tests pass, including render and no-render configurations when affected. (Same pre-existing failure set as `main`.)
- [x] I checked for CPU, latency, and memory regressions.
- [x] Public API or user-facing behavior changes are documented. (No API change.)
