### PR TITLE
fix(js): keep page task errors from killing the event loop (#699)

### DIFF
--- a/crates/obscura-browser/src/page.rs
+++ b/crates/obscura-browser/src/page.rs
@@ -1763,8 +1763,17 @@ impl Page {
                     }
                 }
                 Ok(Err(error)) => {
-                    tracing::warn!("load-delaying dynamic script event loop failed: {error}");
-                    return false;
+                    if obscura_js::runtime::is_fatal_event_loop_error(&error) {
+                        tracing::warn!("load-delaying dynamic script event loop failed: {error}");
+                        return false;
+                    }
+                    // A load-delaying script threw or left an unhandled
+                    // rejection. Chrome reports the error and runs the rest;
+                    // killing the pump would strand every still-pending script
+                    // (#699). The absolute deadline above bounds a page that
+                    // errors on every turn.
+                    tracing::warn!("load-delaying script task error, continuing: {error}");
+                    tokio::task::yield_now().await;
                 }
                 Err(_) => {
                     // This timeout only cancels a parked event-loop poll. The

--- a/crates/obscura-js/src/runtime.rs
+++ b/crates/obscura-js/src/runtime.rs
@@ -87,6 +87,18 @@ fn panic_payload_message(payload: &(dyn std::any::Any + Send)) -> &str {
         .unwrap_or("unknown panic")
 }
 
+/// Whether an event-loop task error is fatal to the page or page-local noise.
+/// deno_core reports a task's uncaught exception and an unhandled promise
+/// rejection as an event-loop error, but a browser treats both as page-local:
+/// window.onerror / unhandledrejection fire and later tasks still run. Only
+/// engine-level failures (watchdog termination, the heap cap, an exhausted
+/// task budget) make the loop itself unusable. (#699)
+pub fn is_fatal_event_loop_error(error: &str) -> bool {
+    error.contains("execution terminated")
+        || error.contains("heap limit exceeded")
+        || error.contains("task budget")
+}
+
 #[cfg(feature = "render")]
 fn with_sync_render_loading_disabled<R>(
     state: &mut ObscuraState,
@@ -304,6 +316,7 @@ impl ObscuraJsRuntime {
             let _create_guard = ISOLATE_CREATE_LOCK
                 .lock()
                 .unwrap_or_else(|poisoned| poisoned.into_inner());
+
 
             let mut runtime = JsRuntime::new(RuntimeOptions {
                 extensions: vec![build_extension()],
@@ -2439,7 +2452,17 @@ impl ObscuraJsRuntime {
                     self.runtime.v8_isolate().perform_microtask_checkpoint();
                     tokio::task::yield_now().await;
                 }
-                Ok(Err(error)) => break Err(error),
+                Ok(Err(error)) => {
+                    if is_fatal_event_loop_error(&error) {
+                        break Err(error);
+                    }
+                    // A page task threw or a promise rejected without a
+                    // handler. Chrome reports it and keeps scheduling; the
+                    // pump must do the same, or one throwing script starves
+                    // every later task (#699). The wall deadline above still
+                    // bounds a page that errors on every turn.
+                    tracing::warn!("page task error, continuing the event loop: {error}");
+                }
                 Err(_) => break Ok(()),
             }
         };
@@ -2555,6 +2578,15 @@ impl ObscuraJsRuntime {
             }
             match tick {
                 std::task::Poll::Ready(Ok(())) => std::task::Poll::Ready(Ok(true)),
+                // A page task error (uncaught exception, unhandled rejection)
+                // is page-local in a browser: log it, report one delivered
+                // task, and let the owner keep pumping (#699).
+                std::task::Poll::Ready(Err(error))
+                    if !is_fatal_event_loop_error(&error.to_string()) =>
+                {
+                    tracing::warn!("page task error, continuing the event loop: {error}");
+                    std::task::Poll::Ready(Ok(false))
+                }
                 std::task::Poll::Ready(Err(error)) => std::task::Poll::Ready(Err(format!(
                     "Event loop error: {error}"
                 ))),
@@ -2694,6 +2726,11 @@ impl ObscuraJsRuntime {
             match tick {
                 Ok(Ok(true)) => break Ok(()),
                 Ok(Ok(false)) | Err(_) => {}
+                // A page task error is page-local noise, not a reason to stop
+                // settling: later timers and fetches still run (#699).
+                Ok(Err(error)) if !is_fatal_event_loop_error(&error) => {
+                    tracing::warn!("page task error, continuing the event loop: {error}");
+                }
                 Ok(Err(error)) => break Err(error),
             }
         };
@@ -16741,4 +16778,31 @@ mod tests {
             .unwrap();
         assert_eq!(result, serde_json::json!("writer,one,two"));
     }
+
+    /// #699: an unhandled rejection from a failed dynamic import is page-local
+    /// noise in a browser. The bounded event loop must report it and keep
+    /// driving later tasks instead of dying on the error and starving every
+    /// pending timer.
+    #[tokio::test(flavor = "current_thread")]
+    async fn unhandled_rejection_does_not_starve_later_tasks() {
+        let mut rt = setup_runtime("<html><body></body></html>");
+        rt.evaluate(
+            "(function() { \
+                import('http://192.0.0.1/unreachable-module.js'); \
+                globalThis.__t = false; \
+                setTimeout(() => { globalThis.__t = true; }, 5); \
+                return 'ok'; \
+            })()",
+        )
+        .unwrap();
+        rt.run_event_loop_bounded(2_000)
+            .await
+            .expect("the pump must survive a page-local rejection");
+        assert_eq!(
+            rt.evaluate("globalThis.__t").unwrap(),
+            serde_json::json!(true),
+            "the pending timer must still fire after a page task error"
+        );
+    }
 }
+


### PR DESCRIPTION
A script exception or unhandled promise rejection reached the event-loop drivers as a fatal error, so one throwing page script starved every later task (pending dynamic scripts, timers). Chrome reports the error and keeps scheduling. The bounded, quiescent, autonomous, and load-delaying script pumps now log the page-local error and continue; watchdog termination, the heap cap, and an exhausted task budget stay fatal.

Fixes #699.

## What changed

`run_event_loop_bounded`, `run_event_loop_until_quiescent`, `run_autonomous_event_loop_turn` (runtime.rs) and `drive_load_delaying_scripts` (page.rs) broke out of the pump on any event-loop task error. deno_core reports a task's uncaught exception and an unhandled rejection the same way, so one throwing `JSON.parse` in an obfuscated bundle ended script processing for the page: on the reporter's site the device-fingerprint SDK was never inserted. A shared `is_fatal_event_loop_error` classifier keeps engine-level failures (watchdog termination, heap limit, task budget) fatal and treats page-local errors as log-and-continue, bounded by the existing deadlines.

## Validation

• Reproduced on a minimal page: a dynamically inserted script doing a failing `import()` plus a 5ms `setTimeout`. Before: the pump returned `Err("Event loop error: Uncaught (in promise) ...")` and the timer never fired. After: timer fires, error logged as a warning.
• New regression test `runtime::tests::unhandled_rejection_does_not_starve_later_tasks`: red on the old code, green with the fix. `cargo nextest run --release --features render -p obscura-js unhandled_rejection`
• Full suite: `cargo nextest run --release --features render --no-fail-fast` -> 1508 passed, 0 failed, 4 skipped.
• Obstacle course: `OBSCURA_BIN=./target/release/obscura python3 obstacle-course/run.py --runs 1 --warmup 0` -> 33/33.

## Rendering

Not applicable.

## Performance

The change only touches the error path of the event-loop pumps; successful pages run the identical turn sequence. A pathological page that throws on every task now runs until the existing deadlines (`OBSCURA_SCRIPT_DEADLINE_MS`, settle budgets) instead of stopping early, which is the intended Chrome-like behavior and remains bounded. No hot-path, memory, or rendering changes.

## Checklist

• [x] The change is focused and does not remove existing behavior without justification.
• [x] Tests cover the failure or feature.
• [x] Existing tests pass, including render and no-render configurations when affected.
• [x] I checked for CPU, latency, and memory regressions.
• [x] Public API or user-facing behavior changes are documented.