### PR TITLE
fix(js): pin the ICU default locale to en-US (#734)

### DIFF
--- a/crates/obscura-js/src/runtime.rs
+++ b/crates/obscura-js/src/runtime.rs
@@ -317,6 +317,14 @@ impl ObscuraJsRuntime {
                 .lock()
                 .unwrap_or_else(|poisoned| poisoned.into_inner());
 
+            // ICU falls back to the host OS locale when no default is set,
+            // so Intl.* formats and resolvedOptions().locale leaked the
+            // operator's real locale (an en-AU host showed en-AU) while
+            // navigator.language and Accept-Language say en-US. Pin the one
+            // locale the other surfaces claim (#734). Process-global and
+            // idempotent; setting it under the create lock guarantees it
+            // lands before the first isolate exists.
+            deno_core::v8::icu::set_default_locale("en-US");
 
             let mut runtime = JsRuntime::new(RuntimeOptions {
                 extensions: vec![build_extension()],
@@ -16804,5 +16812,28 @@ mod tests {
             "the pending timer must still fire after a page task error"
         );
     }
+
+    /// #734: ICU inherits the host OS locale when no default is set, so
+    /// Intl.resolvedOptions() contradicted navigator.language on any host
+    /// whose OS locale is not en-US. The pinned default must win.
+    #[test]
+    fn intl_locale_matches_navigator_language_regardless_of_host() {
+        // nextest runs each test in its own process, so setting the process
+        // locale here cannot race another test's V8 init.
+        std::env::set_var("LC_ALL", "de-DE");
+        std::env::set_var("LANG", "de-DE");
+        let mut rt = setup_runtime("<html><body></body></html>");
+        let result = rt
+            .evaluate(
+                "Intl.DateTimeFormat().resolvedOptions().locale + '|' + navigator.language",
+            )
+            .unwrap();
+        assert_eq!(
+            result,
+            serde_json::json!("en-US|en-US"),
+            "Intl must not leak the host OS locale while navigator.language says en-US"
+        );
+    }
 }
+
 


### PR DESCRIPTION
ICU falls back to the host OS locale when no default is set, so Intl formatting and `resolvedOptions().locale` leaked the operator's real locale (an en-AU host reported en-AU) while `navigator.language` and `Accept-Language` say en-US. The default locale is now pinned to en-US at isolate creation, so every locale surface tells the same story.

Fixes #734.

## What changed

`ObscuraJsRuntime::with_base_url_and_proxy` calls `v8::icu::set_default_locale("en-US")` under the process-wide isolate-creation lock before the first isolate exists. The call is process-global and idempotent, so repeated page creation is unaffected. The pinned value matches the hardcoded `navigator.language` / `navigator.languages` in bootstrap.js and the default `Accept-Language` header.

## Validation

• Reproduced the leak: `LC_ALL=de_DE.UTF-8 obscura fetch "data:text/html,<p>x</p>" --eval "Intl.DateTimeFormat().resolvedOptions().locale"` printed `de-DE` before the fix and prints `en-US` after, with US date formatting (`1/31/2026`).
• New regression test `runtime::tests::intl_locale_matches_navigator_language_regardless_of_host` sets a non-en-US process locale and asserts Intl and navigator agree: `cargo nextest run --release --features render -p obscura-js intl_locale`
• Full suite: `cargo nextest run --release --features render --no-fail-fast` -> all green (run together with the #699 branch).
• Obstacle course 33/33.

## Rendering

Not applicable.

## Performance

One process-global ICU call per runtime construction, before isolate creation. No runtime path is affected after startup.

## Checklist

• [x] The change is focused and does not remove existing behavior without justification.
• [x] Tests cover the failure or feature.
• [x] Existing tests pass, including render and no-render configurations when affected.
• [x] I checked for CPU, latency, and memory regressions.
• [x] Public API or user-facing behavior changes are documented.