### PR TITLE
js: read XHR response bodies as bytes, not through text()

### DIFF
--- a/crates/obscura-js/js/bootstrap.js
+++ b/crates/obscura-js/js/bootstrap.js
@@ -7104,8 +7104,21 @@ globalThis.XMLHttpRequest = class XMLHttpRequest extends XMLHttpRequestEventTarg
 
       xhr._setReadyState(2); // HEADERS_RECEIVED
 
-      const text = await resp.text();
+      // Read the body as bytes, ALWAYS. Going through resp.text() and then
+      // TextEncoder().encode() for the binary responseTypes is not a
+      // round-trip: the decode is lossy for anything that is not valid UTF-8,
+      // so bytes >= 0x80 come back re-encoded as the UTF-8 of whatever code
+      // point they decoded to, and the length changes with the content.
+      // Emscripten loaders fetch .wasm and data files this way, so they saw
+      // corrupted assets while fetch() was byte-correct.
+      const buffer = await resp.arrayBuffer();
       if (xhr._aborted) return;
+
+      const wantsText = xhr.responseType === '' || xhr.responseType === 'text'
+                     || xhr.responseType === 'json' || xhr.responseType === 'document';
+      // Decoding a multi-megabyte binary body into a string nobody reads is
+      // pure waste, and responseText is not defined for the binary types.
+      const text = wantsText ? new TextDecoder().decode(buffer) : '';
 
       xhr.responseText = text;
       xhr._setReadyState(3); // LOADING
@@ -7119,10 +7132,10 @@ globalThis.XMLHttpRequest = class XMLHttpRequest extends XMLHttpRequestEventTarg
           xhr.response = text;
           break;
         case 'arraybuffer':
-          xhr.response = new TextEncoder().encode(text).buffer;
+          xhr.response = buffer;
           break;
         case 'blob':
-          xhr.response = new Blob([text]);
+          xhr.response = new Blob([buffer]);
           break;
         case 'document':
           xhr.response = text; // simplified

--- a/crates/obscura/tests/xhr_binary_response.rs
+++ b/crates/obscura/tests/xhr_binary_response.rs
@@ -1,0 +1,126 @@
+//! XMLHttpRequest with `responseType = 'arraybuffer'` must return the response
+//! bytes unchanged.
+//!
+//! XHR is implemented over fetch and used to read every body with
+//! `resp.text()`, then rebuild the binary response types from that string.
+//! `text()` -> `TextEncoder().encode()` is not a round-trip: a lenient UTF-8
+//! decode treats any high byte as a lead byte, so `82 83` becomes U+0083 and
+//! re-encodes as `c2 83`. Every byte >= 0x80 was rewritten and the length
+//! changed with the content, while `fetch()` — which never took that detour —
+//! was correct.
+//!
+//! The fixture is 256 bytes holding every byte value, so a lossy path cannot
+//! coincidentally survive it, and the assertion is on the bytes rather than
+//! only the length: a same-length corruption would otherwise pass.
+
+use std::io::{Read, Write};
+
+use obscura::Browser;
+
+/// Serve `/bytes.bin` as the 256 values 0x00..=0xFF, and anything else as a
+/// page to run the probe from.
+fn spawn_server() -> String {
+    let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+    let addr = listener.local_addr().unwrap();
+    std::thread::spawn(move || {
+        for incoming in listener.incoming() {
+            let Ok(mut stream) = incoming else { continue };
+            std::thread::spawn(move || {
+                let mut buf = [0u8; 4096];
+                let n = stream.read(&mut buf).unwrap_or(0);
+                let request = String::from_utf8_lossy(&buf[..n]);
+                let target = request.split_whitespace().nth(1).unwrap_or("").to_string();
+
+                let (content_type, body): (&str, Vec<u8>) = if target.starts_with("/bytes.bin") {
+                    ("application/octet-stream", (0u8..=255).collect())
+                } else {
+                    (
+                        "text/html",
+                        b"<!doctype html><html><head><title>fixture</title></head><body></body></html>"
+                            .to_vec(),
+                    )
+                };
+                let head = format!(
+                    "HTTP/1.1 200 OK\r\nContent-Type: {}\r\nContent-Length: {}\r\nAccess-Control-Allow-Origin: *\r\nConnection: close\r\n\r\n",
+                    content_type,
+                    body.len(),
+                );
+                let _ = stream.write_all(head.as_bytes());
+                let _ = stream.write_all(&body);
+                let _ = stream.shutdown(std::net::Shutdown::Both);
+            });
+        }
+    });
+    format!("http://{}", addr)
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn xhr_arraybuffer_returns_the_response_bytes_unchanged() {
+    std::env::set_var("OBSCURA_ALLOW_PRIVATE_NETWORK", "1");
+    let base = spawn_server();
+
+    let browser = Browser::new().unwrap();
+    let mut page = browser.new_page().await.unwrap();
+    page.goto(&format!("{base}/page")).await.unwrap();
+
+    page.evaluate(
+        r#"(function () {
+            var out = document.createElement('pre');
+            out.id = 'probe-results';
+            document.body.appendChild(out);
+            function done(v) {
+                out.textContent = JSON.stringify(v);
+                document.body.setAttribute('data-done', '1');
+            }
+            var x = new XMLHttpRequest();
+            x.open('GET', 'bytes.bin', true);
+            x.responseType = 'arraybuffer';
+            x.onload = function () {
+                var u8 = new Uint8Array(x.response);
+                done({ length: u8.length, bytes: Array.prototype.slice.call(u8) });
+            };
+            x.onerror = function () { done({ error: 'xhr failed' }); };
+            x.send();
+        })()"#,
+    );
+
+    for _ in 0..40 {
+        page.settle(250).await;
+        if page.evaluate("document.body.getAttribute('data-done')") == serde_json::json!("1") {
+            break;
+        }
+    }
+    assert_eq!(
+        page.evaluate("document.body.getAttribute('data-done')"),
+        serde_json::json!("1"),
+        "the XHR never completed"
+    );
+
+    let raw = page.evaluate("document.getElementById('probe-results').textContent");
+    let result: serde_json::Value =
+        serde_json::from_str(raw.as_str().unwrap_or("")).unwrap_or(serde_json::Value::Null);
+
+    assert!(result["error"].is_null(), "probe reported {:?}", result["error"]);
+    assert_eq!(
+        result["length"].as_u64(),
+        Some(256),
+        "expected all 256 bytes, got {:?} — a lossy text round-trip changes the length",
+        result["length"]
+    );
+
+    let got: Vec<u64> = result["bytes"]
+        .as_array()
+        .expect("probe returned no bytes")
+        .iter()
+        .map(|b| b.as_u64().unwrap_or(u64::MAX))
+        .collect();
+    let expected: Vec<u64> = (0..=255).collect();
+    let first_diff = got.iter().zip(&expected).position(|(a, b)| a != b);
+    assert!(
+        first_diff.is_none(),
+        "byte {} differs: expected {:?}, got {:?}",
+        first_diff.unwrap(),
+        expected.get(first_diff.unwrap()),
+        got.get(first_diff.unwrap()),
+    );
+}


### PR DESCRIPTION
Fixes #754.

`XMLHttpRequest` is implemented over `fetch` and read every response with
`resp.text()` before choosing a `responseType`, so the binary types were rebuilt
from a string:

```js
case 'arraybuffer': xhr.response = new TextEncoder().encode(text).buffer;
case 'blob':        xhr.response = new Blob([text]);
```

`text()` → `TextEncoder().encode()` is not a round-trip for bytes that are not
valid UTF-8. A lenient decode treats any high byte as a lead byte, so `82 83`
becomes U+0083 and re-encodes as `c2 83` — every byte ≥ `0x80` is rewritten and
the length changes with the content. `fetch()` was unaffected because it never
took that detour, which is why this hid: ASCII bodies, and therefore all JSON
and text over XHR, are untouched.

## The change

Read the body once as an `ArrayBuffer` and decode to text only for the text-ish
response types.

`blob` had the same bug and is fixed with it. Not decoding the body for the
binary types also avoids building a multi-megabyte string that nothing reads;
`responseText` is not defined for those types, so it is left `''` rather than
throwing — the conservative option, but say if you would rather it threw.

## Test

`crates/obscura/tests/xhr_binary_response.rs` serves a 256-byte fixture holding
every byte value and asserts on the bytes, not just the length — a same-length
corruption would otherwise pass. Confirmed to fail without the fix:

```
expected all 256 bytes, got Number(255) — a lossy text round-trip changes the length
```

## Before / after

```
before   fetch len 256 | xhr len 255 | diverge at 128
after    fetch len 256 | xhr len 256 | diverge at 256      (matches Chrome 147)
```

On a real 4,196,020-byte asset, XHR returned 4,118,955 bytes with a corrupted
header; it is now byte-exact. This matters beyond the obvious, because
Emscripten's generated loader fetches `.wasm` and data files with
`XMLHttpRequest` + `responseType='arraybuffer'` rather than `fetch()` — so WASM
applications were loading corrupted assets and failing far from the cause. One
that previously aborted on a nonsense allocation derived from a mangled header
now starts and runs, rendering to a 2D canvas and responding to
`Input.dispatchKeyEvent`.

Related to #716, which covers binary **request** bodies and the CDP fulfill
path. This is the response side of XHR and a separate code path, though likely
the same underlying habit of reaching for `String` where `Vec<u8>` belongs.
