### PR TITLE
render: keep a float's percentage width when it has a percentage margin

### DIFF
--- a/crates/obscura-render/src/dom.rs
+++ b/crates/obscura-render/src/dom.rs
@@ -13605,7 +13605,6 @@ fn clear_matches_float_sides(clear: crate::Clear, has_left: bool, has_right: boo
 
 fn has_deferred_or_auto_margin(style: &crate::LayoutStyle) -> bool {
     style.margin_auto.iter().any(|value| *value)
-        || style.margin_percent.iter().any(Option::is_some)
         || style.margin_relative.iter().any(Option::is_some)
         || style.margin_expressions.iter().any(Option::is_some)
 }

--- a/crates/obscura-render/tests/layout_test.rs
+++ b/crates/obscura-render/tests/layout_test.rs
@@ -4471,3 +4471,49 @@ fn grid_ordinary_aspect_ratio_preserves_normal_alignment_provenance() {
     assert_eq!(size("parent-align-stretch"), (400.0, 200.0));
     assert_eq!(size("parent-justify-stretch"), (300.0, 150.0));
 }
+
+/// A float with a percentage width must keep that width when it also carries a
+/// percentage margin. It used to be disqualified from the native float band by
+/// `has_deferred_or_auto_margin`, fall onto the synthetic float-zone path, and
+/// shrink to its content width — taking the row's height to zero with it, so
+/// following flow content was painted over the float.
+///
+/// This is exactly the Bootstrap 3 grid: `.col-*-N` is `float:left` plus a
+/// percentage width, and `.col-*-offset-M` adds the percentage margin.
+#[test]
+fn a_float_keeps_its_percentage_width_when_it_has_a_percentage_margin() {
+    let tree = parse_html(include_str!(
+        "../../../render-repros/float-percentage-margin.html"
+    ));
+    let layout = layout_dom(&tree, (1400.0, 1000.0));
+    let rect = |id| layout.rects[&tree.get_element_by_id(id).unwrap()];
+
+    let offset = rect("offset");
+    let plain = rect("plain");
+    let row = rect("row-offset");
+
+    // 83.33333333% of the 1200px row, offset by 8.33333333% of it.
+    assert!(
+        (offset.width - 1000.0).abs() < 1.0,
+        "offset column should be 1000px wide, got {}",
+        offset.width
+    );
+    assert!(
+        (offset.x - 100.0).abs() < 1.0,
+        "offset column should start at x=100, got {}",
+        offset.x
+    );
+    // The margin must not change the width.
+    assert!(
+        (offset.width - plain.width).abs() < 1.0,
+        "a percentage margin changed the width: {} vs {}",
+        offset.width,
+        plain.width
+    );
+    // The clearfixed row must still contain the float rather than collapsing,
+    // or whatever follows is laid out on top of it.
+    assert!(
+        row.height > 0.0,
+        "the row collapsed to zero height around its float"
+    );
+}

--- a/render-repros/float-percentage-margin.html
+++ b/render-repros/float-percentage-margin.html
@@ -1,0 +1,19 @@
+<!doctype html>
+<html><head><meta charset="utf-8"><title>float with a percentage margin</title>
+<style>
+  body { margin: 0 }
+  /* Bootstrap 3's grid shape: a floated column with a percentage width and a
+     percentage offset margin, inside a clearfixed row. */
+  .row { width: 1200px }
+  .row:before, .row:after { content: " "; display: table }
+  .row:after { clear: both }
+  #offset { float: left; width: 83.33333333%; margin-left: 8.33333333% }
+  #plain  { float: left; width: 83.33333333% }
+  #inner  { width: 300px; height: 40px }
+  #after  { height: 20px }
+</style></head>
+<body>
+  <div class="row" id="row-offset"><div id="offset"><div id="inner">offset</div></div></div>
+  <div class="row" id="row-plain"><div id="plain"><div>plain</div></div></div>
+  <div id="after">after</div>
+</body></html>


### PR DESCRIPTION
Fixes #757.

`can_use_native_float_band` rejects any float carrying a percentage margin, via
`has_deferred_or_auto_margin`. The container then falls back to the synthetic
float-zone path, where the float's percentage width is not resolved against the
containing block — so it shrinks to its content width, and the row collapses to
zero height around it, leaving following flow content painted over the float.

Percentage margins are resolved during layout like any other percentage, so
they do not need to disqualify the native band. Auto, relative and functional
margins still do.

## The change

One line: drop `margin_percent` from `has_deferred_or_auto_margin`.

```
  float + width:83.33%                       1333  ->  1333   (unchanged)
  float + width:83.33% + margin-left:8.33%    420  ->  1334
  row height around that float                  0  ->    19
```

Chrome 147 gives 1333 for both and a non-zero row in every case.

## Why it matters

This is the Bootstrap 3 grid — `.col-*-N` is `float:left` plus a percentage
width, `.col-*-offset-M` adds the percentage margin. Measured on a real
Bootstrap 3 admin at a 1600px viewport, walking up from a form field, every
ancestor agreed until the grid column:

```
                                Chrome    before    after
DIV.row                         w=1600    w=1600    w=1600
DIV.col-sm-10.col-sm-offset-1   w=1333    w=445     w=1334
DIV.row height                  353       0         352
```

Before, the page's centred panel landed at x=190 instead of x=615, `body`
measured 450px tall instead of 806, and a block that should follow the row was
painted over the login form — `elementFromPoint` at the field returned that
block rather than the input, so coordinate-based clicks hit the wrong element.
All four now match Chrome.

## Test

`render-repros/float-percentage-margin.html` plus a layout test asserting the
width, the offset, that the margin does not change the width, and that the row
does not collapse. Without the change it fails with:

```
offset column should be 1000px wide, got 333
```

`cargo test -p obscura-render --test layout_test` goes 96 passed / 11 failed on
`main` to 97 passed / 11 failed here — the same 11, which were already failing
before this change.
