### PR TITLE
render: size percentage-width table columns instead of leaving them at max-content

### DIFF
--- a/crates/obscura-render/src/dom.rs
+++ b/crates/obscura-render/src/dom.rs
@@ -6156,6 +6156,20 @@ fn layout_dom_once(
 
         let deferred_cyclic_inline_sizes =
             defer_cyclic_flex_inline_sizes(tree, &mut styles, root_fs, vw, vh);
+        // A percentage inline size inside a flex item is cyclic, so it is
+        // neutralized to `0px` for the intrinsic measuring pass and restored
+        // once the item's used size is known. The table used-width pass runs
+        // between those two points and must read the pending percentage
+        // rather than the `0px` placeholder, or a `width:100%` table sizes its
+        // columns to max-content and keeps them after the box is stretched.
+        let deferred_percent_widths: HashMap<NodeId, f32> = deferred_cyclic_inline_sizes
+            .iter()
+            .filter(|entry| entry.slot == 0)
+            .filter_map(|entry| match entry.source {
+                DeferredCyclicInlineSource::Percent(percent) => Some((entry.node, percent)),
+                DeferredCyclicInlineSource::Expression(_) => None,
+            })
+            .collect();
 
         if let Some(taffy_root) = build(
             tree,
@@ -6247,9 +6261,16 @@ fn layout_dom_once(
                     }
                     let group = &tables[table_index..group_end];
                     let mut available_widths: HashMap<taffy::NodeId, f32> = HashMap::new();
+                    let effective_width = |dom: &NodeId, style: &crate::LayoutStyle| {
+                        deferred_percent_widths
+                            .get(dom)
+                            .map(|percent| crate::Dimension::Percent(*percent))
+                            .unwrap_or(style.width)
+                    };
                     let needs_layout_snapshot = group.iter().any(|(_, dom, _)| {
                         styles.get(dom).is_some_and(|style| {
-                            (style.width == crate::Dimension::Auto
+                            let style_width = effective_width(dom, style);
+                            (style_width == crate::Dimension::Auto
                                 && (depth > 0
                                     || reliable_table_available_width(
                                         tree,
@@ -6258,8 +6279,16 @@ fn layout_dom_once(
                                         initial_cb_width,
                                     )
                                     .is_none()))
-                                || (style.table_layout_fixed
-                                    && matches!(style.width, crate::Dimension::Percent(_)))
+                                || (matches!(style_width, crate::Dimension::Percent(_))
+                                    && (style.table_layout_fixed
+                                        || depth > 0
+                                        || reliable_table_available_width(
+                                            tree,
+                                            *dom,
+                                            &styles,
+                                            initial_cb_width,
+                                        )
+                                        .is_none()))
                         })
                     });
                     if needs_layout_snapshot {
@@ -6273,19 +6302,33 @@ fn layout_dom_once(
                             &mut measure,
                         );
                         for &(tnode, dom, _) in group {
-                            if styles
-                                .get(&dom)
-                                .is_some_and(|style| {
-                                    style.width == crate::Dimension::Auto
-                                        || (style.table_layout_fixed
-                                            && matches!(
-                                                style.width,
-                                                crate::Dimension::Percent(_)
-                                            ))
-                                })
-                            {
+                            let Some(style) = styles.get(&dom) else {
+                                continue;
+                            };
+                            let style_width = effective_width(&dom, style);
+                            if style_width == crate::Dimension::Auto {
                                 if let Ok(layout) = taffy_tree.layout(tnode) {
                                     available_widths.insert(tnode, layout.size.width.max(0.0));
+                                }
+                            } else if matches!(style_width, crate::Dimension::Percent(_)) {
+                                // A percentage resolves against the containing
+                                // block, so sample the parent's content box.
+                                // The table's own snapshot width is not usable
+                                // here: inside a flex/grid subtree the table has
+                                // just been measured at max-content, which is
+                                // the very collapse this pass exists to undo.
+                                let basis = taffy_tree
+                                    .parent(tnode)
+                                    .and_then(|parent| taffy_tree.layout(parent).ok())
+                                    .map(|layout| layout.content_box_width())
+                                    .or_else(|| {
+                                        taffy_tree
+                                            .layout(tnode)
+                                            .ok()
+                                            .map(|layout| layout.size.width)
+                                    });
+                                if let Some(basis) = basis {
+                                    available_widths.insert(tnode, basis.max(0.0));
                                 }
                             }
                         }
@@ -6294,6 +6337,7 @@ fn layout_dom_once(
                         let Some(table_style) = styles.get(&dom) else {
                             continue;
                         };
+                        let width_style = effective_width(&dom, table_style);
                         if let Some(columns) = ifc_items.fixed_table_cols.get(&tnode) {
                             let ncols = columns.len();
                             if ncols == 0 {
@@ -6301,7 +6345,7 @@ fn layout_dom_once(
                             }
                             let inline_outer_edges = table_inline_outer_edges(table_style);
                             let (horizontal_spacing, _) = table_spacing(table_style);
-                            let mut used_outer = match table_style.width {
+                            let mut used_outer = match width_style {
                                 crate::Dimension::Px(width)
                                     if table_style.box_sizing
                                         == crate::BoxSizing::ContentBox =>
@@ -6315,18 +6359,26 @@ fn layout_dom_once(
                                             .max(0.0)
                                 }
                                 crate::Dimension::Px(width) => width.max(0.0),
-                                crate::Dimension::Percent(_) => available_widths
-                                    .get(&tnode)
-                                    .copied()
-                                    .unwrap_or_else(|| {
-                                        reliable_table_available_width(
-                                            tree,
-                                            dom,
-                                            &styles,
-                                            initial_cb_width,
-                                        )
-                                        .unwrap_or(initial_cb_width)
-                                    }),
+                                // `available_widths` now holds the containing
+                                // block for every percentage table, so apply
+                                // the fraction rather than taking the basis as
+                                // the used width (which only ever agreed for
+                                // `width:100%`).
+                                crate::Dimension::Percent(fraction) => {
+                                    let basis = available_widths
+                                        .get(&tnode)
+                                        .copied()
+                                        .unwrap_or_else(|| {
+                                            reliable_table_available_width(
+                                                tree,
+                                                dom,
+                                                &styles,
+                                                initial_cb_width,
+                                            )
+                                            .unwrap_or(initial_cb_width)
+                                        });
+                                    (basis * fraction).max(0.0)
+                                }
                                 _ => continue,
                             };
                             let interior_spacing =
@@ -6360,12 +6412,14 @@ fn layout_dom_once(
                             }
                             continue;
                         }
-                        // A percentage-width table resolves against its container, so
-                        // leave taffy's percentage handling in place.
-                        let width_style = table_style.width;
-                        if matches!(width_style, crate::Dimension::Percent(_)) {
-                            continue;
-                        }
+                        // A percentage-width table resolves against its container.
+                        // Taffy can do that itself only when the containing
+                        // block is definite; inside a flex/grid subtree the
+                        // basis is indefinite while the parent is being
+                        // measured, and the grid then sizes every column to
+                        // max-content and never revisits them. Resolve the
+                        // percentage here and share the auto-width table's
+                        // column distribution below.
                         let min_c = {
                             let _ = taffy_tree.compute_layout_with_measure(
                                 tnode,
@@ -6408,15 +6462,6 @@ fn layout_dom_once(
                                 .unwrap_or(0.0)
                         };
                         let inline_outer_edges = table_inline_outer_edges(table_style);
-                        let preferred_outer = match width_style {
-                            crate::Dimension::Px(w)
-                                if table_style.box_sizing == crate::BoxSizing::ContentBox =>
-                            {
-                                w + inline_outer_edges
-                            }
-                            crate::Dimension::Px(w) => w,
-                            _ => max_c,
-                        };
                         let available_outer = available_widths
                             .get(&tnode)
                             .copied()
@@ -6429,11 +6474,30 @@ fn layout_dom_once(
                                 )
                             })
                             .unwrap_or(initial_cb_width);
+                        let preferred_outer = match width_style {
+                            crate::Dimension::Px(w)
+                                if table_style.box_sizing == crate::BoxSizing::ContentBox =>
+                            {
+                                w + inline_outer_edges
+                            }
+                            crate::Dimension::Px(w) => w,
+                            crate::Dimension::Percent(fraction) => {
+                                let resolved = (fraction * available_outer).max(0.0);
+                                if table_style.box_sizing == crate::BoxSizing::ContentBox {
+                                    resolved + inline_outer_edges
+                                } else {
+                                    resolved
+                                }
+                            }
+                            _ => max_c,
+                        };
                         let mut used_outer = match width_style {
                             // A definite table width is not clamped to its
                             // containing block. Like other fixed boxes it may
                             // overflow, while min-content can still make it wider.
-                            crate::Dimension::Px(_) => preferred_outer.max(min_c),
+                            crate::Dimension::Px(_) | crate::Dimension::Percent(_) => {
+                                preferred_outer.max(min_c)
+                            }
                             _ => preferred_outer.max(min_c).min(available_outer.max(min_c)),
                         };
                         let mut used_declaration =

--- a/crates/obscura-render/tests/layout_test.rs
+++ b/crates/obscura-render/tests/layout_test.rs
@@ -4471,3 +4471,74 @@ fn grid_ordinary_aspect_ratio_preserves_normal_alignment_provenance() {
     assert_eq!(size("parent-align-stretch"), (400.0, 200.0));
     assert_eq!(size("parent-justify-stretch"), (300.0, 150.0));
 }
+
+/// A `width:100%` table nested two or more flex containers deep must still
+/// distribute its used width across the columns.
+///
+/// A percentage inline size inside a flex item is cyclic, so it is neutralized
+/// to `0px` while the item is measured intrinsically and restored once the used
+/// size is known. The table used-width pass runs between those two points; when
+/// it read the `0px` placeholder it sized every column to max-content and never
+/// revisited them, so the table box stretched to 100% while the columns kept a
+/// max-content sum (a Bootstrap admin table filled 821px of 1518px). One flex
+/// level did not reproduce it, because only a nested item defers the size.
+#[cfg(feature = "paint")]
+#[test]
+fn percentage_table_in_nested_flex_distributes_columns() {
+    const CELLS: &str = "<thead><tr><th>Title</th><th>Type</th><th>Status</th></tr></thead>\
+        <tbody><tr><td id=c1>Homepage</td><td id=c2>Page</td><td id=c3>Live</td></tr></tbody>";
+    let style = "<style>body{margin:0;font:14px sans-serif}.fx{display:flex}\
+        table{width:100%;border-collapse:collapse}td,th{border:1px solid #999;padding:4px}</style>";
+
+    for depth in 0..=3 {
+        let html = format!(
+            "{style}{open}<div id=host style='width:1000px'><table id=t>{CELLS}</table></div>{close}",
+            open = "<div class=fx>".repeat(depth),
+            close = "</div>".repeat(depth),
+        );
+        let tree = parse_html(&html);
+        let layout = layout_dom(&tree, (1600.0, 1000.0));
+        let width = |id| layout.rects[&tree.get_element_by_id(id).unwrap()].width;
+
+        assert!(
+            (width("t") - 1000.0).abs() < 1.0,
+            "depth {depth}: table box should be 100% of its 1000px container, got {}",
+            width("t")
+        );
+        let cells = [width("c1"), width("c2"), width("c3")];
+        let sum: f32 = cells.iter().sum();
+        assert!(
+            (sum - 1000.0).abs() < 2.0,
+            "depth {depth}: columns should fill the table, got {cells:?} summing to {sum}"
+        );
+        // Chromium 147 gives 453/244/303: the surplus follows each column's
+        // max-content width, so the prose column stays the widest.
+        assert!(
+            cells[0] > cells[1] && cells[0] > cells[2] && cells[0] > 400.0,
+            "depth {depth}: surplus should follow content width, got {cells:?}"
+        );
+    }
+}
+
+/// Surplus table width is shared in proportion to each column's max-content
+/// width (CSS 2.1 17.5.2.2), not equally. A `width:100%` table used to skip the
+/// used-width pass entirely and fall back to the grid's equal share, which
+/// starved a wide prose column to feed one-character columns.
+#[cfg(feature = "paint")]
+#[test]
+fn percentage_table_surplus_follows_column_content_width() {
+    let html = "<style>body{margin:0;font:14px sans-serif}\
+        table{width:100%;border-collapse:collapse}td{border:1px solid #999;padding:4px}</style>\
+        <div style='width:1000px'><table id=t><tbody><tr>\
+        <td id=c1>A very much longer piece of column content here</td>\
+        <td id=c2>Mid</td><td id=c3>X</td></tr></tbody></table></div>";
+    let tree = parse_html(html);
+    let layout = layout_dom(&tree, (1600.0, 1000.0));
+    let width = |id| layout.rects[&tree.get_element_by_id(id).unwrap()].width;
+    let cells = [width("c1"), width("c2"), width("c3")];
+    // Chromium 147 gives 861/87/51; an equal split would be about 333 each.
+    assert!(
+        cells[0] > 800.0 && cells[1] < 150.0 && cells[2] < 120.0,
+        "surplus should follow max-content widths, got {cells:?}"
+    );
+}


### PR DESCRIPTION
### What

A `width:100%` table returned early from the table used-width pass, so its columns never got the CSS 2.1 [17.5.2.2](https://www.w3.org/TR/CSS21/tables.html#auto-table-layout) treatment and fell back to the grid's equal share of the surplus. Two symptoms, one guard:

**1. Surplus split equally instead of by content width.** Three columns in a 1000px block:

| | col 1 (long prose) | col 2 | col 3 (`X`) |
|---|---|---|---|
| Chromium 147 | 861 | 87 | 51 |
| before | 526 | 243 | 231 |
| after | 856 | 90 | 54 |

A one-character column was taking 231px.

**2. Columns stuck at max-content inside nested flex.** A percentage inline size inside a flex item is cyclic, so it is neutralized to `0px` while the item is measured intrinsically and restored once the used size is known. The table pass runs between those two points and read the `0px` placeholder: it sized every column to max-content and never revisited them, so the box stretched to 100% while the columns kept a max-content sum.

```html
<div style="display:flex"><div style="display:flex">
  <div style="width:1000px">
    <table style="width:100%"><thead><tr><th>Title</th><th>Type</th><th>Status</th></tr></thead>
    <tbody><tr><td>Homepage</td><td>Page</td><td>Live</td></tr></tbody></table>
  </div>
</div></div>
```

Table box 1000px in both engines; columns `453,244,303` in Chromium, `79,43,53` here — a sum of 175. It needs **two** nested flex levels, because only a nested item defers its size; one level and the same markup directly under `<body>` were both fine, which is what made it look like a table bug rather than a deferral one.

On a Bootstrap admin page this is very visible: a `.table` filled 821px of its 1518px box, and the identical table cloned under `<body>` laid out correctly.

### Fix

Resolve the percentage in the table pass instead of returning early: read the pending percentage for deferred nodes, resolve it against the parent's content box, and share the auto-width column distribution.

The fixed-layout branch needed a matching change. It treated the snapshot as the table's own already-resolved width, which only ever agreed for `width:100%`; now that the snapshot is uniformly the containing block, it applies the fraction. Without that, `fixed_percentage_table_resolves_tracks_against_final_used_width` fails (a `width:50%` table came out 800 instead of 400).

### Verification

Real admin table, same page, against Chromium 147:

| | table | columns | sum |
|---|---|---|---|
| Chromium 147 | 1518 | 696, 252, 143, 179, 248 | 1518 |
| before | 1518 | 450, 42, 76, 93, 160 | **821** |
| after | 1518 | 701, 253, 145, 170, 249 | 1518 |

Two regression tests added, both failing without the change. `cargo test -p obscura-render --features paint` is green (471 lib + 114 layout). Without `--features paint` the layout suite has the same 11 failures as `main` — unchanged by this branch, and they do not occur in a paint build.
