### PR TITLE
render: a block whose only children are floats has no auto height

### DIFF
--- a/crates/obscura-render/src/dom.rs
+++ b/crates/obscura-render/src/dom.rs
@@ -13769,7 +13769,17 @@ fn can_use_native_float_band(
     // distinct taffy-side representation, so they are not an escape signal.
     let parent_is_native_bfc =
         parent_style.overflow_scroll_container && !parent_style.overflow_propagated_to_viewport;
-    saw_float && (saw_flow_after_floats || saw_clear_after_floats || parent_is_native_bfc)
+    // Reaching here with `saw_float` and nothing else means the children are
+    // floats only (anything in flow before a float already returned false).
+    // Such a block has no line box, so its auto height is zero and the floats
+    // overflow it. Taffy's native band models that because floats are out of
+    // flow there; the legacy zone fallback makes them ordinary children and
+    // grows the parent to the float's height instead. A parent that does
+    // establish a BFC must still contain them, and only the scroll-container
+    // form has a native representation, so leave the rest on the fallback.
+    let float_only = !establishes_block_formatting_context(parent_style);
+    saw_float
+        && (saw_flow_after_floats || saw_clear_after_floats || parent_is_native_bfc || float_only)
 }
 
 fn set_native_float_clear(
@@ -15868,10 +15878,15 @@ mod tests {
                 "{id}: {rect:?}"
             );
         }
+        // `#container` is an ordinary block whose only children are floats, so
+        // it has no line box and its auto height is zero; the floats overflow
+        // it until something clears them or it establishes a BFC. Chromium 147
+        // agrees: container 780x0 with the four cells at y=0, exactly the
+        // per-float geometry asserted above.
         let container = laid.rects[&tree.get_element_by_id("container").unwrap()];
         assert!(
-            (container.height - 150.0).abs() < 0.01,
-            "one float band must be as tall as its tallest float: {container:?}"
+            container.height.abs() < 0.01,
+            "a block containing only floats has no auto height: {container:?}"
         );
     }
 

--- a/crates/obscura-render/tests/layout_test.rs
+++ b/crates/obscura-render/tests/layout_test.rs
@@ -4471,3 +4471,40 @@ fn grid_ordinary_aspect_ratio_preserves_normal_alignment_provenance() {
     assert_eq!(size("parent-align-stretch"), (400.0, 200.0));
     assert_eq!(size("parent-justify-stretch"), (300.0, 150.0));
 }
+
+/// An ordinary block whose only in-flow children are floats has no line box,
+/// so its auto height is zero and the floats overflow it. A block that does
+/// establish a BFC must still contain them.
+///
+/// The float-only case used to decline taffy's native float band (which
+/// requires in-flow content, a clear box or a scroll container after the
+/// floats) and fall back to the legacy zone, where floats are ordinary
+/// children and grow the parent. Bootstrap's `.navbar-container` holds nothing
+/// but floated headers, so it reported 120px against Chromium's 60px and
+/// pushed every following section down the page.
+#[test]
+fn block_with_only_floats_has_no_auto_height() {
+    let style = "<style>body{margin:0;font:14px sans-serif}\
+        .f{float:left;width:200px;height:60px}</style>";
+    // Two floats are needed: a single float already declined the zone path.
+    let height = |css: &str| {
+        let html = format!(
+            "{style}<div id=b style='width:800px;{css}'><div class=f>a</div><div class=f>b</div></div>"
+        );
+        let tree = parse_html(&html);
+        let layout = layout_dom(&tree, (1600.0, 1000.0));
+        layout.rects[&tree.get_element_by_id("b").unwrap()].height
+    };
+    // Chromium 147: 0 for the plain block, 60 for either BFC form.
+    assert!(height("").abs() < 0.01, "plain block: got {}", height(""));
+    assert!(
+        (height("overflow:hidden") - 60.0).abs() < 0.01,
+        "overflow BFC must contain its float: got {}",
+        height("overflow:hidden")
+    );
+    assert!(
+        (height("display:flow-root") - 60.0).abs() < 0.01,
+        "flow-root must contain its float: got {}",
+        height("display:flow-root")
+    );
+}


### PR DESCRIPTION
### What

An ordinary block whose only in-flow children are floats establishes no line box, so its auto height is zero and the floats overflow it until something clears them or the block establishes a BFC. We grew it to the tallest float's height instead.

```html
<style>.f{float:left;width:200px;height:60px}</style>
<div id=b style="width:800px"><div class=f>a</div><div class=f>b</div></div>
```

`#b` is `800x0` in Chromium 147 and was `800x60` here.

Bootstrap's `.navbar-container` holds nothing but floated headers, so on the Preside admin it measured `1560x120` where Chromium gives `1560x0`.

A single float already declined the zone path, so **two or more floats** are needed to reproduce — which is why the existing single-float coverage stayed green.

### Fix

`can_use_native_float_band` required in-flow content, a clear box, or a scroll container *after* the floats. A float-only block therefore declined taffy's native band and fell back to the legacy zone, where floats are ordinary children and grow the parent.

Accept the float-only case, except when the parent itself establishes a BFC and so must contain them. Only the scroll-container form has a native representation, so the rest stay on the fallback:

| parent | Chromium 147 | before | after |
|---|---|---|---|
| plain block | 0 | 60 | 0 |
| `overflow:hidden` | 60 | 60 | 60 |
| `display:flow-root` | 60 | 60 | 60 |

### One existing assertion changes

`consecutive_percentage_floats_collect_against_the_full_band_width` asserted that its container was as tall as its tallest float (150). `#container` there is a plain block whose only children are four floats, so that expectation does not match a browser. Chromium 147 on that exact markup:

```
container [0,0,780,0]
a [0,0,195,87]  b [195,0,195,85]  c [390,0,195,150]  d [585,0,195,76]
```

The four per-float assertions the test already makes (195px wide, `y=0`, `x = index*195`) are reproduced exactly and are unaffected. Only the container height changes, from 150 to 0, which is what the browser gives. I've updated it with that reasoning in a comment rather than leaving a red test.

### Verification

`cargo test -p obscura-render --features paint` green (471 lib + 113 layout). The added test fails without the change (`plain block: got 60`). Without `--features paint` the layout suite has the same 11 failures as `main`, unchanged by this branch.

`.navbar-container` on the Preside admin goes `1560x120` → `1560x0`, matching Chromium. The navbar box itself is still taller than Chromium's for an unrelated reason — its second floated header measures 514x120 against Chromium's 496x60, so the content wraps — which I'm looking at separately and is not addressed here.
