### PR TITLE
js: expose five missing longhands and the cssFloat alias to getComputedStyle

### DIFF
--- a/crates/obscura-js/js/bootstrap.js
+++ b/crates/obscura-js/js/bootstrap.js
@@ -8124,6 +8124,10 @@ globalThis.getComputedStyle = (el) => {
     // (`-webkit-line-clamp`). Normalize the prefix once for every WebKit
     // property instead of adding per-property aliases to the native snapshot.
     if (kebab.startsWith('webkit-')) kebab = '-' + kebab;
+    // `cssFloat` is the CSSOM IDL alias for `float` (`float` being reserved in
+    // early ECMAScript). Naive camelCase splitting yields `css-float`, which
+    // matches no property, so the getter returned ''.
+    if (kebab === 'css-float') kebab = 'float';
     if (snapshot.rendered && Object.prototype.hasOwnProperty.call(snapshot.rendered, kebab))
       return snapshot.rendered[kebab];
     // Non-render builds and properties outside the renderer snapshot retain

--- a/crates/obscura-render/src/paint.rs
+++ b/crates/obscura-render/src/paint.rs
@@ -1346,6 +1346,58 @@ impl PreparedRender {
             .to_string(),
         );
         out.insert(
+            "vertical-align",
+            match style.vertical_align {
+                Some(crate::VerticalAlign::Top) => "top",
+                Some(crate::VerticalAlign::Middle) => "middle",
+                Some(crate::VerticalAlign::Bottom) => "bottom",
+                None => "baseline",
+            }
+            .to_string(),
+        );
+        out.insert(
+            "text-transform",
+            match style.text_transform {
+                Some(crate::TextTransform::Uppercase) => "uppercase",
+                Some(crate::TextTransform::Lowercase) => "lowercase",
+                Some(crate::TextTransform::Capitalize) => "capitalize",
+                Some(crate::TextTransform::None) | None => "none",
+            }
+            .to_string(),
+        );
+        out.insert(
+            "list-style-type",
+            match style.list_style {
+                Some(crate::ListStyle::Disc) => "disc",
+                Some(crate::ListStyle::Circle) => "circle",
+                Some(crate::ListStyle::Square) => "square",
+                Some(crate::ListStyle::Decimal) => "decimal",
+                Some(crate::ListStyle::None) => "none",
+                // The initial value is `disc`; the UA sheet only sets a marker
+                // on list items, so an unstyled element still reports it.
+                None => "disc",
+            }
+            .to_string(),
+        );
+        out.insert(
+            "border-collapse",
+            if style.border_collapse == Some(true) {
+                "collapse"
+            } else {
+                "separate"
+            }
+            .to_string(),
+        );
+        out.insert(
+            "table-layout",
+            if style.table_layout_fixed {
+                "fixed"
+            } else {
+                "auto"
+            }
+            .to_string(),
+        );
+        out.insert(
             "clear",
             match style.clear {
                 Some(crate::Clear::Left) => "left",
@@ -15020,6 +15072,43 @@ mod tests {
         assert_eq!(computed("right")["clear"], "both");
         assert_eq!(computed("plain")["float"], "none");
         assert_eq!(computed("plain")["clear"], "none");
+    }
+
+    /// `vertical-align`, `text-transform`, `list-style-type`, `border-collapse`
+    /// and `table-layout` are cascaded and used by layout, but were never put
+    /// in the computed-style snapshot, so `getComputedStyle()` returned `''`
+    /// for them even when the page declared them explicitly. Chromium 147
+    /// values are asserted for both the declared and the initial case.
+    #[test]
+    fn computed_style_exposes_table_list_and_text_longhands() {
+        let tree = parse_html(
+            r#"<style>#set{vertical-align:middle;list-style-type:square;
+                 border-collapse:collapse;table-layout:fixed;text-transform:uppercase}</style>
+               <table id="set"><tr><td>x</td></tr></table>
+               <div id="unset">a</div>"#,
+        );
+        let mut resources = RenderResourceCache::default();
+        let prepared =
+            prepare_dom(&tree, (320.0, 200.0), None, &mut resources).expect("prepared render");
+        let computed = |id| {
+            prepared
+                .computed_style(tree.get_element_by_id(id).unwrap())
+                .expect("computed style")
+        };
+
+        let set = computed("set");
+        assert_eq!(set["vertical-align"], "middle");
+        assert_eq!(set["list-style-type"], "square");
+        assert_eq!(set["border-collapse"], "collapse");
+        assert_eq!(set["table-layout"], "fixed");
+        assert_eq!(set["text-transform"], "uppercase");
+
+        let unset = computed("unset");
+        assert_eq!(unset["vertical-align"], "baseline");
+        assert_eq!(unset["list-style-type"], "disc");
+        assert_eq!(unset["border-collapse"], "separate");
+        assert_eq!(unset["table-layout"], "auto");
+        assert_eq!(unset["text-transform"], "none");
     }
 
     #[test]


### PR DESCRIPTION
### What

Six properties come back as the empty string from `getComputedStyle()` — and not only for the initial value, but **even when the page declares them explicitly**.

```html
<style>#set{vertical-align:middle;list-style-type:square;border-collapse:collapse;
            table-layout:fixed;text-transform:uppercase;float:right}</style>
<div id=unset>a</div>
<table id=set><tr><td>x</td></tr></table>
```

| property | Chromium 147 (unset / set) | before | after |
|---|---|---|---|
| `verticalAlign` | `baseline` / `middle` | `''` / `''` | ✅ |
| `listStyleType` | `disc` / `square` | `''` / `''` | ✅ |
| `borderCollapse` | `separate` / `collapse` | `''` / `''` | ✅ |
| `tableLayout` | `auto` / `fixed` | `''` / `''` | ✅ |
| `textTransform` | `none` / `uppercase` | `''` / `''` | ✅ |
| `cssFloat` | `none` / `right` | `''` / `''` | ✅ |

All five longhands are already cascaded and used by layout (`style.vertical_align`, `style.text_transform`, `style.list_style`, `style.border_collapse`, `style.table_layout_fixed`) — they were simply never added to the computed-style snapshot in `paint.rs::computed_style`.

`cssFloat` is the CSSOM IDL alias for `float` (`float` was reserved in early ECMAScript). Naive camelCase splitting produces `css-float`, which matches no property, so the getter returned `''` while plain `float` worked. Normalized next to the existing `-webkit-` prefix fix-up.

### Why it's worth fixing

An empty string is indistinguishable from "not set" to a caller, so anything branching on these values silently takes the wrong path instead of failing visibly. I hit it while diffing a Bootstrap admin against Chromium over CDP: `getComputedStyle(el).display` never reports `table` / `table-row` / `table-cell` / `list-item` either, so a table's box type can't be read back at all and layout has to be inferred from rects.

### Scope

Deliberately narrow: only the properties already tracked on `LayoutStyle`. Not addressed here, and worth separate issues:

- `display` never returns the table or `list-item` values (a `<table>` reports `block`).
- `getComputedStyle(el, '::before').content` returns `''` where Chromium gives `'""'`, and pseudo-element lookups appear to fall back to the originating element's own box.
- `font-family` is returned lowercased and re-quoted (`"poppins","helvetica neue"`) rather than in the authored/canonical form Chromium reports (`Poppins, "Helvetica Neue"`).

### Verification

`cargo test -p obscura-render --features paint` is green (472 lib + 112 layout). The added test fails without the change. Verified end-to-end against a live `obscura serve` over CDP: all six now match Chromium 147 for both the declared and the initial case.

Note `cargo test -p obscura-js` aborts under V8 (`# Check failed: !IsFrozen()`) on `main` as well as on this branch — pre-existing and unrelated.
