### PR TITLE
render: resolve the initial font-family to serif, not the sans face

### DIFF
--- a/crates/obscura-render/src/dom.rs
+++ b/crates/obscura-render/src/dom.rs
@@ -16058,12 +16058,16 @@ mod tests {
         let logo = rect("logo");
 
         assert_eq!((logo.width, logo.height), (70.0, 70.0));
+        // Chromium 147 gives exactly 215: the 70px logo plus 2x15px padding
+        // plus a 115px `porkbun` at 34.5px in the UA default (serif) face.
+        // The old `> 220` threshold was calibrated against our sans default.
         assert!(
-            brand.width > 220.0,
+            (brand.width - 215.0).abs() < 1.0,
             "the nested float must aggregate the image and label on its max-content line: {brand:?}"
         );
+        // Chromium 147 gives exactly 248 here (215 + the 33px margin below).
         assert!(
-            header.width > 255.0 && header.width < 259.0,
+            (header.width - 248.0).abs() < 1.0,
             "the hidden 22px toggle icon must not cap the outer shrink-to-fit width: {header:?}"
         );
         assert!(

--- a/crates/obscura-render/src/inline.rs
+++ b/crates/obscura-render/src/inline.rs
@@ -98,7 +98,12 @@ pub(crate) fn text_may_need_emoji_font(text: &str) -> bool {
 /// DejaVu Sans, while `sans-serif`/Arial/Helvetica resolve to Liberation Sans.
 /// The first recognizable family wins, matching CSS fallback order.
 fn resolve_font_family(fam: Option<&str>) -> &'static str {
-    let Some(f) = fam else { return FAMILY };
+    // The initial `font-family` is the UA default, and every major engine uses
+    // a serif there (Chrome/Firefox/Safari all report and render Times). We
+    // returned the sans face, so unstyled text measured ~8% wider than the
+    // `font-family` we report for it, and a shrink-to-fit box built from it
+    // disagreed with Chromium.
+    let Some(f) = fam else { return SERIF_FAMILY };
     for tok in f.split(',') {
         if let Some(family) = bundled_family_for_css_token(tok) {
             return family;

--- a/crates/obscura-render/tests/layout_test.rs
+++ b/crates/obscura-render/tests/layout_test.rs
@@ -4471,3 +4471,33 @@ fn grid_ordinary_aspect_ratio_preserves_normal_alignment_provenance() {
     assert_eq!(size("parent-align-stretch"), (400.0, 200.0));
     assert_eq!(size("parent-justify-stretch"), (300.0, 150.0));
 }
+
+/// The initial `font-family` is the UA default, which every major engine
+/// renders and reports as a serif (Chromium 147 reports `Times`). We resolved
+/// an absent `font-family` to the bundled *sans* face while `getComputedStyle`
+/// still reported `Times`, so unstyled text measured ~8% wider than the family
+/// we claimed for it and any shrink-to-fit box built from it disagreed with
+/// Chromium. An explicit `serif` was already correct — only the initial value
+/// was wrong, which is why it survived in pages that set a font anywhere.
+#[test]
+fn initial_font_family_matches_an_explicit_serif() {
+    let html = |css: &str| {
+        format!("<div id=t style='float:left;{css}'>Content library</div>")
+    };
+    let width = |css: &str| {
+        let tree = parse_html(&html(css));
+        let layout = layout_dom(&tree, (1600.0, 1000.0));
+        layout.rects[&tree.get_element_by_id("t").unwrap()].width
+    };
+    let initial = width("");
+    let serif = width("font-family:serif");
+    let sans = width("font-family:sans-serif");
+    assert!(
+        (initial - serif).abs() < 0.5,
+        "the initial font-family must resolve like `serif`: initial={initial}, serif={serif}"
+    );
+    assert!(
+        (sans - serif).abs() > 1.0,
+        "sanity: the sans face must actually differ from serif: sans={sans}, serif={serif}"
+    );
+}


### PR DESCRIPTION
### What

The initial `font-family` — the value inherited by any element the page never styles — resolved to the bundled **sans** face, while `getComputedStyle` reported `Times`. So unstyled text measured about 8% wider than the family we claim for it, and any shrink-to-fit box built from it disagreed with the browser.

```html
<div style="float:left">Content library</div>
```

| | initial (nothing set) | explicit `serif` | explicit `sans-serif` | reported family |
|---|---|---|---|---|
| Chromium 147 | 97.3 | 97.3 | 104 | `Times` |
| before | **105** | 98 | 105 | `Times` |
| after | 98 | 98 | 105 | `Times` |

Chrome, Firefox and Safari all use a serif for the initial value, so `resolve_font_family(None)` now returns `SERIF_FAMILY`. An explicit `serif` was already correct — only the initial value was wrong, which is why it survived in any page that sets a font anywhere, and why it took a delta-debugged reduction of a real page to isolate.

### Two existing thresholds move — and land exactly on the browser's numbers

`auto_width_float_uses_its_own_bfc_for_nested_float_max_content` asserted `brand.width > 220.0` and `255.0 < header.width < 259.0`. Both were calibrated against the old sans default. Chromium 147 on that fixture's exact markup gives:

```
brand  215.0     header  248.0     (label font reported as "Times")
```

which is precisely what this change produces, so I pinned both to the browser values (±1) instead of a range. The assertions' purpose — that the nested float aggregates the image and label on its max-content line, and that the hidden toggle does not cap the outer float — is unchanged and still enforced.

### Verification

`cargo test -p obscura-render --features paint` green: 471 lib + 113 layout. The added test fails without the change (`initial=105, serif=98`) and includes a sanity assertion that sans and serif genuinely differ, so it cannot pass by both collapsing to one face. Without `--features paint` the layout suite has the same failures as `main`, unchanged by this branch.

I have not touched the `'font-family': 'Times'` fallback in `bootstrap.js`; it was already reporting the correct thing, and it is now consistent with what actually gets rendered.
