### PR TITLE
js: reflect HTMLTableCellElement.colSpan/rowSpan to the content attributes

### DIFF
--- a/crates/obscura-js/js/bootstrap.js
+++ b/crates/obscura-js/js/bootstrap.js
@@ -4843,6 +4843,15 @@ function _convertNodes(nodes) {
     return (ln === "button" || ln === "input" || ln === "select" || ln === "textarea" || ln === "iframe") ? 0 : -1;
   });
 
+  // HTMLTableCellElement.colSpan/rowSpan. These are IDL attributes that reflect
+  // the `colspan`/`rowspan` content attributes, and layout reads the content
+  // attribute. Without the reflection, `cell.colSpan = 9` stored a plain JS
+  // property that nothing else could see: DataTables sets exactly that on its
+  // "No records found" row, so the cell stayed one column wide and the message
+  // wrapped one word per line instead of spanning the table.
+  reflectLong("colSpan", "colspan", 1);
+  reflectLong("rowSpan", "rowspan", 1);
+
   // ARIAMixin: aria-* content attributes reflected as nullable DOMString IDL
   // properties (ariaAtomic <-> aria-atomic, ...).
   const ARIA = {

--- a/crates/obscura-js/src/runtime.rs
+++ b/crates/obscura-js/src/runtime.rs
@@ -5161,6 +5161,48 @@ mod tests {
         );
     }
 
+    /// `colSpan`/`rowSpan` are IDL attributes that reflect `colspan`/`rowspan`.
+    /// Layout reads the content attribute, so without the reflection a
+    /// `cell.colSpan = n` assignment stored an invisible JS property and the
+    /// cell never spanned. DataTables sets exactly that on its "No records
+    /// found" row, which then wrapped one word per line instead of spanning
+    /// the table.
+    #[test]
+    fn table_cell_colspan_and_rowspan_reflect_through_the_idl_surface() {
+        let mut rt = setup_runtime(
+            r#"<html><body><table><tbody>
+                <tr><td id="plain">a</td></tr>
+                <tr><td id="markup" colspan="4" rowspan="2">b</td></tr>
+                <tr><td id="invalid" colspan="abc">c</td></tr>
+                <tr><td id="setter">d</td></tr>
+            </tbody></table></body></html>"#,
+        );
+        let result = rt
+            .evaluate(
+                r#"
+                const cell = document.getElementById("setter");
+                cell.colSpan = 5;
+                cell.rowSpan = 2;
+                const plain = document.getElementById("plain");
+                const markup = document.getElementById("markup");
+                const invalid = document.getElementById("invalid");
+                return [
+                    plain.colSpan, plain.rowSpan, plain.getAttribute("colspan"),
+                    markup.colSpan, markup.rowSpan,
+                    invalid.colSpan,
+                    cell.colSpan, cell.rowSpan,
+                    cell.getAttribute("colspan"), cell.getAttribute("rowspan")
+                ];
+                "#,
+            )
+            .unwrap();
+        // Chromium 147 gives exactly this for the same markup and assignments.
+        assert_eq!(
+            result,
+            serde_json::json!([1, 1, null, 4, 2, 1, 5, 2, "5", "2"])
+        );
+    }
+
     #[test]
     fn hyperlink_content_attributes_reflect_through_the_idl_surface() {
         let mut rt = setup_runtime(


### PR DESCRIPTION
### What

`HTMLTableCellElement.colSpan` / `rowSpan` are not implemented. Reading them gives `undefined` even when the markup has the attribute, and assigning to them stores a plain JS property that nothing else can observe — including layout, which reads the `colspan` content attribute.

```html
<table><thead><tr><th>A</th><th>B</th><th>C</th></tr></thead>
<tbody><tr><td id=t>No records found</td></tr></tbody></table>
<script>document.getElementById('t').colSpan = 3;</script>
```

| | Chromium 147 | before | after |
|---|---|---|---|
| `t.getAttribute('colspan')` | `"3"` | `null` | `"3"` |
| `t.outerHTML` | `<td id="t" colspan="3">` | `<td id="t">` | `<td id="t" colspan="3">` |
| cell width in a 600px table | 599 | 443 | 600 |

Reading is broken too: `<td colspan="4">` returned `undefined` for `.colSpan`.

### Why it matters

DataTables builds its empty state as `<td class="dataTables_empty">` with the span assigned from JS. On a Preside admin listing with no records the cell stayed one column wide — **65px inside a 1560px table** — so "No records found" wrapped one word per line down four lines. Every empty listing in the admin renders that way.

After the fix the cell spans the table and the row is a single line, matching Chromium.

### Implementation

Reflected with the existing `reflectLong` helper, default 1 for both, alongside `tabIndex`. Verified against Chromium 147 across the absent, markup, invalid-value (`colspan="abc"`), `rowspan`, and JS-assigned cases — all ten observable values agree exactly:

```
[1, 1, null, 4, 2, 1, 5, 2, "5", "2"]
```

### Verification

The added test fails without the change (every value comes back `null`).

Note `cargo test -p obscura-js --lib` aborts under V8 with `# Check failed: !IsFrozen()` on `main` as well as on this branch, both serially and in parallel — pre-existing and unrelated to this change.
