### PR TITLE
render: scale measure_text by the em square, not the font's height

### DIFF
--- a/crates/obscura-render/src/paint.rs
+++ b/crates/obscura-render/src/paint.rs
@@ -6743,7 +6743,17 @@ fn fallback_font_bytes(family: Option<&str>) -> &'static [u8] {
 
 pub fn measure_text(text: &str, size: f32, is_bold: bool, family: Option<&str>) -> f32 {
     let font = FontRef::try_from_slice(fallback_font_bytes(family)).unwrap();
-    let scale = PxScale::from(size);
+    // `PxScale` maps the font's *height* (ascent + descent + line gap) to the
+    // given value, not its em square, so `PxScale::from(css_px)` renders every
+    // advance short by `units_per_em / height_unscaled` — 12% for Liberation
+    // Sans (2048/2288). Scale by the em ratio so one CSS pixel of `font-size`
+    // is one em, matching the shaped inline path and the browser.
+    let em_scale = font
+        .units_per_em()
+        .filter(|em| *em > 0.0)
+        .map(|em| size * font.height_unscaled() / em)
+        .unwrap_or(size);
+    let scale = PxScale::from(em_scale);
     let scaled_font = font.as_scaled(scale);
     let mut width = 0.0;
     for c in text.chars() {
@@ -11317,6 +11327,30 @@ fn paint_mask(
         clip.as_ref(),
     );
     true
+}
+
+#[cfg(test)]
+mod measure_text_scale_tests {
+    use super::measure_text;
+
+    /// `measure_text` sizes native form-control labels and list markers. It uses
+    /// ab_glyph, whose `PxScale` maps the font's *height* (ascent + descent +
+    /// line gap) to the given value rather than its em square — so passing a CSS
+    /// pixel size directly rendered every advance short by
+    /// `units_per_em / height_unscaled`, which is 2048/2288 = 12% for Liberation
+    /// Sans. A `<button>` label therefore measured ~11% narrower than the same
+    /// text in a `<span>`, and the button shrink-wrapped too tightly.
+    #[test]
+    fn measure_text_matches_browser_advance_widths() {
+        // Chromium 147, Liberation Sans (its `Arial` substitute) at 14px.
+        for (text, chromium) in [("abcdefghij", 63.8_f32), ("ab", 15.6), ("Create new form", 103.0)] {
+            let got = measure_text(text, 14.0, false, Some("Arial"));
+            assert!(
+                (got - chromium).abs() < 1.0,
+                "measure_text({text:?}) = {got}, Chromium gives {chromium}"
+            );
+        }
+    }
 }
 
 #[cfg(test)]
@@ -17129,3 +17163,4 @@ mod tests {
         assert!(!at_end.has_active_css_animations());
     }
 }
+


### PR DESCRIPTION
### What

`measure_text` sizes native form-control labels (`native_button_intrinsic_content`) and list markers. It measures with ab_glyph, whose `PxScale` maps the font's **height** — ascent + descent + line gap — to the given value, not its em square. Passing a CSS pixel size straight in makes every advance short by `units_per_em / height_unscaled`: 2048/2288 for Liberation Sans, a 12% under-measure.

```
measure_text("abcdefghij", 14px, "Arial")
  before    57.13
  after     63.83
  Chromium  63.8
```

### How it shows up

A `<button>` label measures ~11% narrower than the identical text in a `<span>`, so an auto-width button shrink-wraps too tightly and the label wraps:

```html
<style>.q{padding:0;border:0;font:14px Arial;display:inline-block}</style>
<span class=q>Create new form</span>
<button class=q>Create new form</button>
```

| text | Chromium 147 span / button | before | after |
|---|---|---|---|
| `ab` | 15.6 / 15.6 | 16 / 14 | 16 / 16 |
| `abcdefghij` | 63.8 / 63.8 | 64 / 57 | 64 / 64 |
| 30 chars | 191.5 / 191.5 | 192 / 171 | 192 / 191 |

The span and button agree in Chromium at every length; before this change ours disagreed by a constant 0.891 ratio. That the error was a *constant ratio* rather than a fixed offset is what pointed at a scale factor rather than a layout bug.

### Fix

Scale by `size * height_unscaled / units_per_em`, so one CSS pixel of `font-size` is one em — matching the shaped inline path (cosmic-text) and the browser. Falls back to the previous behaviour if the font reports no `units_per_em`.

### Verification

`cargo test -p obscura-render --features paint` green: 472 lib + 112 layout. The added test asserts three Chromium 147 advance widths and fails without the change (`measure_text("abcdefghij") = 57.13, Chromium gives 63.8`).

### Not fixed here

On a real Bootstrap button (`<i class="fa fa-plus"></i> Create new form`) this takes the box from 104px to 113px against Chromium's 142px, so it is an improvement but not the whole story. The remainder is a separate gap: `native_button_intrinsic_content` only adds width for elements it treats as atomic (`svg`, `img`, `video`, `canvas`, `iframe`, `embed`, `object`), so an `inline-block` icon such as a Font Awesome `<i>` contributes nothing to the estimate. I have not attempted that here since it is a design question about the approximation rather than a defect in it.
