### PR TITLE
js: report the inset properties as insets, not bounding-rect coordinates

### DIFF
--- a/crates/obscura-js/js/bootstrap.js
+++ b/crates/obscura-js/js/bootstrap.js
@@ -8076,10 +8076,12 @@ globalThis.getComputedStyle = (el) => {
           return r.width != null ? `${r.width}px` : null;
         case 'height': case 'block-size':
           return r.height != null ? `${r.height}px` : null;
-        case 'left': return r.left != null ? `${r.left}px` : null;
-        case 'top': return r.top != null ? `${r.top}px` : null;
-        case 'right': return r.right != null ? `${r.right}px` : null;
-        case 'bottom': return r.bottom != null ? `${r.bottom}px` : null;
+        // NOTE: `top`/`left`/`right`/`bottom` are deliberately NOT served from
+        // the bounding rect. They are CSS *insets*, not box coordinates: a
+        // statically positioned element computes them to `auto` no matter where
+        // it sits on the page. Returning the rect made every element look
+        // positioned, and reported a relative element's viewport offset instead
+        // of its declared inset.
         case 'client-width': case 'offset-width':
           return r.width != null ? `${r.width}px` : null;
         case 'client-height': case 'offset-height':
@@ -8113,6 +8115,9 @@ globalThis.getComputedStyle = (el) => {
     'justify-content': 'normal', gap: 'normal',
     'grid-template-columns': 'none', 'grid-template-rows': 'none',
     'will-change': 'auto', 'backface-visibility': 'visible',
+    // Initial value of the inset properties. A positioned element overrides
+    // these from its own declarations through the cascade below.
+    'top': 'auto', 'right': 'auto', 'bottom': 'auto', 'left': 'auto',
   };
 
   const lookup = (rawProp) => {

--- a/crates/obscura-render/src/paint.rs
+++ b/crates/obscura-render/src/paint.rs
@@ -1345,6 +1345,28 @@ impl PreparedRender {
             }
             .to_string(),
         );
+        // The inset properties. A static box computes them to `auto` however it
+        // is laid out; a positioned one reports its own declared value. These
+        // are not box coordinates, so they must not be taken from the rect.
+        {
+            let names = ["top", "right", "bottom", "left"];
+            // `position: static` is represented as `None` here.
+            let positioned = style.position.is_some();
+            for (index, name) in names.into_iter().enumerate() {
+                let value = if !positioned {
+                    "auto".to_string()
+                } else {
+                    match style.inset[index] {
+                        Some(crate::Dimension::Px(px)) => css_px(px),
+                        Some(crate::Dimension::Percent(fraction)) => {
+                            format!("{}%", fraction * 100.0)
+                        }
+                        _ => "auto".to_string(),
+                    }
+                };
+                out.insert(name, value);
+            }
+        }
         out.insert(
             "clear",
             match style.clear {
@@ -14997,6 +15019,43 @@ mod tests {
             computed.get("word-break").map(String::as_str),
             Some("keep-all")
         );
+    }
+
+    /// The inset properties are CSS *insets*, not box coordinates. A statically
+    /// positioned element computes them to `auto` wherever it sits on the page.
+    /// `getComputedStyle` served them from `getBoundingClientRect`, so every
+    /// element looked positioned and a relative box reported its viewport
+    /// offset (21px) instead of its declared inset (5px).
+    #[test]
+    fn computed_style_reports_insets_not_box_coordinates() {
+        let tree = parse_html(
+            r#"<style>
+                 body{margin:0}
+                 #stat{height:20px}
+                 #rel{position:relative;top:5px;left:7px}
+                 #abs{position:absolute;top:10px;left:12px}
+               </style>
+               <div id="stat">s</div><div id="rel">r</div><div id="abs">a</div>"#,
+        );
+        let mut resources = RenderResourceCache::default();
+        let prepared =
+            prepare_dom(&tree, (320.0, 200.0), None, &mut resources).expect("prepared render");
+        let computed = |id| {
+            prepared
+                .computed_style(tree.get_element_by_id(id).unwrap())
+                .expect("computed style")
+        };
+
+        // Chromium 147: a static box is `auto` on every side, however far down
+        // the page it is laid out.
+        let stat = computed("stat");
+        for side in ["top", "right", "bottom", "left"] {
+            assert_eq!(stat[side], "auto", "static {side}");
+        }
+        assert_eq!(computed("rel")["top"], "5px");
+        assert_eq!(computed("rel")["left"], "7px");
+        assert_eq!(computed("abs")["top"], "10px");
+        assert_eq!(computed("abs")["left"], "12px");
     }
 
     #[test]


### PR DESCRIPTION
### What

`getComputedStyle` served `top` / `right` / `bottom` / `left` from `getBoundingClientRect`, so they came back as **viewport coordinates**. Those properties are CSS *insets*: a statically positioned element computes them to `auto` however far down the page it lands, and a positioned one reports its declared value — not where it happens to sit.

```html
<div id=stat>static</div>
<div id=rel style="position:relative;top:5px;left:7px">relative</div>
<div id=abs style="position:absolute;top:10px;left:12px">absolute</div>
```

| | Chromium 147 | before | after |
|---|---|---|---|
| `stat.top` | `auto` | `0px` | `auto` |
| `stat.left` | `auto` | `0px` | `auto` |
| `rel.top` | `5px` | `21px` | `5px` |
| `rel.left` | `7px` | `7px`&nbsp;(coincidence) | `7px` |
| `abs.top` | `10px` | `10px`&nbsp;(coincidence) | `10px` |

The `rel` row is the clearest: `21px` is where the box sits in the viewport, not the `5px` it was given. Where the numbers matched before, it was because the element happened to be at that offset.

Every element therefore looked positioned — which is exactly the test a lot of library code makes before deciding whether to read or write an offset.

### Fix

Two halves:

- Drop the four inset cases from the `dimensionFor` bounding-rect helper in `bootstrap.js`, and give the insets their `auto` initial value in the defaults table. The `width`/`height` cases stay: those genuinely are the used box size, and the comment above them records why virtualization libraries depend on it.
- Emit the insets from the renderer snapshot (`style.inset`), so a positioned element reports its declared value through the normal cascade.

### Known limitation

An inset the page does not declare reports `auto` where Chromium resolves the used value — `right: -7px` for the relative box above, since CSSOM returns used values for positioned elements. Computing that needs the containing block, so I left it rather than guess. The common cases (static is `auto`, declared insets report their value) now match.

### Verification

`cargo test -p obscura-render --features paint` green: 472 lib + 112 layout. Without `--features paint` the layout suite has the same failures as `main`. The added test asserts all four sides are `auto` on a static box and that declared insets survive.

### Found alongside

Diffing a Bootstrap admin against Chromium also showed `animation-name` returning `''` for a running animation (Chromium gives the name, or `none`), and `min-height` returning `auto` on a plain block where Chromium resolves `0px`. Both are the same "property missing from the computed-style snapshot" shape as #762 and are not addressed here.
