### PR TITLE
render: paint a text input's value

### DIFF
--- a/crates/obscura-render/src/paint.rs
+++ b/crates/obscura-render/src/paint.rs
@@ -4661,6 +4661,48 @@ fn paint_laid_dom_scrolled(
                 .unwrap_or(false)
                 || (name.local.as_ref() == "textarea"
                     && !tree.text_content(nid).is_empty());
+            // A text `<input>`'s value is not a DOM text node either, so it
+            // needs painting from the attribute the same way. Without this the
+            // control renders empty however it was filled in — from markup,
+            // from script, or by typing — while its `value` reads back
+            // correctly, so only a screenshot or PDF shows anything wrong.
+            // `<textarea>` is unaffected: its value *is* a text node.
+            if has_value && name.local.as_ref() == "input" {
+                if let Some(value) = node.get_attribute("value") {
+                    if !value.is_empty() {
+                        let fsize = style.font_size.unwrap_or(16.0);
+                        let text_x = rect.x + style.padding.left + style.border.left;
+                        let text_y = rect.y + style.padding.top + style.border.top;
+                        let color = style.color.unwrap_or([0, 0, 0, 255]);
+                        let masked;
+                        let shown = if node
+                            .get_attribute("type")
+                            .is_some_and(|kind| kind.eq_ignore_ascii_case("password"))
+                        {
+                            masked = "\u{2022}".repeat(value.chars().count());
+                            masked.as_str()
+                        } else {
+                            value
+                        };
+                        if color[3] != 0 {
+                            draw_text(
+                                &mut pixmap,
+                                shown,
+                                text_x,
+                                text_y,
+                                color,
+                                fsize,
+                                false,
+                                style.font_family.as_deref(),
+                                style.letter_spacing.unwrap_or(0.0),
+                                clip,
+                                element_clip_mask,
+                                raster_scale,
+                            );
+                        }
+                    }
+                }
+            }
             if !has_value {
                 if let Some(placeholder) = node.get_attribute("placeholder") {
                     if !placeholder.is_empty() {
@@ -11634,10 +11676,21 @@ mod tests {
             "the authored placeholder color must reach glyph paint"
         );
         assert_eq!(non_white(60), 0, "opacity:0 must suppress placeholder glyphs");
-        assert_eq!(
-            non_white(90),
-            0,
-            "a non-empty control value must suppress placeholder glyphs"
+        // `#filled` carries `value="actual"`, so the placeholder is suppressed
+        // and the value paints in its place — Chromium 147 renders the value
+        // here too. Assert glyphs are present *and* that they are the value's
+        // near-black text rather than the grey `rgb(117,117,117)` placeholder,
+        // so this still fails if the placeholder leaks through.
+        assert!(
+            non_white(90) > 10,
+            "a control's value must paint where its placeholder is suppressed"
+        );
+        assert!(
+            (90..120).any(|y| (0..180).any(|x| {
+                let pixel = pixmap.pixel(x, y).unwrap();
+                pixel.red() < 60 && pixel.green() < 60 && pixel.blue() < 60
+            })),
+            "the painted glyphs must be the value's color, not the grey placeholder"
         );
     }
 
@@ -14997,6 +15050,41 @@ mod tests {
             computed.get("word-break").map(String::as_str),
             Some("keep-all")
         );
+    }
+
+    /// A text `<input>`'s value has no DOM text node, so it needs painting from
+    /// the attribute the way the placeholder does. Without it the control
+    /// rendered empty while `value` read back correctly — visible only in a
+    /// screenshot or PDF. `type=password` masks with bullets.
+    #[test]
+    fn input_values_paint_like_placeholders() {
+        let tree = parse_html(
+            r#"<html><head><style>
+                 body{margin:0;background:#fff}
+                 input{display:block;width:180px;height:30px;border:0;padding:0;font-size:16px}
+               </style></head><body>
+                 <input id="filled" value="ABC">
+                 <input id="empty">
+                 <input id="secret" type="password" value="ABC">
+               </body></html>"#,
+        );
+        let mut resources = RenderResourceCache::default();
+        let mut prepared = prepare_dom(&tree, (200.0, 120.0), None, &mut resources)
+            .expect("input layout");
+        let pixmap = paint_prepared(&tree, &mut prepared, &mut resources, (0.0, 0.0))
+            .expect("input paint");
+        let ink = |top: u32| {
+            (top..top + 30)
+                .flat_map(|y| (0..180).map(move |x| (x, y)))
+                .filter(|&(x, y)| {
+                    let pixel = pixmap.pixel(x, y).unwrap();
+                    pixel.red() < 200 || pixel.green() < 200 || pixel.blue() < 200
+                })
+                .count()
+        };
+        assert!(ink(0) > 10, "a value from markup must paint");
+        assert_eq!(ink(30), 0, "an empty control paints nothing");
+        assert!(ink(60) > 10, "a password value must paint as bullets");
     }
 
     #[test]


### PR DESCRIPTION
### What

A text `<input>`'s value never painted. The control renders empty however it was filled in, while `value` reads back correctly — so nothing looks wrong until you take a screenshot or a PDF.

```html
<input value="markup value">
<input placeholder="placeholder only">
<textarea>textarea value</textarea>
```

| | Chromium 147 | before | after |
|---|---|---|---|
| `<input value>` | paints the text | **blank** | paints the text |
| `<input placeholder>` | grey placeholder | grey placeholder | grey placeholder |
| `<textarea>` | paints the text | paints the text | paints the text |

`<textarea>` was fine all along because its value really is a DOM text node, which is probably why this went unnoticed. An `<input>`'s value is not, so — exactly like the `placeholder` beside it — it has to be painted from the attribute. The code right there already had the `has_value` check; it used it only to *suppress* the placeholder and then painted nothing in its place.

`type=password` masks with bullets rather than showing the value.

I found this driving a Preside admin over CDP: the form fields came out blank in every screenshot even though the values were set and read back correctly.

### Scope, and what is not covered

This paints the `value` **content attribute**, which covers markup and anything that sets the attribute — server-rendered forms, which is the common case.

A value assigned through the `value` **IDL property** is not covered. That does not reflect to the content attribute, and correctly so: Chromium agrees `getAttribute('value')` is `null` after `el.value = 'x'`. The live control state lives on the JS side, where the renderer cannot reach it. Chromium paints those; we now render the authored value, which is the same thing whenever script has not overwritten it, and no worse than blank when it has. Closing that gap needs a channel from the JS control state into the render tree, which felt like a separate change.

### One existing assertion changes

`native_placeholders_honor_default_author_color_opacity_and_value_state` asserted that its `#filled` control — `placeholder="must not paint" value="actual"` — paints **zero** pixels. The intent is that the *placeholder* is suppressed, but the value legitimately paints there now (as it does in Chromium).

Rather than weaken it, it now asserts both that glyphs are present *and* that they are the value's near-black text rather than the grey `rgb(117,117,117)` placeholder — so it still fails if a placeholder leaks through, which is what the test was guarding.

### Verification

`cargo test -p obscura-render --features paint` green: 472 lib + 112 layout. The added test paints three controls and checks ink per band; it fails without the change (`a value from markup must paint`).
