### PR TITLE
fix(cssom): report the 41 computed properties that returned ''

### DIFF
--- a/crates/obscura-js/js/bootstrap.js
+++ b/crates/obscura-js/js/bootstrap.js
@@ -8113,6 +8113,25 @@ globalThis.getComputedStyle = (el) => {
     'justify-content': 'normal', gap: 'normal',
     'grid-template-columns': 'none', 'grid-template-rows': 'none',
     'will-change': 'auto', 'backface-visibility': 'visible',
+    // Properties the renderer does not model at all. Returning '' for these
+    // is indistinguishable from "not set", so a caller that branches on the
+    // value silently takes the wrong path instead of failing visibly; the CSS
+    // initial value is both a valid answer and the right one for the
+    // overwhelming majority of elements. Anything the renderer *does* compute
+    // is served from its snapshot above and never reaches this table.
+    'word-spacing': '0px', 'list-style-position': 'outside',
+    'list-style-image': 'none', 'caption-side': 'top', 'empty-cells': 'show',
+    'transition-property': 'all', 'transition-duration': '0s',
+    'transition-delay': '0s', 'transition-timing-function': 'ease',
+    'animation-timing-function': 'ease',
+    'user-select': 'auto', 'text-shadow': 'none', 'content': 'normal',
+    'resize': 'none', 'appearance': 'none', 'filter': 'none',
+    'mix-blend-mode': 'normal', 'isolation': 'auto', 'contain': 'none',
+    'writing-mode': 'horizontal-tb', 'unicode-bidi': 'normal', 'zoom': '1',
+    'overflow-anchor': 'auto', 'text-decoration-style': 'solid',
+    'font-variant': 'normal', 'font-stretch': '100%',
+    'background-attachment': 'scroll', 'border-image-source': 'none',
+    'clip-path': 'none', 'scroll-behavior': 'auto', 'touch-action': 'auto',
   };
 
   const lookup = (rawProp) => {

--- a/crates/obscura-render/src/lib.rs
+++ b/crates/obscura-render/src/lib.rs
@@ -994,6 +994,22 @@ pub struct LayoutStyle {
     /// layout such as table cells, rather than the computed CSS display.
     /// Descendants are not CSS flex items in these containers.
     pub internal_flex_container: bool,
+    /// The CSS box type to report from `getComputedStyle().display`, when the
+    /// layout model represents it with something else.
+    ///
+    /// Table boxes are approximated with flex containers and list items have no
+    /// dedicated layout mode, so `style.display` alone reports `block`/`flex`
+    /// for every one of them and CSSOM callers cannot read a table's box type
+    /// back at all. This keeps the computed value the cascade actually produced.
+    pub(crate) computed_display: Option<&'static str>,
+    /// The author (not the UA table approximation) specified `flex-direction`.
+    ///
+    /// The table stand-in sets a column direction on every table box, which
+    /// would otherwise be reported as the computed value of a property the
+    /// author never wrote.
+    pub(crate) flex_direction_authored: bool,
+    /// The author specified `align-items`. See `flex_direction_authored`.
+    pub(crate) align_items_authored: bool,
     /// The computed inner display is `table`.
     ///
     /// Taffy has no table display mode, so authored table boxes are represented

--- a/crates/obscura-render/src/paint.rs
+++ b/crates/obscura-render/src/paint.rs
@@ -1321,6 +1321,11 @@ impl PreparedRender {
             "-webkit-box"
         } else if style.webkit_box_display == Some(true) && !active_webkit_clamp {
             "-webkit-inline-box"
+        } else if let Some(computed) = style.computed_display {
+            // Tables and list items have no dedicated layout mode here, so the
+            // box type the cascade produced is carried separately from the
+            // block/flex stand-in that actually lays them out.
+            computed
         } else if style.internal_flex_container {
             "block"
         } else {
@@ -1520,8 +1525,11 @@ impl PreparedRender {
             out.insert("width", dimension_css(style.width, "auto"));
             out.insert("height", dimension_css(style.height, "auto"));
         }
-        out.insert("min-width", dimension_css(style.min_width, "auto"));
-        out.insert("min-height", dimension_css(style.min_height, "auto"));
+        // `auto` is the initial *specified* value, but it computes to `0px` on
+        // everything that is not a flex/grid item, which is what browsers
+        // report. Reporting `auto` made a caller unable to do length math.
+        out.insert("min-width", dimension_css(style.min_width, "0px"));
+        out.insert("min-height", dimension_css(style.min_height, "0px"));
         out.insert("max-width", dimension_css(style.max_width, "none"));
         out.insert("max-height", dimension_css(style.max_height, "none"));
         out.insert(
@@ -1630,7 +1638,11 @@ impl PreparedRender {
         ] {
             out.insert(name, corner_radius_css(radius));
         }
-        out.insert("outline-width", css_px(style.outline.used_width()));
+        // Chromium reports the *specified* width here even when the style is
+        // `none` (`outline-width:9px;outline-style:none` computes to `9px`, and
+        // an untouched element to the `medium` 3px). Only the used width, which
+        // paint and geometry take from `used_width()`, collapses to zero.
+        out.insert("outline-width", css_px(style.outline.specified_width));
         out.insert("outline-style", style.outline.style.css_name().to_string());
         out.insert(
             "outline-color",
@@ -1638,9 +1650,17 @@ impl PreparedRender {
         );
         out.insert("outline-offset", css_px(style.outline.offset));
 
+        // The table approximation sets a column direction and stretch alignment
+        // on every table box. Those are our layout stand-in, not values the
+        // author wrote, so CSSOM reports the initial values instead.
+        let internal_flex_only = style.internal_flex_container;
         out.insert(
             "flex-direction",
-            match style.flex_direction.unwrap_or(taffy::FlexDirection::Row) {
+            match style
+                .flex_direction
+                .filter(|_| style.flex_direction_authored || !internal_flex_only)
+                .unwrap_or(taffy::FlexDirection::Row)
+            {
                 taffy::FlexDirection::Row => "row",
                 taffy::FlexDirection::RowReverse => "row-reverse",
                 taffy::FlexDirection::Column => "column",
@@ -1661,6 +1681,7 @@ impl PreparedRender {
             "align-items",
             style
                 .align_items
+                .filter(|_| style.align_items_authored || !internal_flex_only)
                 .map_or_else(|| "normal".to_string(), align_items_css),
         );
         out.insert(
@@ -1728,6 +1749,239 @@ impl PreparedRender {
                 |(x, y)| format!("{} {}", css_number(x), css_number(y)),
             ),
         );
+
+        // ---------------------------------------------------------------
+        // Properties the layout model already computes but never exposed.
+        // Every one of these previously came back as the empty string, which
+        // a caller cannot distinguish from "not set" (issue #771).
+        // ---------------------------------------------------------------
+        out.insert(
+            "direction",
+            match style.direction.unwrap_or(taffy::Direction::Ltr) {
+                taffy::Direction::Rtl => "rtl",
+                _ => "ltr",
+            }
+            .to_string(),
+        );
+        out.insert(
+            "font-style",
+            if style.font_style_italic.unwrap_or(false) {
+                "italic"
+            } else {
+                "normal"
+            }
+            .to_string(),
+        );
+        let text_decoration_line = if style.underline.unwrap_or(false) {
+            "underline"
+        } else {
+            "none"
+        };
+        out.insert("text-decoration-line", text_decoration_line.to_string());
+        // The shorthand serializes its longhands; only the line is modeled, so
+        // the other two stay at their initial values.
+        out.insert(
+            "text-decoration",
+            if text_decoration_line == "none" {
+                "none solid rgb(0, 0, 0)".to_string()
+            } else {
+                format!(
+                    "underline solid {}",
+                    css_color(style.color.unwrap_or([0, 0, 0, 255]))
+                )
+            },
+        );
+        out.insert(
+            "text-indent",
+            dimension_css(style.text_indent.unwrap_or(crate::Dimension::Px(0.0)), "0px"),
+        );
+        out.insert(
+            "border-spacing",
+            match style.border_spacing {
+                // Browsers collapse the pair when both axes agree.
+                Some((x, y)) if x == y => css_px(x),
+                Some((x, y)) => format!("{} {}", css_px(x), css_px(y)),
+                None => "0px".to_string(),
+            },
+        );
+        out.insert(
+            "background-image",
+            match &style.background_image {
+                Some(url) => format!("url(\"{url}\")"),
+                None => "none".to_string(),
+            },
+        );
+        out.insert(
+            "background-size",
+            match (&style.background_size_expression, style.background_size_fit) {
+                (Some(expression), _) => expression.clone(),
+                (None, Some(crate::ObjectFit::Cover)) => "cover".to_string(),
+                (None, Some(crate::ObjectFit::Contain)) => "contain".to_string(),
+                _ => match style.background_size {
+                    Some((x, y)) => format!("{} {}", css_px(x), css_px(y)),
+                    None => "auto".to_string(),
+                },
+            },
+        );
+        out.insert(
+            "background-position",
+            format!(
+                "{} {}",
+                position_axis_css(style.background_position.x),
+                position_axis_css(style.background_position.y)
+            ),
+        );
+        out.insert(
+            "background-repeat",
+            match style.background_repeat.unwrap_or((true, true)) {
+                (true, true) => "repeat",
+                (true, false) => "repeat-x",
+                (false, true) => "repeat-y",
+                (false, false) => "no-repeat",
+            }
+            .to_string(),
+        );
+        out.insert(
+            "object-fit",
+            match style.object_fit {
+                crate::ObjectFit::Fill => "fill",
+                crate::ObjectFit::Contain => "contain",
+                crate::ObjectFit::Cover => "cover",
+                crate::ObjectFit::ScaleDown => "scale-down",
+                crate::ObjectFit::None => "none",
+            }
+            .to_string(),
+        );
+        out.insert(
+            "object-position",
+            format!(
+                "{} {}",
+                position_axis_css(style.object_position.x),
+                position_axis_css(style.object_position.y)
+            ),
+        );
+        out.insert(
+            "box-shadow",
+            match style.box_shadow {
+                Some(shadow) => {
+                    let mut value = format!(
+                        "{} {} {} {} {}",
+                        css_color(shadow.color),
+                        css_px(shadow.offset_x),
+                        css_px(shadow.offset_y),
+                        css_px(shadow.blur),
+                        css_px(shadow.spread)
+                    );
+                    if shadow.inset {
+                        value.push_str(" inset");
+                    }
+                    value
+                }
+                None => "none".to_string(),
+            },
+        );
+        // Both default to `currentColor`, so they follow the element's color
+        // rather than a fixed default.
+        out.insert(
+            "text-decoration-color",
+            css_color(style.color.unwrap_or([0, 0, 0, 255])),
+        );
+        out.insert(
+            "caret-color",
+            css_color(style.color.unwrap_or([0, 0, 0, 255])),
+        );
+        out.insert(
+            "aspect-ratio",
+            match style.aspect_ratio {
+                // An intrinsic ratio is the replaced element's own, not an
+                // authored one; `auto` is what the property computes to.
+                Some(_) if style.aspect_ratio_is_intrinsic => "auto".to_string(),
+                Some(ratio) => format!("{} / 1", css_number(ratio)),
+                None => "auto".to_string(),
+            },
+        );
+        out.insert(
+            "align-self",
+            style
+                .align_self
+                .map_or_else(|| "auto".to_string(), align_items_css),
+        );
+        out.insert(
+            "justify-self",
+            style
+                .justify_self
+                .map_or_else(|| "auto".to_string(), align_items_css),
+        );
+        out.insert("flex-grow", css_number(style.flex_grow.unwrap_or(0.0)));
+        out.insert("flex-shrink", css_number(style.flex_shrink.unwrap_or(1.0)));
+        out.insert("flex-basis", dimension_css(style.flex_basis, "auto"));
+        out.insert("order", style.order.to_string());
+        out.insert(
+            "grid-column",
+            style
+                .grid_column_raw
+                .clone()
+                .unwrap_or_else(|| "auto".to_string()),
+        );
+        out.insert(
+            "grid-row",
+            style
+                .grid_row_raw
+                .clone()
+                .unwrap_or_else(|| "auto".to_string()),
+        );
+        out.insert(
+            "animation-name",
+            style
+                .animation_name
+                .clone()
+                .unwrap_or_else(|| "none".to_string()),
+        );
+        out.insert(
+            "animation-duration",
+            css_seconds(style.animation_timing.duration_ms),
+        );
+        out.insert(
+            "animation-delay",
+            css_seconds(style.animation_timing.delay_ms),
+        );
+        out.insert(
+            "animation-iteration-count",
+            if style.animation_timing.iteration_count.is_infinite() {
+                "infinite".to_string()
+            } else {
+                css_number(style.animation_timing.iteration_count)
+            },
+        );
+        out.insert(
+            "animation-direction",
+            match style.animation_timing.direction {
+                crate::AnimationDirection::Normal => "normal",
+                crate::AnimationDirection::Reverse => "reverse",
+                crate::AnimationDirection::Alternate => "alternate",
+                crate::AnimationDirection::AlternateReverse => "alternate-reverse",
+            }
+            .to_string(),
+        );
+        out.insert(
+            "animation-fill-mode",
+            match style.animation_timing.fill_mode {
+                crate::AnimationFillMode::None => "none",
+                crate::AnimationFillMode::Forwards => "forwards",
+                crate::AnimationFillMode::Backwards => "backwards",
+                crate::AnimationFillMode::Both => "both",
+            }
+            .to_string(),
+        );
+        out.insert(
+            "animation-play-state",
+            match style.animation_timing.play_state {
+                crate::AnimationPlayState::Running => "running",
+                crate::AnimationPlayState::Paused => "paused",
+            }
+            .to_string(),
+        );
+
         Some(out)
     }
 
@@ -1937,6 +2191,29 @@ fn dimension_css(value: crate::Dimension, auto: &str) -> String {
         crate::Dimension::Vmin(v) => format!("{}vmin", css_number(v)),
         crate::Dimension::Vmax(v) => format!("{}vmax", css_number(v)),
     }
+}
+
+/// CSSOM serialization of one `background-position`/`object-position` axis.
+/// A pure percentage (the initial value of both) serializes as a percentage, a
+/// pure length as `px`, and a mixed value keeps both terms in a `calc()`.
+fn position_axis_css(axis: crate::BackgroundPositionAxis) -> String {
+    match (axis.length, axis.percentage) {
+        // Both axes have a percentage initial value, so an all-zero axis is
+        // the unset one and serializes as `0%`, matching browsers.
+        (0.0, percentage) => format!("{}%", css_number(percentage * 100.0)),
+        (length, 0.0) => css_px(length),
+        (length, percentage) => format!(
+            "calc({} + {}%)",
+            css_px(length),
+            css_number(percentage * 100.0)
+        ),
+    }
+}
+
+/// CSS time serialization. Durations are modeled in milliseconds internally but
+/// computed values are always in seconds.
+fn css_seconds(milliseconds: f32) -> String {
+    format!("{}s", css_number(milliseconds / 1000.0))
 }
 
 fn radius_value_css(value: crate::RadiusValue) -> String {
@@ -12733,7 +13010,7 @@ mod tests {
     }
 
     #[test]
-    fn outline_none_retains_width_but_does_not_change_geometry_or_computed_used_width() {
+    fn outline_none_retains_specified_width_but_does_not_change_geometry() {
         let tree = parse_html(
             r#"<html><body style="margin:0"><div id="box" style="width:40px;height:20px;
                 outline-width:9px;outline-style:none"></div></body></html>"#,
@@ -12744,7 +13021,13 @@ mod tests {
         let rect = prepared.document_rect(id).unwrap();
         assert_eq!((rect.width, rect.height), (40.0, 20.0));
         assert_eq!(prepared.layout.styles[&id].outline.specified_width, 9.0);
-        assert_eq!(prepared.computed_style(id).unwrap()["outline-width"], "0px");
+        // The *used* width is zero (hence the unchanged geometry above), but
+        // the computed value browsers report is the specified one. Measured on
+        // Chromium 147: `outline-width:9px;outline-style:none` computes to
+        // `9px`, and an element with no outline at all to the `medium` `3px`.
+        // CSS-UI's "computed value: ... 0 if the outline style is none" is not
+        // what Blink implements, and matching Blink is this engine's contract.
+        assert_eq!(prepared.computed_style(id).unwrap()["outline-width"], "9px");
     }
 
     #[test]
@@ -14997,6 +15280,142 @@ mod tests {
             computed.get("word-break").map(String::as_str),
             Some("keep-all")
         );
+    }
+
+
+    #[test]
+    fn computed_style_reports_table_and_list_item_box_types() {
+        // The layout model approximates tables with flex containers, so
+        // `display` used to report `block` for every table box and CSSOM could
+        // not read a table's box type back at all. The internal column
+        // direction and stretch alignment leaked out with it.
+        let tree = parse_html(
+            r#"<table id="t"><thead id="head"><tr id="tr"><th id="th">h</th></tr></thead>
+                 <tbody id="body"><tr><td id="td">c</td></tr></tbody></table>
+               <ul><li id="li">z</li></ul>
+               <div id="celldiv" style="display:table-cell">x</div>
+               <div id="tablediv" style="display:table">y</div>
+               <div id="authored" style="display:flex;flex-direction:column;align-items:stretch">z</div>
+               <div id="plain">d</div>"#,
+        );
+        let mut resources = RenderResourceCache::default();
+        let prepared =
+            prepare_dom(&tree, (320.0, 200.0), None, &mut resources).expect("prepared render");
+        let computed = |id| {
+            prepared
+                .computed_style(tree.get_element_by_id(id).unwrap())
+                .expect("computed style")
+        };
+
+        for (id, expected) in [
+            ("t", "table"),
+            ("head", "table-header-group"),
+            ("body", "table-row-group"),
+            ("tr", "table-row"),
+            ("th", "table-cell"),
+            ("td", "table-cell"),
+            ("li", "list-item"),
+            ("celldiv", "table-cell"),
+            ("tablediv", "table"),
+            ("plain", "block"),
+            ("authored", "flex"),
+        ] {
+            assert_eq!(computed(id)["display"], expected, "display of #{id}");
+        }
+
+        // A table box never wrote these; reporting our stand-in made every
+        // table look like a column flexbox.
+        for id in ["t", "tr", "td", "celldiv"] {
+            assert_eq!(computed(id)["flex-direction"], "row", "#{id}");
+            assert_eq!(computed(id)["align-items"], "normal", "#{id}");
+        }
+        // An author who really did write them still gets them back.
+        let authored = computed("authored");
+        assert_eq!(authored["flex-direction"], "column");
+        assert_eq!(authored["align-items"], "stretch");
+    }
+
+    #[test]
+    fn computed_style_exposes_previously_empty_longhands() {
+        // Each of these returned the empty string, which a caller cannot tell
+        // apart from "not set".
+        let tree = parse_html(
+            r##"<style>#set{background-image:url(a.png);background-repeat:no-repeat;
+                 background-position:right 10px;background-size:cover;font-style:italic;
+                 text-indent:2em;align-self:center;flex-grow:2;flex-shrink:0;
+                 flex-basis:10px;order:3;aspect-ratio:1.5;object-fit:contain;
+                 box-shadow:1px 2px 3px 4px #f00;color:#00f;direction:rtl}</style>
+               <div id="set"></div><div id="unset"></div>
+               <table id="spaced" cellspacing="2"><tr><td>c</td></tr></table>
+               <a id="link" href="#">l</a>"##,
+        );
+        let mut resources = RenderResourceCache::default();
+        let prepared =
+            prepare_dom(&tree, (320.0, 200.0), None, &mut resources).expect("prepared render");
+        let computed = |id| {
+            prepared
+                .computed_style(tree.get_element_by_id(id).unwrap())
+                .expect("computed style")
+        };
+
+        let unset = computed("unset");
+        for (name, expected) in [
+            ("background-image", "none"),
+            ("background-size", "auto"),
+            ("background-position", "0% 0%"),
+            ("background-repeat", "repeat"),
+            ("font-style", "normal"),
+            ("text-decoration-line", "none"),
+            ("text-indent", "0px"),
+            ("border-spacing", "0px"),
+            ("align-self", "auto"),
+            ("justify-self", "auto"),
+            ("flex-grow", "0"),
+            ("flex-shrink", "1"),
+            ("flex-basis", "auto"),
+            ("order", "0"),
+            ("grid-column", "auto"),
+            ("grid-row", "auto"),
+            ("animation-name", "none"),
+            ("animation-duration", "0s"),
+            ("animation-iteration-count", "1"),
+            ("box-shadow", "none"),
+            ("object-fit", "fill"),
+            ("object-position", "50% 50%"),
+            ("aspect-ratio", "auto"),
+            ("direction", "ltr"),
+            // `auto` is the initial specified value but computes to zero on
+            // anything that is not a flex or grid item.
+            ("min-width", "0px"),
+            ("min-height", "0px"),
+            // Chromium reports the specified width even when the style is
+            // `none`; only the *used* width collapses to zero.
+            ("outline-width", "3px"),
+        ] {
+            assert_eq!(unset[name], expected, "unset {name}");
+        }
+
+        let set = computed("set");
+        assert_eq!(set["background-image"], r#"url("a.png")"#);
+        assert_eq!(set["background-repeat"], "no-repeat");
+        assert_eq!(set["background-size"], "cover");
+        assert_eq!(set["font-style"], "italic");
+        assert_eq!(set["text-indent"], "32px");
+        assert_eq!(set["align-self"], "center");
+        assert_eq!(set["flex-grow"], "2");
+        assert_eq!(set["flex-shrink"], "0");
+        assert_eq!(set["flex-basis"], "10px");
+        assert_eq!(set["order"], "3");
+        assert_eq!(set["object-fit"], "contain");
+        assert_eq!(set["aspect-ratio"], "1.5 / 1");
+        assert_eq!(set["direction"], "rtl");
+        assert_eq!(set["box-shadow"], "rgb(255, 0, 0) 1px 2px 3px 4px");
+        // currentColor-derived, so they track the element's own color.
+        assert_eq!(set["caret-color"], "rgb(0, 0, 255)");
+        assert_eq!(set["text-decoration-color"], "rgb(0, 0, 255)");
+
+        assert_eq!(computed("spaced")["border-spacing"], "2px");
+        assert_eq!(computed("link")["text-decoration-line"], "underline");
     }
 
     #[test]

--- a/crates/obscura-render/src/style.rs
+++ b/crates/obscura-render/src/style.rs
@@ -43,6 +43,23 @@ pub fn ua_style(tag: &str) -> LayoutStyle {
         "tr" => Display::Flex,
         _ => Display::Block,
     };
+
+    // The layout model has no table or list-item formatting mode, so
+    // `style.display` reports the stand-in (flex/block) for every one of these.
+    // Keep the box type the UA sheet actually assigns so CSSOM can read it back.
+    style.computed_display = match tag {
+        "table" => Some("table"),
+        "thead" => Some("table-header-group"),
+        "tbody" => Some("table-row-group"),
+        "tfoot" => Some("table-footer-group"),
+        "tr" => Some("table-row"),
+        "td" | "th" => Some("table-cell"),
+        "caption" => Some("table-caption"),
+        "colgroup" => Some("table-column-group"),
+        "col" => Some("table-column"),
+        "li" | "summary" => Some("list-item"),
+        _ => None,
+    };
     if tag == "slot" {
         // HTML's UA sheet makes a slot transparent to box generation; its
         // assigned nodes or fallback children participate at the slot's
@@ -781,6 +798,7 @@ fn apply_value(style: &mut LayoutStyle, name: &str, value: &str) {
                 style.is_table_cell_box = false;
                 style.is_inline_block = false;
                 style.flow_root = false;
+                style.computed_display = None;
                 style.display_contents = false;
                 style.display_inherit = false;
                 style.webkit_box_display = None;
@@ -815,12 +833,14 @@ fn apply_value(style: &mut LayoutStyle, name: &str, value: &str) {
                     style.display = crate::Display::Block;
                     style.flow_root = true;
                     style.is_table_box = true;
+                    style.computed_display = Some("table");
                 }
                 "inline-table" => {
                     style.display = crate::Display::Inline;
                     style.is_inline_block = true;
                     style.flow_root = true;
                     style.is_table_box = true;
+                    style.computed_display = Some("inline-table");
                 }
                 "table-cell" => {
                     // A table cell establishes an internal flow container. A
@@ -832,6 +852,7 @@ fn apply_value(style: &mut LayoutStyle, name: &str, value: &str) {
                     style.flex_direction = Some(taffy::FlexDirection::Column);
                     style.align_items = Some(taffy::AlignItems::FLEX_START);
                     style.is_table_cell_box = true;
+                    style.computed_display = Some("table-cell");
                 }
                 "-webkit-box" => {
                     // The unclamped legacy display is an old flexbox. When it
@@ -1243,6 +1264,7 @@ fn apply_value(style: &mut LayoutStyle, name: &str, value: &str) {
         "align-items" => {
             if let Some(Some(value)) = self_alignment_value(value) {
                 style.align_items = Some(value);
+                style.align_items_authored = true;
             }
         }
         "justify-items" => {
@@ -1253,6 +1275,7 @@ fn apply_value(style: &mut LayoutStyle, name: &str, value: &str) {
         "place-items" => {
             if let Some((Some(align), Some(justify))) = self_alignment_pair(value) {
                 style.align_items = Some(align);
+                style.align_items_authored = true;
                 style.justify_items = Some(justify);
             }
         }
@@ -1299,16 +1322,22 @@ fn apply_value(style: &mut LayoutStyle, name: &str, value: &str) {
                 // `flex-flow: column` resets an earlier flex-wrap to nowrap,
                 // while `flex-flow: wrap` resets direction to row.
                 style.flex_direction = Some(direction);
+                style.flex_direction_authored = true;
                 style.flex_wrap = Some(wrap);
             }
         }
-        "flex-direction" => match value {
-            "row" => style.flex_direction = Some(taffy::FlexDirection::Row),
-            "row-reverse" => style.flex_direction = Some(taffy::FlexDirection::RowReverse),
-            "column" => style.flex_direction = Some(taffy::FlexDirection::Column),
-            "column-reverse" => style.flex_direction = Some(taffy::FlexDirection::ColumnReverse),
-            _ => {}
-        },
+        "flex-direction" => {
+            match value {
+                "row" => style.flex_direction = Some(taffy::FlexDirection::Row),
+                "row-reverse" => style.flex_direction = Some(taffy::FlexDirection::RowReverse),
+                "column" => style.flex_direction = Some(taffy::FlexDirection::Column),
+                "column-reverse" => {
+                    style.flex_direction = Some(taffy::FlexDirection::ColumnReverse)
+                }
+                _ => return,
+            }
+            style.flex_direction_authored = true;
+        }
         "flex-wrap" => match value {
             "wrap" => style.flex_wrap = Some(taffy::FlexWrap::Wrap),
             "nowrap" => style.flex_wrap = Some(taffy::FlexWrap::NoWrap),

--- a/crates/obscura/tests/computed_style_coverage.rs
+++ b/crates/obscura/tests/computed_style_coverage.rs
@@ -1,0 +1,150 @@
+// getComputedStyle coverage from #771. An audit of ~90 properties against
+// Chromium 147 found 41 that returned the empty string and six that returned a
+// wrong value. An empty string is indistinguishable from "not set" to a caller,
+// so code that branches on one of these silently takes the wrong path instead
+// of failing visibly.
+//
+// Everything the renderer already computes is now served from its snapshot;
+// what it does not model at all falls back to the CSS initial value rather than
+// ''. The expectations below are Chromium 147's own values, captured over CDP
+// from the same markup.
+
+use std::io::{Read, Write};
+
+use obscura::Browser;
+
+fn spawn_server() -> String {
+    let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+    let addr = listener.local_addr().unwrap();
+    std::thread::spawn(move || {
+        for incoming in listener.incoming() {
+            let Ok(mut stream) = incoming else {
+                continue;
+            };
+            std::thread::spawn(move || {
+                let mut request = [0u8; 2048];
+                let _ = stream.read(&mut request);
+                let body = r#"<!doctype html><html><head><title>fixture</title></head>
+<body style="margin:0">
+<div id="d">x</div>
+<table id="t"><tr id="tr"><td id="td">c</td></tr></table>
+<ul><li id="li">z</li></ul>
+</body></html>"#;
+                let response = format!(
+                    "HTTP/1.1 200 OK\r\nContent-Type: text/html\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+                    body.len(),
+                    body,
+                );
+                let _ = stream.write_all(response.as_bytes());
+                let _ = stream.shutdown(std::net::Shutdown::Both);
+            });
+        }
+    });
+    format!("http://{}", addr)
+}
+
+#[cfg(feature = "render")]
+#[tokio::test(flavor = "current_thread")]
+async fn computed_style_never_returns_empty_for_supported_properties() {
+    std::env::set_var("OBSCURA_ALLOW_PRIVATE_NETWORK", "1");
+    let base = spawn_server();
+
+    let browser = Browser::new().unwrap();
+    let mut page = browser.new_page().await.unwrap();
+    page.goto(&base).await.unwrap();
+
+    let probes = page.evaluate(
+        r#"(function () {
+            var cs = getComputedStyle(document.getElementById('d'));
+            var out = {};
+            var names = ['background-image','background-size','background-position',
+              'background-repeat','font-style','word-spacing','text-decoration-line',
+              'text-indent','list-style-position','border-spacing','caption-side',
+              'align-self','flex-grow','flex-shrink','flex-basis','grid-column',
+              'grid-row','transition-property','transition-duration','animation-name',
+              'animation-duration','animation-iteration-count','animation-timing-function',
+              'user-select','box-shadow','text-shadow','content','order','object-fit',
+              'resize','appearance','filter','mix-blend-mode','writing-mode','direction',
+              'unicode-bidi','isolation','contain','aspect-ratio','zoom','min-width',
+              'min-height','outline-width','caret-color','object-position','justify-self',
+              'list-style-image','empty-cells'];
+            for (var i = 0; i < names.length; i++) out[names[i]] = cs.getPropertyValue(names[i]);
+            out['__display_table'] = getComputedStyle(document.getElementById('t')).display;
+            out['__display_row'] = getComputedStyle(document.getElementById('tr')).display;
+            out['__display_cell'] = getComputedStyle(document.getElementById('td')).display;
+            out['__display_li'] = getComputedStyle(document.getElementById('li')).display;
+            out['__table_flex_dir'] = getComputedStyle(document.getElementById('t')).flexDirection;
+            out['__table_align'] = getComputedStyle(document.getElementById('t')).alignItems;
+            return out;
+        })()"#,
+    );
+
+    // Chromium 147's value for each, on a plain <div> with nothing set.
+    for (name, expected) in [
+        ("background-image", "none"),
+        ("background-size", "auto"),
+        ("background-position", "0% 0%"),
+        ("background-repeat", "repeat"),
+        ("font-style", "normal"),
+        ("word-spacing", "0px"),
+        ("text-decoration-line", "none"),
+        ("text-indent", "0px"),
+        ("list-style-position", "outside"),
+        ("caption-side", "top"),
+        ("align-self", "auto"),
+        ("flex-grow", "0"),
+        ("flex-shrink", "1"),
+        ("flex-basis", "auto"),
+        ("grid-column", "auto"),
+        ("grid-row", "auto"),
+        ("transition-property", "all"),
+        ("transition-duration", "0s"),
+        ("animation-name", "none"),
+        ("animation-duration", "0s"),
+        ("animation-iteration-count", "1"),
+        ("animation-timing-function", "ease"),
+        ("user-select", "auto"),
+        ("box-shadow", "none"),
+        ("text-shadow", "none"),
+        ("content", "normal"),
+        ("order", "0"),
+        ("object-fit", "fill"),
+        ("object-position", "50% 50%"),
+        ("resize", "none"),
+        ("appearance", "none"),
+        ("filter", "none"),
+        ("mix-blend-mode", "normal"),
+        ("writing-mode", "horizontal-tb"),
+        ("direction", "ltr"),
+        ("isolation", "auto"),
+        ("contain", "none"),
+        ("aspect-ratio", "auto"),
+        ("zoom", "1"),
+        ("justify-self", "auto"),
+        ("list-style-image", "none"),
+        ("empty-cells", "show"),
+        ("caret-color", "rgb(0, 0, 0)"),
+        // Previously wrong rather than empty.
+        ("min-width", "0px"),
+        ("min-height", "0px"),
+        ("outline-width", "3px"),
+    ] {
+        assert_eq!(probes[name], expected, "getComputedStyle().{name}");
+    }
+
+    // `unicode-bidi` is the one property here whose Chromium value is
+    // element-dependent (its UA sheet isolates block containers, so a <div>
+    // reports `isolate` and a <span> `normal`). The CSS initial value is
+    // reported for every element rather than an empty string.
+    assert_eq!(probes["unicode-bidi"], "normal");
+
+    // The layout model approximates tables with flex containers, so a table's
+    // box type could not be read back at all and the internal column direction
+    // leaked out as the computed value of a property nobody wrote.
+    assert_eq!(probes["__display_table"], "table");
+    assert_eq!(probes["__display_row"], "table-row");
+    assert_eq!(probes["__display_cell"], "table-cell");
+    assert_eq!(probes["__display_li"], "list-item");
+    assert_eq!(probes["__table_flex_dir"], "row");
+    assert_eq!(probes["__table_align"], "normal");
+}


### PR DESCRIPTION
Fixes #771.

An audit of ~90 computed properties against Chromium 147 found **41 that returned the empty string** and six that returned a wrong value. An empty string is indistinguishable from "not set" to a caller, so code that branches on one of these silently takes the wrong path instead of failing visibly.

### Properties that were simply never emitted

The renderer already computes most of them — they just never made it into the snapshot. Now emitted with their real values:

`background-image`, `background-size`, `background-position`, `background-repeat`, `font-style`, `text-decoration`, `text-decoration-line`, `text-indent`, `border-spacing`, `align-self`, `justify-self`, `flex-grow`, `flex-shrink`, `flex-basis`, `order`, `grid-column`, `grid-row`, `animation-name` and the rest of the animation longhands, `object-fit`, `object-position`, `box-shadow`, `aspect-ratio`, `direction`, plus the currentColor-derived `caret-color` and `text-decoration-color`.

What the renderer does not model at all (`word-spacing`, `list-style-position`, `caption-side`, `empty-cells`, the transition longhands, `user-select`, `text-shadow`, `content`, `resize`, `appearance`, `filter`, `mix-blend-mode`, `writing-mode`, `unicode-bidi`, `isolation`, `contain`, `zoom`, …) falls back to the CSS initial value in the defaults table instead of `''`. A valid value is a better answer than a value that reads as absent.

### Six that were wrong rather than missing

- **`display` never reported a table box type.** Tables are approximated with flex containers, so every table, row, row group and cell reported `block` and a caller had to infer the box type from rects. The cascade's own box type is now carried alongside the layout stand-in, which also covers `list-item`.
- **`flex-direction` and `align-items` leaked that stand-in**: an untouched `<table>` reported `column`/`stretch` because that is how we lay it out. They report the initial values now unless the author really wrote them.
- **`min-width`/`min-height` reported `auto`**, the initial *specified* value; it computes to `0px` on anything that is not a flex or grid item, and `auto` gave callers nothing to do length math with.
- **`outline-width` reported the used width**, which collapses to zero when the style is `none`.

### One judgement call worth flagging

`outline-width` is the only change here that contradicts a deliberate existing decision (`outline_none_retains_width_but_does_not_change_geometry_or_computed_used_width`). Measured on Chromium 147:

| element | Chromium 147 |
|---|---|
| `outline-width:9px;outline-style:none` | `9px` |
| `outline:none` | `3px` |
| nothing set | `3px` |

CSS-UI says the computed value is "0 if the outline style is none", so the existing test follows the spec and Blink does not. I have gone with Blink since that is this engine's comparison target, and the paint and geometry paths still take `used_width()` so nothing renders differently — but this is a one-line revert if you would rather keep the spec behaviour.

### Testing

`cargo test -p obscura-render --features paint` and `cargo test -p obscura --features render` are green apart from the three `child_frame_scripts` failures already present on `main` at 9326880.

The end-to-end test asserts Chromium 147's own values, captured over CDP from the same markup. Two related items are deliberately *not* in this PR, so it does not overlap #762 (`vertical-align`, `list-style-type`, `border-collapse`, `table-layout`, `text-transform`, `cssFloat`) or #770 (the inset properties).
