### PR TITLE
fix(layout): a cyclic inline size behaves as auto, not as zero

### DIFF
--- a/crates/obscura-render/src/dom.rs
+++ b/crates/obscura-render/src/dom.rs
@@ -11427,13 +11427,16 @@ fn assign_native_control_size(
 ) {
     let (stretch_inline, stretch_block) = stretched_grid_item;
     let content_box = style.box_sizing == crate::BoxSizing::ContentBox;
+    let declared_inline = if content_box {
+        (intrinsic_width - horizontal_edges).max(0.0)
+    } else {
+        intrinsic_width
+    };
+    // Kept even when an authored width wins, because a *cyclic* authored width
+    // is neutralized after this pass and then has nothing to fall back on.
+    style.native_control_intrinsic_width = Some(declared_inline);
     if style.width == crate::Dimension::Auto && !stretch_inline {
-        let declared = if content_box {
-            (intrinsic_width - horizontal_edges).max(0.0)
-        } else {
-            intrinsic_width
-        };
-        style.width = crate::Dimension::Px(declared);
+        style.width = crate::Dimension::Px(declared_inline);
     }
     if style.height == crate::Dimension::Auto && !stretch_block {
         let declared = if content_box {
@@ -11745,7 +11748,34 @@ fn defer_cyclic_flex_inline_sizes(
         if let Some(style) = styles.get_mut(&id) {
             let intrinsic = crate::Dimension::Px(intrinsic.max(0.0));
             match slot {
-                0 => style.width = intrinsic,
+                // A cyclic inline size behaves as `auto` during intrinsic
+                // contribution sizing (CSS Sizing 3 §5.2.3), exactly as the
+                // max-size arm below already does. Evaluating the expression
+                // at a zero basis instead made `calc(100% - 32px)` a permanent
+                // `0px`: every shrink-to-fit ancestor then wrapped that zero,
+                // and the basis re-sampled after flex sizing came back as the
+                // neutralized box's own padding instead of a containing block,
+                // so the second pass could not recover it either (#767).
+                //
+                // Two kinds of box cannot say "auto" and mean their own size:
+                //
+                // - A replaced element would contribute its full natural width
+                //   and inflate every ancestor's max-content size. It keeps the
+                //   zero-basis value, which the resolve pass below lifts back
+                //   to that natural width once the flex item is pinned (#698).
+                // - A native control's intrinsic geometry is assigned before
+                //   this pass and only to an *auto* width, so one with a cyclic
+                //   width never received any and would contribute nothing.
+                0 => {
+                    style.width = match (
+                        style.native_control_intrinsic_width,
+                        style.replaced_intrinsic.is_some() || style.has_replaced_sizing,
+                    ) {
+                        (Some(control), _) => crate::Dimension::Px(control),
+                        (None, true) => intrinsic,
+                        (None, false) => crate::Dimension::Auto,
+                    }
+                }
                 2 => style.min_width = intrinsic,
                 // A cyclic percentage max-size behaves as its initial value
                 // during intrinsic contribution sizing; treating 50% as a

--- a/crates/obscura-render/src/lib.rs
+++ b/crates/obscura-render/src/lib.rs
@@ -1055,6 +1055,14 @@ pub struct LayoutStyle {
     /// size when percentage dimensions are resolved through an auto-sized
     /// wrapper (`img { width:100%; height:auto }`).
     pub intrinsic_size: Option<(f32, f32)>,
+    /// The intrinsic inline size of a native form control (`<input>`,
+    /// `<select>`, `<textarea>`), whether or not it was used.
+    ///
+    /// Control geometry is assigned before cyclic inline sizes are deferred,
+    /// and only to an auto width, so a control with a cyclic `width` never
+    /// receives one. The deferral needs the size the control would have had in
+    /// order to neutralize to something other than zero.
+    pub(crate) native_control_intrinsic_width: Option<f32>,
     /// Per-axis decoded intrinsic metadata used by the replaced sizing path.
     /// SVG can expose only one dimension or a `viewBox` ratio, distinctions
     /// that the stable public `intrinsic_size` tuple cannot represent.

--- a/crates/obscura-render/src/paint.rs
+++ b/crates/obscura-render/src/paint.rs
@@ -15000,6 +15000,62 @@ mod tests {
     }
 
     #[test]
+    fn cyclic_functional_inline_size_survives_a_flex_ancestor() {
+        // #767: `width:calc(100% - 32px)` collapsed to 0 as soon as anything
+        // above it was a flex container. The size is cyclic there, so it is
+        // neutralized for the intrinsic pass and re-resolved afterwards, but
+        // the neutral value used was the expression evaluated at a *zero*
+        // percentage basis -- which clamps to `0px`. Every shrink-to-fit
+        // ancestor then wrapped that zero, and the basis re-sampled after flex
+        // sizing came back as the collapsed box's own padding rather than a
+        // containing block, so the second pass could not recover either.
+        //
+        // Chromium 147 on this markup: the shrink-to-fit wrapper takes the
+        // control's intrinsic width and the input resolves to wrapper - 32.
+        // The wrapper's own width still differs from Chromium's because our
+        // native text-control intrinsic width is ~24px wide (a separate
+        // issue), so the relationship is what is asserted here.
+        let tree = parse_html(
+            r#"<body style="margin:0;font:14px Arial">
+            <div style="display:flex;flex:1;width:1560px"><div id="wrap"><div><label><span>
+            <input id="control" style="width:calc(100% - 32px);padding-left:25px;
+              height:30px;margin:0;border:1px solid #999">
+            </span></label></div></div></div>
+            <div style="width:1560px"><div><div><label><span>
+            <input id="noflex" style="width:calc(100% - 32px);padding-left:25px;
+              height:30px;margin:0;border:1px solid #999">
+            </span></label></div></div></div>
+            <div style="display:flex;flex:1;width:1560px"><div id="textwrap"><div><span>
+            <div id="text" style="width:calc(100% - 32px);height:20px">hello world</div>
+            </span></div></div></div></body>"#,
+        );
+        let mut resources = RenderResourceCache::default();
+        let prepared =
+            prepare_dom(&tree, (1600.0, 900.0), None, &mut resources).expect("prepared render");
+        let width = |id: &str| {
+            prepared
+                .document_rect(tree.get_element_by_id(id).unwrap())
+                .expect("rect")
+                .width
+        };
+
+        // Without a flex ancestor the size was never cyclic; both engines
+        // already agreed on this one, and it must not move.
+        assert_eq!(width("noflex"), 1528.0);
+
+        // A native control keeps the intrinsic geometry it would have had with
+        // an auto width, so its wrapper has something to shrink-wrap around.
+        let wrap = width("wrap");
+        assert!(wrap > 100.0, "wrapper collapsed to {wrap}");
+        assert_eq!(width("control"), wrap - 32.0);
+
+        // A non-replaced box contributes its max-content width, the same as it
+        // would with `width:auto`. Chromium 147: 66.94 and 34.94.
+        assert_eq!(width("textwrap"), 67.0);
+        assert_eq!(width("text"), 35.0);
+    }
+
+    #[test]
     fn computed_style_exposes_float_and_clear() {
         let tree = parse_html(
             r#"<style>#left{float:left} #right{float:right;clear:both}</style>


### PR DESCRIPTION
Fixes #767.

`width:calc(100% - 32px)` resolved to `0px` as soon as anything above the element was a flex container, so Bootstrap/DataTables search fields rendered as ~30px stubs with their placeholder text spilling outside them. Without the flex ancestor both engines already agreed exactly (`1528px`).

### What was happening

The size is cyclic under a flex item with an indefinite inline size, so it is neutralized for the intrinsic pass and re-resolved once flex sizing has picked the item's used width. The neutral value used was **the expression evaluated at a zero percentage basis**, which for `calc(100% - 32px)` is negative and clamps to `0px`.

That is not a neutral value, it is a permanent floor. Instrumenting the pass on the reduced markup:

```
DEFER   node=11 slot=0 was_width=Some(Px(1528.0)) intrinsic=-32
RESOLVE node=11 slot=0 basis=29
```

The width was *already resolved* to `Px(1528)` when the deferral ran, it was replaced by `0px`, every shrink-to-fit ancestor then wrapped that zero, and the basis re-sampled afterwards came back as the collapsed box's own padding (29) rather than a containing block — so the second pass computed `calc(29px - 32px)` and could not recover either. Zero twice over.

### The fix

CSS Sizing 3 §5.2.3 says a cyclic percentage behaves as `auto` for intrinsic contribution, which is what the `max_width` arm of this same `match` already does and cites. The `width` arm now does it too, with two exceptions that cannot say `auto` and mean their own size:

- **A replaced element** would contribute its full natural width and inflate every ancestor's max-content size. It keeps the zero-basis value, which the resolve pass lifts back to the natural width once the item is pinned (#698) — switching it to `auto` regressed exactly that test (`bare_and_functional_cyclic_image_percentages_use_the_final_flex_width`), which is how the exception was found.
- **A native control's** intrinsic geometry is assigned before this pass, and only to an *auto* width, so a control with a cyclic width never received any and would contribute nothing at all. `assign_native_control_size` now records the width it would have used whether or not it applied it.

### Verified against Chromium 147

| case | Chromium 147 | before | after |
|---|---|---|---|
| non-replaced box in flex (`width`) | 34.94 | 0 | **35** |
| its shrink-to-fit wrapper | 66.94 | 0 | **67** |
| `<input>` in flex (`width`) | 142 | 29 | 166 |
| `<input>`, no flex ancestor | 1528 | 1528 | 1528 |

The non-replaced case now matches to the pixel. The control case matches in *relationship* (`wrapper - 32`, exactly as Chromium does it) but not absolutely, because our intrinsic text control is ~24px wider than Chromium's: a plain `<input>` with no flex and no `calc()` anywhere measures 177 where Chromium measures 153. That is an unrelated pre-existing gap in the control metrics and is out of scope here — happy to file it separately if useful.

### Testing

`cargo test -p obscura-render --features paint` is fully green (587 tests), and `cargo test -p obscura --features render` is green apart from the three `child_frame_scripts` failures already present on `main` at 9326880.
