### PR TITLE
fix(layout): a display:none float must not widen its parent

### DIFF
--- a/crates/obscura-render/src/dom.rs
+++ b/crates/obscura-render/src/dom.rs
@@ -12509,10 +12509,18 @@ fn build(
     // leave floats on children after a newer rule turns their parent into a
     // flex container; routing those children through the block float-zone
     // approximation corrupts flex sizing and percentage-margin placement.
+    // `display:none` generates no box, so it cannot float. Counting one here
+    // sent the whole container down the legacy float-zone path instead of
+    // `build_mixed_block`, and the two size an inline run holding an atomic
+    // box differently, so a hidden `.dropdown-menu{display:none;float:left}`
+    // silently widened every Bootstrap navbar item that contains an icon
+    // (#764).
     let has_float_child = style.display == crate::Display::Block
-        && dom_children
-            .iter()
-            .any(|&cid| styles.get(&cid).map(|s| s.float.is_some()).unwrap_or(false));
+        && dom_children.iter().any(|&cid| {
+            styles.get(&cid).is_some_and(|s| {
+                s.display != crate::Display::None && s.float.is_some()
+            })
+        });
     let native_float_band =
         has_float_child && can_use_native_float_band(tree, style, &dom_children, styles);
     let has_in_flow_block_child = dom_children

--- a/crates/obscura-render/src/paint.rs
+++ b/crates/obscura-render/src/paint.rs
@@ -15000,6 +15000,53 @@ mod tests {
     }
 
     #[test]
+    fn a_hidden_float_does_not_widen_a_shrink_to_fit_parent() {
+        // #764: `display:none` generates no box, so it cannot float -- but the
+        // check that decides whether a block container has a floating child
+        // did not say so. One hidden float sent the whole container down the
+        // legacy float-zone path instead of the mixed-block builder, and those
+        // two size an inline run holding an atomic box differently.
+        //
+        // This is the Bootstrap navbar shape: `.dropdown-menu{display:none;
+        // float:left}` inside a nav item whose link contains icons. Every
+        // top-level item came out several px too wide, enough to wrap the last
+        // one onto a second row and double the navbar's height.
+        //
+        // Chromium 147 reports 71.1 for all three cases with an atomic inline
+        // and 31.1 for the one without.
+        let case = |inner: &str| {
+            let html = format!(
+                r#"<body style="margin:0;font:14px Arial,sans-serif">
+                   <style>.ib{{display:inline-block;width:20px}}</style>
+                   <div id="t" style="float:left">{inner}</div></body>"#
+            );
+            let tree = parse_html(&html);
+            let mut resources = RenderResourceCache::default();
+            let prepared =
+                prepare_dom(&tree, (800.0, 600.0), None, &mut resources).expect("prepared render");
+            prepared
+                .document_rect(tree.get_element_by_id("t").unwrap())
+                .expect("rect")
+                .width
+        };
+
+        let icons = r##"<a href="#"><i class="ib"></i>CMS<i class="ib"></i></a>"##;
+        let hidden_float = r#"<div style="display:none;float:left">A much longer hidden string</div>"#;
+        let hidden_block = r#"<div style="display:none">A much longer hidden string</div>"#;
+
+        let baseline = case(icons);
+        // Neither half alone was ever wrong; only the combination.
+        assert_eq!(case(&format!("{icons}{hidden_block}")), baseline);
+        assert_eq!(case(&format!("{icons}{hidden_float}")), baseline);
+        // ... and a hidden float with no atomic inline beside it is still the
+        // width of the visible text alone.
+        assert!(
+            case(&format!(r##"<a href="#">CMS</a>{hidden_float}"##)) < baseline,
+            "a hidden float must not contribute its own content width"
+        );
+    }
+
+    #[test]
     fn computed_style_exposes_float_and_clear() {
         let tree = parse_html(
             r#"<style>#left{float:left} #right{float:right;clear:both}</style>


### PR DESCRIPTION
Fixes #764.

`display:none` generates no box, so it cannot float. The check that decides whether a block container has a floating child did not say so:

```rust
let has_float_child = style.display == crate::Display::Block
    && dom_children
        .iter()
        .any(|&cid| styles.get(&cid).map(|s| s.float.is_some()).unwrap_or(false));
```

The equivalent test elsewhere in the same file already excludes `Display::None`; this one just asks `float.is_some()`.

### Why it needed both halves to show up

One hidden float was enough to set `has_float_child`, which disqualifies the container from `build_mixed_block` and routes it through the legacy float-zone path instead. Those two size an inline run holding an atomic box differently — which is exactly why the issue's matrix looked so strange:

| case | Chromium 147 | before | after |
|---|---|---|---|
| atomic inline + `display:none` float | 71.1 | **75** | 71 |
| atomic inline, no hidden float | 71.1 | 71 | 71 |
| `display:none` float, no atomic inline | 31.1 | 32 | 32 |
| `display:none` *without* `float` + atomic inline | 71.1 | 71 | 71 |

Neither half was ever wrong alone. The hidden element was correctly ignored for its own box, and the inline-blocks were sized correctly on their own; only the combination diverged, because only the combination made the two code paths disagree.

This is the Bootstrap navbar shape — `.dropdown-menu { display:none; float:left }` inside a nav item whose link contains icons. Every top-level item came out several px too wide, which is enough to wrap the last item onto a second row and double the navbar's height.

I originally suspected this shared a cause with #722 ("a run containing an atomic inline takes a different path"). It does touch the same divergence, but the trigger here is upstream of it: the container should never have been on that path at all.

### Testing

`cargo test -p obscura-render --features paint` is fully green (587 tests), and `cargo test -p obscura --features render` is green apart from the three `child_frame_scripts` failures already present on `main` at 9326880.
