### PR TITLE
fix(js): enter the isolate per operation instead of for its lifetime

### DIFF
--- a/crates/obscura-js/src/runtime.rs
+++ b/crates/obscura-js/src/runtime.rs
@@ -128,7 +128,7 @@ pub struct RemoteObjectInfo {
 }
 
 pub struct ObscuraJsRuntime {
-    runtime: JsRuntime,
+    js_runtime: JsRuntime,
     state: Rc<RefCell<ObscuraState>>,
     object_store: HashMap<String, String>,
     object_counter: u64,
@@ -271,7 +271,85 @@ impl WatchdogToken {
 const SYNCHRONOUS_TASK_FLOOR_MS: u64 = 5_000;
 const WATCHDOG_SCHEDULING_MARGIN_MS: u64 = 500;
 
+/// A [`JsRuntime`] whose isolate is entered for the duration of one operation.
+///
+/// V8 requires the isolate that owns a context to be the thread's *current*
+/// one whenever that context is entered or left, and rusty_v8's scopes do not
+/// arrange that themselves -- they only ever pass the isolate explicitly. What
+/// made it work by accident was rusty_v8 entering an isolate when it is
+/// constructed and leaving it entered for life: with a single page, that page's
+/// isolate is trivially the current one.
+///
+/// With two pages it is not. The isolates form a stack, only the newest is
+/// current, and the consequences were both immediate and fatal:
+///
+/// - running any script on the *older* page aborted the process
+///   (`Check failed: heap->isolate() == Isolate::TryGetCurrent()`), so a second
+///   page effectively disabled the first;
+/// - dropping either page aborted too, because rusty_v8 requires isolates to
+///   be dropped in reverse construction order -- a contract an embedder holding
+///   independent `Page` objects cannot keep (#756).
+///
+/// So the isolate is exited once construction finishes and entered again only
+/// around work that touches V8. Entries are then properly nested no matter how
+/// many pages exist or what order they are used and dropped in.
+struct EnteredRuntime<'a>(&'a mut JsRuntime);
+
+impl std::ops::Deref for EnteredRuntime<'_> {
+    type Target = JsRuntime;
+
+    fn deref(&self) -> &JsRuntime {
+        self.0
+    }
+}
+
+impl std::ops::DerefMut for EnteredRuntime<'_> {
+    fn deref_mut(&mut self) -> &mut JsRuntime {
+        self.0
+    }
+}
+
+impl Drop for EnteredRuntime<'_> {
+    fn drop(&mut self) {
+        // SAFETY: this isolate was entered by the matching `runtime()` call
+        // and, entries being a per-thread stack, is the current one: any
+        // isolate entered since belongs to a nested operation that has already
+        // exited it.
+        unsafe {
+            self.0.v8_isolate().exit();
+        }
+    }
+}
+
+impl Drop for ObscuraJsRuntime {
+    fn drop(&mut self) {
+        // Teardown needs the isolate current as much as any other V8 work:
+        // deno_core's context cleanup clears the context's embedder slots, and
+        // rusty_v8's `OwnedIsolate::drop` asserts it before disposing. Both run
+        // when `js_runtime` is dropped, immediately after this returns, and
+        // that `OwnedIsolate::drop` performs the matching exit.
+        //
+        // SAFETY: `enter` only pushes this isolate onto the current thread's
+        // entry stack; the pop is guaranteed by the drop that follows.
+        unsafe {
+            self.js_runtime.v8_isolate().enter();
+        }
+    }
+}
+
 impl ObscuraJsRuntime {
+    /// The V8 runtime, with its isolate entered for as long as the returned
+    /// guard lives. Every path that touches V8 goes through here; see
+    /// [`EnteredRuntime`] for why.
+    fn runtime(&mut self) -> EnteredRuntime<'_> {
+        // SAFETY: entering is always sound -- it pushes this isolate onto the
+        // current thread's entry stack -- and the guard's `Drop` pops it.
+        unsafe {
+            self.js_runtime.v8_isolate().enter();
+        }
+        EnteredRuntime(&mut self.js_runtime)
+    }
+
     /// Freeze the document timeline for one JavaScript task. Browser timelines
     /// update at task/rendering boundaries, not on each forced style or layout
     /// read. Keeping one sample across the task also lets repeated CSSOM reads
@@ -361,7 +439,7 @@ impl ObscuraJsRuntime {
         };
 
         let mut instance = ObscuraJsRuntime {
-            runtime,
+            js_runtime: runtime,
             state,
             object_store: HashMap::new(),
             object_counter: 0,
@@ -377,6 +455,17 @@ impl ObscuraJsRuntime {
         // Take the op table before any page script can run, and drop the global
         // that exposed it in the same step.
         instance.ops_handoff = instance.take_ops_handoff();
+
+        // `JsRuntime::new` entered this isolate and rusty_v8 would leave it
+        // entered for life. Leave the thread's entry stack empty instead; every
+        // operation enters for its own duration. See `EnteredRuntime`.
+        //
+        // SAFETY: this isolate is the current one -- it was entered above and
+        // nothing on this thread has entered another since.
+        unsafe {
+            instance.js_runtime.v8_isolate().exit();
+        }
+
         instance
     }
 
@@ -395,7 +484,8 @@ impl ObscuraJsRuntime {
         &mut self,
     ) -> Option<deno_core::v8::Global<deno_core::v8::Context>> {
         let context = {
-            let isolate = self.runtime.v8_isolate();
+            let mut entered = self.runtime();
+            let isolate = entered.v8_isolate();
             let scope = &mut deno_core::v8::HandleScope::new(isolate);
             let context = deno_core::v8::Context::from_snapshot(
                 scope,
@@ -423,8 +513,9 @@ impl ObscuraJsRuntime {
     fn take_ops_handoff(&mut self) -> Option<deno_core::v8::Global<deno_core::v8::Value>> {
         use deno_core::v8;
 
-        let main = self.runtime.main_context();
-        let isolate = self.runtime.v8_isolate();
+        let main = self.runtime().main_context();
+        let mut entered = self.runtime();
+        let isolate = entered.v8_isolate();
         let scope = &mut v8::HandleScope::new(isolate);
         let context = v8::Local::new(scope, main);
         let scope = &mut v8::ContextScope::new(scope, context);
@@ -459,7 +550,8 @@ impl ObscuraJsRuntime {
         let Some(ops) = self.ops_handoff.clone() else {
             return false;
         };
-        let isolate = self.runtime.v8_isolate();
+        let mut entered = self.runtime();
+        let isolate = entered.v8_isolate();
         let scope = &mut v8::HandleScope::new(isolate);
         let context = v8::Local::new(scope, realm);
         let scope = &mut v8::ContextScope::new(scope, context);
@@ -519,7 +611,8 @@ impl ObscuraJsRuntime {
     ) -> Result<String, String> {
         use deno_core::v8;
 
-        let isolate = self.runtime.v8_isolate();
+        let mut entered = self.runtime();
+        let isolate = entered.v8_isolate();
         let scope = &mut v8::HandleScope::new(isolate);
         let context = v8::Local::new(scope, realm);
         let scope = &mut v8::ContextScope::new(scope, context);
@@ -559,8 +652,9 @@ impl ObscuraJsRuntime {
             "__obscura_geo_lon",
         ];
 
-        let main = self.runtime.main_context();
-        let isolate = self.runtime.v8_isolate();
+        let main = self.runtime().main_context();
+        let mut entered = self.runtime();
+        let isolate = entered.v8_isolate();
         let scope = &mut v8::HandleScope::new(isolate);
 
         let main_context = v8::Local::new(scope, main);
@@ -635,8 +729,9 @@ impl ObscuraJsRuntime {
     ) {
         use deno_core::v8;
 
-        let main = self.runtime.main_context();
-        let isolate = self.runtime.v8_isolate();
+        let main = self.runtime().main_context();
+        let mut entered = self.runtime();
+        let isolate = entered.v8_isolate();
         let scope = &mut v8::HandleScope::new(isolate);
         let main = v8::Local::new(scope, main);
         let realm = v8::Local::new(scope, realm);
@@ -660,8 +755,9 @@ impl ObscuraJsRuntime {
     ) -> bool {
         use deno_core::v8;
 
-        let main = self.runtime.main_context();
-        let isolate = self.runtime.v8_isolate();
+        let main = self.runtime().main_context();
+        let mut entered = self.runtime();
+        let isolate = entered.v8_isolate();
         let scope = &mut v8::HandleScope::new(isolate);
 
         // Read the frame's globals first, then install them in the page realm.
@@ -716,7 +812,8 @@ impl ObscuraJsRuntime {
 
     /// The table ops consult to find the calling realm's document.
     pub(crate) fn realm_states(&self) -> Rc<RefCell<crate::ops::RealmStates>> {
-        self.runtime
+        // `op_state` is a plain Rust-side table; no V8 access, no guard.
+        self.js_runtime
             .op_state()
             .borrow()
             .borrow::<Rc<RefCell<crate::ops::RealmStates>>>()
@@ -751,18 +848,16 @@ impl ObscuraJsRuntime {
             return false;
         }
 
-        self.runtime.v8_isolate().cancel_terminate_execution();
+        self.runtime().v8_isolate().cancel_terminate_execution();
         let restore_limit = self
             .heap_limit_state
             .restore_limit
             .swap(0, std::sync::atomic::Ordering::SeqCst);
-        self.runtime
+        self.runtime()
             .remove_near_heap_limit_callback(restore_limit);
-        install_heap_limit_guard(
-            &mut self.runtime,
-            self.isolate_handle.clone(),
-            self.heap_limit_state.clone(),
-        );
+        let isolate_handle = self.isolate_handle.clone();
+        let heap_limit_state = self.heap_limit_state.clone();
+        install_heap_limit_guard(&mut *self.runtime(), isolate_handle, heap_limit_state);
         tracing::warn!("V8 heap limit reached: terminated the current JavaScript task");
         true
     }
@@ -781,7 +876,7 @@ impl ObscuraJsRuntime {
         source: String,
     ) -> Result<deno_core::v8::Global<deno_core::v8::Value>, String> {
         let result = self
-            .runtime
+            .runtime()
             .execute_script(name, source)
             .map_err(|error| error.to_string());
         self.finish_heap_checked(result)
@@ -1954,7 +2049,7 @@ impl ObscuraJsRuntime {
         // already-rendered page, full for an unmounted SPA shell (#205).
         let module_id = match tokio::time::timeout(
             budget,
-            self.runtime.load_side_es_module(&specifier),
+            self.runtime().load_side_es_module(&specifier),
         )
         .await
         {
@@ -2013,7 +2108,7 @@ impl ObscuraJsRuntime {
         // observable when mod_evaluate checks V8's private module status, so
         // contain that dependency assertion at this boundary as well.
         let evaluation = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-            self.runtime.mod_evaluate(module_id)
+            self.runtime().mod_evaluate(module_id)
         }));
         let result = match evaluation {
             Ok(result) => result,
@@ -2031,9 +2126,9 @@ impl ObscuraJsRuntime {
         tokio::pin!(result);
 
         let outcome = tokio::time::timeout(budget, async {
-            let event_loop = self
-                .runtime
-                .run_event_loop(deno_core::PollEventLoopOptions::default());
+            let mut entered = self.runtime();
+            let event_loop =
+                entered.run_event_loop(deno_core::PollEventLoopOptions::default());
             tokio::pin!(event_loop);
             tokio::select! {
                 biased;
@@ -2093,7 +2188,7 @@ impl ObscuraJsRuntime {
 
         let module_id = match tokio::time::timeout(
             budget,
-            self.runtime.load_side_es_module_from_code(
+            self.runtime().load_side_es_module_from_code(
                 &specifier,
                 deno_core::ModuleCodeString::from(code.to_string()),
             ),
@@ -2183,7 +2278,8 @@ impl ObscuraJsRuntime {
         // origin as import()'s referrer, so compile in the runtime's main
         // context directly instead of substituting the fixed "<script>" name.
         let result = (|| {
-            let scope = &mut self.runtime.handle_scope();
+            let mut entered = self.runtime();
+            let scope = &mut entered.handle_scope();
             let source = deno_core::v8::String::new(scope, source)
                 .ok_or_else(|| "JS error: source allocation failed".to_string())?;
             let name = deno_core::v8::String::new(scope, name)
@@ -2260,7 +2356,7 @@ impl ObscuraJsRuntime {
             return self.execute_classic_script(name, source);
         }
 
-        let isolate_handle = self.runtime.v8_isolate().thread_safe_handle();
+        let isolate_handle = self.runtime().v8_isolate().thread_safe_handle();
 
         let pair = std::sync::Arc::new((std::sync::Mutex::new(false), std::sync::Condvar::new()));
         let pair_clone = pair.clone();
@@ -2315,13 +2411,13 @@ impl ObscuraJsRuntime {
         // pending, leaving an already-resolved Promise continuation stranded
         // (document.fonts.load(...).then(...), framework post-render hooks,
         // and hydration follow-ups all rely on this boundary).
-        self.runtime.v8_isolate().perform_microtask_checkpoint();
+        self.runtime().v8_isolate().perform_microtask_checkpoint();
         let result = self
-            .runtime
+            .runtime()
             .run_event_loop(deno_core::PollEventLoopOptions::default())
             .await
             .map_err(|e| format!("Event loop error: {}", e));
-        self.runtime.v8_isolate().perform_microtask_checkpoint();
+        self.runtime().v8_isolate().perform_microtask_checkpoint();
         self.finish_heap_checked(result)
     }
 
@@ -2389,7 +2485,7 @@ impl ObscuraJsRuntime {
     /// `budget` elapses, forcing V8 to throw an uncatchable error and hand
     /// control back. Always balance with [`Self::disarm_watchdog`].
     pub fn arm_watchdog(&mut self, budget: std::time::Duration) -> WatchdogToken {
-        spawn_watchdog(self.runtime.v8_isolate().thread_safe_handle(), budget)
+        spawn_watchdog(self.runtime().v8_isolate().thread_safe_handle(), budget)
     }
 
     /// Stop a watchdog armed by [`Self::arm_watchdog`]. If it had already fired
@@ -2398,7 +2494,7 @@ impl ObscuraJsRuntime {
     pub fn disarm_watchdog(&mut self, token: WatchdogToken) -> bool {
         let fired = token.stop();
         if fired {
-            self.runtime.v8_isolate().cancel_terminate_execution();
+            self.runtime().v8_isolate().cancel_terminate_execution();
             tracing::warn!("V8 watchdog fired: terminated a synchronous overrun");
         }
         fired
@@ -2415,7 +2511,7 @@ impl ObscuraJsRuntime {
     /// isolate handle) fired, so the isolate is usable for the next command.
     /// No-op when the isolate is not terminating.
     pub fn cancel_termination(&mut self) {
-        self.runtime.v8_isolate().cancel_terminate_execution();
+        self.runtime().v8_isolate().cancel_terminate_execution();
     }
 
     /// Drive the event loop for at most `budget_ms`, bounded against BOTH async
@@ -2457,7 +2553,7 @@ impl ObscuraJsRuntime {
                     // queued from them belongs to a subsequent cooperative
                     // turn. Yield so the wall deadline remains observable even
                     // when every turn immediately schedules another one.
-                    self.runtime.v8_isolate().perform_microtask_checkpoint();
+                    self.runtime().v8_isolate().perform_microtask_checkpoint();
                     tokio::task::yield_now().await;
                 }
                 Ok(Err(error)) => {
@@ -2512,11 +2608,11 @@ impl ObscuraJsRuntime {
     /// adaptive settle loop does not poll at a fixed frequency.
     async fn run_cooperative_event_loop_tick(&mut self) -> Result<bool, String> {
         self.begin_javascript_task();
-        self.runtime.v8_isolate().perform_microtask_checkpoint();
+        self.runtime().v8_isolate().perform_microtask_checkpoint();
         let mut waiting_for_wake = false;
         let result = std::future::poll_fn(|cx| {
             let tick = self
-                .runtime
+                .runtime()
                 .poll_event_loop(cx, deno_core::PollEventLoopOptions::default());
             match tick {
                 std::task::Poll::Ready(Ok(())) => std::task::Poll::Ready(Ok(true)),
@@ -2558,7 +2654,7 @@ impl ObscuraJsRuntime {
             self.isolate_handle(),
             std::time::Duration::from_millis(AUTONOMOUS_TASK_WATCHDOG_MS),
         );
-        self.runtime.v8_isolate().perform_microtask_checkpoint();
+        self.runtime().v8_isolate().perform_microtask_checkpoint();
         if crate::cdp_watchdog::disarm(checkpoint_watchdog) {
             self.cancel_termination();
             return Err("autonomous microtask checkpoint exceeded its task budget".into());
@@ -2575,11 +2671,11 @@ impl ObscuraJsRuntime {
                 std::time::Duration::from_millis(AUTONOMOUS_TASK_WATCHDOG_MS),
             );
             let tick = self
-                .runtime
+                .runtime()
                 .poll_event_loop(cx, deno_core::PollEventLoopOptions::default());
             let watchdog_fired = crate::cdp_watchdog::disarm(watchdog);
             if watchdog_fired {
-                self.runtime.v8_isolate().cancel_terminate_execution();
+                self.runtime().v8_isolate().cancel_terminate_execution();
                 return std::task::Poll::Ready(Err(
                     "autonomous browser task exceeded its task budget".into(),
                 ));
@@ -2730,7 +2826,7 @@ impl ObscuraJsRuntime {
             if tick_fired {
                 break Ok(());
             }
-            self.runtime.v8_isolate().perform_microtask_checkpoint();
+            self.runtime().v8_isolate().perform_microtask_checkpoint();
             match tick {
                 Ok(Ok(true)) => break Ok(()),
                 Ok(Ok(false)) | Err(_) => {}
@@ -2764,7 +2860,7 @@ impl ObscuraJsRuntime {
         self.begin_javascript_task();
         let wrapped = Self::wrap_expression(expression);
         let token = self.arm_watchdog(timeout);
-        let result = self.runtime.execute_script("<eval>", wrapped);
+        let result = self.runtime().execute_script("<eval>", wrapped);
         let fired = self.disarm_watchdog(token);
         if self.recover_heap_limit() {
             return Err("JavaScript heap limit exceeded; execution terminated".to_string());
@@ -2788,7 +2884,7 @@ impl ObscuraJsRuntime {
         // Default settle: just pump until idle or 5s.
         let _ = tokio::time::timeout(
             tokio::time::Duration::from_secs(5),
-            self.runtime
+            self.runtime()
                 .run_event_loop(deno_core::PollEventLoopOptions::default()),
         )
         .await;
@@ -2830,7 +2926,7 @@ impl ObscuraJsRuntime {
             // run_event_loop returns Ok and we check the predicate again.
             let _ = tokio::time::timeout(
                 tokio::time::Duration::from_millis(tick_ms),
-                self.runtime
+                self.runtime()
                     .run_event_loop(deno_core::PollEventLoopOptions::default()),
             )
             .await;
@@ -3046,7 +3142,8 @@ impl ObscuraJsRuntime {
         &mut self,
         result: deno_core::v8::Global<deno_core::v8::Value>,
     ) -> Result<serde_json::Value, String> {
-        let scope = &mut self.runtime.handle_scope();
+        let mut entered = self.runtime();
+        let scope = &mut entered.handle_scope();
         let local = deno_core::v8::Local::new(scope, result);
 
         if local.is_undefined() || local.is_null() {

--- a/crates/obscura/tests/concurrent_isolate_teardown.rs
+++ b/crates/obscura/tests/concurrent_isolate_teardown.rs
@@ -1,0 +1,147 @@
+//! #756: dropping a page while another one is alive aborted the process.
+//!
+//! Each `Page` owns its own `ObscuraJsRuntime`, so N pages means N isolates on
+//! the thread. rusty_v8 enters an isolate when it is constructed and exits it
+//! when it is dropped, which makes V8's entered-isolate stack the construction
+//! order and means isolates have to be dropped in exactly the reverse of it --
+//! a contract an embedder holding independent `Page` objects cannot keep. The
+//! process died either at deno_core's context cleanup
+//! (`Check failed: heap->isolate() == Isolate::TryGetCurrent()`) or, once that
+//! was addressed naively, at `Isolate::Dispose` ("Disposing the isolate that is
+//! entered by a thread").
+
+use std::io::{Read, Write};
+
+use obscura::Browser;
+
+fn spawn_server() -> String {
+    let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+    let addr = listener.local_addr().unwrap();
+    std::thread::spawn(move || {
+        for incoming in listener.incoming() {
+            let Ok(mut stream) = incoming else { continue };
+            std::thread::spawn(move || {
+                let mut buf = [0u8; 4096];
+                let _ = stream.read(&mut buf);
+                let body = "<!doctype html><html><head><title>fixture</title></head><body>hi</body></html>";
+                let response = format!(
+                    "HTTP/1.1 200 OK\r\nContent-Type: text/html\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+                    body.len(), body,
+                );
+                let _ = stream.write_all(response.as_bytes());
+                let _ = stream.shutdown(std::net::Shutdown::Both);
+            });
+        }
+    });
+    format!("http://{}", addr)
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn a_second_browser_can_be_dropped_without_aborting() {
+    std::env::set_var("OBSCURA_ALLOW_PRIVATE_NETWORK", "1");
+    let base = spawn_server();
+
+    let first = Browser::new().unwrap();
+    let mut page_one = first.new_page().await.unwrap();
+    page_one.goto(&base).await.unwrap();
+
+    let second = Browser::new().unwrap();
+    let mut page_two = second.new_page().await.unwrap();
+    page_two.goto(&base).await.unwrap();
+
+    // Both isolates are live, and the first was entered first.
+    drop(page_one);
+    drop(first);
+
+    assert_eq!(
+        page_two.evaluate("document.title"),
+        serde_json::json!("fixture"),
+        "the surviving page should still work after its neighbour was dropped"
+    );
+}
+
+/// The single-page case, which always worked: its isolate is the only one on
+/// the stack, so it is necessarily dropped last.
+#[tokio::test(flavor = "current_thread")]
+async fn one_browser_one_page_drops_cleanly() {
+    std::env::set_var("OBSCURA_ALLOW_PRIVATE_NETWORK", "1");
+    let base = spawn_server();
+    let browser = Browser::new().unwrap();
+    let mut page = browser.new_page().await.unwrap();
+    page.goto(&base).await.unwrap();
+    assert_eq!(page.evaluate("document.title"), serde_json::json!("fixture"));
+}
+
+/// Two pages on ONE browser — one isolate each, same context.
+#[tokio::test(flavor = "current_thread")]
+async fn two_pages_on_one_browser_drop_cleanly() {
+    std::env::set_var("OBSCURA_ALLOW_PRIVATE_NETWORK", "1");
+    let base = spawn_server();
+    let browser = Browser::new().unwrap();
+    let mut one = browser.new_page().await.unwrap();
+    one.goto(&base).await.unwrap();
+    let mut two = browser.new_page().await.unwrap();
+    two.goto(&base).await.unwrap();
+    drop(one);
+    assert_eq!(two.evaluate("document.title"), serde_json::json!("fixture"));
+}
+
+/// Dropping from the *middle* of the stack, which needs the isolates entered
+/// after it to be unwound and then put back, not just its own entered.
+#[tokio::test(flavor = "current_thread")]
+async fn a_page_in_the_middle_can_be_dropped_and_the_rest_keep_working() {
+    std::env::set_var("OBSCURA_ALLOW_PRIVATE_NETWORK", "1");
+    let base = spawn_server();
+    let browser = Browser::new().unwrap();
+
+    let mut first = browser.new_page().await.unwrap();
+    first.goto(&base).await.unwrap();
+    let mut middle = browser.new_page().await.unwrap();
+    middle.goto(&base).await.unwrap();
+    let mut last = browser.new_page().await.unwrap();
+    last.goto(&base).await.unwrap();
+
+    drop(middle);
+
+    // Both neighbours must still be able to run script: the one below the
+    // hole on the entry stack and the one above it, which was exited and
+    // re-entered to reach it.
+    assert_eq!(first.evaluate("document.title"), serde_json::json!("fixture"));
+    assert_eq!(last.evaluate("document.title"), serde_json::json!("fixture"));
+
+    // And a page created after the hole works, so the stack was left in a
+    // state a new isolate can be pushed onto.
+    let mut fresh = browser.new_page().await.unwrap();
+    fresh.goto(&base).await.unwrap();
+    assert_eq!(fresh.evaluate("document.title"), serde_json::json!("fixture"));
+
+    // Finally drop out of order again, oldest first, and keep using the rest.
+    drop(first);
+    assert_eq!(last.evaluate("document.title"), serde_json::json!("fixture"));
+    assert_eq!(fresh.evaluate("document.title"), serde_json::json!("fixture"));
+}
+
+/// The half of this that has nothing to do with dropping: a second page put
+/// the first one's isolate below the top of V8's entry stack, and running any
+/// script on a non-current isolate aborts. A second page therefore disabled
+/// the first one outright, with no teardown involved at all.
+#[tokio::test(flavor = "current_thread")]
+async fn an_older_page_still_runs_script_while_a_newer_one_is_alive() {
+    std::env::set_var("OBSCURA_ALLOW_PRIVATE_NETWORK", "1");
+    let base = spawn_server();
+    let browser = Browser::new().unwrap();
+
+    let mut first = browser.new_page().await.unwrap();
+    first.goto(&base).await.unwrap();
+    let mut second = browser.new_page().await.unwrap();
+    second.goto(&base).await.unwrap();
+
+    // The newest page always worked; the older one is what aborted.
+    assert_eq!(second.evaluate("document.title"), serde_json::json!("fixture"));
+    assert_eq!(first.evaluate("document.title"), serde_json::json!("fixture"));
+
+    // Interleaving the two must keep working in both directions.
+    assert_eq!(first.evaluate("1 + 1"), serde_json::json!(2.0));
+    assert_eq!(second.evaluate("2 + 2"), serde_json::json!(4.0));
+    assert_eq!(first.evaluate("3 + 3"), serde_json::json!(6.0));
+}


### PR DESCRIPTION
Fixes #756.

Two live pages in one process aborted V8 on the first drop, whichever page it was:

```
# Check failed: heap->isolate() == Isolate::TryGetCurrent().
```

### Why an embedder could not avoid it

rusty_v8 enters an isolate when it is constructed and exits it when it is dropped, and documents the consequence in `OwnedIsolate::drop`:

> v8::OwnedIsolate instances must be dropped in the reverse order of creation. They are entered upon creation and exited upon being dropped.

Each `Page` owns its own `ObscuraJsRuntime`, so N pages are N isolates stacked in construction order — and independent `Page` objects handed to a caller cannot honour that contract.

Entering the doomed isolate before teardown is not enough on its own: it is then entered twice, and `Isolate::Dispose` aborts in turn with *"Disposing the isolate that is entered by a thread"*.

### The larger half, found while chasing that

V8 also requires the owning isolate to be the thread's current one whenever a **context** is entered or left, and rusty_v8's scopes never arrange it — they only ever pass the isolate explicitly. Keeping an isolate entered for life made that true *by accident* for a single page, because that page's isolate is trivially the current one.

With two pages only the newest is current, so **running any script on the older page aborted with the same check, with no teardown involved at all**. A second page silently disabled the first:

```rust
let mut first = browser.new_page().await?;   first.goto(&base).await?;
let mut second = browser.new_page().await?;  second.goto(&base).await?;
second.evaluate("document.title");           // fine
first.evaluate("document.title");            // aborts the process
```

I confirmed that on a clean `main` at 9326880 before touching anything. It is the same root cause as the reported crash, so it is fixed here rather than filed separately — the issue's stated expectation ("dropping one page leaves the others usable") is not reachable without it.

### The fix

Exit the isolate once construction is done and enter it only around work that touches V8:

- `ObscuraJsRuntime::runtime()` returns a guard that enters on creation and exits on drop.
- The field is renamed to `js_runtime` so the compiler finds every path that reaches V8 and forces it through the guard. `realm_states` is the one caller that keeps the raw field — `op_state` is a Rust-side table with no V8 access.
- `Drop` enters once for the teardown that `OwnedIsolate::drop` will exit.

Entries then nest properly however many pages exist, and in whatever order they are used and dropped.

### Testing

New coverage for an older page still running script while a newer one is alive, for interleaving two pages in both directions, and for dropping the first, the last, and one out of the *middle* of three while the survivors keep working (plus creating a fresh page afterwards, so the entry stack is left in a state a new isolate can be pushed onto).

`cargo test -p obscura --features render` is green apart from the three `child_frame_scripts` failures already present on `main` at 9326880; `cargo test -p obscura-render --features paint` is fully green.

Two pre-existing things this does **not** fix, noted so they are not mistaken for fallout:
- `cargo test -p obscura-js --lib` still aborts on `# Check failed: !IsFrozen()`, unchanged from `main`.
- `cargo test -p obscura-render --lib` without `--features paint` does not compile on `main` (`no field word_ifc_items` at `dom.rs:19710` — a `#[cfg(feature = "paint")]` field used from an ungated test).
