### PR TITLE
fix(cdp): honor acceptLanguage on both spellings of setUserAgentOverride

### DIFF
--- a/crates/obscura-browser/src/page.rs
+++ b/crates/obscura-browser/src/page.rs
@@ -1447,6 +1447,15 @@ impl Page {
                 &self.context.ua_platform_version,
             );
         }
+        // navigator.language(s) come from the same Accept-Language value the
+        // client sends, exactly as navigator.userAgent is seeded from the
+        // client's user agent above. Reading it here rather than at the
+        // override means a CDP locale change reaches the page on the next
+        // navigation without this command having to touch the isolate.
+        if let Ok(accept_language) = self.http_client.accept_language.try_read() {
+            rt.set_language(&accept_language);
+        }
+
         if let Some((lat, lon)) = env_geolocation() {
             rt.set_geolocation(lat, lon);
         }

--- a/crates/obscura-browser/src/page.rs
+++ b/crates/obscura-browser/src/page.rs
@@ -1452,6 +1452,20 @@ impl Page {
         // client's user agent above. Reading it here rather than at the
         // override means a CDP locale change reaches the page on the next
         // navigation without this command having to touch the isolate.
+        //
+        // Seeding here moves the two navigator globals and nothing else. ICU's
+        // default locale stays where `ObscuraJsRuntime::new` pinned it (#734):
+        // it is process-global, so re-pinning it per navigation would let one
+        // page's override decide what `Intl` resolves to in a sibling page in
+        // the same process that has not read `Intl` yet, and V8 caches that
+        // resolution per isolate at first use.
+        //
+        // The cost is that Chrome applies an override to navigator.language
+        // immediately, while a page here keeps the previous value until it
+        // navigates. That is chosen, not missed: the clients that set a locale
+        // (Playwright's `newContext({ locale })`) set it before navigating, and
+        // a mid-session re-pin could not reach an already-cached `Intl`
+        // resolution anyway.
         if let Ok(accept_language) = self.http_client.accept_language.try_read() {
             rt.set_language(&accept_language);
         }

--- a/crates/obscura-cdp/src/dispatch.rs
+++ b/crates/obscura-cdp/src/dispatch.rs
@@ -402,6 +402,7 @@ fn is_v8_free_method(method: &str) -> bool {
             | "Network.setBlockedURLs"
             | "Network.setExtraHTTPHeaders"
             | "Network.setUserAgentOverride"
+            | "Emulation.setUserAgentOverride"
             | "Network.getCookies"
             | "Network.getAllCookies"
             | "Network.setCookie"

--- a/crates/obscura-cdp/src/domains/emulation.rs
+++ b/crates/obscura-cdp/src/domains/emulation.rs
@@ -124,6 +124,14 @@ pub async fn handle(
         // Touch emulation does not affect layout yet, but acknowledging it is
         // compatible with clients that pair it with a metrics override.
         "setTouchEmulationEnabled" => Ok(json!({})),
+        // The current spelling of setUserAgentOverride; Network's is the
+        // deprecated one. Without this arm it reached the catch-all below and
+        // was acknowledged without being applied, so a client that set a user
+        // agent or a locale here was told it worked and got neither.
+        "setUserAgentOverride" => {
+            super::network::apply_user_agent_override(params, ctx, session_id).await;
+            Ok(json!({}))
+        }
         _ => Ok(json!({})),
     }
 }
@@ -131,6 +139,72 @@ pub async fn handle(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[tokio::test]
+    async fn emulation_set_user_agent_override_is_applied() {
+        let mut ctx = CdpContext::new();
+        let page_id = ctx.create_page();
+        let session_id = Some("emu-ua-session".to_string());
+        ctx.sessions.insert(session_id.clone().unwrap(), page_id);
+
+        handle(
+            "setUserAgentOverride",
+            &json!({ "userAgent": "UA/2.0", "acceptLanguage": "fr-FR,fr;q=0.9" }),
+            &mut ctx,
+            &session_id,
+        )
+        .await
+        .expect("Emulation.setUserAgentOverride must succeed");
+
+        let page = ctx.get_session_page(&session_id).expect("page");
+        assert_eq!(
+            *page.http_client.user_agent.read().await,
+            "UA/2.0",
+            "Emulation.setUserAgentOverride must apply the user agent"
+        );
+        assert_eq!(
+            *page.http_client.accept_language.read().await,
+            "fr-FR,fr;q=0.9",
+            "Emulation.setUserAgentOverride must apply the locale"
+        );
+    }
+
+    #[tokio::test]
+    async fn emulation_user_agent_override_leaves_unsent_fields_alone() {
+        // A locale-only call must not blank the user agent, which is what the
+        // previous unwrap_or("") would have done once this command started
+        // carrying more than one field.
+        let mut ctx = CdpContext::new();
+        let page_id = ctx.create_page();
+        let session_id = Some("emu-partial".to_string());
+        ctx.sessions.insert(session_id.clone().unwrap(), page_id);
+
+        let before = ctx
+            .get_session_page(&session_id)
+            .expect("page")
+            .http_client
+            .user_agent
+            .read()
+            .await
+            .clone();
+
+        handle(
+            "setUserAgentOverride",
+            &json!({ "acceptLanguage": "ja-JP" }),
+            &mut ctx,
+            &session_id,
+        )
+        .await
+        .expect("a locale-only override must succeed");
+
+        let page = ctx.get_session_page(&session_id).expect("page");
+        assert_eq!(
+            *page.http_client.user_agent.read().await,
+            before,
+            "an unsent userAgent must be left as it was"
+        );
+        assert_eq!(*page.http_client.accept_language.read().await, "ja-JP");
+    }
 
     #[tokio::test]
     async fn device_metrics_override_updates_page_and_window_viewport() {

--- a/crates/obscura-cdp/src/domains/network.rs
+++ b/crates/obscura-cdp/src/domains/network.rs
@@ -24,6 +24,34 @@ fn cookie_jar_for<'a>(ctx: &'a CdpContext, session_id: &Option<String>) -> &'a A
         .unwrap_or(&ctx.default_context.cookie_jar)
 }
 
+/// Apply a `setUserAgentOverride` call to a session's HTTP client.
+///
+/// Chrome exposes this command on both `Network` (deprecated) and
+/// `Emulation` (current), and clients are split across the two spellings,
+/// so both dispatch here rather than each growing its own copy.
+///
+/// Only the fields the caller actually sent are applied. The user agent
+/// previously defaulted to the empty string, which was harmless while this
+/// command carried nothing else, but would now let a locale-only call blank
+/// the user agent as a side effect.
+pub(crate) async fn apply_user_agent_override(
+    params: &Value,
+    ctx: &mut CdpContext,
+    session_id: &Option<String>,
+) {
+    let Some(page) = ctx.get_session_page(session_id) else {
+        return;
+    };
+    if let Some(ua) = params.get("userAgent").and_then(|v| v.as_str()) {
+        page.http_client.set_user_agent(ua).await;
+    }
+    if let Some(language) = params.get("acceptLanguage").and_then(|v| v.as_str()) {
+        if !language.trim().is_empty() {
+            page.http_client.set_accept_language(language).await;
+        }
+    }
+}
+
 pub async fn handle(
     method: &str,
     params: &Value,
@@ -56,10 +84,7 @@ pub async fn handle(
             Ok(json!({}))
         }
         "setUserAgentOverride" => {
-            let ua = params.get("userAgent").and_then(|v| v.as_str()).unwrap_or("");
-            if let Some(page) = ctx.get_session_page(session_id) {
-                page.http_client.set_user_agent(ua).await;
-            }
+            apply_user_agent_override(params, ctx, session_id).await;
             Ok(json!({}))
         }
         "getCookies" | "getAllCookies" => {
@@ -157,6 +182,35 @@ mod tests {
             same_site: String::new(),
             expires: None,
         }
+    }
+
+    #[tokio::test]
+    async fn set_user_agent_override_applies_accept_language() {
+        let mut ctx = CdpContext::new();
+        let page_id = ctx.create_page();
+        let session_id = Some("ua-session".to_string());
+        ctx.sessions.insert(session_id.clone().unwrap(), page_id);
+
+        handle(
+            "setUserAgentOverride",
+            &json!({ "userAgent": "UA/1.0", "acceptLanguage": "de-DE,de;q=0.9" }),
+            &mut ctx,
+            &session_id,
+        )
+        .await
+        .expect("setUserAgentOverride must succeed");
+
+        let page = ctx.get_session_page(&session_id).expect("page");
+        assert_eq!(
+            *page.http_client.user_agent.read().await,
+            "UA/1.0",
+            "userAgent must reach the client"
+        );
+        assert_eq!(
+            *page.http_client.accept_language.read().await,
+            "de-DE,de;q=0.9",
+            "acceptLanguage must reach the client"
+        );
     }
 
     #[tokio::test]

--- a/crates/obscura-js/js/bootstrap.js
+++ b/crates/obscura-js/js/bootstrap.js
@@ -15,6 +15,7 @@
     '__obscura_errors', '__obscura_init', '__obscura_hide_list',
     '__obscura_objects', '__obscura_oid', '__obscura_ua',
     '__obscura_platform', '__obscura_ua_platform', '__obscura_ua_platform_version',
+    '__obscura_language', '__obscura_languages',
     '__obscura_stealth', '__obscura_markTrusted', '__obscura_core_handoff',
     '__obscura_frameId', '__obscura_parentFrameId', '__obscura_frameWindows',
     '__obscura_frameObjects', '__obscura_frameElements', '__obscura_deliverMessage',
@@ -6656,8 +6657,18 @@ globalThis.navigator = {
   defGetter('platform', function() {
     return globalThis.__obscura_platform || "Win32";
   });
-  defGetter('language', function() { return "en-US"; });
-  defGetter('languages', function() { return ["en-US", "en"]; });
+  defGetter('language', function() {
+    return globalThis.__obscura_language || "en-US";
+  });
+  defGetter('languages', function() {
+    var configured = globalThis.__obscura_languages;
+    // A fresh array each read, matching the literal this replaced: the list
+    // is observable, so handing out the stored one would let a page mutate
+    // what every later read reports.
+    return (Array.isArray(configured) && configured.length)
+      ? configured.slice()
+      : ["en-US", "en"];
+  });
 
   // Cache plugins/mimeTypes so navigator.plugins === navigator.plugins.
   var _plugins = new PluginArray([

--- a/crates/obscura-js/src/frame.rs
+++ b/crates/obscura-js/src/frame.rs
@@ -474,6 +474,7 @@ mod tests {
         let mut parent = ObscuraJsRuntime::new();
         parent.set_user_agent(user_agent);
         parent.set_platform("Win32", "Windows", "19.0.0");
+        parent.set_language("de-DE,de;q=0.9");
         parent.set_dom(parse_html("<html><body></body></html>"));
         parent.set_url("https://parent.example/");
         parent.run_page_init();
@@ -491,6 +492,8 @@ mod tests {
             "navigator.userAgent",
             "navigator.platform",
             "navigator.userAgentData.platform",
+            "navigator.language",
+            "navigator.languages.join(',')",
         ] {
             assert_eq!(
                 frame.evaluate(&mut parent, surface).unwrap(),
@@ -501,6 +504,11 @@ mod tests {
         assert_eq!(
             frame.evaluate(&mut parent, "navigator.userAgent").unwrap(),
             serde_json::json!(user_agent)
+        );
+        assert_eq!(
+            frame.evaluate(&mut parent, "navigator.language").unwrap(),
+            serde_json::json!("de-DE"),
+            "the frame must carry the parent's locale, not the built-in default"
         );
     }
 

--- a/crates/obscura-js/src/runtime.rs
+++ b/crates/obscura-js/src/runtime.rs
@@ -93,6 +93,23 @@ fn panic_payload_message(payload: &(dyn std::any::Any + Send)) -> &str {
 /// window.onerror / unhandledrejection fire and later tasks still run. Only
 /// engine-level failures (watchdog termination, the heap cap, an exhausted
 /// task budget) make the loop itself unusable. (#699)
+/// The language tags an `Accept-Language` value names, in the order it names
+/// them: `de-DE,de;q=0.9` becomes `["de-DE", "de"]`.
+///
+/// Quality values order the list rather than appearing in it, and Chrome
+/// reports `navigator.languages` as the tags alone, so they are dropped here.
+/// A `*` entry is a wildcard rather than a language and never reaches
+/// `navigator.languages`.
+pub fn languages_from_accept_language(value: &str) -> Vec<String> {
+    value
+        .split(',')
+        .filter_map(|entry| entry.split(';').next())
+        .map(str::trim)
+        .filter(|tag| !tag.is_empty() && *tag != "*")
+        .map(str::to_string)
+        .collect()
+}
+
 pub fn is_fatal_event_loop_error(error: &str) -> bool {
     error.contains("execution terminated")
         || error.contains("heap limit exceeded")
@@ -549,11 +566,13 @@ impl ObscuraJsRuntime {
     ) {
         use deno_core::v8;
 
-        const IDENTITY_GLOBALS: [&str; 7] = [
+        const IDENTITY_GLOBALS: [&str; 9] = [
             "__obscura_ua",
             "__obscura_platform",
             "__obscura_ua_platform",
             "__obscura_ua_platform_version",
+            "__obscura_language",
+            "__obscura_languages",
             "__obscura_stealth",
             "__obscura_geo_lat",
             "__obscura_geo_lon",
@@ -933,6 +952,32 @@ impl ObscuraJsRuntime {
         let _ = self.execute_runtime_script(
             "<set-ua>",
             format!("globalThis.__obscura_ua = '{}';", escaped),
+        );
+    }
+
+    /// Point `navigator.language` and `navigator.languages` at the locale the
+    /// client sends in `Accept-Language`.
+    ///
+    /// Both come from the one header value for the same reason
+    /// `navigator.userAgent` is seeded from the client's user agent: a page
+    /// and the wire that fetched it must not be able to disagree about who
+    /// they are.
+    ///
+    /// The values are interpolated as JSON rather than quoted by hand, so a
+    /// tag carrying a quote or a backslash cannot escape into the script.
+    pub fn set_language(&mut self, accept_language: &str) {
+        let languages = languages_from_accept_language(accept_language);
+        let Some(primary) = languages.first() else {
+            return;
+        };
+        let primary = serde_json::Value::String(primary.clone());
+        let all = serde_json::json!(languages);
+        let _ = self.execute_runtime_script(
+            "<set-language>",
+            format!(
+                "globalThis.__obscura_language={};globalThis.__obscura_languages={};",
+                primary, all
+            ),
         );
     }
 
@@ -3192,6 +3237,77 @@ impl Default for ObscuraJsRuntime {
 mod tests {
     use super::*;
     use obscura_dom::parse_html;
+
+    #[test]
+    fn set_language_drives_navigator_language_and_languages() {
+        let mut rt = setup_runtime("<html><body></body></html>");
+        assert_eq!(
+            rt.evaluate("navigator.language + '|' + navigator.languages.join(',')")
+                .unwrap(),
+            serde_json::json!("en-US|en-US,en"),
+            "the built-in default must stand until an override arrives"
+        );
+
+        // The header form a client actually sends, quality values and all.
+        rt.set_language("de-DE,de;q=0.9");
+        assert_eq!(
+            rt.evaluate("navigator.language + '|' + navigator.languages.join(',')")
+                .unwrap(),
+            serde_json::json!("de-DE|de-DE,de"),
+            "both surfaces must follow the Accept-Language value"
+        );
+    }
+
+    #[test]
+    fn navigator_languages_hands_out_a_fresh_array_each_read() {
+        // The list is observable, so returning the stored array would let one
+        // page mutate what every later read reports.
+        let mut rt = setup_runtime("<html><body></body></html>");
+        rt.set_language("de-DE,de;q=0.9");
+        assert_eq!(
+            rt.evaluate("(function () { navigator.languages.push('zz-ZZ'); return navigator.languages.join(','); })()")
+            .unwrap(),
+            serde_json::json!("de-DE,de")
+        );
+    }
+
+    #[test]
+    fn an_empty_accept_language_leaves_the_default_alone() {
+        let mut rt = setup_runtime("<html><body></body></html>");
+        rt.set_language("");
+        rt.set_language("*");
+        assert_eq!(
+            rt.evaluate("navigator.language").unwrap(),
+            serde_json::json!("en-US")
+        );
+    }
+
+    #[test]
+    fn a_language_tag_cannot_escape_the_generated_script() {
+        // set_language interpolates JSON rather than hand-quoting, so a tag
+        // carrying a quote is data and not the rest of the statement.
+        let mut rt = setup_runtime("<html><body></body></html>");
+        rt.set_language("de-DE','x');globalThis.__pwned=1;//");
+        assert_eq!(
+            rt.evaluate("typeof globalThis.__pwned").unwrap(),
+            serde_json::json!("undefined"),
+            "a language tag must not be able to run code"
+        );
+    }
+
+    #[test]
+    fn accept_language_parsing_drops_quality_values_and_wildcards() {
+        assert_eq!(
+            languages_from_accept_language("de-DE,de;q=0.9"),
+            vec!["de-DE", "de"]
+        );
+        assert_eq!(
+            languages_from_accept_language("fr-CH, fr;q=0.9, en;q=0.8, *;q=0.5"),
+            vec!["fr-CH", "fr", "en"]
+        );
+        assert!(languages_from_accept_language("").is_empty());
+        assert!(languages_from_accept_language("*").is_empty());
+    }
 
     fn setup_runtime(html: &str) -> ObscuraJsRuntime {
         let dom = parse_html(html);


### PR DESCRIPTION
## What changed

Fixes #777.

`setUserAgentOverride` carries three fields. obscura read one of them, on the deprecated spelling of the command only:

- **`Emulation.setUserAgentOverride` applied nothing at all.** It is not one of the `Emulation` handler's four arms, so it fell to the trailing `_ => Ok(json!({}))` and was acknowledged without being applied — user agent included. This is the spelling the CDP spec lists as current.
- **`Network.setUserAgentOverride` discarded `acceptLanguage`.** It read `userAgent` and replied `{}`.

Both returned success, so a client that set a locale was told it worked and got `en-US` on every surface. That is the same shape as #734, which you fixed last week: a browser disagreeing with itself about where it is — except here it disagrees with the operator who told it.

### What made this small

The plumbing was already built and wired to nothing. `HttpClient::set_accept_language` is `pub` and `accept_language_override_reaches_the_wire` proves it reaches the socket, but no production caller existed. And the JS side already had the pattern to copy — at runtime creation `page.rs` seeds `navigator.userAgent` *from the HTTP client's user agent*, so the header and the page cannot drift:

```rust
if let Ok(ua) = self.http_client.user_agent.try_read() {
    rt.set_user_agent(&ua);
}
```

The locale now follows the same route, one line below it. That is what keeps this change off the V8 lock: the override writes only `http_client`, and the isolate reads it back at its next construction, so `setUserAgentOverride` remains a `get_session_page` / no-`JsRuntime` method.

| file | change |
|---|---|
| `network.rs` | `apply_user_agent_override` extracted; honours `acceptLanguage` |
| `emulation.rs` | the missing `setUserAgentOverride` arm, delegating to it |
| `dispatch.rs` | `Emulation.setUserAgentOverride` added to `is_v8_free_method` — same audit as the `Network` entry already there: `get_session_page` and client field writes, no `JsRuntime` |
| `runtime.rs` | `set_language`, `languages_from_accept_language`, and the two new globals in `IDENTITY_GLOBALS` |
| `bootstrap.js` | `navigator.language` / `languages` read the override; both globals added to the pre-hide list |
| `page.rs` | seeds the locale from the client at runtime creation |

Three details worth a reviewer's eye:

**Unsent fields are no longer overwritten.** `userAgent` used to be `unwrap_or("")`. That was harmless while the command carried nothing else, but now a locale-only call would blank the user agent as a side effect, so each field is applied only if the caller sent it.

**`IDENTITY_GLOBALS` grew from 7 to 9.** That array is what carries identity into child realms so "a frame must present the same identity as its parent". Adding `navigator.language` without adding it there would have made an iframe report `en-US` while the top document reported `de-DE` — a fresh instance of exactly the inconsistency this fixes.

**The generated script interpolates JSON, not hand-quoted strings.** The neighbouring setters do `replace('\'', "\\'")`; `acceptLanguage` arrives from the wire in a way a configured user agent does not, so `set_language` formats through `serde_json::Value` instead.

## Validation

`cargo nextest run --release --features render -p obscura-cdp -p obscura-js -E 'test(user_agent_override) or test(language) or test(frame_inherits)'`

Both repro tests from #777 fail on `9326880` and pass here. New tests:

- `set_user_agent_override_applies_accept_language` — Network, both fields
- `emulation_set_user_agent_override_is_applied` — Emulation, both fields
- `emulation_user_agent_override_leaves_unsent_fields_alone` — a locale-only call must not blank the user agent
- `set_language_drives_navigator_language_and_languages`
- `navigator_languages_hands_out_a_fresh_array_each_read` — the list is observable, so a page must not be able to mutate what later reads report
- `an_empty_accept_language_leaves_the_default_alone` — `""` and `"*"` are no-ops
- `a_language_tag_cannot_escape_the_generated_script` — feeds `de-DE','x');globalThis.__pwned=1;//` and asserts nothing ran
- `accept_language_parsing_drops_quality_values_and_wildcards`

`frame_inherits_the_parent_browser_identity` — the existing test for the invariant `IDENTITY_GLOBALS` serves — now seeds a non-default locale on the parent and checks `navigator.language` and `navigator.languages` alongside the user agent and platform it already checked. It asserts the value as well as the agreement, so it cannot pass by both realms falling back to `en-US`.

Full `obscura-cdp`, `obscura-js` and `obscura-browser` suites run in both the render and no-render configurations; results in a comment below.

## Rendering

Not applicable. No layout, paint, screenshot, screencast or PDF output changes.

## Performance

No expected impact. The added work is one `Accept-Language` parse and one small script execution per `JsRuntime` construction, on the same path that already runs `set_user_agent` and `set_platform`. The override handlers themselves stay off the V8 lock, so no request-path latency changes.

## Checklist

- [x] The change is focused and does not remove existing behavior without justification.
- [x] Tests cover the failure or feature.
- [x] Existing tests pass, including render and no-render configurations when affected.
- [x] I checked for CPU, latency, and memory regressions.
- [x] Public API or user-facing behavior changes are documented.

## Deliberately not in scope

- **`platform`**, the third field, is dropped the same way. It belongs to #481's territory (`navigator.platform` vs the header), which is under active discussion with two conflicting measurements, so I left it alone rather than pre-empting that thread.
- **`Intl`.** It cannot follow a mid-session override: V8 resolves the ICU default once per isolate and caches it at first `Intl` use, so a pin after `JsRuntime::new` is a silent no-op. I checked this against your #734 fix — moving `set_default_locale` below the isolate construction fails `intl_locale_matches_navigator_language_regardless_of_host`. Making `Intl` follow a CDP locale would mean building the isolate with the locale already known, which is a different change.
