### PR TITLE
Fix <body onload> content attribute reflection

### DIFF
--- a/crates/obscura-browser/src/page.rs
+++ b/crates/obscura-browser/src/page.rs
@@ -2528,8 +2528,13 @@ impl Page {
             let _ = js.execute_script(
                 "<load-event>",
                 "globalThis.__documentReadyState__ = 'complete';\n\
-                 if (typeof window.onload === 'function') { try { window.onload(); } catch(e) {} }\n\
-                 try { window.dispatchEvent(new Event('load', {bubbles:false,cancelable:false})); } catch(e) {}",
+                 try {\n\
+                   const loadEvent = new Event('load', {bubbles:false,cancelable:false});\n\
+                   if (typeof window.onload === 'function') {\n\
+                     try { window.onload.call(window, loadEvent); } catch(e) {}\n\
+                   }\n\
+                   try { window.dispatchEvent(loadEvent); } catch(e) {}\n\
+                 } catch(e) {}",
             );
         }
         if let Some(token) = exec_wd {
@@ -5473,6 +5478,76 @@ mod tests {
                 .recv_timeout(std::time::Duration::from_secs(1))
                 .unwrap(),
             "/app/later.js"
+        );
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn body_onload_content_attribute_reflects_to_window() {
+        let mut page = import_map_test_page(
+            "body-onload-content-attribute",
+            "http://127.0.0.1:9",
+            r#"<html><head></head><body onload="
+                globalThis.__bodyOnloadCalls++;
+                globalThis.__bodyOnloadThisIsWindow = this === window;
+                globalThis.__bodyOnloadEventType = event && event.type;
+                throw new Error('body onload failure');
+            "><script>
+                globalThis.__bodyOnloadCalls = 0;
+                globalThis.__bodyOnloadThisIsWindow = false;
+                globalThis.__bodyOnloadEventType = null;
+                globalThis.__bodyOnloadReflectedBeforeLoad =
+                    typeof document.body.onload === 'function' &&
+                    document.body.onload === window.onload;
+                globalThis.__windowLoadListenerCalls = 0;
+                window.addEventListener('load', () => __windowLoadListenerCalls++);
+            </script></body></html>"#,
+        );
+
+        page.execute_scripts().await;
+
+        assert_eq!(
+            page.js
+                .as_mut()
+                .unwrap()
+                .evaluate(
+                    r#"[
+                        __bodyOnloadCalls,
+                        __bodyOnloadThisIsWindow,
+                        __bodyOnloadEventType,
+                        __bodyOnloadReflectedBeforeLoad,
+                        __windowLoadListenerCalls
+                    ]"#,
+                )
+                .unwrap(),
+            serde_json::json!([1, true, "load", true, 1]),
+        );
+
+        assert_eq!(
+            page.js
+                .as_mut()
+                .unwrap()
+                .evaluate(
+                    r#"(function() {
+                        const fromBody = function fromBody() {};
+                        document.body.onload = fromBody;
+                        const bodySetsWindow = window.onload === fromBody;
+                        const fromWindow = function fromWindow() {};
+                        window.onload = fromWindow;
+                        const windowSetsBody = document.body.onload === fromWindow;
+                        document.body.setAttribute('onload', 'globalThis.__bodyOnloadFromAttribute = true');
+                        const attributeReplacesWindow = document.body.onload !== fromWindow
+                            && document.body.onload === window.onload;
+                        const reflected = window.onload;
+                        const detachedBody = document.createElement('body');
+                        detachedBody.onload = function detachedBodyOnload() {};
+                        const detachedBodyStaysLocal = window.onload === reflected
+                            && detachedBody.onload !== window.onload;
+                        return bodySetsWindow && windowSetsBody && attributeReplacesWindow
+                            && detachedBodyStaysLocal;
+                    })()"#,
+                )
+                .unwrap(),
+            serde_json::json!(true),
         );
     }
 

--- a/crates/obscura-js/js/bootstrap.js
+++ b/crates/obscura-js/js/bootstrap.js
@@ -3309,6 +3309,11 @@ class Element extends Node {
       }
     }
     if (n === "style") this._style._replaceFromAttribute(value);
+    if (n === "onload" && _isWindowReflectingBodyElement(this)) {
+      _windowOnloadOverrideSet = false;
+      _windowOnloadOverride = null;
+      if (this.__inlineHandlerCache) delete this.__inlineHandlerCache.onload;
+    }
     if (popoverPrev !== undefined) this._popoverTypeMaybeChanged(popoverPrev);
     if (globalThis.__mutationObservers?.length) globalThis.__notifyMutation('attributes', this._nid, [], [], n);
     if (this.localName === "source"
@@ -3349,6 +3354,11 @@ class Element extends Node {
       _reconcileWindowNamedProperty(previousWindowName);
     }
     if (n === "style") this._style._replaceFromAttribute("");
+    if (n === "onload" && _isWindowReflectingBodyElement(this)) {
+      _windowOnloadOverrideSet = false;
+      _windowOnloadOverride = null;
+      if (this.__inlineHandlerCache) delete this.__inlineHandlerCache.onload;
+    }
     if (popoverPrev !== undefined) this._popoverTypeMaybeChanged(popoverPrev);
     if (this.localName === "source"
         && (n === "srcset" || n === "sizes" || n === "media" || n === "type")) {
@@ -6352,6 +6362,48 @@ for (const _ev of [
     }
   }
 }
+
+let _windowOnloadOverrideSet = false;
+let _windowOnloadOverride = null;
+function _windowReflectingBodyElement() {
+  const document = globalThis.document;
+  return document && (document.body || document.querySelector('frameset'));
+}
+function _isWindowReflectingBodyElement(element) {
+  return element === _windowReflectingBodyElement();
+}
+Object.defineProperty(globalThis, 'onload', {
+  get() {
+    if (_windowOnloadOverrideSet) return _windowOnloadOverride;
+    const body = _windowReflectingBodyElement();
+    return body && body._resolveInlineHandler
+      ? body._resolveInlineHandler('onload')
+      : null;
+  },
+  set(value) {
+    _windowOnloadOverrideSet = true;
+    _windowOnloadOverride = typeof value === 'function' ? value : null;
+  },
+  configurable: true,
+  enumerable: true,
+});
+Object.defineProperty(Element.prototype, 'onload', {
+  get() {
+    if (_isWindowReflectingBodyElement(this)) {
+      return globalThis.onload;
+    }
+    return this.__onload || null;
+  },
+  set(value) {
+    if (_isWindowReflectingBodyElement(this)) {
+      globalThis.onload = value;
+      return;
+    }
+    this.__onload = typeof value === 'function' ? value : null;
+  },
+  configurable: true,
+  enumerable: false,
+});
 
 globalThis.Window = globalThis.Window || function Window() {};
 Object.defineProperty(globalThis.Window, Symbol.hasInstance, {

--- a/crates/obscura-js/src/frame.rs
+++ b/crates/obscura-js/src/frame.rs
@@ -135,9 +135,10 @@ impl FrameRealm {
                  { bubbles: false, cancelable: false })); } catch (_) {}\
              globalThis.__documentReadyState__ = 'complete';\
              try { document.dispatchEvent(new Event('readystatechange')); } catch (_) {}\
-             if (typeof window.onload === 'function') { try { window.onload(); } catch (_) {} }\
-             try { window.dispatchEvent(new Event('load', \
-                 { bubbles: false, cancelable: false })); } catch (_) {}",
+             try { const loadEvent = new Event('load', \
+                 { bubbles: false, cancelable: false }); \
+                 if (typeof window.onload === 'function') { try { window.onload.call(window, loadEvent); } catch (_) {} } \
+                 try { window.dispatchEvent(loadEvent); } catch (_) {} } catch (_) {}",
         )
     }
 
@@ -554,6 +555,43 @@ mod tests {
         assert_eq!(
             parent.evaluate("document.body.innerHTML").unwrap(),
             serde_json::json!("")
+        );
+    }
+
+    #[test]
+    fn frame_body_onload_content_attribute_reflects_to_window() {
+        let mut parent = page("https://parent.example/", "<html><body></body></html>");
+        let frame = FrameRealm::new(
+            &mut parent,
+            1,
+            0,
+            "https://child.example/",
+            r#"<html><body onload="
+                globalThis.__frameBodyOnload = [this === window, event.type];
+                throw new Error('frame body onload failure');
+            "><script>
+                globalThis.__frameBodyOnload = null;
+                globalThis.__frameLoadListenerCalls = 0;
+                window.addEventListener('load', () => __frameLoadListenerCalls++);
+            </script></body></html>"#,
+        )
+        .expect("frame realm");
+
+        assert!(frame
+            .run_document_scripts(&mut parent, |_| None)
+            .is_empty());
+        frame
+            .dispatch_load_events(&mut parent)
+            .expect("frame load events");
+
+        assert_eq!(
+            frame
+                .evaluate(
+                    &mut parent,
+                    "[globalThis.__frameBodyOnload, globalThis.__frameLoadListenerCalls]",
+                )
+                .unwrap(),
+            serde_json::json!([[true, "load"], 1]),
         );
     }
 


### PR DESCRIPTION
## Summary

Fixes #768.

The HTML `<body onload="...">` content attribute is a Window-reflecting event handler, but obscura previously left it disconnected from `window.onload`. This patch:

- reflects the active document body/frameset `onload` handler through `window.onload`;
- compiles inline `onload` content attributes through the existing inline-handler resolver;
- keeps detached body elements isolated;
- dispatches one shared `load` event object and invokes `window.onload` with `this === window`;
- applies the same behavior to frame realms;
- preserves load-listener delivery when an `onload` handler throws.

## Validation

- `cargo test -p obscura-browser body_onload_content_attribute_reflects_to_window --lib --features render`
- `cargo test -p obscura-js frame_body_onload_content_attribute_reflects_to_window --lib`
- Reproduction now returns `x=1` instead of `x=undefined`.
