### PR TITLE
test(js): pin the Chrome shape of a blob URL and its synchronous store

### DIFF
--- a/crates/obscura-js/js/bootstrap.js
+++ b/crates/obscura-js/js/bootstrap.js
@@ -40,6 +40,7 @@
     '_urlResolveOp', '_decodeBodyWithCharset', '_utf8DecodeBytes',
     '_selectionFor', '_isConstructorCE', '_isValidCustomElementName', '_shadowRootForHost',
     '_blobPartToBytes', '_bytesToBinaryString', '_formEncode', '_hexv',
+    '_blobUrlOrigin', '_isBlobLike', '_blobUuid',
     '_commonFonts', '_isXMLDocument', '_isValidPITarget', '_isHTMLEl',
     '_nodeList', '_rngNodeLength', '_rngNodeIndex', '_rngSame', '_rngRoot',
     '_rngAncestors', '_rngOrder', '_rngCmp', '_rngCheckOffset',
@@ -7387,8 +7388,9 @@ if (typeof URL === 'undefined' || !URL.prototype || !URL.__obscura) {
     _updateSearch(qs) { this._set('search', qs ? ('?' + qs) : ''); }
     toString() { return this._c.href; }
     toJSON() { return this._c.href; }
-    static createObjectURL() { return 'blob:null/fake-' + Math.random().toString(36).slice(2); }
-    static revokeObjectURL() {}
+    // createObjectURL/revokeObjectURL are installed further down, next to the
+    // blob store they read and write. Defining stubs here only risked one of
+    // them surviving and handing a page a 'fake-' id to fingerprint. (#751)
     // WHATWG URL.parse: like the constructor but returns null instead of throwing.
     static parse(url, base) { const c = _urlParseOp(url, base); if (!c) return null; const u = Object.create(_URL.prototype); u._c = c; u._sp = null; return u; }
     static canParse(url, base) { return _urlParseOp(url, base) !== null; }
@@ -13281,28 +13283,58 @@ globalThis.Worker = class Worker {
 };
 
 globalThis.__blobStore = globalThis.__blobStore || {};
-URL.createObjectURL = function(blob) {
-  if (blob) {
-    const id = 'blob:obscura/' + Math.random().toString(36).substring(2);
-    // Store synchronously so a Worker built from the blob URL in the same
-    // tick sees its source. Blob-URL Worker construction is synchronous in
-    // real browsers; the previous async blob.text().then() store raced the
-    // Worker constructor, so new Worker(blobURL) fell through to fetch() and
-    // failed (net::ERR_FAILED), which broke AWS WAF's proof-of-work worker.
-    // The obscura Blob materializes _bytes in its constructor; fall back to
-    // the async text() store only for foreign Blob shims without _bytes.
-    if (blob._bytes) {
-      let text = '';
-      try { text = new TextDecoder().decode(blob._bytes); } catch (e) {}
-      globalThis.__blobStore[id] = text;
-    } else if (typeof blob.text === 'function') {
-      blob.text().then(text => { globalThis.__blobStore[id] = text; });
-    } else {
-      globalThis.__blobStore[id] = '';
+// Chrome mints blob:<document origin>/<v4 UUID>, and blob:null/<uuid> on an
+// opaque origin. The old 'blob:obscura/' + base36 form named the engine to any
+// page that read a blob URL back -- a Worker's scriptURL, an anchor href,
+// new URL(u).origin, a CSP violation report -- so one startsWith() was a
+// complete check, and the base36 id failed every UUID parser. (#751)
+function _blobUrlOrigin() {
+  try {
+    const href = globalThis.location && globalThis.location.href;
+    if (href) {
+      const origin = new URL(href).origin;
+      if (origin) return origin;
     }
-    return id;
+  } catch (e) {}
+  return 'null';
+}
+// Chrome takes a Blob (File included) or a MediaSource and throws for anything
+// else. Duck-typing keeps the tolerance for foreign Blob shims that the store
+// below already relies on, while still rejecting strings, numbers and null.
+function _isBlobLike(value) {
+  if (!value || typeof value !== 'object') return false;
+  if (typeof Blob === 'function' && value instanceof Blob) return true;
+  return typeof value.size === 'number'
+    && (value._bytes != null || typeof value.text === 'function' || typeof value.slice === 'function');
+}
+// Bound at bootstrap so a page that later replaces globalThis.crypto cannot
+// observe or steer minting.
+var _blobUuid = globalThis.crypto.randomUUID.bind(globalThis.crypto);
+URL.createObjectURL = function(blob) {
+  if (arguments.length < 1) {
+    throw new TypeError("Failed to execute 'createObjectURL' on 'URL': 1 argument required, but only 0 present.");
   }
-  return 'blob:obscura/fallback';
+  if (!_isBlobLike(blob)) {
+    throw new TypeError("Failed to execute 'createObjectURL' on 'URL': parameter 1 is not of type 'Blob'.");
+  }
+  const id = 'blob:' + _blobUrlOrigin() + '/' + _blobUuid();
+  // Store synchronously so a Worker built from the blob URL in the same
+  // tick sees its source. Blob-URL Worker construction is synchronous in
+  // real browsers; the previous async blob.text().then() store raced the
+  // Worker constructor, so new Worker(blobURL) fell through to fetch() and
+  // failed (net::ERR_FAILED), which broke AWS WAF's proof-of-work worker.
+  // The obscura Blob materializes _bytes in its constructor; fall back to
+  // the async text() store only for foreign Blob shims without _bytes.
+  if (blob._bytes) {
+    let text = '';
+    try { text = new TextDecoder().decode(blob._bytes); } catch (e) {}
+    globalThis.__blobStore[id] = text;
+  } else if (typeof blob.text === 'function') {
+    blob.text().then(text => { globalThis.__blobStore[id] = text; });
+  } else {
+    globalThis.__blobStore[id] = '';
+  }
+  return id;
 };
 URL.revokeObjectURL = function(url) {
   delete globalThis.__blobStore[url];

--- a/crates/obscura-js/src/runtime.rs
+++ b/crates/obscura-js/src/runtime.rs
@@ -14785,6 +14785,80 @@ mod tests {
         assert_eq!(seen[1].as_str().unwrap(), "http://example.com/app/data/y.json");
     }
 
+    #[test]
+    fn a_blob_url_is_chrome_shaped_and_non_blob_input_throws() {
+        let mut rt = setup_runtime("<html><body></body></html>");
+
+        assert_eq!(
+            rt.evaluate(
+                r#"(() => {
+                    const url = URL.createObjectURL(new Blob(["x"]));
+                    const uuid = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/;
+                    const second = URL.createObjectURL(new Blob(["y"]));
+                    const threw = argument => {
+                        try {
+                            argument === undefined ? URL.createObjectURL() : URL.createObjectURL(argument);
+                            return "did not throw";
+                        } catch (error) {
+                            return error instanceof TypeError ? error.message : String(error);
+                        }
+                    };
+                    return {
+                        origin: url.slice(0, "blob:http://example.com/".length),
+                        uuid: uuid.test(url.slice("blob:http://example.com/".length)),
+                        names_the_engine: /obscura|fake/.test(url),
+                        unique: url !== second,
+                        no_argument: threw(undefined),
+                        string: threw("nope"),
+                        number: threw(7),
+                        null_value: threw(null),
+                        file_is_a_blob: URL.createObjectURL(new File(["x"], "a.txt")).startsWith("blob:http://example.com/"),
+                    };
+                })()"#,
+            )
+            .unwrap(),
+            serde_json::json!({
+                "origin": "blob:http://example.com/",
+                "uuid": true,
+                "names_the_engine": false,
+                "unique": true,
+                "no_argument": "Failed to execute 'createObjectURL' on 'URL': 1 argument required, but only 0 present.",
+                "string": "Failed to execute 'createObjectURL' on 'URL': parameter 1 is not of type 'Blob'.",
+                "number": "Failed to execute 'createObjectURL' on 'URL': parameter 1 is not of type 'Blob'.",
+                "null_value": "Failed to execute 'createObjectURL' on 'URL': parameter 1 is not of type 'Blob'.",
+                "file_is_a_blob": true,
+            })
+        );
+    }
+
+    #[test]
+    fn a_blob_url_still_feeds_a_worker_and_survives_revocation() {
+        let mut rt = setup_runtime("<html><body></body></html>");
+
+        assert_eq!(
+            rt.evaluate(
+                r#"(() => {
+                    const url = URL.createObjectURL(new Blob(["self.onmessage = () => {};"]));
+                    const stored = globalThis.__blobStore[url];
+                    URL.revokeObjectURL(url);
+                    return {
+                        stored_synchronously: stored === "self.onmessage = () => {};",
+                        revoked: globalThis.__blobStore[url] === undefined,
+                        helpers_hidden: Object.keys(globalThis).filter(
+                            name => name === "_blobUrlOrigin" || name === "_isBlobLike" || name === "_blobUuid",
+                        ),
+                    };
+                })()"#,
+            )
+            .unwrap(),
+            serde_json::json!({
+                "stored_synchronously": true,
+                "revoked": true,
+                "helpers_hidden": [],
+            })
+        );
+    }
+
     #[tokio::test(flavor = "current_thread")]
     async fn test_fetch_url_input_decodes_binary_body_base64() {
         let mut rt = setup_runtime("<html><body></body></html>");

--- a/crates/obscura-js/src/runtime.rs
+++ b/crates/obscura-js/src/runtime.rs
@@ -3703,6 +3703,86 @@ mod tests {
         );
     }
 
+    // #751 — the accepted case above only asserts the `blob:` scheme, which the
+    // old `blob:obscura/<base36>` form also satisfied. Pin the shape itself:
+    // Chrome mints `blob:<document origin>/<v4 UUID>`, so a URL that names the
+    // engine, or carries a token no UUID parser accepts, is a regression even
+    // though it still starts with `blob:`.
+    #[test]
+    fn a_blob_url_is_chrome_shaped() {
+        let mut rt = setup_runtime("<html><body></body></html>");
+
+        assert_eq!(
+            rt.evaluate(
+                r#"(() => {
+                    const url = URL.createObjectURL(new Blob(["x"]));
+                    const uuid = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/;
+                    const second = URL.createObjectURL(new Blob(["y"]));
+                    const threw = argument => {
+                        try {
+                            argument === undefined ? URL.createObjectURL() : URL.createObjectURL(argument);
+                            return "did not throw";
+                        } catch (error) {
+                            return error instanceof TypeError ? error.message : String(error);
+                        }
+                    };
+                    return {
+                        origin: url.slice(0, "blob:http://example.com/".length),
+                        uuid: uuid.test(url.slice("blob:http://example.com/".length)),
+                        names_the_engine: /obscura|fake/.test(url),
+                        unique: url !== second,
+                        no_argument: threw(undefined),
+                        string: threw("nope"),
+                        number: threw(7),
+                        null_value: threw(null),
+                        file_is_a_blob: URL.createObjectURL(new File(["x"], "a.txt")).startsWith("blob:http://example.com/"),
+                    };
+                })()"#,
+            )
+            .unwrap(),
+            serde_json::json!({
+                "origin": "blob:http://example.com/",
+                "uuid": true,
+                "names_the_engine": false,
+                "unique": true,
+                "no_argument": "Failed to execute 'createObjectURL' on 'URL': 1 argument required, but only 0 present.",
+                "string": "Failed to execute 'createObjectURL' on 'URL': parameter 1 is not of type 'Blob'.",
+                "number": "Failed to execute 'createObjectURL' on 'URL': parameter 1 is not of type 'Blob'.",
+                "null_value": "Failed to execute 'createObjectURL' on 'URL': parameter 1 is not of type 'Blob'.",
+                "file_is_a_blob": true,
+            })
+        );
+    }
+
+    // #751 — the source has to be in the store by the time createObjectURL
+    // returns. Blob-URL Worker construction is synchronous in a real browser,
+    // so an async `blob.text().then()` store races the Worker constructor and
+    // the Worker falls through to fetch() and fails; revocation then has to
+    // remove it again rather than leaving the entry readable.
+    #[test]
+    fn a_blob_url_is_stored_synchronously_and_revocation_removes_it() {
+        let mut rt = setup_runtime("<html><body></body></html>");
+
+        assert_eq!(
+            rt.evaluate(
+                r#"(() => {
+                    const url = URL.createObjectURL(new Blob(["self.onmessage = () => {};"]));
+                    const stored = globalThis.__blobStore[url];
+                    URL.revokeObjectURL(url);
+                    return {
+                        stored_synchronously: stored === "self.onmessage = () => {};",
+                        revoked: globalThis.__blobStore[url] === undefined,
+                    };
+                })()"#,
+            )
+            .unwrap(),
+            serde_json::json!({
+                "stored_synchronously": true,
+                "revoked": true,
+            })
+        );
+    }
+
     // SEC-301 / SEC-302 / #792 — the profile setters must embed values safely.
     // set_platform must not allow a backslash-before-quote to break out of the
     // JS string literal (injection), and set_user_agent must not silently fail


### PR DESCRIPTION
## What

This PR no longer changes behaviour. `main` already mints Chrome-shaped blob URLs — @963s landed that in #804 (`c9e4c9f`) while this was open, and the production half of what I had here is redundant. Rebased onto it and narrowed to the two tests that fix landed without.

## Why

`create_object_url_rejects_non_blob_input` (SEC-503 / #820) covers the rejection half well, but the accepted half only asserts the scheme:

```js
URL.createObjectURL(new Blob(['hello'])).startsWith('blob:')
```

The form #751 was filed about — `blob:obscura/<base36>` — satisfies that too, so the assertion cannot tell the fixed shape from the bug. The shape is the whole point of #751: a page that reads a blob URL back (a Worker's `scriptURL`, an anchor href, `new URL(u).origin`, a CSP report) saw the engine's name, and the base36 token failed every UUID parser.

Two paths in the merged fix also have no coverage: the source is stored *synchronously* so a Worker constructed from the URL in the same tick can read it — the async `blob.text().then()` store is what broke AWS WAF's proof-of-work worker — and `revokeObjectURL` has to remove the entry again.

## Testing

Run in a Linux container on rustc 1.98, against `main`'s implementation:

```
cargo nextest run -p obscura-js -E 'test(a_blob_url) + test(create_object_url_rejects_non_blob_input)'
    PASS obscura-js runtime::tests::a_blob_url_is_chrome_shaped
    PASS obscura-js runtime::tests::a_blob_url_is_stored_synchronously_and_revocation_removes_it
    PASS obscura-js runtime::tests::create_object_url_rejects_non_blob_input
3 tests run: 3 passed, 385 skipped
```

To show the new tests earn their place rather than restating a green build, I reintroduced the exact bug — `const id = 'blob:obscura/' + Math.random().toString(36).slice(2);` at the mint site — and re-ran the same three:

```
    FAIL obscura-js runtime::tests::a_blob_url_is_chrome_shaped
       left:  "origin": "blob:obscura/mgrloud2qak", "uuid": false, "names_the_engine": true
       right: "origin": "blob:http://example.com/", "uuid": true,  "names_the_engine": false
    PASS obscura-js runtime::tests::a_blob_url_is_stored_synchronously_and_revocation_removes_it
    PASS obscura-js runtime::tests::create_object_url_rejects_non_blob_input
3 tests run: 2 passed, 1 failed, 385 skipped
```

That is the gap: the existing test stays green while the URL names the engine again.
