### PR TITLE
fix(text): preserve whitespace across inline spans

### DIFF
--- a/crates/obscura-cli/src/main.rs
+++ b/crates/obscura-cli/src/main.rs
@@ -1396,6 +1396,28 @@ fn dump_markdown(page: &mut Page) -> String {
     result.as_str().unwrap_or_default().to_string()
 }
 
+fn is_html_whitespace(c: char) -> bool {
+    matches!(c, '\t' | '\n' | '\x0C' | '\r' | ' ')
+}
+
+fn append_readable_text_segment(result: &mut String, pending_space: &mut bool, contents: &str) {
+    let trimmed = contents.trim_matches(is_html_whitespace);
+    if trimmed.is_empty() {
+        if contents.chars().any(is_html_whitespace) {
+            *pending_space = true;
+        }
+        return;
+    }
+
+    let begins_with_space = contents.chars().next().is_some_and(is_html_whitespace);
+    let result_ends_with_space = result.chars().next_back().is_some_and(char::is_whitespace);
+    if (*pending_space || begins_with_space) && !result.is_empty() && !result_ends_with_space {
+        result.push(' ');
+    }
+    result.push_str(trimmed);
+    *pending_space = contents.chars().next_back().is_some_and(is_html_whitespace);
+}
+
 fn extract_readable_text(dom: &obscura_dom::DomTree, node_id: obscura_dom::NodeId) -> String {
     use obscura_dom::NodeData;
 
@@ -1415,6 +1437,7 @@ fn extract_readable_text(dom: &obscura_dom::DomTree, node_id: obscura_dom::NodeI
     const MAX_NODES: usize = 5_000_000;
 
     let mut result = String::new();
+    let mut pending_space = false;
     let mut stack: Vec<Work> = vec![Work::Visit(node_id)];
     let mut visited = 0usize;
 
@@ -1422,6 +1445,7 @@ fn extract_readable_text(dom: &obscura_dom::DomTree, node_id: obscura_dom::NodeI
         let id = match work {
             Work::Newline => {
                 result.push('\n');
+                pending_space = false;
                 continue;
             }
             Work::Visit(id) => id,
@@ -1439,10 +1463,7 @@ fn extract_readable_text(dom: &obscura_dom::DomTree, node_id: obscura_dom::NodeI
 
         match &node.data {
             NodeData::Text { contents } => {
-                let trimmed = contents.trim();
-                if !trimmed.is_empty() {
-                    result.push_str(trimmed);
-                }
+                append_readable_text_segment(&mut result, &mut pending_space, contents);
             }
             NodeData::Element { name, .. } => {
                 let tag = name.local.as_ref();
@@ -1495,6 +1516,7 @@ fn extract_readable_text(dom: &obscura_dom::DomTree, node_id: obscura_dom::NodeI
 
                 if is_block {
                     result.push('\n');
+                    pending_space = false;
                     // Processed after all children (stack is LIFO): the trailing newline.
                     stack.push(Work::Newline);
                 }

--- a/crates/obscura-cli/tests/mcp_client.rs
+++ b/crates/obscura-cli/tests/mcp_client.rs
@@ -16,6 +16,12 @@ const QUEUED_NAVIGATION_SELECTOR: &str = "#queued";
 const QUEUED_NAVIGATION_TITLE: &str = "queued-task-finished";
 const TIMER_TEST_INITIAL_PAGE: &str = "data:text/html,<title>initial</title>";
 const TIMER_TEST_TIMEOUT_SECONDS: u64 = 1;
+const INLINE_TEXT_URL: &str = "data:text/html,\
+<html><body>\
+<h1><span>H</span><span>e</span><span>l</span><span>l</span><span>o</span>%20\
+<span>w</span><span>o</span><span>r</span><span>l</span><span>d</span><span>.</span></h1>\
+<p><span>Hello</span><span>,</span>%20<span>world</span><span>!</span></p>\
+</body></html>";
 
 /// A loopback fixture keeps protocol tests independent of public-site bot
 /// policy, DNS, and content changes. The previous example.com dependency can
@@ -200,6 +206,27 @@ fn test_initialize() {
     );
     assert_eq!(resp["result"]["protocolVersion"], "2024-11-05");
     assert_eq!(resp["result"]["serverInfo"]["name"], "obscura-mcp");
+}
+
+#[test]
+fn snapshot_preserves_whitespace_between_inline_spans() {
+    let mut client = McpClient::spawn();
+    let navigation = client.tool(
+        "browser_navigate",
+        serde_json::json!({ "url": INLINE_TEXT_URL }),
+    );
+    assert!(
+        navigation.get("error").is_none(),
+        "navigation failed: {navigation}"
+    );
+
+    let snapshot = client.tool("browser_snapshot", serde_json::json!({}));
+    let text = content_text(&snapshot);
+    assert!(
+        text.contains("Hello world.\n\nHello, world!"),
+        "snapshot mangled inline text: {text}"
+    );
+    assert!(!text.contains("H e l l o"), "snapshot inserted spaces: {text}");
 }
 
 #[test]

--- a/crates/obscura-cli/tests/text_whitespace.rs
+++ b/crates/obscura-cli/tests/text_whitespace.rs
@@ -1,0 +1,34 @@
+use std::process::Command;
+
+const INLINE_TEXT_URL: &str = "data:text/html,\
+<html><body>\
+<h1><span>H</span><span>e</span><span>l</span><span>l</span><span>o</span>%20\
+<span>w</span><span>o</span><span>r</span><span>l</span><span>d</span><span>.</span></h1>\
+<p><span>Hello</span><span>,</span>%20<span>world</span><span>!</span></p>\
+</body></html>";
+
+#[test]
+fn dump_text_preserves_whitespace_between_inline_spans() {
+    let output = Command::new(env!("CARGO_BIN_EXE_obscura"))
+        .args([
+            "fetch",
+            INLINE_TEXT_URL,
+            "--dump",
+            "text",
+            "--quiet",
+        ])
+        .output()
+        .expect("run obscura fetch");
+
+    assert!(
+        output.status.success(),
+        "obscura fetch failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert_eq!(
+        String::from_utf8(output.stdout)
+            .expect("UTF-8 text dump")
+            .trim(),
+        "Hello world.\n\nHello, world!",
+    );
+}

--- a/crates/obscura-mcp/src/lib.rs
+++ b/crates/obscura-mcp/src/lib.rs
@@ -1825,52 +1825,94 @@ fn tool_tab_close(args: &Value, state: &mut BrowserState) -> Result<String, Stri
     Ok(summary)
 }
 
+fn is_html_whitespace(c: char) -> bool {
+    matches!(c, '\t' | '\n' | '\x0C' | '\r' | ' ')
+}
+
+fn append_text_segment(result: &mut String, pending_space: &mut bool, contents: &str) {
+    let trimmed = contents.trim_matches(is_html_whitespace);
+    if trimmed.is_empty() {
+        if contents.chars().any(is_html_whitespace) {
+            *pending_space = true;
+        }
+        return;
+    }
+
+    let begins_with_space = contents.chars().next().is_some_and(is_html_whitespace);
+    let result_ends_with_space = result.chars().next_back().is_some_and(char::is_whitespace);
+    if (*pending_space || begins_with_space) && !result.is_empty() && !result_ends_with_space {
+        result.push(' ');
+    }
+    result.push_str(trimmed);
+    *pending_space = contents.chars().next_back().is_some_and(is_html_whitespace);
+}
+
 fn extract_text(dom: &obscura_dom::DomTree, node_id: obscura_dom::NodeId) -> String {
     use obscura_dom::NodeData;
 
+    enum Work {
+        Visit(obscura_dom::NodeId),
+        Newline,
+    }
+
+    const MAX_NODES: usize = 5_000_000;
+
     let mut result = String::new();
-    let node = match dom.get_node(node_id) {
-        Some(n) => n,
-        None => return result,
-    };
+    let mut pending_space = false;
+    let mut stack = vec![Work::Visit(node_id)];
+    let mut visited = 0usize;
 
-    match &node.data {
-        NodeData::Text { contents } => {
-            let trimmed = contents.trim();
-            if !trimmed.is_empty() {
-                result.push_str(trimmed);
-                result.push(' ');
-            }
-        }
-        NodeData::Element { name, .. } => {
-            let tag = name.local.as_ref();
-            if matches!(tag, "script" | "style" | "noscript") {
-                return result;
-            }
-
-            let is_block = matches!(
-                tag,
-                "div" | "p" | "h1" | "h2" | "h3" | "h4" | "h5" | "h6"
-                    | "li" | "tr" | "br" | "hr" | "section" | "article"
-                    | "header" | "footer" | "nav" | "main" | "aside"
-                    | "blockquote" | "pre" | "ul" | "ol" | "table"
-            );
-
-            if is_block {
+    while let Some(work) = stack.pop() {
+        let id = match work {
+            Work::Newline => {
                 result.push('\n');
+                pending_space = false;
+                continue;
             }
+            Work::Visit(id) => id,
+        };
 
-            for child in dom.children(node_id) {
-                result.push_str(&extract_text(dom, child));
-            }
-
-            if is_block {
-                result.push('\n');
-            }
+        visited += 1;
+        if visited > MAX_NODES {
+            break;
         }
-        _ => {
-            for child in dom.children(node_id) {
-                result.push_str(&extract_text(dom, child));
+
+        let node = match dom.get_node(id) {
+            Some(node) => node,
+            None => continue,
+        };
+
+        match &node.data {
+            NodeData::Text { contents } => {
+                append_text_segment(&mut result, &mut pending_space, contents);
+            }
+            NodeData::Element { name, .. } => {
+                let tag = name.local.as_ref();
+                if matches!(tag, "script" | "style" | "noscript") {
+                    continue;
+                }
+
+                let is_block = matches!(
+                    tag,
+                    "div" | "p" | "h1" | "h2" | "h3" | "h4" | "h5" | "h6"
+                        | "li" | "tr" | "br" | "hr" | "section" | "article"
+                        | "header" | "footer" | "nav" | "main" | "aside"
+                        | "blockquote" | "pre" | "ul" | "ol" | "table"
+                );
+
+                if is_block {
+                    result.push('\n');
+                    pending_space = false;
+                    stack.push(Work::Newline);
+                }
+                for child in dom.children(id).into_iter().rev() {
+                    stack.push(Work::Visit(child));
+                }
+            }
+            _ => {
+                for child in dom.children(id).into_iter().rev() {
+                    stack.push(Work::Visit(child));
+                }
             }
         }
     }


### PR DESCRIPTION
## What changed

- Preserve authored HTML whitespace between inline text nodes for `--dump text` and MCP `browser_snapshot`.
- Keep adjacent character spans contiguous instead of dropping real word boundaries or inserting a space after every character.
- Use a bounded iterative traversal for MCP text extraction, matching the CLI traversal safety limit.

Fixes #785

## Validation

- Focused release/render CLI regression: 1/1 passed.
- Focused release/render MCP regression: 1/1 passed.
- Affected CLI and MCP release/render suites: 88/88 passed.
- Affected CLI and MCP release/no-render suites: 82/82 passed.
- Full workspace release/render nextest: 1552/1552 passed, 4 configured skips.
- Exact release/render CLI build passed.
- The issue reproduction now returns `Hello world.` from both text paths.
- Obstacle course: 32/33 passed. The only failure, `observer-intersection`, reproduces on the unmodified base commit with the same fixture and command.

## Rendering

Not applicable.

## Performance

A 5,000-inline-span local `--dump text --wait 0` smoke test was run in five alternating samples. Base and candidate both had a 20ms median end-to-end latency. The traversal remains bounded and does not add persistent state.
