### PR TITLE
fix(js): propagate DOM events through window

### DIFF
--- a/crates/obscura-browser/src/page.rs
+++ b/crates/obscura-browser/src/page.rs
@@ -2902,8 +2902,7 @@ impl Page {
             // a DOMContentLoaded listener.
             let _ = js.execute_script(
                 "<dom-content-loaded>",
-                "try { document.dispatchEvent(new Event('DOMContentLoaded', {bubbles:false,cancelable:false})); } catch(e) {}\n\
-                 try { window.dispatchEvent(new Event('DOMContentLoaded', {bubbles:false,cancelable:false})); } catch(e) {}",
+                "try { document.dispatchEvent(new Event('DOMContentLoaded', {bubbles:true,cancelable:false})); } catch(e) {}",
             );
 
             let load_blockers_finished =
@@ -2920,13 +2919,7 @@ impl Page {
             let _ = js.execute_script(
                 "<load-event>",
                 "globalThis.__documentReadyState__ = 'complete';\n\
-                 try {\n\
-                   const loadEvent = new Event('load', {bubbles:false,cancelable:false});\n\
-                   if (typeof window.onload === 'function') {\n\
-                     try { window.onload.call(window, loadEvent); } catch(e) {}\n\
-                   }\n\
-                   try { window.dispatchEvent(loadEvent); } catch(e) {}\n\
-                 } catch(e) {}",
+                 try { globalThis.__obscura_dispatchWindowLoad(); } catch(e) {}",
             );
         }
         if let Some(token) = exec_wd {
@@ -6644,12 +6637,38 @@ mod tests {
         let html = format!(
             r#"<html><head></head><body><script>
                 globalThis.__lifecycleOrder = [];
+                globalThis.__domContentLoadedPath = [];
+                globalThis.__windowLoadPath = [];
+                globalThis.__capturedWindowLoad = null;
+                const recordDomContentLoaded = label => event =>
+                    globalThis.__domContentLoadedPath.push([
+                        label, event.eventPhase, event.target === document,
+                        event.currentTarget === window,
+                    ]);
+                window.addEventListener('DOMContentLoaded',
+                    recordDomContentLoaded('window-capture'), true);
+                document.addEventListener('DOMContentLoaded',
+                    recordDomContentLoaded('document-target'));
+                window.addEventListener('DOMContentLoaded',
+                    recordDomContentLoaded('window-bubble'));
                 document.addEventListener('DOMContentLoaded', () =>
                     globalThis.__lifecycleOrder.push('dom-content-loaded'));
-                window.onload = () =>
+                window.onload = event => {{
+                    globalThis.__capturedWindowLoad = event;
                     globalThis.__lifecycleOrder.push('window-onload');
-                window.addEventListener('load', () =>
-                    globalThis.__lifecycleOrder.push('window-load'));
+                    globalThis.__windowLoadPath.push([
+                        'property', event.target === document,
+                        event.currentTarget === window, event.eventPhase,
+                        event.isTrusted]);
+                    throw new Error('load-listener-test');
+                }};
+                window.addEventListener('load', event => {{
+                    globalThis.__lifecycleOrder.push('window-load');
+                    globalThis.__windowLoadPath.push([
+                        'listener', event.target === document,
+                        event.currentTarget === window, event.eventPhase,
+                        event.isTrusted]);
+                }});
                 const script = document.createElement('script');
                 script.src = '{base}/preload-dynamic.js';
                 script.onload = () => globalThis.__lifecycleOrder.push('script-load');
@@ -6689,12 +6708,59 @@ mod tests {
             page.js
                 .as_mut()
                 .unwrap()
+                .evaluate("globalThis.__domContentLoadedPath")
+                .unwrap(),
+            serde_json::json!([
+                ["window-capture", 1, true, true],
+                ["document-target", 2, true, false],
+                ["window-bubble", 3, true, true],
+            ]),
+            "DOMContentLoaded must traverse Document to Window exactly once",
+        );
+        assert_eq!(
+            page.js
+                .as_mut()
+                .unwrap()
                 .evaluate(
                     "globalThis.__lifecycleOrder.filter(value => value === 'window-onload').length",
                 )
                 .unwrap(),
             serde_json::json!(1.0),
             "window.onload must fire exactly once",
+        );
+        assert_eq!(
+            page.js
+                .as_mut()
+                .unwrap()
+                .evaluate("globalThis.__windowLoadPath")
+                .unwrap(),
+            serde_json::json!([
+                ["property", true, true, 2, true],
+                ["listener", true, true, 2, true],
+            ]),
+            "browser-generated Window load uses the Document legacy target",
+        );
+        assert_eq!(
+            page.js
+                .as_mut()
+                .unwrap()
+                .evaluate(
+                    "(() => {\
+                         const browserEvent = globalThis.__capturedWindowLoad;\
+                         let seen;\
+                         window.addEventListener('load', event => {\
+                             if (event === browserEvent) seen = [\
+                                 event.target === window,\
+                                 event.currentTarget === window,\
+                                 event.eventPhase, event.isTrusted];\
+                         }, { once: true });\
+                         window.dispatchEvent(browserEvent);\
+                         return seen;\
+                     })()",
+                )
+                .unwrap(),
+            serde_json::json!([true, true, 2, false]),
+            "redispatched browser load must use author-dispatch semantics",
         );
     }
 

--- a/crates/obscura-js/js/bootstrap.js
+++ b/crates/obscura-js/js/bootstrap.js
@@ -78,27 +78,22 @@ globalThis.__obscura_core_handoff = Deno.core;
 
 globalThis.__obscura_errors = [];
 
-globalThis.addEventListener = globalThis.addEventListener || function(){};
-globalThis.onunhandledrejection = function(e) { if (e?.preventDefault) e.preventDefault(); };
+// Listener state belongs to the JS wrapper. Window uses a stable private key
+// because V8 may expose different global-proxy wrappers across evaluations.
+const _eventTargetListeners = new WeakMap();
+const _eventHandlerSlots = new WeakMap();
+const _eventDispatchStates = new WeakMap();
+const _windowEventTargetKey = {};
+let _eventListenerOrder = 0;
 
-globalThis.onerror = function(msg, src, line, col, error) {
-  globalThis.__obscura_errors.push({msg: String(msg), src: String(src||""), line, error: String(error||"")});
+globalThis.addEventListener = function(type, fn, options) {
+  _eventTargetAdd(globalThis, type, fn, options);
 };
-globalThis.__windowListeners = {};
-globalThis.addEventListener = function(type, fn) {
-  if (!globalThis.__windowListeners[type]) globalThis.__windowListeners[type] = [];
-  globalThis.__windowListeners[type].push(fn);
-};
-globalThis.removeEventListener = function(type, fn) {
-  if (globalThis.__windowListeners[type]) {
-    globalThis.__windowListeners[type] = globalThis.__windowListeners[type].filter(h => h !== fn);
-  }
+globalThis.removeEventListener = function(type, fn, options) {
+  _eventTargetRemove(globalThis, type, fn, options);
 };
 globalThis.dispatchEvent = function(event) {
-  if (!event) return true;
-  const handlers = globalThis.__windowListeners[event.type] || [];
-  for (const h of handlers) { try { h.call(globalThis, event); } catch(e) { console.error(e); } }
-  return !event.defaultPrevented;
+  return _eventTargetDispatch(globalThis, event);
 };
 
 let _domMutationEpoch = 0;
@@ -696,11 +691,9 @@ function _getFp() {
   return _fpCache;
 }
 function _fp(key) { return _getFp()[key]; }
-globalThis._eventRegistry = globalThis._eventRegistry || {};
 globalThis._formValues = globalThis._formValues || {};
 globalThis._formChecked = globalThis._formChecked || {};
 globalThis._formIndeterminate = globalThis._formIndeterminate || {};
-const _eventRegistry = globalThis._eventRegistry;
 const _formValues = globalThis._formValues;
 const _formChecked = globalThis._formChecked;
 const _formIndeterminate = globalThis._formIndeterminate;
@@ -1783,25 +1776,61 @@ function _shallowCloneNode(node) {
   return el;
 }
 
-// EventTarget listener state belongs to the JS wrapper rather than the backing
-// DOM node.  This is also what makes `new EventTarget()` and subclasses used by
-// framework schedulers work: those targets deliberately have no native node id.
-const _eventTargetListeners = new WeakMap();
+function _eventTargetKey(target) {
+  return target === globalThis ? _windowEventTargetKey : target;
+}
+function _eventHandlerGet(target, name) {
+  name = String(name);
+  return _eventHandlerSlots
+    .get(_eventTargetKey(target))?.get(name)?.callback || null;
+}
+function _eventHandlerSet(target, name, callback) {
+  name = String(name);
+  const key = _eventTargetKey(target);
+  let slots = _eventHandlerSlots.get(key);
+  if (!slots) {
+    slots = new Map();
+    _eventHandlerSlots.set(key, slots);
+  }
+  if (typeof callback !== "function") {
+    slots.delete(name);
+    return;
+  }
+  const previous = slots.get(name);
+  slots.set(name, { callback, order: previous?.order ?? ++_eventListenerOrder });
+}
 function _eventCapture(options) {
   return typeof options === "boolean" ? options : !!(options && options.capture);
+}
+function _eventSyncWindowOnloadHandler() {
+  if (_eventHandlerSlots.get(_windowEventTargetKey)?.has("onload")) return;
+  const reflected = globalThis.onload;
+  if (typeof reflected === "function") {
+    _eventHandlerSet(globalThis, "onload", reflected);
+  }
 }
 function _eventTargetAdd(target, type, callback, options) {
   if (callback == null) return;
   const isFunction = typeof callback === "function";
   if (!isFunction && typeof callback.handleEvent !== "function") return;
   type = String(type);
+  if (target === globalThis && type === "load") _eventSyncWindowOnloadHandler();
+  if (target !== globalThis && globalThis.Element && target instanceof globalThis.Element) {
+    const handlerName = "on" + type;
+    const key = _eventTargetKey(target);
+    if (!_eventHandlerSlots.get(key)?.has(handlerName)
+        && target.getAttribute(handlerName) !== null) {
+      _eventHandlerSet(target, handlerName, target._resolveInlineHandler(handlerName));
+    }
+  }
   const capture = _eventCapture(options);
   const signal = options && typeof options === "object" ? options.signal : null;
   if (signal && signal.aborted) return;
-  let byType = _eventTargetListeners.get(target);
+  const key = _eventTargetKey(target);
+  let byType = _eventTargetListeners.get(key);
   if (!byType) {
     byType = new Map();
-    _eventTargetListeners.set(target, byType);
+    _eventTargetListeners.set(key, byType);
   }
   let listeners = byType.get(type);
   if (!listeners) {
@@ -1816,6 +1845,8 @@ function _eventTargetAdd(target, type, callback, options) {
     passive: !!(options && typeof options === "object" && options.passive),
     signal,
     abortHandler: null,
+    order: ++_eventListenerOrder,
+    removed: false,
   };
   listeners.push(entry);
   if (signal && typeof signal.addEventListener === "function") {
@@ -1824,7 +1855,8 @@ function _eventTargetAdd(target, type, callback, options) {
   }
 }
 function _eventTargetRemove(target, type, callback, options) {
-  const byType = _eventTargetListeners.get(target);
+  const key = _eventTargetKey(target);
+  const byType = _eventTargetListeners.get(key);
   if (!byType) return;
   type = String(type);
   const listeners = byType.get(type);
@@ -1833,6 +1865,7 @@ function _eventTargetRemove(target, type, callback, options) {
   for (let i = 0; i < listeners.length; i++) {
     const entry = listeners[i];
     if (entry.callback !== callback || entry.capture !== capture) continue;
+    entry.removed = true;
     listeners.splice(i, 1);
     if (entry.signal && entry.abortHandler && typeof entry.signal.removeEventListener === "function") {
       entry.signal.removeEventListener("abort", entry.abortHandler);
@@ -1840,36 +1873,238 @@ function _eventTargetRemove(target, type, callback, options) {
     break;
   }
   if (listeners.length === 0) byType.delete(type);
-  if (byType.size === 0) _eventTargetListeners.delete(target);
+  if (byType.size === 0) _eventTargetListeners.delete(key);
 }
-function _eventTargetDispatch(target, event) {
-  if (!event || typeof event.type === "undefined") {
-    throw new TypeError("Failed to execute 'dispatchEvent' on 'EventTarget': parameter 1 is not of type 'Event'.");
+
+function _eventShadowRoot(node) {
+  if (!node || typeof node.getRootNode !== "function") return null;
+  const root = node.getRootNode();
+  return typeof ShadowRoot !== "undefined" && root instanceof ShadowRoot ? root : null;
+}
+function _eventRetarget(node, against) {
+  let candidate = node;
+  while (candidate) {
+    const root = _eventShadowRoot(candidate);
+    if (!root) return candidate;
+    if (against === root || (against instanceof Node && root.contains(against))) {
+      return candidate;
+    }
+    candidate = root.host;
   }
-  if (String(event.type) === "") {
-    throw new DOMException("The event's type was not specified.", "InvalidStateError");
+  return null;
+}
+function _eventPathFor(target, composed, closedRootIndexes) {
+  const path = [target];
+  let hasShadowRoot = typeof ShadowRoot !== "undefined" && target instanceof ShadowRoot;
+  if (hasShadowRoot && target.mode === "closed") closedRootIndexes.push(0);
+  let current = target;
+  while (current && typeof Node !== "undefined" && current instanceof Node) {
+    let parent = current.parentNode || null;
+    if (!parent && typeof ShadowRoot !== "undefined" && current instanceof ShadowRoot) {
+      if (!composed) break;
+      parent = current.host || null;
+    }
+    if (!parent) break;
+    path.push(parent);
+    if (typeof ShadowRoot !== "undefined" && parent instanceof ShadowRoot) {
+      hasShadowRoot = true;
+      if (parent.mode === "closed") closedRootIndexes.push(path.length - 1);
+    }
+    current = parent;
   }
-  if (!event.target) event.target = target;
-  event.currentTarget = target;
-  event.eventPhase = 2;
-  const listeners = (_eventTargetListeners.get(target)?.get(String(event.type)) || []).slice();
-  for (const entry of listeners) {
-    const current = _eventTargetListeners.get(target)?.get(String(event.type));
-    if (!current || !current.includes(entry)) continue;
-    if (entry.once) _eventTargetRemove(target, event.type, entry.callback, entry.capture);
-    const callback = entry.callback;
+  if (path[path.length - 1] instanceof Document) path.push(globalThis);
+  return { path, hasShadowRoot };
+}
+function _eventVisiblePath(path, currentIndex, closedRootIndexes) {
+  if (closedRootIndexes.length === 0) return path;
+  let hiddenThrough = -1;
+  for (const rootIndex of closedRootIndexes) {
+    if (rootIndex < currentIndex) hiddenThrough = rootIndex;
+  }
+  return hiddenThrough < 0 ? path : path.slice(hiddenThrough + 1);
+}
+function _eventSetSurface(event, name, value) {
+  try { event[name] = value; } catch (_) {}
+}
+function _eventInvoke(state, node, pathIndex, phase, capture) {
+  const key = _eventTargetKey(node);
+  const listeners = _eventTargetListeners.get(key)?.get(state.eventType);
+  let hasMatchingListener = false;
+  if (listeners) {
+    for (const entry of listeners) {
+      if (!entry.removed && entry.capture === capture) {
+        hasMatchingListener = true;
+        break;
+      }
+    }
+  }
+  let handler = null;
+  let handlerName = null;
+  if (!capture) {
+    handlerName = "on" + state.eventType;
+    handler = _eventHandlerSlots.get(key)?.get(handlerName);
+    if (!handler && node === globalThis && state.eventType === "load") {
+      _eventSyncWindowOnloadHandler();
+      handler = _eventHandlerSlots.get(key)?.get(handlerName);
+    }
+    const inlineCache = node?.__inlineHandlerCache;
+    const inlineAlreadyResolved = inlineCache
+      && Object.prototype.hasOwnProperty.call(inlineCache, handlerName);
+    if (!handler && !inlineAlreadyResolved
+        && typeof node?._resolveInlineHandler === "function") {
+      const inline = node._resolveInlineHandler(handlerName);
+      if (inline) {
+        _eventHandlerSet(node, handlerName, inline);
+        handler = _eventHandlerSlots.get(key)?.get(handlerName);
+      }
+    }
+  }
+  if (!hasMatchingListener && !handler) return;
+  const retargetedTarget = state.hasShadowRoot
+    ? _eventRetarget(state.dispatchTarget, node) : state.dispatchTarget;
+  const retargetedRelated = state.hasShadowRoot
+    ? _eventRetarget(state.originalRelatedTarget, node) : state.originalRelatedTarget;
+  if (state.originalRelatedTarget && retargetedTarget === retargetedRelated) return;
+  _eventSetSurface(state.event, 'target', retargetedTarget);
+  if ("relatedTarget" in state.event) {
+    _eventSetSurface(state.event, 'relatedTarget', retargetedRelated);
+  }
+  _eventSetSurface(state.event, 'currentTarget', node);
+  _eventSetSurface(state.event, 'eventPhase', phase);
+  state.currentPathIndex = pathIndex;
+  state.composedPathCache = null;
+  let invocations;
+  if (handler) {
+    invocations = [];
+    if (listeners) {
+      for (const entry of listeners) {
+        if (!entry.removed && entry.capture === capture) invocations.push(entry);
+      }
+    }
+    invocations.push({
+      handler: true, handlerName, order: handler.order,
+      capture: false, once: false, passive: false,
+    });
+    invocations.sort((a, b) => a.order - b.order);
+  } else {
+    invocations = listeners.slice();
+  }
+  for (const entry of invocations) {
+    if (!entry.handler && (entry.removed || entry.capture !== capture)) continue;
+    const liveHandler = entry.handler
+      ? _eventHandlerSlots.get(key)?.get(entry.handlerName) : null;
+    if (entry.handler && (!liveHandler || liveHandler.order !== entry.order)) continue;
+    if (entry.once && !entry.removed) {
+      _eventTargetRemove(node, state.eventType, entry.callback, entry.capture);
+    }
     try {
-      if (typeof callback === "function") callback.call(target, event);
-      else callback.handleEvent.call(callback, event);
+      state.inPassiveListener = entry.passive;
+      const callback = entry.handler ? liveHandler.callback : entry.callback;
+      const result = typeof callback === "function"
+        ? (entry.handler && node === globalThis && state.eventType === "error"
+          ? callback.call(node, state.event.message, state.event.filename || "",
+              state.event.lineno || 0, state.event.colno || 0, state.event.error)
+          : callback.call(node, state.event))
+        : callback.handleEvent.call(callback, state.event);
+      if (entry.handler && ((node === globalThis && state.eventType === "error")
+          ? result === true : result === false)) state.event.preventDefault();
     } catch (error) {
       console.error(error);
+    } finally {
+      state.inPassiveListener = false;
     }
-    if (event._immediatePropagationStopped) break;
+    if (state.immediatePropagationStopped) break;
   }
-  event.currentTarget = null;
-  event.eventPhase = 0;
-  return !event.defaultPrevented;
 }
+function _eventTargetDispatch(target, event, dispatchTargetOverride = null) {
+  if (!event) {
+    throw new TypeError("Failed to execute 'dispatchEvent' on 'EventTarget': parameter 1 is not of type 'Event'.");
+  }
+  const firstTrustedDispatch = _pendingTrustedEvents.delete(event);
+  let eventType, dispatchTarget, path, closedRootIndexes, hasShadowRoot, originalRelatedTarget;
+  let dispatchState = null;
+  try {
+    if (_eventDispatchStates.has(event)) {
+      throw new DOMException("The event is already being dispatched.", "InvalidStateError");
+    }
+    const rawEventType = event.type;
+    if (typeof rawEventType === "undefined") {
+      throw new TypeError("Failed to execute 'dispatchEvent' on 'EventTarget': parameter 1 is not of type 'Event'.");
+    }
+    eventType = String(rawEventType);
+    if (eventType === "") {
+      throw new DOMException("The event's type was not specified.", "InvalidStateError");
+    }
+    if (!firstTrustedDispatch) _trustedEvents.delete(event);
+    dispatchTarget = target === globalThis && eventType === 'load'
+        && dispatchTargetOverride === globalThis.document
+      ? globalThis.document : target;
+    const composed = !!event.composed;
+    closedRootIndexes = [];
+    ({ path, hasShadowRoot } = _eventPathFor(target, composed, closedRootIndexes));
+    originalRelatedTarget = event.relatedTarget || null;
+    dispatchState = {
+      event, eventType, dispatchTarget, originalRelatedTarget, hasShadowRoot,
+      path, closedRootIndexes, currentPathIndex: -1, composedPathCache: null,
+      propagationStopped: false, immediatePropagationStopped: false,
+      inPassiveListener: false, bubbles: !!event.bubbles,
+      cancelable: !!event.cancelable, defaultPrevented: !!event.defaultPrevented,
+    };
+    _eventDispatchStates.set(event, dispatchState);
+  } catch (error) {
+    if (firstTrustedDispatch) _trustedEvents.delete(event);
+    throw error;
+  }
+
+  try {
+    for (let i = path.length - 1; i > 0 && !dispatchState.propagationStopped; i--) {
+      const crossesShadowBoundary = typeof ShadowRoot !== "undefined"
+        && path[i - 1] instanceof ShadowRoot;
+      _eventInvoke(dispatchState, path[i], i, crossesShadowBoundary ? 2 : 1, true);
+    }
+    if (!dispatchState.propagationStopped) {
+      _eventInvoke(dispatchState, target, 0, 2, true);
+      if (!dispatchState.immediatePropagationStopped) _eventInvoke(dispatchState, target, 0, 2, false);
+    }
+    if (dispatchState.bubbles && !dispatchState.propagationStopped) {
+      for (let i = 1; i < path.length && !dispatchState.propagationStopped; i++) {
+        const crossesShadowBoundary = typeof ShadowRoot !== "undefined"
+          && path[i - 1] instanceof ShadowRoot;
+        _eventInvoke(dispatchState, path[i], i, crossesShadowBoundary ? 2 : 3, false);
+      }
+    } else if (!dispatchState.bubbles && !dispatchState.propagationStopped) {
+      // A composed non-bubbling event treats each shadow host as an additional
+      // target. Its non-capture listeners run on the forward leg after the
+      // inner target, rather than during capture descent.
+      for (let i = 1; i < path.length && !dispatchState.propagationStopped; i++) {
+        if (typeof ShadowRoot !== "undefined" && path[i - 1] instanceof ShadowRoot) {
+          _eventInvoke(dispatchState, path[i], i, 2, false);
+        }
+      }
+    }
+    return !dispatchState.defaultPrevented;
+  } finally {
+    try {
+      const outermost = path[path.length - 1];
+      _eventSetSurface(event, 'target', hasShadowRoot
+        ? _eventRetarget(dispatchTarget, outermost) : dispatchTarget);
+      if ("relatedTarget" in event) _eventSetSurface(event, 'relatedTarget', hasShadowRoot
+        ? _eventRetarget(originalRelatedTarget, outermost) : originalRelatedTarget);
+      _eventSetSurface(event, 'currentTarget', null);
+      _eventSetSurface(event, 'eventPhase', 0);
+    } finally {
+      _eventDispatchStates.delete(event);
+    }
+  }
+}
+
+globalThis.addEventListener("unhandledrejection", event => event?.preventDefault?.());
+globalThis.addEventListener("error", event => {
+  globalThis.__obscura_errors.push({
+    msg: String(event?.message || event || ""), src: String(event?.filename || ""),
+    line: event?.lineno, error: String(event?.error || ""),
+  });
+});
 
 // During custom-element upgrade, HTMLElement's constructor must return the
 // already-existing element being upgraded. A class constructor cannot be
@@ -3469,10 +3704,15 @@ class Element extends Node {
       }
     }
     if (n === "style") this._style._replaceFromAttribute(value);
-    if (n === "onload" && _isWindowReflectingBodyElement(this)) {
-      _windowOnloadOverrideSet = false;
-      _windowOnloadOverride = null;
-      if (this.__inlineHandlerCache) delete this.__inlineHandlerCache.onload;
+    if (n.startsWith("on")) {
+      if (this.__inlineHandlerCache) delete this.__inlineHandlerCache[n];
+      if (n === "onload" && _isWindowReflectingBodyElement(this)) {
+        _windowOnloadOverrideSet = false;
+        _windowOnloadOverride = null;
+        _eventHandlerSet(globalThis, n, this._resolveInlineHandler(n));
+      } else {
+        _eventHandlerSet(this, n, this._resolveInlineHandler(n));
+      }
     }
     if (popoverPrev !== undefined) this._popoverTypeMaybeChanged(popoverPrev);
     if (globalThis.__mutationObservers?.length) globalThis.__notifyMutation('attributes', this._nid, [], [], n);
@@ -3498,9 +3738,14 @@ class Element extends Node {
     // instead of maintaining a second, subtly different key space here.
     this._nullNamespaceAttrs = null;
     if (ns === "" && n === "style") this._style._replaceFromAttribute(value);
+    if (ns === "" && n.startsWith("on")) {
+      if (this.__inlineHandlerCache) delete this.__inlineHandlerCache[n];
+      _eventHandlerSet(this, n, this._resolveInlineHandler(n));
+    }
   }
   removeAttribute(n) {
     n = _htmlAttrName(this, n);
+    const hadEventAttribute = n.startsWith("on") && this.getAttribute(n) !== null;
     const popoverPrev = (n === "popover") ? this.popover : undefined;
     const previousWindowName = (n === "id" || n === "name")
       ? this.getAttribute(n)
@@ -3514,10 +3759,15 @@ class Element extends Node {
       _reconcileWindowNamedProperty(previousWindowName);
     }
     if (n === "style") this._style._replaceFromAttribute("");
-    if (n === "onload" && _isWindowReflectingBodyElement(this)) {
-      _windowOnloadOverrideSet = false;
-      _windowOnloadOverride = null;
-      if (this.__inlineHandlerCache) delete this.__inlineHandlerCache.onload;
+    if (hadEventAttribute) {
+      if (this.__inlineHandlerCache) delete this.__inlineHandlerCache[n];
+      if (n === "onload" && _isWindowReflectingBodyElement(this)) {
+        _windowOnloadOverrideSet = false;
+        _windowOnloadOverride = null;
+        _eventHandlerSet(globalThis, n, null);
+      } else {
+        _eventHandlerSet(this, n, null);
+      }
     }
     if (popoverPrev !== undefined) this._popoverTypeMaybeChanged(popoverPrev);
     if (this.localName === "source"
@@ -3534,9 +3784,15 @@ class Element extends Node {
   removeAttributeNS(ns, n) {
     ns = String(ns == null ? "" : ns);
     n = String(n);
+    const hadEventAttribute = ns === "" && n.startsWith("on")
+      && this.getAttributeNS(ns, n) !== null;
     _dom("remove_attribute_ns", this._nid, ns + "\0" + n);
     this._nullNamespaceAttrs = null;
     if (ns === "" && n === "style") this._style._replaceFromAttribute("");
+    if (hadEventAttribute) {
+      if (this.__inlineHandlerCache) delete this.__inlineHandlerCache[n];
+      _eventHandlerSet(this, n, null);
+    }
   }
   hasAttribute(n) { return this.getAttribute(n) !== null; }
   hasAttributes() { return this.attributes.length > 0; }
@@ -3654,44 +3910,13 @@ class Element extends Node {
     return null;
   }
   addEventListener(type, handler, opts) {
-    const key = this._nid;
-    if (!_eventRegistry[key]) _eventRegistry[key] = {};
-    if (!_eventRegistry[key][type]) _eventRegistry[key][type] = [];
-    _eventRegistry[key][type].push(handler);
+    _eventTargetAdd(this, type, handler, opts);
   }
-  removeEventListener(type, handler) {
-    const key = this._nid;
-    if (_eventRegistry[key] && _eventRegistry[key][type]) {
-      _eventRegistry[key][type] = _eventRegistry[key][type].filter(h => h !== handler);
-    }
+  removeEventListener(type, handler, opts) {
+    _eventTargetRemove(this, type, handler, opts);
   }
   dispatchEvent(event) {
-    if (!event) return true;
-    if (!event.target) event.target = this;
-    event.currentTarget = this;
-    // Spec: inline `onclick="..."` content attributes are event handlers
-    // for the matching event type. Fire them alongside any
-    // addEventListener handlers. Also honor the IDL property
-    // `el.onclick = fn` if set. Without this, b.click() never invokes
-    // the inline handler and forms with onsubmit / buttons with onclick
-    // are silently dead.
-    const handlerName = 'on' + event.type;
-    const inlineFn = this[handlerName] || this._resolveInlineHandler(handlerName);
-    if (typeof inlineFn === 'function') {
-      try {
-        const ret = inlineFn.call(this, event);
-        if (ret === false) event.preventDefault();
-      } catch(e) { console.error(e); }
-    }
-    const handlers = (_eventRegistry[this._nid] || {})[event.type] || [];
-    for (const h of handlers) {
-      try { h.call(this, event); } catch(e) { console.error(e); }
-      if (event._immediatePropagationStopped) break;
-    }
-    if (event.bubbles && !event._propagationStopped && this.parentNode) {
-      this.parentNode.dispatchEvent(event);
-    }
-    return !event.defaultPrevented;
+    return _eventTargetDispatch(this, event);
   }
   _resolveInlineHandler(name) {
     // name = 'onclick' / 'onsubmit' / etc. Compile the content attribute
@@ -3908,10 +4133,10 @@ class Element extends Node {
   set open(v) { if (v) { if (!this.hasAttribute('open')) this.setAttribute('open', ''); } else if (this.hasAttribute('open')) { this.removeAttribute('open'); this._dialogModal = false; } }
   get returnValue() { return this._returnValue != null ? this._returnValue : ''; }
   set returnValue(v) { this._returnValue = String(v); }
-  get oncancel() { return this._oncancel || null; }
-  set oncancel(f) { this._oncancel = typeof f === 'function' ? f : null; }
-  get onclose() { return this._onclose || null; }
-  set onclose(f) { this._onclose = typeof f === 'function' ? f : null; }
+  get oncancel() { return _eventHandlerGet(this, "oncancel"); }
+  set oncancel(f) { _eventHandlerSet(this, "oncancel", f); }
+  get onclose() { return _eventHandlerGet(this, "onclose"); }
+  set onclose(f) { _eventHandlerSet(this, "onclose", f); }
   get closedBy() { const v = (this.getAttribute('closedby') || '').toLowerCase(); return (v === 'any' || v === 'closerequest' || v === 'none') ? v : 'auto'; }
   set closedBy(v) { this.setAttribute('closedby', String(v)); }
   show() {
@@ -5480,21 +5705,13 @@ class Document extends Node {
   }
   createRange() { return new Range(); }
   addEventListener(type, fn, opts) {
-    if (typeof fn !== 'function') return;
-    if (!this._listeners) this._listeners = {};
-    if (!this._listeners[type]) this._listeners[type] = [];
-    if (!this._listeners[type].includes(fn)) this._listeners[type].push(fn);
+    _eventTargetAdd(this, type, fn, opts);
   }
-  removeEventListener(type, fn) {
-    if (this._listeners?.[type]) {
-      this._listeners[type] = this._listeners[type].filter(h => h !== fn);
-    }
+  removeEventListener(type, fn, opts) {
+    _eventTargetRemove(this, type, fn, opts);
   }
   dispatchEvent(event) {
-    if (!event) return true;
-    const handlers = (this._listeners?.[event.type] || []).slice();
-    for (const h of handlers) { try { h.call(this, event); } catch(e) { console.error('document event error:', e); } }
-    return !event.defaultPrevented;
+    return _eventTargetDispatch(this, event);
   }
   createTreeWalker(root, whatToShow, filter) {
     // whatToShow is unsigned long; default SHOW_ALL only when the arg is omitted.
@@ -6064,18 +6281,18 @@ class HTMLImageElement extends Element {
     this._queueImageRequest();
     return this._imageNaturalHeight;
   }
-  get onload() { return this._imageOnload || null; }
+  get onload() { return _eventHandlerGet(this, "onload"); }
   set onload(value) {
-    this._imageOnload = typeof value === "function" ? value : null;
-    if (this._imageOnload) {
+    _eventHandlerSet(this, "onload", value);
+    if (_eventHandlerGet(this, "onload")) {
       this._refreshImageFromCache();
       this._queueImageRequest();
     }
   }
-  get onerror() { return this._imageOnerror || null; }
+  get onerror() { return _eventHandlerGet(this, "onerror"); }
   set onerror(value) {
-    this._imageOnerror = typeof value === "function" ? value : null;
-    if (this._imageOnerror) {
+    _eventHandlerSet(this, "onerror", value);
+    if (_eventHandlerGet(this, "onerror")) {
       this._refreshImageFromCache();
       this._queueImageRequest();
     }
@@ -6579,11 +6796,18 @@ for (const _ev of [
   "unload","volumechange","waiting","wheel",
 ]) {
   const _on = "on" + _ev;
-  if (!(_on in globalThis)) globalThis[_on] = null;
-  for (const _proto of [Document.prototype, Element.prototype]) {
-    if (!(_on in _proto)) {
-      Object.defineProperty(_proto, _on, { value: null, writable: true, configurable: true, enumerable: false });
-    }
+  for (const _owner of [globalThis, Document.prototype, Element.prototype]) {
+    const _descriptor = Object.getOwnPropertyDescriptor(_owner, _on);
+    if (_descriptor && _owner !== globalThis) continue;
+    if (_descriptor && !_descriptor.configurable) continue;
+    const _existingHandler = _descriptor && "value" in _descriptor ? _descriptor.value : null;
+    Object.defineProperty(_owner, _on, {
+      get() { return _eventHandlerGet(this, _on); },
+      set(value) { _eventHandlerSet(this, _on, value); },
+      configurable: true,
+      enumerable: false,
+    });
+    if (typeof _existingHandler === "function") _eventHandlerSet(_owner, _on, _existingHandler);
   }
 }
 
@@ -6607,6 +6831,7 @@ Object.defineProperty(globalThis, 'onload', {
   set(value) {
     _windowOnloadOverrideSet = true;
     _windowOnloadOverride = typeof value === 'function' ? value : null;
+    _eventHandlerSet(globalThis, 'onload', _windowOnloadOverride);
   },
   configurable: true,
   enumerable: true,
@@ -6616,14 +6841,14 @@ Object.defineProperty(Element.prototype, 'onload', {
     if (_isWindowReflectingBodyElement(this)) {
       return globalThis.onload;
     }
-    return this.__onload || null;
+    return _eventHandlerGet(this, 'onload');
   },
   set(value) {
     if (_isWindowReflectingBodyElement(this)) {
       globalThis.onload = value;
       return;
     }
-    this.__onload = typeof value === 'function' ? value : null;
+    _eventHandlerSet(this, 'onload', value);
   },
   configurable: true,
   enumerable: false,
@@ -9775,7 +10000,18 @@ globalThis.DOMException = (function () {
 // obscura's CDP input pipeline marks its synthetic events via the
 // non-enumerable __obscura_markTrusted helper.
 const _trustedEvents = new WeakSet();
-globalThis.__obscura_markTrusted = function(ev) { try { if (ev) _trustedEvents.add(ev); } catch (_e) {} return ev; };
+const _pendingTrustedEvents = new WeakSet();
+globalThis.__obscura_markTrusted = function(ev) { try { if (ev) { _trustedEvents.add(ev); _pendingTrustedEvents.add(ev); } } catch (_e) {} return ev; };
+Object.defineProperty(globalThis, '__obscura_dispatchWindowLoad', {
+  value: function() {
+    const event = globalThis.__obscura_markTrusted(
+      new Event('load', { bubbles: false, cancelable: false }));
+    return _eventTargetDispatch(globalThis, event, globalThis.document);
+  },
+  writable: false,
+  enumerable: false,
+  configurable: false,
+});
 
 // Write value/checked through the element's *prototype* accessor, skipping any
 // per-instance property a framework layered on top. React (and Preact/Vue)
@@ -9832,17 +10068,20 @@ globalThis.__obscura_setInputFiles = function(el, specs) {
   try { el.dispatchEvent(globalThis.__obscura_markTrusted(new Event("change", { bubbles: true }))); } catch (_e) {}
 };
 globalThis.Event = class Event {
-  constructor(t,o={}) { if (arguments.length < 1) throw new TypeError("Failed to construct 'Event': 1 argument required, but only 0 present."); this.type=String(t);this.bubbles=!!o.bubbles;this.cancelable=!!o.cancelable;this.composed=!!o.composed;this.defaultPrevented=false;this.target=null;this.currentTarget=null;this.eventPhase=0;this.timeStamp=Date.now();this._propagationStopped=false;this._immediatePropagationStopped=false; }
+  constructor(t,o={}) { if (arguments.length < 1) throw new TypeError("Failed to construct 'Event': 1 argument required, but only 0 present."); this.type=String(t);this.bubbles=!!o.bubbles;this.cancelable=!!o.cancelable;this.composed=!!o.composed;this.defaultPrevented=false;this.target=null;this.currentTarget=null;this.eventPhase=0;this.timeStamp=Date.now(); }
   get isTrusted() { return _trustedEvents.has(this); }
-  preventDefault() { if (this.cancelable) this.defaultPrevented=true; } stopPropagation(){ this._propagationStopped=true; } stopImmediatePropagation(){ this._propagationStopped=true; this._immediatePropagationStopped=true; }
-  initEvent(type,bubbles,cancelable) { if (arguments.length < 1) throw new TypeError("Failed to execute 'initEvent' on 'Event': 1 argument required, but only 0 present."); this.type=String(type);this.bubbles=!!bubbles;this.cancelable=!!cancelable;this.defaultPrevented=false;this._propagationStopped=false;this._immediatePropagationStopped=false; }
+  preventDefault() { const s=_eventDispatchStates.get(this); if ((s ? s.cancelable : this.cancelable) && !(s && s.inPassiveListener)) { if (s) s.defaultPrevented=true; try { this.defaultPrevented=true; } catch (_) {} } }
+  stopPropagation(){ const s=_eventDispatchStates.get(this); if (s) s.propagationStopped=true; }
+  stopImmediatePropagation(){ const s=_eventDispatchStates.get(this); if (s) { s.propagationStopped=true; s.immediatePropagationStopped=true; } }
+  initEvent(type,bubbles,cancelable) { if (arguments.length < 1) throw new TypeError("Failed to execute 'initEvent' on 'Event': 1 argument required, but only 0 present."); if (_eventDispatchStates.has(this)) return; this.type=String(type);this.bubbles=!!bubbles;this.cancelable=!!cancelable;this.composed=false;this.defaultPrevented=false; }
   composedPath() {
-    if (!this.target) return [];
-    const path = [];
-    let n = this.target;
-    while (n) { path.push(n); n = n.parentNode || null; }
-    if (typeof window !== "undefined" && window && path[path.length - 1] !== window) path.push(window);
-    return path;
+    const state = _eventDispatchStates.get(this);
+    if (!state) return [];
+    if (!state.composedPathCache) {
+      state.composedPathCache = _eventVisiblePath(
+        state.path, state.currentPathIndex, state.closedRootIndexes || []);
+    }
+    return state.composedPathCache.slice();
   }
 };
 _markNative(Event);
@@ -9852,9 +10091,8 @@ globalThis.CustomEvent = class extends Event {
   // analytics shims) still call createEvent('CustomEvent') + initCustomEvent
   // instead of new CustomEvent(...). See issue #41.
   initCustomEvent(type,bubbles,cancelable,detail) {
-    this.type = type;
-    this.bubbles = !!bubbles;
-    this.cancelable = !!cancelable;
+    if (_eventDispatchStates.has(this)) return;
+    this.initEvent(type,bubbles,cancelable);
     this.detail = detail;
   }
 };
@@ -9863,6 +10101,7 @@ globalThis.MouseEvent = class extends Event {
   // Legacy DOM Level 2 initializer. Positional signature per UI Events spec.
   initMouseEvent(type,canBubble,cancelable,view,detail,screenX,screenY,clientX,clientY,ctrlKey,altKey,shiftKey,metaKey,button,relatedTarget) {
     if (arguments.length < 1) throw new TypeError("Failed to execute 'initMouseEvent' on 'MouseEvent': 1 argument required, but only 0 present.");
+    if (_eventDispatchStates.has(this)) return;
     this.initEvent(type,canBubble,cancelable);
     this.view=view===undefined?null:view;
     this.detail=detail||0;
@@ -9883,6 +10122,7 @@ globalThis.KeyboardEvent = class extends Event {
   // Legacy DOM Level 3 initializer. Positional signature per the WebKit/Gecko form.
   initKeyboardEvent(type,canBubble,cancelable,view,key,location,ctrlKey,altKey,shiftKey,metaKey) {
     if (arguments.length < 1) throw new TypeError("Failed to execute 'initKeyboardEvent' on 'KeyboardEvent': 1 argument required, but only 0 present.");
+    if (_eventDispatchStates.has(this)) return;
     this.initEvent(type,canBubble,cancelable);
     this.view=view===undefined?null:view;
     this.key=key===undefined?"":String(key);
@@ -9904,6 +10144,7 @@ globalThis.UIEvent = class extends Event {
   // Legacy DOM Level 2 initializer. Positional signature per UI Events spec.
   initUIEvent(type,canBubble,cancelable,view,detail) {
     if (arguments.length < 1) throw new TypeError("Failed to execute 'initUIEvent' on 'UIEvent': 1 argument required, but only 0 present.");
+    if (_eventDispatchStates.has(this)) return;
     this.initEvent(type,canBubble,cancelable);
     this.view=view===undefined?null:view;
     this.detail=detail||0;
@@ -9921,6 +10162,7 @@ globalThis.CompositionEvent = class extends Event {
   // Legacy DOM Level 3 initializer. Positional signature per UI Events spec.
   initCompositionEvent(type,canBubble,cancelable,view,data) {
     if (arguments.length < 1) throw new TypeError("Failed to execute 'initCompositionEvent' on 'CompositionEvent': 1 argument required, but only 0 present.");
+    if (_eventDispatchStates.has(this)) return;
     this.initEvent(type,canBubble,cancelable);
     this.view=view===undefined?null:view;
     this.data=data===undefined?"":String(data);
@@ -10021,6 +10263,7 @@ globalThis.StorageEvent = class StorageEvent extends Event {
     this.storageArea = init.storageArea || null;
   }
   initStorageEvent(type, bubbles, cancelable, key, oldValue, newValue, url, storageArea) {
+    if (_eventDispatchStates.has(this)) return;
     this.initEvent(type, bubbles, cancelable);
     this.key = key !== undefined ? key : null;
     this.oldValue = oldValue !== undefined ? oldValue : null;

--- a/crates/obscura-js/src/frame.rs
+++ b/crates/obscura-js/src/frame.rs
@@ -134,15 +134,10 @@ impl FrameRealm {
             parent,
             "globalThis.__documentReadyState__ = 'interactive';\
              try { document.dispatchEvent(new Event('DOMContentLoaded', \
-                 { bubbles: false, cancelable: false })); } catch (_) {}\
-             try { window.dispatchEvent(new Event('DOMContentLoaded', \
-                 { bubbles: false, cancelable: false })); } catch (_) {}\
+                 { bubbles: true, cancelable: false })); } catch (_) {}\
              globalThis.__documentReadyState__ = 'complete';\
              try { document.dispatchEvent(new Event('readystatechange')); } catch (_) {}\
-             try { const loadEvent = new Event('load', \
-                 { bubbles: false, cancelable: false }); \
-                 if (typeof window.onload === 'function') { try { window.onload.call(window, loadEvent); } catch (_) {} } \
-                 try { window.dispatchEvent(loadEvent); } catch (_) {} } catch (_) {}",
+             try { globalThis.__obscura_dispatchWindowLoad(); } catch (_) {}",
         )
     }
 
@@ -444,6 +439,88 @@ mod tests {
         assert_eq!(frame.frame_id(), 1);
         assert!(!frame.is_same_origin_as("https://parent.example"));
         assert!(frame.is_same_origin_as("https://child.example"));
+    }
+
+    #[test]
+    fn frame_window_load_handlers_run_once_in_registration_order() {
+        let mut parent = page("https://parent.example/", "<html><body></body></html>");
+        let frame = FrameRealm::new(
+            &mut parent,
+            1,
+            0,
+            "https://child.example/frame",
+            "<html><body></body></html>",
+        )
+        .expect("frame realm");
+
+        frame
+            .execute_script(
+                &mut parent,
+                "globalThis.loadEvents = [];\
+                 globalThis.domContentLoadedEvents = [];\
+                 const recordDomContentLoaded = label => event =>\
+                     domContentLoadedEvents.push([\
+                         label, event.eventPhase, event.target === document,\
+                         event.currentTarget === window]);\
+                 window.addEventListener('DOMContentLoaded',\
+                     recordDomContentLoaded('window-capture'), true);\
+                 document.addEventListener('DOMContentLoaded',\
+                     recordDomContentLoaded('document-target'));\
+                 window.addEventListener('DOMContentLoaded',\
+                     recordDomContentLoaded('window-bubble'));\
+                 globalThis.capturedLoadEvent = null;\
+                 window.onload = event => {\
+                     capturedLoadEvent = event;\
+                     loadEvents.push([\
+                         'property', event.target === document,\
+                         event.currentTarget === window, event.eventPhase, event.isTrusted]);\
+                     throw new Error('load-listener-test');\
+                 };\
+                 window.addEventListener('load', event => loadEvents.push([\
+                     'listener', event.target === document,\
+                     event.currentTarget === window, event.eventPhase, event.isTrusted]));",
+            )
+            .unwrap();
+        frame.dispatch_load_events(&mut parent).unwrap();
+
+        assert_eq!(
+            frame.evaluate(&mut parent, "loadEvents").unwrap(),
+            serde_json::json!([
+                ["property", true, true, 2, true],
+                ["listener", true, true, 2, true],
+            ]),
+        );
+        assert_eq!(
+            frame
+                .evaluate(
+                    &mut parent,
+                    "(() => {\
+                         const browserEvent = capturedLoadEvent;\
+                         let redispatched;\
+                         window.addEventListener('load', event => {\
+                             if (event === browserEvent) redispatched = [\
+                                 event.target === window,\
+                                 event.currentTarget === window,\
+                                 event.eventPhase, event.isTrusted];\
+                         }, { once: true });\
+                         window.dispatchEvent(browserEvent);\
+                         return redispatched;\
+                     })()",
+                )
+                .unwrap(),
+            serde_json::json!([true, true, 2, false]),
+            "redispatched browser load must use author-dispatch semantics",
+        );
+        assert_eq!(
+            frame
+                .evaluate(&mut parent, "domContentLoadedEvents")
+                .unwrap(),
+            serde_json::json!([
+                ["window-capture", 1, true, true],
+                ["document-target", 2, true, false],
+                ["window-bubble", 3, true, true],
+            ]),
+        );
     }
 
     #[test]

--- a/crates/obscura-js/src/runtime.rs
+++ b/crates/obscura-js/src/runtime.rs
@@ -18466,6 +18466,614 @@ mod tests {
     }
 
     #[test]
+    fn dom_event_path_observes_phases_handlers_stops_and_once() {
+        let mut rt = setup_runtime(r#"<main id="parent"><button id="target">go</button></main>"#);
+        let result = rt
+            .evaluate(
+                r#"(function(){
+                    const parent = document.getElementById("parent");
+                    const target = document.getElementById("target");
+                    const calls = [];
+                    const record = name => event => calls.push([
+                        name, event.eventPhase, event.target.id,
+                        event.currentTarget === window ? "window" :
+                          event.currentTarget === document ? "document" : event.currentTarget.id,
+                        event.composedPath().map(node => node === window ? "window" :
+                          node === document ? "document" : (node.id || node.nodeName)),
+                    ]);
+                    window.addEventListener("probe", record("window-capture"), true);
+                    document.addEventListener("probe", record("document-capture"), true);
+                    parent.addEventListener("probe", record("parent-capture"), true);
+                    target.addEventListener("probe", record("target-capture"), true);
+                    target.addEventListener("probe", record("target-bubble"));
+                    parent.addEventListener("probe", record("parent-bubble"));
+                    document.addEventListener("probe", record("document-bubble"));
+                    window.addEventListener("probe", record("window-bubble"));
+                    const probe = new Event("probe", {bubbles: true, composed: true});
+                    target.dispatchEvent(probe);
+
+                    const targetStop = [];
+                    target.addEventListener("target-stop", event => {
+                        targetStop.push("capture"); event.stopPropagation();
+                    }, true);
+                    target.addEventListener("target-stop", () => targetStop.push("bubble"));
+                    parent.addEventListener("target-stop", () => targetStop.push("parent"));
+                    target.dispatchEvent(new Event("target-stop", {bubbles: true}));
+
+                    const immediate = [];
+                    target.addEventListener("immediate", event => {
+                        immediate.push("first"); event.stopImmediatePropagation();
+                    });
+                    target.addEventListener("immediate", () => immediate.push("second"));
+                    target.dispatchEvent(new Event("immediate", {bubbles: true}));
+
+                    let once = 0;
+                    parent.addEventListener("once", () => once++, {once: true});
+                    target.dispatchEvent(new Event("once", {bubbles: true}));
+                    target.dispatchEvent(new Event("once", {bubbles: true}));
+
+                    const handlerOrder = [];
+                    target.addEventListener("change", () => handlerOrder.push("before"));
+                    target.onchange = () => handlerOrder.push("handler");
+                    target.addEventListener("change", () => handlerOrder.push("after"));
+                    target.dispatchEvent(new Event("change"));
+                    const removedHandler = [];
+                    target.addEventListener("reset", () => {
+                        removedHandler.push("listener"); target.onreset = null;
+                    });
+                    target.onreset = () => removedHandler.push("stale-handler");
+                    target.dispatchEvent(new Event("reset"));
+                    const replacedHandler = [];
+                    target.addEventListener("select", () => {
+                        replacedHandler.push("listener");
+                        target.onselect = () => replacedHandler.push("replacement");
+                    });
+                    target.onselect = () => replacedHandler.push("stale-handler");
+                    target.dispatchEvent(new Event("select"));
+                    const imageOrder = [];
+                    const image = document.createElement("img");
+                    image.addEventListener("load", () => imageOrder.push("before"));
+                    image.onload = () => imageOrder.push("handler");
+                    image.addEventListener("load", () => imageOrder.push("after"));
+                    image.dispatchEvent(new Event("load"));
+                    const passive = new Event("passive", {cancelable:true});
+                    target.addEventListener("passive", event => event.preventDefault(), {passive:true});
+                    const passiveResult = target.dispatchEvent(passive);
+
+                    const reusable = new Event("reusable", {bubbles:true, cancelable:true});
+                    const reuse = [];
+                    target.addEventListener("reusable", event => {
+                        let redispatchError = "";
+                        try { target.dispatchEvent(event); }
+                        catch (error) { redispatchError = error.name; }
+                        event.initEvent("changed-during-dispatch", false, false);
+                        reuse.push([event.type, event.bubbles, event.cancelable, redispatchError]);
+                    });
+                    target.dispatchEvent(reusable);
+                    target.dispatchEvent(reusable);
+                    reusable.initEvent("renamed", false, false);
+                    target.addEventListener("renamed", () => reuse.push(["renamed"]));
+                    target.dispatchEvent(reusable);
+
+                    let deep = target;
+                    for (let i = 0; i < 64; i++) {
+                        const wrapper = document.createElement("div");
+                        deep.parentNode.insertBefore(wrapper, deep);
+                        wrapper.appendChild(deep);
+                    }
+                    const lazy = {};
+                    target.addEventListener("lazy-path", event => {
+                        lazy.internalKeys = Object.keys(event).filter(key => key.startsWith("_"));
+                        const first = event.composedPath();
+                        const second = event.composedPath();
+                        lazy.distinctResults = first !== second;
+                        lazy.length = first.length;
+                    });
+                    target.dispatchEvent(new Event("lazy-path", {bubbles:true, composed:true}));
+                    return {calls, targetStop, immediate, once, handlerOrder,
+                        removedHandler, replacedHandler, imageOrder,
+                        passiveResult, passiveDefault:passive.defaultPrevented, reuse, lazy,
+                        pathAfter: probe.composedPath(), phaseAfter: probe.eventPhase,
+                        currentAfter: probe.currentTarget};
+                })()"#,
+            )
+            .unwrap();
+        let names: Vec<&str> = result["calls"].as_array().unwrap().iter()
+            .map(|call| call[0].as_str().unwrap()).collect();
+        assert_eq!(names, [
+            "window-capture", "document-capture", "parent-capture", "target-capture",
+            "target-bubble", "parent-bubble", "document-bubble", "window-bubble",
+        ]);
+        assert_eq!(result["calls"][0][1], 1);
+        assert_eq!(result["calls"][3][1], 2);
+        assert_eq!(result["calls"][5][1], 3);
+        assert_eq!(result["targetStop"], serde_json::json!(["capture", "bubble"]));
+        assert_eq!(result["immediate"], serde_json::json!(["first"]));
+        assert_eq!(result["once"], 1);
+        assert_eq!(result["handlerOrder"], serde_json::json!(["before", "handler", "after"]));
+        assert_eq!(result["removedHandler"], serde_json::json!(["listener"]));
+        assert_eq!(result["replacedHandler"], serde_json::json!(["listener", "replacement"]));
+        assert_eq!(result["imageOrder"], serde_json::json!(["before", "handler", "after"]));
+        assert_eq!(result["passiveResult"], true);
+        assert_eq!(result["passiveDefault"], false);
+        assert_eq!(result["reuse"], serde_json::json!([
+            ["reusable", true, true, "InvalidStateError"],
+            ["reusable", true, true, "InvalidStateError"], ["renamed"],
+        ]));
+        assert_eq!(result["lazy"], serde_json::json!({
+            "internalKeys": [], "distinctResults": true, "length": 70,
+        }));
+        assert_eq!(result["pathAfter"], serde_json::json!([]));
+        assert_eq!(result["phaseAfter"], 0);
+        assert!(result["currentAfter"].is_null());
+    }
+
+    #[test]
+    fn failed_trusted_event_setup_cannot_leak_trust_to_redispatch() {
+        let mut rt = setup_runtime(r#"<button id="target"></button>"#);
+        let result = rt
+            .evaluate(
+                r#"(() => {
+                    const target = document.getElementById("target");
+                    const event = globalThis.__obscura_markTrusted(new Event("probe"));
+                    Object.defineProperty(event, "type", {
+                        configurable: true,
+                        get() { throw new Error("setup failed"); },
+                    });
+                    let failed = false;
+                    try { target.dispatchEvent(event); } catch (_) { failed = true; }
+                    Object.defineProperty(event, "type", {
+                        configurable: true, value: "probe",
+                    });
+                    let trustedOnRedispatch = null;
+                    target.addEventListener("probe", current => {
+                        trustedOnRedispatch = current.isTrusted;
+                    });
+                    target.dispatchEvent(event);
+
+                    const nested = globalThis.__obscura_markTrusted(new Event("nested"));
+                    const outerTrust = [];
+                    let nestedError = null;
+                    target.addEventListener("nested", current => {
+                        outerTrust.push(current.isTrusted);
+                        try { target.dispatchEvent(current); }
+                        catch (error) { nestedError = error.name; }
+                        outerTrust.push(current.isTrusted);
+                    }, {once:true});
+                    target.addEventListener("nested", current => {
+                        outerTrust.push(current.isTrusted);
+                    }, {once:true});
+                    target.dispatchEvent(nested);
+                    return [failed, trustedOnRedispatch, nestedError, outerTrust];
+                })()"#,
+            )
+            .unwrap();
+        assert_eq!(result, serde_json::json!([
+            true, false, "InvalidStateError", [true, true, true],
+        ]));
+    }
+
+    #[test]
+    fn dispatch_cleanup_survives_throwing_event_surface_setters() {
+        let mut rt = setup_runtime(r#"<button id="target"></button>"#);
+        let result = rt
+            .evaluate(
+                r#"(() => {
+                    const target = document.getElementById("target");
+                    const calls = [];
+                    target.addEventListener("probe", event => calls.push(event.isTrusted));
+                    const event = globalThis.__obscura_markTrusted(new Event("probe"));
+                    for (const name of ["target", "currentTarget", "eventPhase"]) {
+                        Object.defineProperty(event, name, {
+                            configurable: true,
+                            get() { return null; },
+                            set() { throw new Error("blocked " + name); },
+                        });
+                    }
+                    const first = target.dispatchEvent(event);
+                    const second = target.dispatchEvent(event);
+                    const fresh = target.dispatchEvent(new Event("probe"));
+                    return {first, second, fresh, calls, trustedAfter:event.isTrusted};
+                })()"#,
+            )
+            .unwrap();
+        assert_eq!(result, serde_json::json!({
+            "first": true, "second": true, "fresh": true,
+            "calls": [true, false, false], "trustedAfter": false,
+        }));
+    }
+
+    #[test]
+    fn no_listener_dispatch_blocks_redispatch_from_target_setter() {
+        let mut rt = setup_runtime(r#"<button id="target"></button>"#);
+        let result = rt
+            .evaluate(
+                r#"(() => {
+                    const target = document.getElementById("target");
+                    const event = new Event("probe");
+                    let setterCalls = 0;
+                    let nestedError = null;
+                    let lateCalls = 0;
+                    Object.defineProperty(event, "target", {
+                        configurable: true,
+                        get() { return null; },
+                        set() {
+                            setterCalls++;
+                            target.addEventListener("probe", () => lateCalls++);
+                            try { target.dispatchEvent(event); }
+                            catch (error) { nestedError = error.name; }
+                        },
+                    });
+                    const result = target.dispatchEvent(event);
+                    return {result, setterCalls, nestedError, lateCalls};
+                })()"#,
+            )
+            .unwrap();
+        assert_eq!(result, serde_json::json!({
+            "result": true, "setterCalls": 1,
+            "nestedError": "InvalidStateError", "lateCalls": 0,
+        }));
+    }
+
+    #[test]
+    fn dispatch_snapshots_type_and_bubbling_before_capture_listeners() {
+        let mut rt = setup_runtime(r#"<main id="parent"><button id="target"></button></main>"#);
+        let result = rt
+            .evaluate(
+                r#"(() => {
+                    const parent = document.getElementById("parent");
+                    const target = document.getElementById("target");
+                    const calls = [];
+                    addEventListener("original", event => {
+                        calls.push("window-capture");
+                        event.type = "renamed";
+                        event.bubbles = false;
+                    }, true);
+                    document.addEventListener("original", () => calls.push("document-capture"), true);
+                    parent.addEventListener("original", () => calls.push("parent-capture"), true);
+                    target.addEventListener("original", () => calls.push("target"));
+                    parent.addEventListener("original", () => calls.push("parent-bubble"));
+                    document.addEventListener("original", () => calls.push("document-bubble"));
+                    addEventListener("original", () => calls.push("window-bubble"));
+                    for (const node of [target, parent, document, globalThis]) {
+                        node.addEventListener("renamed", () => calls.push("wrong-type"));
+                    }
+                    target.dispatchEvent(new Event("original", {bubbles:true, composed:true}));
+                    return calls;
+                })()"#,
+            )
+            .unwrap();
+        assert_eq!(result, serde_json::json!([
+            "window-capture", "document-capture", "parent-capture", "target",
+            "parent-bubble", "document-bubble", "window-bubble",
+        ]));
+    }
+
+    #[test]
+    fn dispatch_coerces_type_once_and_reentrant_guard_precedes_type_access() {
+        let mut rt = setup_runtime(r#"<button id="target"></button>"#);
+        let result = rt
+            .evaluate(
+                r#"(() => {
+                    const target = document.getElementById("target");
+                    let coercions = 0;
+                    const event = new Event("initial");
+                    event.type = {
+                        toString() {
+                            coercions++;
+                            if (coercions > 1) throw new Error("coerced twice");
+                            return "coerced";
+                        }
+                    };
+                    let nestedError = null;
+                    target.addEventListener("coerced", current => {
+                        Object.defineProperty(current, "type", {
+                            configurable: true,
+                            get() { throw new Error("nested type read"); },
+                        });
+                        try { target.dispatchEvent(current); }
+                        catch (error) { nestedError = error.name; }
+                    });
+                    const dispatched = target.dispatchEvent(event);
+                    return {coercions, nestedError, dispatched};
+                })()"#,
+            )
+            .unwrap();
+        assert_eq!(result, serde_json::json!({
+            "coercions": 1, "nestedError": "InvalidStateError", "dispatched": true,
+        }));
+    }
+
+    #[test]
+    fn listener_mutation_reentrancy_abort_and_non_bubbling_document_path_match_browser() {
+        let mut rt = setup_runtime(r#"<button id="target"></button>"#);
+        let result = rt
+            .evaluate(
+                r#"(() => {
+                    const target = document.getElementById("target");
+                    const mutation = [];
+                    const late = () => mutation.push("late");
+                    target.addEventListener("mutate", () => {
+                        mutation.push("once");
+                        target.addEventListener("mutate", late);
+                        target.dispatchEvent(new Event("mutate"));
+                    }, {once:true});
+                    target.addEventListener("mutate", () => mutation.push("existing"));
+                    target.dispatchEvent(new Event("mutate"));
+
+                    const aborted = [];
+                    const controller = new AbortController();
+                    target.addEventListener("aborted", () => aborted.push("called"), {
+                        signal: controller.signal,
+                    });
+                    controller.abort();
+                    target.dispatchEvent(new Event("aborted"));
+
+                    const documentPath = [];
+                    addEventListener("document-only", () => documentPath.push("window-capture"), true);
+                    addEventListener("document-only", () => documentPath.push("window-bubble"));
+                    document.addEventListener("document-only", () => documentPath.push("document-target"));
+                    document.dispatchEvent(new Event("document-only", {bubbles:false}));
+                    return {mutation, aborted, documentPath};
+                })()"#,
+            )
+            .unwrap();
+        assert_eq!(result, serde_json::json!({
+            "mutation": ["once", "existing", "late", "existing"],
+            "aborted": [],
+            "documentPath": ["window-capture", "document-target"],
+        }));
+    }
+
+    #[test]
+    fn shadow_event_path_retargets_and_hides_closed_internals() {
+        let mut rt = setup_runtime(r#"<div id="open"></div><div id="closed"></div>"#);
+        let result = rt
+            .evaluate(
+                r#"(function(){
+                    const openHost = document.getElementById("open");
+                    const openRoot = openHost.attachShadow({mode:"open"});
+                    const openTarget = document.createElement("button");
+                    openTarget.id = "open-target";
+                    openRoot.appendChild(openTarget);
+                    const openSeen = [];
+                    openRoot.addEventListener("open-probe", event => openSeen.push([
+                        "root", event.target.id, event.composedPath().includes(openTarget), event.eventPhase,
+                    ]));
+                    openHost.addEventListener("open-probe", event => openSeen.push([
+                        "host", event.target.id, event.composedPath().includes(openTarget), event.eventPhase,
+                    ]));
+                    document.addEventListener("open-probe", event => openSeen.push([
+                        "document", event.target.id, event.composedPath().includes(openTarget), event.eventPhase,
+                    ]));
+                    openTarget.dispatchEvent(new Event("open-probe", {bubbles:true, composed:true}));
+
+                    const nonBubbling = [];
+                    openHost.addEventListener("non-bubbling", () => nonBubbling.push("host-capture"), true);
+                    openHost.addEventListener("non-bubbling", () => nonBubbling.push("host-bubble"));
+                    openTarget.addEventListener("non-bubbling", () => nonBubbling.push("target"));
+                    openTarget.dispatchEvent(new Event("non-bubbling", {bubbles:false, composed:true}));
+                    const stoppedAtHost = [];
+                    openHost.addEventListener("stopped-at-host", event => {
+                        stoppedAtHost.push("host-capture"); event.stopPropagation();
+                    }, true);
+                    openHost.addEventListener("stopped-at-host", () => stoppedAtHost.push("host-bubble"));
+                    openTarget.addEventListener("stopped-at-host", () => stoppedAtHost.push("target"));
+                    openTarget.dispatchEvent(new Event("stopped-at-host", {bubbles:false, composed:true}));
+
+                    const closedHost = document.getElementById("closed");
+                    const closedRoot = closedHost.attachShadow({mode:"closed"});
+                    const closedTarget = document.createElement("button");
+                    const related = document.createElement("span");
+                    closedTarget.id = "closed-target";
+                    related.id = "related";
+                    closedRoot.appendChild(closedTarget);
+                    closedRoot.appendChild(related);
+                    const closedSeen = [];
+                    closedRoot.addEventListener("closed-probe", event => closedSeen.push([
+                        "root", event.target.id, event.relatedTarget.id,
+                        event.composedPath().includes(closedTarget),
+                    ]));
+                    document.addEventListener("closed-probe", event => closedSeen.push([
+                        "document", event.target.id, event.relatedTarget.id,
+                        event.composedPath().includes(closedTarget),
+                    ]));
+                    closedTarget.dispatchEvent(new MouseEvent("closed-probe", {
+                        bubbles:true, composed:true, relatedTarget:document.body,
+                    }));
+
+                    const confined = [];
+                    closedRoot.addEventListener("confined", () => confined.push("root"));
+                    closedHost.addEventListener("confined", () => confined.push("host"));
+                    document.addEventListener("confined", () => confined.push("document"));
+                    closedTarget.dispatchEvent(new Event("confined", {bubbles:true, composed:false}));
+
+                    let suppressedOutside = 0;
+                    document.addEventListener("related", () => suppressedOutside++);
+                    closedTarget.dispatchEvent(new MouseEvent("related", {
+                        bubbles:true, composed:true, relatedTarget:related,
+                    }));
+                    return {openSeen, nonBubbling, stoppedAtHost, closedSeen, confined, suppressedOutside};
+                })()"#,
+            )
+            .unwrap();
+        assert_eq!(result["openSeen"], serde_json::json!([
+            ["root", "open-target", true, 3], ["host", "open", true, 2],
+            ["document", "open", true, 3],
+        ]));
+        assert_eq!(result["nonBubbling"], serde_json::json!([
+            "host-capture", "target", "host-bubble",
+        ]));
+        assert_eq!(result["stoppedAtHost"], serde_json::json!(["host-capture"]));
+        assert_eq!(result["closedSeen"], serde_json::json!([
+            ["root", "closed-target", "", true], ["document", "closed", "", false],
+        ]));
+        assert_eq!(result["confined"], serde_json::json!(["root"]));
+        assert_eq!(result["suppressedOutside"], 0);
+    }
+
+    #[test]
+    fn direct_shadow_root_dispatch_retargets_and_cleanup_survives_hostile_root_lookup() {
+        let mut rt = setup_runtime(r#"<div id="open"></div><div id="closed"></div>"#);
+        let result = rt
+            .evaluate(
+                r#"(() => {
+                    const seen = [];
+                    for (const mode of ["open", "closed"]) {
+                        const host = document.getElementById(mode);
+                        const root = host.attachShadow({mode});
+                        root.addEventListener(mode, event => seen.push([
+                            mode, "root", event.target === root,
+                            event.composedPath().includes(root),
+                        ]));
+                        document.addEventListener(mode, event => seen.push([
+                            mode, "document", event.target === host,
+                            event.composedPath().includes(root),
+                        ]));
+                        root.dispatchEvent(new Event(mode, {bubbles:true, composed:true}));
+                    }
+
+                    const host = document.createElement("div");
+                    document.body.appendChild(host);
+                    const root = host.attachShadow({mode:"open"});
+                    const target = document.createElement("button");
+                    root.appendChild(target);
+                    const originalGetRootNode = target.getRootNode;
+                    target.getRootNode = () => { throw new Error("hostile root lookup"); };
+                    const event = new Event("hostile", {bubbles:true, composed:true});
+                    let firstError = null;
+                    try { target.dispatchEvent(event); }
+                    catch (error) { firstError = error.message; }
+                    target.getRootNode = originalGetRootNode;
+                    let laterCalls = 0;
+                    document.addEventListener("hostile", () => laterCalls++);
+                    const secondResult = target.dispatchEvent(event);
+                    return {seen, firstError, secondResult, laterCalls};
+                })()"#,
+            )
+            .unwrap();
+        assert_eq!(result, serde_json::json!({
+            "seen": [
+                ["open", "root", true, true],
+                ["open", "document", true, true],
+                ["closed", "root", true, true],
+                ["closed", "document", true, false],
+            ],
+            "firstError": "hostile root lookup",
+            "secondResult": true,
+            "laterCalls": 1,
+        }));
+    }
+
+    #[test]
+    fn nested_shadow_hosts_are_additional_targets_on_the_forward_event_leg() {
+        let mut rt = setup_runtime(r#"<div id="outer"></div>"#);
+        let result = rt
+            .evaluate(
+                r#"(function(){
+                    const outer = document.getElementById("outer");
+                    const outerRoot = outer.attachShadow({mode:"open"});
+                    const inner = document.createElement("div");
+                    inner.id = "inner";
+                    outerRoot.appendChild(inner);
+                    const innerRoot = inner.attachShadow({mode:"open"});
+                    const target = document.createElement("button");
+                    innerRoot.appendChild(target);
+                    const calls = [];
+                    const record = name => event => calls.push([name, event.eventPhase]);
+                    outer.addEventListener("probe", record("outer-capture"), true);
+                    outer.addEventListener("probe", record("outer-target"));
+                    inner.addEventListener("probe", record("inner-capture"), true);
+                    inner.addEventListener("probe", record("inner-target"));
+                    target.addEventListener("probe", record("target-capture"), true);
+                    target.addEventListener("probe", record("target"));
+                    target.dispatchEvent(new Event("probe", {bubbles:false, composed:true}));
+
+                    const stopped = [];
+                    outer.addEventListener("stopped", () => stopped.push("outer-capture"), true);
+                    inner.addEventListener("stopped", event => {
+                        stopped.push("inner-capture"); event.stopPropagation();
+                    }, true);
+                    inner.addEventListener("stopped", () => stopped.push("inner-target"));
+                    target.addEventListener("stopped", () => stopped.push("target"));
+                    outer.addEventListener("stopped", () => stopped.push("outer-target"));
+                    target.dispatchEvent(new Event("stopped", {bubbles:false, composed:true}));
+                    return {calls, stopped};
+                })()"#,
+            )
+            .unwrap();
+        assert_eq!(result["calls"], serde_json::json!([
+            ["outer-capture", 2], ["inner-capture", 2],
+            ["target-capture", 2], ["target", 2],
+            ["inner-target", 2], ["outer-target", 2],
+        ]));
+        assert_eq!(result["stopped"], serde_json::json!([
+            "outer-capture", "inner-capture",
+        ]));
+    }
+
+    #[test]
+    fn legacy_event_initializers_are_noops_during_dispatch() {
+        let mut rt = setup_runtime(r#"<div id="target"></div>"#);
+        let result = rt
+            .evaluate(
+                r#"(function(){
+                    const target = document.getElementById("target");
+                    const checks = [];
+                    let initialized = 0;
+                    const preserve = (event, initialize, read) => {
+                        const before = read(event);
+                        target.addEventListener(event.type, () => { initialized++; initialize(event); }, {once:true});
+                        target.dispatchEvent(event);
+                        checks.push([before, read(event)]);
+                    };
+                    preserve(
+                        new CustomEvent("custom", {bubbles:true, composed:true, detail:"old"}),
+                        event => event.initCustomEvent("changed", false, false, "new"),
+                        event => [event.type,event.bubbles,event.composed,event.detail]);
+                    preserve(
+                        new MouseEvent("mouse", {bubbles:true, composed:true, clientX:3, relatedTarget:document.body}),
+                        event => event.initMouseEvent("changed",false,false,null,9,1,2,30,40,true,true,true,true,2,null),
+                        event => [event.type,event.bubbles,event.composed,event.clientX,event.relatedTarget===document.body]);
+                    preserve(
+                        new KeyboardEvent("keyboard", {bubbles:true, composed:true, key:"Old", location:1}),
+                        event => event.initKeyboardEvent("changed",false,false,null,"New",2,true,true,true,true),
+                        event => [event.type,event.bubbles,event.composed,event.key,event.location]);
+                    preserve(
+                        new UIEvent("ui", {bubbles:true, composed:true, detail:4}),
+                        event => event.initUIEvent("changed",false,false,null,9),
+                        event => [event.type,event.bubbles,event.composed,event.detail]);
+                    preserve(
+                        new CompositionEvent("composition", {bubbles:true, composed:true, data:"old"}),
+                        event => event.initCompositionEvent("changed",false,false,null,"new"),
+                        event => [event.type,event.bubbles,event.composed,event.data]);
+                    preserve(
+                        new StorageEvent("storage", {bubbles:true, composed:true, key:"old", newValue:"value"}),
+                        event => event.initStorageEvent("changed",false,false,"new",null,"other","x",null),
+                        event => [event.type,event.bubbles,event.composed,event.key,event.newValue]);
+
+                    const outside = new Event("before", {bubbles:false, cancelable:false, composed:true});
+                    outside.initEvent("after", true, true);
+                    const outsideCustom = new CustomEvent("before-custom", {composed:true, detail:"old"});
+                    outsideCustom.initCustomEvent("after-custom", true, true, "new");
+                    return {checks, initialized,
+                        outside:[outside.type,outside.bubbles,outside.cancelable,outside.composed],
+                        outsideCustom:[outsideCustom.type,outsideCustom.bubbles,
+                            outsideCustom.cancelable,outsideCustom.composed,outsideCustom.detail]};
+                })()"#,
+            )
+            .unwrap();
+        for check in result["checks"].as_array().unwrap() {
+            assert_eq!(check[0], check[1]);
+        }
+        assert_eq!(result["initialized"], 6);
+        assert_eq!(result["outside"], serde_json::json!(["after", true, true, false]));
+        assert_eq!(result["outsideCustom"], serde_json::json!([
+            "after-custom", true, true, false, "new",
+        ]));
+    }
+
+    #[test]
     fn media_text_tracks_expose_loaded_webvtt_cues() {
         let mut rt = setup_runtime(
             r#"<video><track id="captions" kind="captions" srclang="en" default


### PR DESCRIPTION
## What changed

- build one generic DOM event path through Element, ShadowRoot, Document, and Window
- apply capture, target, bubble, retargeting, composed-path, stop, once, passive, and handler-order semantics on that path
- dispatch DOMContentLoaded and load once through the generic path instead of replaying Window events
- keep dispatch state private and panic-safe under hostile accessors, nested dispatch, listener mutation, and direct ShadowRoot dispatch
- keep body onload reflection in #781 and click reentrancy in #729 rather than duplicating either change

This implements the generic event-path slice from the Obscura 0.2.1 compatibility report.

## Validation

- current base: `14ce517` with merged #824 and #825
- focused event/reentrancy release tests: 12/12 passed
- affected `obscura-js` and `obscura-browser` release nextest: 544/544 passed
- full release nextest with render: 1591/1591 passed, 4 skipped
- all four documented release builds passed: render; render+stealth; no default features; no default features+stealth
- obstacle course: 32/33 standalone, with only the known `observer-intersection` prerequisite; isolated composition with #786 passed 33/33
- independent adversarial correctness and KISS reviews passed after adding hostile-setter, direct open/closed ShadowRoot, and throwing-retarget cleanup regressions

## Rendering

Not applicable. This does not change layout, paint, screenshots, screencast, or PDF output.

## Performance

Seven interleaved release-mode rounds compared exact current `main` with this PR using identical local fixtures.

- representative DOM build: latency +1.9%, peak RSS +0.2%
- representative storage workload: latency -1.7%, peak RSS +0.7%
- dispatch-heavy synthetic cases: peak RSS +0.8% to +2.8%
- 32-listener dispatch: latency +14.7%
- complete shallow propagation adds about 0.40 to 0.45 microseconds per event relative to the old incomplete dispatcher
- a 64-level capture/bubble path adds about 8.7 microseconds per event

The dispatcher keeps a single semantic path. Attempts to add speculative no-listener or capture-count shortcuts were rejected because they either broke reentrancy or worsened performance. Invocation snapshot sorting and shadow retargeting are skipped when they are not needed, and listener removal uses tombstones to avoid repeated linear membership checks.

## Checklist

- [x] The change is focused and does not remove existing behavior without justification.
- [x] Tests cover the failure and adjacent blast radius.
- [x] Existing tests pass, including render and no-render configurations.
- [x] CPU, latency, and memory were measured against exact current main.
- [x] No public Rust API changes.
