### PR TITLE
fix(network): preserve CDP binary response bodies

### DIFF
--- a/crates/obscura-browser/src/page.rs
+++ b/crates/obscura-browser/src/page.rs
@@ -3114,19 +3114,21 @@ impl Page {
             PageError::NetworkError(e.to_string())
         })?;
 
-        // Store binary main resources (images, PDFs, octet-stream) base64 so
-        // Network.getResponseBody returns intact bytes. A UTF-8-lossy text store
-        // corrupts them (issue #340). Text-like types stay as text.
-        let main_is_binary = !is_text_like_content_type(response.content_type());
-        self.record_network_event_with_body(
+        // Apply Chromium's charset-aware DevTools body policy. This preserves
+        // both non-UTF-8 text and opaque binary bytes without lossy conversion.
+        let request_id = self.record_network_event_inner(
             url.as_str(),
             "GET",
             "Document",
             response.status,
             &response.headers,
-            &response.body,
-            main_is_binary,
+            response.body.len(),
         );
+        let body = &response.body;
+        let content_type = response.content_type();
+        self.store_response_body_with(request_id, body.len(), || {
+            stored_devtools_document_response_body(body, content_type)
+        });
 
         if !response.redirected_from.is_empty() {
             self.url = Some(response.url.clone());
@@ -4084,23 +4086,32 @@ impl Page {
     }
 
     fn store_response_body(&mut self, request_id: String, body: &[u8], base64_encoded: bool) {
+        self.store_response_body_with(request_id, body.len(), || StoredResponseBody {
+            body: if base64_encoded {
+                BASE64.encode(body)
+            } else {
+                String::from_utf8_lossy(body).to_string()
+            },
+            base64_encoded,
+        });
+    }
+
+    fn store_response_body_with<F>(
+        &mut self,
+        request_id: String,
+        source_len: usize,
+        make_stored: F,
+    )
+    where
+        F: FnOnce() -> StoredResponseBody,
+    {
         let max_entries = response_body_entry_limit();
         let max_bytes = response_body_byte_limit();
-        if max_entries == 0 || max_bytes == 0 || body.len() > max_bytes {
+        if max_entries == 0 || max_bytes == 0 || source_len > max_bytes {
             return;
         }
-        let body = if base64_encoded {
-            BASE64.encode(body)
-        } else {
-            String::from_utf8_lossy(body).to_string()
-        };
-        self.response_bodies.insert(
-            request_id.clone(),
-            StoredResponseBody {
-                body,
-                base64_encoded,
-            },
-        );
+        let stored = make_stored();
+        self.response_bodies.insert(request_id.clone(), stored);
         self.response_body_order.push_back(request_id);
         while self.response_body_order.len() > max_entries {
             if let Some(oldest) = self.response_body_order.pop_front() {
@@ -4413,6 +4424,63 @@ mod tests {
     use super::remaining_settle_resource_warmup_ms;
     use base64::Engine as _;
     use obscura_dom::parse_html;
+
+    #[test]
+    fn document_devtools_body_matches_fetch_store_decoding_boundaries() {
+        assert_eq!(
+            super::decode_devtools_document_response_body(b"", None),
+            Some(String::new()),
+        );
+        for (body, content_type, expected) in [
+            (b"ABC".as_slice(), None, None),
+            (b"ABC", Some("application/octet-stream"), None),
+            (&[0xff], Some("text/plain"), Some("ÿ".to_string())),
+            (&[0xff], Some("application/json"), None),
+            (
+                &[0x80],
+                Some("text/plain; CHARSET=\"windows-1252\""),
+                Some("€".to_string()),
+            ),
+            (
+                &[0xd6, 0xd0, 0xce, 0xc4],
+                Some("text/html; Charset='GBK'"),
+                Some("中文".to_string()),
+            ),
+            (&[0xff], Some("text/plain; charset=not-real"), None),
+        ] {
+            assert_eq!(
+                super::decode_devtools_document_response_body(body, content_type),
+                expected,
+                "unexpected DevTools body policy for {content_type:?}",
+            );
+        }
+        for content_type in [
+            "application/x-ecmascript",
+            "application/x-javascript",
+            "text/javascript1.5",
+            "text/json",
+        ] {
+            assert_eq!(
+                super::decode_devtools_document_response_body(&[0xff], Some(content_type)),
+                None,
+                "{content_type} must use Chromium's UTF-8 decoder",
+            );
+        }
+        assert_eq!(
+            super::decode_devtools_document_response_body(
+                b"<html/>",
+                Some("application/xhtml+xml"),
+            ),
+            Some("<html/>".to_string()),
+        );
+        for content_type in ["image/svg+xml", "text/xsl", "foo/bar+xml"] {
+            assert_eq!(
+                super::decode_devtools_document_response_body(b"<xml/>", Some(content_type)),
+                None,
+                "{content_type} has no Chromium raw-resource text decoder",
+            );
+        }
+    }
 
     #[test]
     fn navigation_timeout_environment_default_remains_thirty_seconds() {
@@ -7252,27 +7320,100 @@ impl From<ObscuraNetError> for PageError {
     }
 }
 
-/// Whether a Content-Type is text-like and can be stored/returned as a UTF-8
-/// string. Everything else (images, PDF, fonts, octet-stream) is binary and must
-/// be base64-encoded so Network.getResponseBody returns intact bytes.
-fn is_text_like_content_type(content_type: Option<&str>) -> bool {
-    let ct = match content_type {
-        Some(c) => c.split(';').next().unwrap_or(c).trim().to_ascii_lowercase(),
-        // No Content-Type: assume text (matches the HTML-parse default).
-        None => return true,
-    };
-    if ct.is_empty() {
-        return true;
+/// Apply Chromium's charset-aware CDP policy to Page-owned response bodies.
+/// The JS fetch store keeps the same small private policy in obscura-js; sharing
+/// it would expose an engine-internal DevTools detail as public Rust API.
+fn stored_devtools_document_response_body(
+    body: &[u8],
+    content_type: Option<&str>,
+) -> StoredResponseBody {
+    if let Some(body) = decode_devtools_document_response_body(body, content_type) {
+        StoredResponseBody {
+            body,
+            base64_encoded: false,
+        }
+    } else {
+        StoredResponseBody {
+            body: BASE64.encode(body),
+            base64_encoded: true,
+        }
     }
-    ct.starts_with("text/")
-        || ct == "application/json"
-        || ct == "application/xml"
-        || ct == "application/xhtml+xml"
-        || ct == "application/javascript"
-        || ct == "application/ecmascript"
-        || ct == "image/svg+xml"
-        || ct.ends_with("+json")
-        || ct.ends_with("+xml")
+}
+
+fn decode_devtools_document_response_body(
+    body: &[u8],
+    content_type: Option<&str>,
+) -> Option<String> {
+    if body.is_empty() {
+        return Some(String::new());
+    }
+
+    let content_type = content_type?;
+    let mime = content_type
+        .split(';')
+        .next()
+        .unwrap_or(content_type)
+        .trim()
+        .to_ascii_lowercase();
+    let decoder = document_devtools_text_decoder(&mime)?;
+    let explicit_charset = content_type.split(';').skip(1).find_map(|parameter| {
+        let (name, value) = parameter.split_once('=')?;
+        if !name.trim().eq_ignore_ascii_case("charset") {
+            return None;
+        }
+        let value = value.trim().trim_matches(|c| c == '"' || c == '\'');
+        (!value.is_empty()).then_some(value)
+    });
+    let encoding = if let Some(charset) = explicit_charset {
+        charset
+    } else if matches!(decoder, DocumentDevtoolsTextDecoder::Html) {
+        obscura_net::encoding::detect_encoding(body, Some(content_type)).0.name()
+    } else if matches!(decoder, DocumentDevtoolsTextDecoder::Utf8) {
+        "utf-8"
+    } else {
+        "windows-1252"
+    };
+    obscura_net::decode_with_label(encoding, body, true, false)
+}
+
+#[derive(Clone, Copy)]
+enum DocumentDevtoolsTextDecoder {
+    Html,
+    Utf8,
+    Plain,
+}
+
+fn document_devtools_text_decoder(mime: &str) -> Option<DocumentDevtoolsTextDecoder> {
+    if mime == "text/html" {
+        return Some(DocumentDevtoolsTextDecoder::Html);
+    }
+    if matches!(
+        mime,
+        "application/javascript"
+            | "application/ecmascript"
+            | "application/x-ecmascript"
+            | "application/x-javascript"
+            | "text/ecmascript"
+            | "text/javascript"
+            | "text/javascript1.0"
+            | "text/javascript1.1"
+            | "text/javascript1.2"
+            | "text/javascript1.3"
+            | "text/javascript1.4"
+            | "text/javascript1.5"
+            | "text/jscript"
+            | "text/livescript"
+            | "text/x-ecmascript"
+            | "text/x-javascript"
+    ) || matches!(mime, "application/json" | "text/json")
+        || mime.ends_with("+json")
+        || matches!(mime, "application/xml" | "text/xml")
+        || (mime.starts_with("application/") && mime.ends_with("+xml"))
+    {
+        return Some(DocumentDevtoolsTextDecoder::Utf8);
+    }
+    (mime.starts_with("text/") && mime != "text/xsl")
+        .then_some(DocumentDevtoolsTextDecoder::Plain)
 }
 
 fn response_body_entry_limit() -> usize {

--- a/crates/obscura-browser/src/page.rs
+++ b/crates/obscura-browser/src/page.rs
@@ -4432,7 +4432,11 @@ mod tests {
             Some(String::new()),
         );
         for (body, content_type, expected) in [
-            (b"ABC".as_slice(), None, None),
+            (
+                &[0x81, 0x8d][..],
+                None,
+                Some("\u{81}\u{8d}".to_string()),
+            ),
             (b"ABC", Some("application/octet-stream"), None),
             (&[0xff], Some("text/plain"), Some("ÿ".to_string())),
             (&[0xff], Some("application/json"), None),
@@ -7348,7 +7352,9 @@ fn decode_devtools_document_response_body(
         return Some(String::new());
     }
 
-    let content_type = content_type?;
+    let Some(content_type) = content_type else {
+        return obscura_net::decode_with_label("windows-1252", body, true, false);
+    };
     let mime = content_type
         .split(';')
         .next()

--- a/crates/obscura-browser/src/page.rs
+++ b/crates/obscura-browser/src/page.rs
@@ -4622,7 +4622,11 @@ mod tests {
             Some(String::new()),
         );
         for (body, content_type, expected) in [
-            (b"ABC".as_slice(), None, None),
+            (
+                &[0x81, 0x8d][..],
+                None,
+                Some("\u{81}\u{8d}".to_string()),
+            ),
             (b"ABC", Some("application/octet-stream"), None),
             (&[0xff], Some("text/plain"), Some("ÿ".to_string())),
             (&[0xff], Some("application/json"), None),
@@ -8084,7 +8088,9 @@ fn decode_devtools_document_response_body(
         return Some(String::new());
     }
 
-    let content_type = content_type?;
+    let Some(content_type) = content_type else {
+        return obscura_net::decode_with_label("windows-1252", body, true, false);
+    };
     let mime = content_type
         .split(';')
         .next()

--- a/crates/obscura-browser/src/page.rs
+++ b/crates/obscura-browser/src/page.rs
@@ -3294,19 +3294,21 @@ impl Page {
             PageError::NetworkError(e.to_string())
         })?;
 
-        // Store binary main resources (images, PDFs, octet-stream) base64 so
-        // Network.getResponseBody returns intact bytes. A UTF-8-lossy text store
-        // corrupts them (issue #340). Text-like types stay as text.
-        let main_is_binary = !is_text_like_content_type(response.content_type());
-        self.record_network_event_with_body(
+        // Apply Chromium's charset-aware DevTools body policy. This preserves
+        // both non-UTF-8 text and opaque binary bytes without lossy conversion.
+        let request_id = self.record_network_event_inner(
             url.as_str(),
             "GET",
             "Document",
             response.status,
             &response.headers,
-            &response.body,
-            main_is_binary,
+            response.body.len(),
         );
+        let body = &response.body;
+        let content_type = response.content_type();
+        self.store_response_body_with(request_id, body.len(), || {
+            stored_devtools_document_response_body(body, content_type)
+        });
 
         if !response.redirected_from.is_empty() {
             self.url = Some(response.url.clone());
@@ -4270,23 +4272,32 @@ impl Page {
     }
 
     fn store_response_body(&mut self, request_id: String, body: &[u8], base64_encoded: bool) {
+        self.store_response_body_with(request_id, body.len(), || StoredResponseBody {
+            body: if base64_encoded {
+                BASE64.encode(body)
+            } else {
+                String::from_utf8_lossy(body).to_string()
+            },
+            base64_encoded,
+        });
+    }
+
+    fn store_response_body_with<F>(
+        &mut self,
+        request_id: String,
+        source_len: usize,
+        make_stored: F,
+    )
+    where
+        F: FnOnce() -> StoredResponseBody,
+    {
         let max_entries = response_body_entry_limit();
         let max_bytes = response_body_byte_limit();
-        if max_entries == 0 || max_bytes == 0 || body.len() > max_bytes {
+        if max_entries == 0 || max_bytes == 0 || source_len > max_bytes {
             return;
         }
-        let body = if base64_encoded {
-            BASE64.encode(body)
-        } else {
-            String::from_utf8_lossy(body).to_string()
-        };
-        self.response_bodies.insert(
-            request_id.clone(),
-            StoredResponseBody {
-                body,
-                base64_encoded,
-            },
-        );
+        let stored = make_stored();
+        self.response_bodies.insert(request_id.clone(), stored);
         self.response_body_order.push_back(request_id);
         while self.response_body_order.len() > max_entries {
             if let Some(oldest) = self.response_body_order.pop_front() {
@@ -4603,6 +4614,63 @@ mod tests {
     use super::remaining_settle_resource_warmup_ms;
     use base64::Engine as _;
     use obscura_dom::parse_html;
+
+    #[test]
+    fn document_devtools_body_matches_fetch_store_decoding_boundaries() {
+        assert_eq!(
+            super::decode_devtools_document_response_body(b"", None),
+            Some(String::new()),
+        );
+        for (body, content_type, expected) in [
+            (b"ABC".as_slice(), None, None),
+            (b"ABC", Some("application/octet-stream"), None),
+            (&[0xff], Some("text/plain"), Some("ÿ".to_string())),
+            (&[0xff], Some("application/json"), None),
+            (
+                &[0x80],
+                Some("text/plain; CHARSET=\"windows-1252\""),
+                Some("€".to_string()),
+            ),
+            (
+                &[0xd6, 0xd0, 0xce, 0xc4],
+                Some("text/html; Charset='GBK'"),
+                Some("中文".to_string()),
+            ),
+            (&[0xff], Some("text/plain; charset=not-real"), None),
+        ] {
+            assert_eq!(
+                super::decode_devtools_document_response_body(body, content_type),
+                expected,
+                "unexpected DevTools body policy for {content_type:?}",
+            );
+        }
+        for content_type in [
+            "application/x-ecmascript",
+            "application/x-javascript",
+            "text/javascript1.5",
+            "text/json",
+        ] {
+            assert_eq!(
+                super::decode_devtools_document_response_body(&[0xff], Some(content_type)),
+                None,
+                "{content_type} must use Chromium's UTF-8 decoder",
+            );
+        }
+        assert_eq!(
+            super::decode_devtools_document_response_body(
+                b"<html/>",
+                Some("application/xhtml+xml"),
+            ),
+            Some("<html/>".to_string()),
+        );
+        for content_type in ["image/svg+xml", "text/xsl", "foo/bar+xml"] {
+            assert_eq!(
+                super::decode_devtools_document_response_body(b"<xml/>", Some(content_type)),
+                None,
+                "{content_type} has no Chromium raw-resource text decoder",
+            );
+        }
+    }
 
     #[test]
     fn navigation_timeout_environment_default_remains_thirty_seconds() {
@@ -7988,27 +8056,100 @@ impl From<ObscuraNetError> for PageError {
     }
 }
 
-/// Whether a Content-Type is text-like and can be stored/returned as a UTF-8
-/// string. Everything else (images, PDF, fonts, octet-stream) is binary and must
-/// be base64-encoded so Network.getResponseBody returns intact bytes.
-fn is_text_like_content_type(content_type: Option<&str>) -> bool {
-    let ct = match content_type {
-        Some(c) => c.split(';').next().unwrap_or(c).trim().to_ascii_lowercase(),
-        // No Content-Type: assume text (matches the HTML-parse default).
-        None => return true,
-    };
-    if ct.is_empty() {
-        return true;
+/// Apply Chromium's charset-aware CDP policy to Page-owned response bodies.
+/// The JS fetch store keeps the same small private policy in obscura-js; sharing
+/// it would expose an engine-internal DevTools detail as public Rust API.
+fn stored_devtools_document_response_body(
+    body: &[u8],
+    content_type: Option<&str>,
+) -> StoredResponseBody {
+    if let Some(body) = decode_devtools_document_response_body(body, content_type) {
+        StoredResponseBody {
+            body,
+            base64_encoded: false,
+        }
+    } else {
+        StoredResponseBody {
+            body: BASE64.encode(body),
+            base64_encoded: true,
+        }
     }
-    ct.starts_with("text/")
-        || ct == "application/json"
-        || ct == "application/xml"
-        || ct == "application/xhtml+xml"
-        || ct == "application/javascript"
-        || ct == "application/ecmascript"
-        || ct == "image/svg+xml"
-        || ct.ends_with("+json")
-        || ct.ends_with("+xml")
+}
+
+fn decode_devtools_document_response_body(
+    body: &[u8],
+    content_type: Option<&str>,
+) -> Option<String> {
+    if body.is_empty() {
+        return Some(String::new());
+    }
+
+    let content_type = content_type?;
+    let mime = content_type
+        .split(';')
+        .next()
+        .unwrap_or(content_type)
+        .trim()
+        .to_ascii_lowercase();
+    let decoder = document_devtools_text_decoder(&mime)?;
+    let explicit_charset = content_type.split(';').skip(1).find_map(|parameter| {
+        let (name, value) = parameter.split_once('=')?;
+        if !name.trim().eq_ignore_ascii_case("charset") {
+            return None;
+        }
+        let value = value.trim().trim_matches(|c| c == '"' || c == '\'');
+        (!value.is_empty()).then_some(value)
+    });
+    let encoding = if let Some(charset) = explicit_charset {
+        charset
+    } else if matches!(decoder, DocumentDevtoolsTextDecoder::Html) {
+        obscura_net::encoding::detect_encoding(body, Some(content_type)).0.name()
+    } else if matches!(decoder, DocumentDevtoolsTextDecoder::Utf8) {
+        "utf-8"
+    } else {
+        "windows-1252"
+    };
+    obscura_net::decode_with_label(encoding, body, true, false)
+}
+
+#[derive(Clone, Copy)]
+enum DocumentDevtoolsTextDecoder {
+    Html,
+    Utf8,
+    Plain,
+}
+
+fn document_devtools_text_decoder(mime: &str) -> Option<DocumentDevtoolsTextDecoder> {
+    if mime == "text/html" {
+        return Some(DocumentDevtoolsTextDecoder::Html);
+    }
+    if matches!(
+        mime,
+        "application/javascript"
+            | "application/ecmascript"
+            | "application/x-ecmascript"
+            | "application/x-javascript"
+            | "text/ecmascript"
+            | "text/javascript"
+            | "text/javascript1.0"
+            | "text/javascript1.1"
+            | "text/javascript1.2"
+            | "text/javascript1.3"
+            | "text/javascript1.4"
+            | "text/javascript1.5"
+            | "text/jscript"
+            | "text/livescript"
+            | "text/x-ecmascript"
+            | "text/x-javascript"
+    ) || matches!(mime, "application/json" | "text/json")
+        || mime.ends_with("+json")
+        || matches!(mime, "application/xml" | "text/xml")
+        || (mime.starts_with("application/") && mime.ends_with("+xml"))
+    {
+        return Some(DocumentDevtoolsTextDecoder::Utf8);
+    }
+    (mime.starts_with("text/") && mime != "text/xsl")
+        .then_some(DocumentDevtoolsTextDecoder::Plain)
 }
 
 fn response_body_entry_limit() -> usize {

--- a/crates/obscura-cdp/tests/js_fetch_emits_network_events.rs
+++ b/crates/obscura-cdp/tests/js_fetch_emits_network_events.rs
@@ -70,6 +70,8 @@ async fn serve_binary_fetch() -> String {
                     (Some("text/plain"), vec![0xff])
                 } else if request.starts_with("GET /win1252.txt") {
                     (Some("text/plain; charset=windows-1252"), vec![0x80])
+                } else if request.starts_with("GET /gbk.txt") {
+                    (Some("text/plain; charset=gbk"), vec![0xd6, 0xd0, 0xce, 0xc4])
                 } else if request.starts_with("GET /invalid.json") {
                     (Some("application/json"), vec![0xff])
                 } else if request.starts_with("GET /legacy.js") {
@@ -90,6 +92,7 @@ async fn serve_binary_fetch() -> String {
                           fetch('/ascii.bin').then(r => r.arrayBuffer()),
                           fetch('/invalid.txt').then(r => r.text()),
                           fetch('/win1252.txt').then(r => r.text()),
+                          fetch('/gbk.txt').then(r => r.text()),
                           fetch('/invalid.json').then(r => r.arrayBuffer()),
                           fetch('/legacy.js').then(r => r.text()),
                           fetch('/legacy.css').then(r => r.text()),
@@ -246,7 +249,7 @@ async fn js_fetch_get_response_body_preserves_binary_bytes() {
 }
 
 #[tokio::test(flavor = "current_thread")]
-async fn js_fetch_get_response_body_uses_chromium_mime_encoding_rules() {
+async fn network_get_response_body_uses_chromium_mime_encoding_rules() {
     std::env::set_var("OBSCURA_ALLOW_PRIVATE_NETWORK", "1");
     let base = serve_binary_fetch().await;
     let mut ctx = CdpContext::new();
@@ -362,6 +365,62 @@ async fn js_fetch_get_response_body_uses_chromium_mime_encoding_rules() {
     )
     .await;
     assert_eq!(legacy_css, json!({"body": "ÿ", "base64Encoded": false}));
+
+    let gbk_id = response_request_id(&ctx, "/gbk.txt").expect("GBK text response");
+    let gbk = cdp(
+        &mut ctx,
+        11,
+        "Network.getResponseBody",
+        json!({"requestId": gbk_id}),
+        session_id,
+    )
+    .await;
+    assert_eq!(gbk, json!({"body": "中文", "base64Encoded": false}));
+
+    let navigated = cdp(
+        &mut ctx,
+        12,
+        "Page.navigate",
+        json!({"url": format!("{base}gbk.txt")}),
+        session_id,
+    )
+    .await;
+    let loader_id = navigated["loaderId"].as_str().unwrap();
+    let document_gbk = cdp(
+        &mut ctx,
+        13,
+        "Network.getResponseBody",
+        json!({"requestId": loader_id}),
+        session_id,
+    )
+    .await;
+    assert_eq!(
+        document_gbk,
+        json!({"body": "中文", "base64Encoded": false}),
+    );
+
+    let navigated = cdp(
+        &mut ctx,
+        14,
+        "Page.navigate",
+        json!({"url": format!("{base}bytes.bin")}),
+        session_id,
+    )
+    .await;
+    let loader_id = navigated["loaderId"].as_str().unwrap();
+    let document_binary = cdp(
+        &mut ctx,
+        15,
+        "Network.getResponseBody",
+        json!({"requestId": loader_id}),
+        session_id,
+    )
+    .await;
+    assert_eq!(document_binary["base64Encoded"], true);
+    assert_eq!(
+        BASE64.decode(document_binary["body"].as_str().unwrap()).unwrap(),
+        (0u8..=255).collect::<Vec<_>>(),
+    );
 }
 
 #[tokio::test(flavor = "current_thread")]

--- a/crates/obscura-cdp/tests/js_fetch_emits_network_events.rs
+++ b/crates/obscura-cdp/tests/js_fetch_emits_network_events.rs
@@ -7,6 +7,7 @@
 
 use obscura_cdp::dispatch::{dispatch, CdpContext};
 use obscura_cdp::types::CdpRequest;
+use base64::{engine::general_purpose::STANDARD as BASE64, Engine as _};
 use serde_json::{json, Value};
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::net::TcpListener;
@@ -45,6 +46,68 @@ window.__done = new Promise(function (resolve) {
                     body.len()
                 );
                 let _ = socket.write_all(resp.as_bytes()).await;
+            });
+        }
+    });
+    format!("http://{addr}/")
+}
+
+async fn serve_binary_fetch() -> String {
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    tokio::spawn(async move {
+        for _ in 0..16 {
+            let (mut socket, _) = listener.accept().await.unwrap();
+            tokio::spawn(async move {
+                let mut buf = [0u8; 2048];
+                let n = socket.read(&mut buf).await.unwrap_or(0);
+                let request = String::from_utf8_lossy(&buf[..n]);
+                let (content_type, body): (Option<&str>, Vec<u8>) = if request.starts_with("GET /bytes.bin") {
+                    (Some("application/octet-stream"), (0u8..=255).collect())
+                } else if request.starts_with("GET /ascii.bin") {
+                    (Some("application/octet-stream"), b"ABC".to_vec())
+                } else if request.starts_with("GET /invalid.txt") {
+                    (Some("text/plain"), vec![0xff])
+                } else if request.starts_with("GET /win1252.txt") {
+                    (Some("text/plain; charset=windows-1252"), vec![0x80])
+                } else if request.starts_with("GET /invalid.json") {
+                    (Some("application/json"), vec![0xff])
+                } else if request.starts_with("GET /legacy.js") {
+                    (Some("application/x-javascript"), b"legacy()".to_vec())
+                } else if request.starts_with("GET /legacy.css") {
+                    (Some("text/css"), vec![0xff])
+                } else if request.starts_with("GET /no-type") {
+                    (None, vec![0xff])
+                } else if request.starts_with("GET /empty.json") {
+                    (Some("application/json"), Vec::new())
+                } else if request.starts_with("GET /empty-no-type") {
+                    (None, Vec::new())
+                } else {
+                    (
+                        Some("text/html"),
+                        br#"<script>Promise.all([
+                          fetch('/bytes.bin').then(r => r.arrayBuffer()),
+                          fetch('/ascii.bin').then(r => r.arrayBuffer()),
+                          fetch('/invalid.txt').then(r => r.text()),
+                          fetch('/win1252.txt').then(r => r.text()),
+                          fetch('/invalid.json').then(r => r.arrayBuffer()),
+                          fetch('/legacy.js').then(r => r.text()),
+                          fetch('/legacy.css').then(r => r.text()),
+                          fetch('/no-type').then(r => r.arrayBuffer()),
+                          fetch('/empty.json').then(r => r.text()),
+                          fetch('/empty-no-type').then(r => r.text())
+                        ]).then(() => { globalThis.__done = true; });</script>"#.to_vec(),
+                    )
+                };
+                let content_type = content_type
+                    .map(|value| format!("Content-Type: {value}\r\n"))
+                    .unwrap_or_default();
+                let header = format!(
+                    "HTTP/1.1 200 OK\r\n{content_type}Content-Length: {}\r\nConnection: close\r\n\r\n",
+                    body.len(),
+                );
+                let _ = socket.write_all(header.as_bytes()).await;
+                let _ = socket.write_all(&body).await;
             });
         }
     });
@@ -146,6 +209,200 @@ async fn js_fetch_emits_network_request_and_response() {
         Some("{\"value\":42}"),
         "Network.getResponseBody must return the script-fetched JSON"
     );
+    assert_eq!(body.get("base64Encoded"), Some(&json!(false)));
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn js_fetch_get_response_body_preserves_binary_bytes() {
+    std::env::set_var("OBSCURA_ALLOW_PRIVATE_NETWORK", "1");
+    let base = serve_binary_fetch().await;
+    let mut ctx = CdpContext::new();
+    let page_id = ctx.create_page();
+    let session_id = "session-1";
+    ctx.sessions.insert(session_id.to_string(), page_id);
+
+    cdp(
+        &mut ctx,
+        1,
+        "Page.navigate",
+        json!({"url": base, "waitUntil": "networkidle0"}),
+        session_id,
+    )
+    .await;
+
+    let request_id = response_request_id(&ctx, "/bytes.bin")
+        .expect("binary fetch must emit a response with a requestId");
+    let body = cdp(
+        &mut ctx,
+        2,
+        "Network.getResponseBody",
+        json!({"requestId": request_id}),
+        session_id,
+    )
+    .await;
+    assert_eq!(body.get("base64Encoded"), Some(&json!(true)));
+    let encoded = body.get("body").and_then(Value::as_str).expect("response body");
+    assert_eq!(BASE64.decode(encoded).unwrap(), (0u8..=255).collect::<Vec<_>>());
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn js_fetch_get_response_body_uses_chromium_mime_encoding_rules() {
+    std::env::set_var("OBSCURA_ALLOW_PRIVATE_NETWORK", "1");
+    let base = serve_binary_fetch().await;
+    let mut ctx = CdpContext::new();
+    let page_id = ctx.create_page();
+    let session_id = "session-1";
+    ctx.sessions.insert(session_id.to_string(), page_id);
+
+    cdp(
+        &mut ctx,
+        1,
+        "Page.navigate",
+        json!({"url": base, "waitUntil": "networkidle0"}),
+        session_id,
+    )
+    .await;
+
+    let ascii_id = response_request_id(&ctx, "/ascii.bin").expect("ASCII binary response");
+    let ascii = cdp(
+        &mut ctx,
+        2,
+        "Network.getResponseBody",
+        json!({"requestId": ascii_id}),
+        session_id,
+    )
+    .await;
+    assert_eq!(ascii, json!({"body": "QUJD", "base64Encoded": true}));
+
+    let text_id = response_request_id(&ctx, "/invalid.txt").expect("invalid text response");
+    let text = cdp(
+        &mut ctx,
+        3,
+        "Network.getResponseBody",
+        json!({"requestId": text_id}),
+        session_id,
+    )
+    .await;
+    assert_eq!(text, json!({"body": "ÿ", "base64Encoded": false}));
+
+    let windows_id = response_request_id(&ctx, "/win1252.txt").expect("windows-1252 response");
+    let windows = cdp(
+        &mut ctx,
+        4,
+        "Network.getResponseBody",
+        json!({"requestId": windows_id}),
+        session_id,
+    )
+    .await;
+    assert_eq!(windows, json!({"body": "€", "base64Encoded": false}));
+
+    let invalid_json_id = response_request_id(&ctx, "/invalid.json").expect("invalid JSON");
+    let invalid_json = cdp(
+        &mut ctx,
+        5,
+        "Network.getResponseBody",
+        json!({"requestId": invalid_json_id}),
+        session_id,
+    )
+    .await;
+    assert_eq!(invalid_json, json!({"body": "/w==", "base64Encoded": true}));
+
+    let legacy_id = response_request_id(&ctx, "/legacy.js").expect("legacy JavaScript MIME");
+    let legacy = cdp(
+        &mut ctx,
+        6,
+        "Network.getResponseBody",
+        json!({"requestId": legacy_id}),
+        session_id,
+    )
+    .await;
+    assert_eq!(legacy, json!({"body": "legacy()", "base64Encoded": false}));
+
+    let missing_id = response_request_id(&ctx, "/no-type").expect("missing MIME response");
+    let missing = cdp(
+        &mut ctx,
+        7,
+        "Network.getResponseBody",
+        json!({"requestId": missing_id}),
+        session_id,
+    )
+    .await;
+    assert_eq!(missing, json!({"body": "/w==", "base64Encoded": true}));
+
+    let empty_id = response_request_id(&ctx, "/empty.json").expect("empty JSON response");
+    let empty = cdp(
+        &mut ctx,
+        8,
+        "Network.getResponseBody",
+        json!({"requestId": empty_id}),
+        session_id,
+    )
+    .await;
+    assert_eq!(empty, json!({"body": "", "base64Encoded": false}));
+
+    let empty_no_type_id = response_request_id(&ctx, "/empty-no-type")
+        .expect("empty response without MIME type");
+    let empty_no_type = cdp(
+        &mut ctx,
+        9,
+        "Network.getResponseBody",
+        json!({"requestId": empty_no_type_id}),
+        session_id,
+    )
+    .await;
+    assert_eq!(empty_no_type, json!({"body": "", "base64Encoded": false}));
+
+    let legacy_css_id = response_request_id(&ctx, "/legacy.css").expect("legacy CSS text MIME");
+    let legacy_css = cdp(
+        &mut ctx,
+        10,
+        "Network.getResponseBody",
+        json!({"requestId": legacy_css_id}),
+        session_id,
+    )
+    .await;
+    assert_eq!(legacy_css, json!({"body": "ÿ", "base64Encoded": false}));
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn binary_fetch_response_stream_preserves_original_bytes() {
+    std::env::set_var("OBSCURA_ALLOW_PRIVATE_NETWORK", "1");
+    let base = serve_binary_fetch().await;
+    let mut ctx = CdpContext::new();
+    let page_id = ctx.create_page();
+    let session_id = "session-1";
+    ctx.sessions.insert(session_id.to_string(), page_id);
+
+    cdp(
+        &mut ctx,
+        1,
+        "Page.navigate",
+        json!({"url": base, "waitUntil": "networkidle0"}),
+        session_id,
+    )
+    .await;
+    let request_id = response_request_id(&ctx, "/bytes.bin").expect("binary response");
+    let stream = cdp(
+        &mut ctx,
+        2,
+        "Fetch.takeResponseBodyAsStream",
+        json!({"requestId": request_id}),
+        session_id,
+    )
+    .await;
+    let handle = stream.get("stream").and_then(Value::as_str).expect("stream handle");
+    let read = cdp(
+        &mut ctx,
+        3,
+        "IO.read",
+        json!({"handle": handle, "size": 512}),
+        session_id,
+    )
+    .await;
+    assert_eq!(read.get("eof"), Some(&json!(true)));
+    assert_eq!(read.get("base64Encoded"), Some(&json!(true)));
+    let encoded = read.get("data").and_then(Value::as_str).expect("stream data");
+    assert_eq!(BASE64.decode(encoded).unwrap(), (0u8..=255).collect::<Vec<_>>());
 }
 
 #[tokio::test(flavor = "current_thread")]

--- a/crates/obscura-cdp/tests/js_fetch_emits_network_events.rs
+++ b/crates/obscura-cdp/tests/js_fetch_emits_network_events.rs
@@ -79,7 +79,7 @@ async fn serve_binary_fetch() -> String {
                 } else if request.starts_with("GET /legacy.css") {
                     (Some("text/css"), vec![0xff])
                 } else if request.starts_with("GET /no-type") {
-                    (None, vec![0xff])
+                    (None, vec![0x81, 0x8d])
                 } else if request.starts_with("GET /empty.json") {
                     (Some("application/json"), Vec::new())
                 } else if request.starts_with("GET /empty-no-type") {
@@ -330,7 +330,7 @@ async fn network_get_response_body_uses_chromium_mime_encoding_rules() {
         session_id,
     )
     .await;
-    assert_eq!(missing, json!({"body": "/w==", "base64Encoded": true}));
+    assert_eq!(missing, json!({"body": "\u{81}\u{8d}", "base64Encoded": false}));
 
     let empty_id = response_request_id(&ctx, "/empty.json").expect("empty JSON response");
     let empty = cdp(

--- a/crates/obscura-cdp/tests/js_fetch_emits_network_events.rs
+++ b/crates/obscura-cdp/tests/js_fetch_emits_network_events.rs
@@ -85,7 +85,7 @@ async fn serve_binary_fetch() -> String {
                 } else if request.starts_with("GET /legacy.css") {
                     (Some("text/css"), vec![0xff])
                 } else if request.starts_with("GET /no-type") {
-                    (None, vec![0xff])
+                    (None, vec![0x81, 0x8d])
                 } else if request.starts_with("GET /empty.json") {
                     (Some("application/json"), Vec::new())
                 } else if request.starts_with("GET /empty-no-type") {
@@ -335,7 +335,7 @@ async fn network_get_response_body_uses_chromium_mime_encoding_rules() {
         session_id,
     )
     .await;
-    assert_eq!(missing, json!({"body": "/w==", "base64Encoded": true}));
+    assert_eq!(missing, json!({"body": "\u{81}\u{8d}", "base64Encoded": false}));
 
     let empty_id = response_request_id(&ctx, "/empty.json").expect("empty JSON response");
     let empty = cdp(

--- a/crates/obscura-cdp/tests/js_fetch_emits_network_events.rs
+++ b/crates/obscura-cdp/tests/js_fetch_emits_network_events.rs
@@ -76,6 +76,8 @@ async fn serve_binary_fetch() -> String {
                     (Some("text/plain"), vec![0xff])
                 } else if request.starts_with("GET /win1252.txt") {
                     (Some("text/plain; charset=windows-1252"), vec![0x80])
+                } else if request.starts_with("GET /gbk.txt") {
+                    (Some("text/plain; charset=gbk"), vec![0xd6, 0xd0, 0xce, 0xc4])
                 } else if request.starts_with("GET /invalid.json") {
                     (Some("application/json"), vec![0xff])
                 } else if request.starts_with("GET /legacy.js") {
@@ -96,6 +98,7 @@ async fn serve_binary_fetch() -> String {
                           fetch('/ascii.bin').then(r => r.arrayBuffer()),
                           fetch('/invalid.txt').then(r => r.text()),
                           fetch('/win1252.txt').then(r => r.text()),
+                          fetch('/gbk.txt').then(r => r.text()),
                           fetch('/invalid.json').then(r => r.arrayBuffer()),
                           fetch('/legacy.js').then(r => r.text()),
                           fetch('/legacy.css').then(r => r.text()),
@@ -251,7 +254,7 @@ async fn js_fetch_get_response_body_preserves_binary_bytes() {
 }
 
 #[tokio::test(flavor = "current_thread")]
-async fn js_fetch_get_response_body_uses_chromium_mime_encoding_rules() {
+async fn network_get_response_body_uses_chromium_mime_encoding_rules() {
     std::env::set_var("OBSCURA_ALLOW_PRIVATE_NETWORK", "1");
     let base = serve_binary_fetch().await;
     let mut ctx = CdpContext::new();
@@ -367,6 +370,62 @@ async fn js_fetch_get_response_body_uses_chromium_mime_encoding_rules() {
     )
     .await;
     assert_eq!(legacy_css, json!({"body": "ÿ", "base64Encoded": false}));
+
+    let gbk_id = response_request_id(&ctx, "/gbk.txt").expect("GBK text response");
+    let gbk = cdp(
+        &mut ctx,
+        11,
+        "Network.getResponseBody",
+        json!({"requestId": gbk_id}),
+        session_id,
+    )
+    .await;
+    assert_eq!(gbk, json!({"body": "中文", "base64Encoded": false}));
+
+    let navigated = cdp(
+        &mut ctx,
+        12,
+        "Page.navigate",
+        json!({"url": format!("{base}gbk.txt")}),
+        session_id,
+    )
+    .await;
+    let loader_id = navigated["loaderId"].as_str().unwrap();
+    let document_gbk = cdp(
+        &mut ctx,
+        13,
+        "Network.getResponseBody",
+        json!({"requestId": loader_id}),
+        session_id,
+    )
+    .await;
+    assert_eq!(
+        document_gbk,
+        json!({"body": "中文", "base64Encoded": false}),
+    );
+
+    let navigated = cdp(
+        &mut ctx,
+        14,
+        "Page.navigate",
+        json!({"url": format!("{base}bytes.bin")}),
+        session_id,
+    )
+    .await;
+    let loader_id = navigated["loaderId"].as_str().unwrap();
+    let document_binary = cdp(
+        &mut ctx,
+        15,
+        "Network.getResponseBody",
+        json!({"requestId": loader_id}),
+        session_id,
+    )
+    .await;
+    assert_eq!(document_binary["base64Encoded"], true);
+    assert_eq!(
+        BASE64.decode(document_binary["body"].as_str().unwrap()).unwrap(),
+        (0u8..=255).collect::<Vec<_>>(),
+    );
 }
 
 #[tokio::test(flavor = "current_thread")]

--- a/crates/obscura-cdp/tests/js_fetch_emits_network_events.rs
+++ b/crates/obscura-cdp/tests/js_fetch_emits_network_events.rs
@@ -7,6 +7,7 @@
 
 use obscura_cdp::dispatch::{dispatch, CdpContext};
 use obscura_cdp::types::CdpRequest;
+use base64::{engine::general_purpose::STANDARD as BASE64, Engine as _};
 use serde_json::{json, Value};
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::net::TcpListener;
@@ -51,6 +52,68 @@ window.__done = new Promise(function (resolve) {
                     body.len()
                 );
                 let _ = socket.write_all(resp.as_bytes()).await;
+            });
+        }
+    });
+    format!("http://{addr}/")
+}
+
+async fn serve_binary_fetch() -> String {
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    tokio::spawn(async move {
+        for _ in 0..16 {
+            let (mut socket, _) = listener.accept().await.unwrap();
+            tokio::spawn(async move {
+                let mut buf = [0u8; 2048];
+                let n = socket.read(&mut buf).await.unwrap_or(0);
+                let request = String::from_utf8_lossy(&buf[..n]);
+                let (content_type, body): (Option<&str>, Vec<u8>) = if request.starts_with("GET /bytes.bin") {
+                    (Some("application/octet-stream"), (0u8..=255).collect())
+                } else if request.starts_with("GET /ascii.bin") {
+                    (Some("application/octet-stream"), b"ABC".to_vec())
+                } else if request.starts_with("GET /invalid.txt") {
+                    (Some("text/plain"), vec![0xff])
+                } else if request.starts_with("GET /win1252.txt") {
+                    (Some("text/plain; charset=windows-1252"), vec![0x80])
+                } else if request.starts_with("GET /invalid.json") {
+                    (Some("application/json"), vec![0xff])
+                } else if request.starts_with("GET /legacy.js") {
+                    (Some("application/x-javascript"), b"legacy()".to_vec())
+                } else if request.starts_with("GET /legacy.css") {
+                    (Some("text/css"), vec![0xff])
+                } else if request.starts_with("GET /no-type") {
+                    (None, vec![0xff])
+                } else if request.starts_with("GET /empty.json") {
+                    (Some("application/json"), Vec::new())
+                } else if request.starts_with("GET /empty-no-type") {
+                    (None, Vec::new())
+                } else {
+                    (
+                        Some("text/html"),
+                        br#"<script>Promise.all([
+                          fetch('/bytes.bin').then(r => r.arrayBuffer()),
+                          fetch('/ascii.bin').then(r => r.arrayBuffer()),
+                          fetch('/invalid.txt').then(r => r.text()),
+                          fetch('/win1252.txt').then(r => r.text()),
+                          fetch('/invalid.json').then(r => r.arrayBuffer()),
+                          fetch('/legacy.js').then(r => r.text()),
+                          fetch('/legacy.css').then(r => r.text()),
+                          fetch('/no-type').then(r => r.arrayBuffer()),
+                          fetch('/empty.json').then(r => r.text()),
+                          fetch('/empty-no-type').then(r => r.text())
+                        ]).then(() => { globalThis.__done = true; });</script>"#.to_vec(),
+                    )
+                };
+                let content_type = content_type
+                    .map(|value| format!("Content-Type: {value}\r\n"))
+                    .unwrap_or_default();
+                let header = format!(
+                    "HTTP/1.1 200 OK\r\n{content_type}Content-Length: {}\r\nConnection: close\r\n\r\n",
+                    body.len(),
+                );
+                let _ = socket.write_all(header.as_bytes()).await;
+                let _ = socket.write_all(&body).await;
             });
         }
     });
@@ -151,6 +214,200 @@ async fn js_fetch_emits_network_request_and_response() {
         Some("{\"value\":42}"),
         "Network.getResponseBody must return the script-fetched JSON"
     );
+    assert_eq!(body.get("base64Encoded"), Some(&json!(false)));
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn js_fetch_get_response_body_preserves_binary_bytes() {
+    std::env::set_var("OBSCURA_ALLOW_PRIVATE_NETWORK", "1");
+    let base = serve_binary_fetch().await;
+    let mut ctx = CdpContext::new();
+    let page_id = ctx.create_page();
+    let session_id = "session-1";
+    ctx.sessions.insert(session_id.to_string(), page_id);
+
+    cdp(
+        &mut ctx,
+        1,
+        "Page.navigate",
+        json!({"url": base, "waitUntil": "networkidle0"}),
+        session_id,
+    )
+    .await;
+
+    let request_id = response_request_id(&ctx, "/bytes.bin")
+        .expect("binary fetch must emit a response with a requestId");
+    let body = cdp(
+        &mut ctx,
+        2,
+        "Network.getResponseBody",
+        json!({"requestId": request_id}),
+        session_id,
+    )
+    .await;
+    assert_eq!(body.get("base64Encoded"), Some(&json!(true)));
+    let encoded = body.get("body").and_then(Value::as_str).expect("response body");
+    assert_eq!(BASE64.decode(encoded).unwrap(), (0u8..=255).collect::<Vec<_>>());
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn js_fetch_get_response_body_uses_chromium_mime_encoding_rules() {
+    std::env::set_var("OBSCURA_ALLOW_PRIVATE_NETWORK", "1");
+    let base = serve_binary_fetch().await;
+    let mut ctx = CdpContext::new();
+    let page_id = ctx.create_page();
+    let session_id = "session-1";
+    ctx.sessions.insert(session_id.to_string(), page_id);
+
+    cdp(
+        &mut ctx,
+        1,
+        "Page.navigate",
+        json!({"url": base, "waitUntil": "networkidle0"}),
+        session_id,
+    )
+    .await;
+
+    let ascii_id = response_request_id(&ctx, "/ascii.bin").expect("ASCII binary response");
+    let ascii = cdp(
+        &mut ctx,
+        2,
+        "Network.getResponseBody",
+        json!({"requestId": ascii_id}),
+        session_id,
+    )
+    .await;
+    assert_eq!(ascii, json!({"body": "QUJD", "base64Encoded": true}));
+
+    let text_id = response_request_id(&ctx, "/invalid.txt").expect("invalid text response");
+    let text = cdp(
+        &mut ctx,
+        3,
+        "Network.getResponseBody",
+        json!({"requestId": text_id}),
+        session_id,
+    )
+    .await;
+    assert_eq!(text, json!({"body": "ÿ", "base64Encoded": false}));
+
+    let windows_id = response_request_id(&ctx, "/win1252.txt").expect("windows-1252 response");
+    let windows = cdp(
+        &mut ctx,
+        4,
+        "Network.getResponseBody",
+        json!({"requestId": windows_id}),
+        session_id,
+    )
+    .await;
+    assert_eq!(windows, json!({"body": "€", "base64Encoded": false}));
+
+    let invalid_json_id = response_request_id(&ctx, "/invalid.json").expect("invalid JSON");
+    let invalid_json = cdp(
+        &mut ctx,
+        5,
+        "Network.getResponseBody",
+        json!({"requestId": invalid_json_id}),
+        session_id,
+    )
+    .await;
+    assert_eq!(invalid_json, json!({"body": "/w==", "base64Encoded": true}));
+
+    let legacy_id = response_request_id(&ctx, "/legacy.js").expect("legacy JavaScript MIME");
+    let legacy = cdp(
+        &mut ctx,
+        6,
+        "Network.getResponseBody",
+        json!({"requestId": legacy_id}),
+        session_id,
+    )
+    .await;
+    assert_eq!(legacy, json!({"body": "legacy()", "base64Encoded": false}));
+
+    let missing_id = response_request_id(&ctx, "/no-type").expect("missing MIME response");
+    let missing = cdp(
+        &mut ctx,
+        7,
+        "Network.getResponseBody",
+        json!({"requestId": missing_id}),
+        session_id,
+    )
+    .await;
+    assert_eq!(missing, json!({"body": "/w==", "base64Encoded": true}));
+
+    let empty_id = response_request_id(&ctx, "/empty.json").expect("empty JSON response");
+    let empty = cdp(
+        &mut ctx,
+        8,
+        "Network.getResponseBody",
+        json!({"requestId": empty_id}),
+        session_id,
+    )
+    .await;
+    assert_eq!(empty, json!({"body": "", "base64Encoded": false}));
+
+    let empty_no_type_id = response_request_id(&ctx, "/empty-no-type")
+        .expect("empty response without MIME type");
+    let empty_no_type = cdp(
+        &mut ctx,
+        9,
+        "Network.getResponseBody",
+        json!({"requestId": empty_no_type_id}),
+        session_id,
+    )
+    .await;
+    assert_eq!(empty_no_type, json!({"body": "", "base64Encoded": false}));
+
+    let legacy_css_id = response_request_id(&ctx, "/legacy.css").expect("legacy CSS text MIME");
+    let legacy_css = cdp(
+        &mut ctx,
+        10,
+        "Network.getResponseBody",
+        json!({"requestId": legacy_css_id}),
+        session_id,
+    )
+    .await;
+    assert_eq!(legacy_css, json!({"body": "ÿ", "base64Encoded": false}));
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn binary_fetch_response_stream_preserves_original_bytes() {
+    std::env::set_var("OBSCURA_ALLOW_PRIVATE_NETWORK", "1");
+    let base = serve_binary_fetch().await;
+    let mut ctx = CdpContext::new();
+    let page_id = ctx.create_page();
+    let session_id = "session-1";
+    ctx.sessions.insert(session_id.to_string(), page_id);
+
+    cdp(
+        &mut ctx,
+        1,
+        "Page.navigate",
+        json!({"url": base, "waitUntil": "networkidle0"}),
+        session_id,
+    )
+    .await;
+    let request_id = response_request_id(&ctx, "/bytes.bin").expect("binary response");
+    let stream = cdp(
+        &mut ctx,
+        2,
+        "Fetch.takeResponseBodyAsStream",
+        json!({"requestId": request_id}),
+        session_id,
+    )
+    .await;
+    let handle = stream.get("stream").and_then(Value::as_str).expect("stream handle");
+    let read = cdp(
+        &mut ctx,
+        3,
+        "IO.read",
+        json!({"handle": handle, "size": 512}),
+        session_id,
+    )
+    .await;
+    assert_eq!(read.get("eof"), Some(&json!(true)));
+    assert_eq!(read.get("base64Encoded"), Some(&json!(true)));
+    let encoded = read.get("data").and_then(Value::as_str).expect("stream data");
+    assert_eq!(BASE64.decode(encoded).unwrap(), (0u8..=255).collect::<Vec<_>>());
 }
 
 #[tokio::test(flavor = "current_thread")]

--- a/crates/obscura-js/src/ops.rs
+++ b/crates/obscura-js/src/ops.rs
@@ -65,6 +65,104 @@ pub struct StoredNetworkResponseBody {
     pub base64_encoded: bool,
 }
 
+fn stored_network_response_body(
+    body: &[u8],
+    content_type: Option<&str>,
+    body_base64: &str,
+) -> StoredNetworkResponseBody {
+    if let Some(body) = decode_devtools_response_body(body, content_type) {
+        StoredNetworkResponseBody {
+            body,
+            base64_encoded: false,
+        }
+    } else {
+        StoredNetworkResponseBody {
+            body: body_base64.to_string(),
+            base64_encoded: true,
+        }
+    }
+}
+
+/// Apply Chromium's CDP response-body text policy without exposing it through
+/// obscura-net's public API. A body is text only when its MIME type has a text
+/// decoder and decoding is lossless; otherwise CDP returns the original bytes
+/// as base64. Empty bodies are textual even when Content-Type is absent.
+fn decode_devtools_response_body(body: &[u8], content_type: Option<&str>) -> Option<String> {
+    if body.is_empty() {
+        return Some(String::new());
+    }
+
+    let content_type = content_type?;
+    let mime = content_type
+        .split(';')
+        .next()
+        .unwrap_or(content_type)
+        .trim()
+        .to_ascii_lowercase();
+    let decoder = devtools_text_decoder(&mime)?;
+
+    let explicit_charset = content_type.split(';').skip(1).find_map(|parameter| {
+        let (name, value) = parameter.split_once('=')?;
+        if !name.trim().eq_ignore_ascii_case("charset") {
+            return None;
+        }
+        let value = value.trim().trim_matches(|c| c == '"' || c == '\'');
+        (!value.is_empty()).then_some(value)
+    });
+    let encoding = if let Some(charset) = explicit_charset {
+        charset
+    } else if matches!(decoder, DevtoolsTextDecoder::Html) {
+        obscura_net::encoding::detect_encoding(body, Some(content_type)).0.name()
+    } else if matches!(decoder, DevtoolsTextDecoder::Utf8) {
+        "utf-8"
+    } else {
+        // Chromium classifies the remaining text/* family as plain text and
+        // defaults it to ISO-8859-1, whose WHATWG decoder is Windows-1252.
+        "windows-1252"
+    };
+    obscura_net::decode_with_label(encoding, body, true, false)
+}
+
+#[derive(Clone, Copy)]
+enum DevtoolsTextDecoder {
+    Html,
+    Utf8,
+    Plain,
+}
+
+fn devtools_text_decoder(mime: &str) -> Option<DevtoolsTextDecoder> {
+    if mime == "text/html" {
+        return Some(DevtoolsTextDecoder::Html);
+    }
+    if matches!(
+        mime,
+        "application/javascript"
+            | "application/ecmascript"
+            | "application/x-ecmascript"
+            | "application/x-javascript"
+            | "text/ecmascript"
+            | "text/javascript"
+            | "text/javascript1.0"
+            | "text/javascript1.1"
+            | "text/javascript1.2"
+            | "text/javascript1.3"
+            | "text/javascript1.4"
+            | "text/javascript1.5"
+            | "text/jscript"
+            | "text/livescript"
+            | "text/x-ecmascript"
+            | "text/x-javascript"
+    ) || matches!(mime, "application/json" | "text/json")
+        || mime.ends_with("+json")
+        || matches!(mime, "application/xml" | "text/xml")
+        || (mime.starts_with("application/") && mime.ends_with("+xml"))
+    {
+        return Some(DevtoolsTextDecoder::Utf8);
+    }
+    (mime.starts_with("text/") && mime != "text/xsl")
+        .then_some(DevtoolsTextDecoder::Plain)
+}
+
 /// A network request made from page JS (fetch()/XHR/dynamic resource) recorded
 /// so the CDP layer can emit Network.requestWillBeSent / responseReceived for
 /// it. Static navigation subresources go through Page::record_network_event;
@@ -2804,10 +2902,11 @@ async fn op_fetch_url(
         if max_entries > 0 && max_bytes > 0 && resp_bytes.len() <= max_bytes {
             gs.network_response_bodies.insert(
                 request_id.clone(),
-                StoredNetworkResponseBody {
-                    body: resp_body.clone(),
-                    base64_encoded: false,
-                },
+                stored_network_response_body(
+                    &resp_bytes,
+                    resp_headers.get("content-type").map(String::as_str),
+                    &resp_body_base64,
+                ),
             );
             gs.network_response_body_order.push_back(request_id.clone());
             while gs.network_response_body_order.len() > max_entries {
@@ -3057,7 +3156,10 @@ fn glob_match(pattern: &str, url: &str) -> bool {
 
 #[cfg(test)]
 mod tests {
-    use super::{cors_response_allows, glob_match, validate_fetch_url, FetchCredentials};
+    use super::{
+        cors_response_allows, decode_devtools_response_body, glob_match, validate_fetch_url,
+        FetchCredentials,
+    };
     use crate::runtime::ObscuraJsRuntime;
     use obscura_dom::parse_html;
 
@@ -3072,6 +3174,58 @@ mod tests {
 
     use super::read_body_capped;
     use super::{pbkdf2_derive, PBKDF2_MAX_ITERATIONS, PBKDF2_MAX_OUTPUT_BYTES};
+
+    #[test]
+    fn devtools_body_matches_chromium_text_decoding_boundaries() {
+        assert_eq!(decode_devtools_response_body(b"", None), Some(String::new()));
+        assert_eq!(decode_devtools_response_body(b"ABC", None), None);
+        assert_eq!(
+            decode_devtools_response_body(b"ABC", Some("application/octet-stream")),
+            None,
+        );
+        assert_eq!(
+            decode_devtools_response_body(&[0xff], Some("text/plain")),
+            Some("ÿ".to_string()),
+        );
+        assert_eq!(
+            decode_devtools_response_body(&[0xff], Some("application/json")),
+            None,
+        );
+        assert_eq!(
+            decode_devtools_response_body(&[0x80], Some("text/plain; charset=windows-1252")),
+            Some("€".to_string()),
+        );
+        assert_eq!(
+            decode_devtools_response_body(&[0xff], Some("text/css")),
+            Some("ÿ".to_string()),
+        );
+        assert_eq!(
+            decode_devtools_response_body(&[0xff], Some("text/javascript")),
+            None,
+        );
+        for content_type in [
+            "application/x-ecmascript",
+            "text/javascript1.5",
+            "text/json",
+        ] {
+            assert_eq!(
+                decode_devtools_response_body(&[0xff], Some(content_type)),
+                None,
+                "{content_type} must use Chromium's UTF-8 decoder",
+            );
+        }
+        assert_eq!(
+            decode_devtools_response_body(b"<html/>", Some("application/xhtml+xml")),
+            Some("<html/>".to_string()),
+        );
+        for content_type in ["image/svg+xml", "text/xsl", "foo/bar+xml"] {
+            assert_eq!(
+                decode_devtools_response_body(b"<xml/>", Some(content_type)),
+                None,
+                "{content_type} has no Chromium raw-resource text decoder",
+            );
+        }
+    }
 
     // SEC-006 / #580 — PBKDF2 parameters arrive straight from page JS. Without
     // caps, a huge iteration count pins the single-threaded runtime and a huge

--- a/crates/obscura-js/src/ops.rs
+++ b/crates/obscura-js/src/ops.rs
@@ -86,13 +86,15 @@ fn stored_network_response_body(
 /// Apply Chromium's CDP response-body text policy without exposing it through
 /// obscura-net's public API. A body is text only when its MIME type has a text
 /// decoder and decoding is lossless; otherwise CDP returns the original bytes
-/// as base64. Empty bodies are textual even when Content-Type is absent.
+/// as base64. Chromium treats a missing Content-Type as Windows-1252 text.
 fn decode_devtools_response_body(body: &[u8], content_type: Option<&str>) -> Option<String> {
     if body.is_empty() {
         return Some(String::new());
     }
 
-    let content_type = content_type?;
+    let Some(content_type) = content_type else {
+        return obscura_net::decode_with_label("windows-1252", body, true, false);
+    };
     let mime = content_type
         .split(';')
         .next()
@@ -3178,7 +3180,10 @@ mod tests {
     #[test]
     fn devtools_body_matches_chromium_text_decoding_boundaries() {
         assert_eq!(decode_devtools_response_body(b"", None), Some(String::new()));
-        assert_eq!(decode_devtools_response_body(b"ABC", None), None);
+        assert_eq!(
+            decode_devtools_response_body(&[0x81, 0x8d], None),
+            Some("\u{81}\u{8d}".to_string()),
+        );
         assert_eq!(
             decode_devtools_response_body(b"ABC", Some("application/octet-stream")),
             None,

--- a/crates/obscura-js/src/ops.rs
+++ b/crates/obscura-js/src/ops.rs
@@ -86,13 +86,15 @@ fn stored_network_response_body(
 /// Apply Chromium's CDP response-body text policy without exposing it through
 /// obscura-net's public API. A body is text only when its MIME type has a text
 /// decoder and decoding is lossless; otherwise CDP returns the original bytes
-/// as base64. Empty bodies are textual even when Content-Type is absent.
+/// as base64. Chromium treats a missing Content-Type as Windows-1252 text.
 fn decode_devtools_response_body(body: &[u8], content_type: Option<&str>) -> Option<String> {
     if body.is_empty() {
         return Some(String::new());
     }
 
-    let content_type = content_type?;
+    let Some(content_type) = content_type else {
+        return obscura_net::decode_with_label("windows-1252", body, true, false);
+    };
     let mime = content_type
         .split(';')
         .next()
@@ -3239,7 +3241,10 @@ mod tests {
     #[test]
     fn devtools_body_matches_chromium_text_decoding_boundaries() {
         assert_eq!(decode_devtools_response_body(b"", None), Some(String::new()));
-        assert_eq!(decode_devtools_response_body(b"ABC", None), None);
+        assert_eq!(
+            decode_devtools_response_body(&[0x81, 0x8d], None),
+            Some("\u{81}\u{8d}".to_string()),
+        );
         assert_eq!(
             decode_devtools_response_body(b"ABC", Some("application/octet-stream")),
             None,

--- a/crates/obscura-js/src/ops.rs
+++ b/crates/obscura-js/src/ops.rs
@@ -65,6 +65,104 @@ pub struct StoredNetworkResponseBody {
     pub base64_encoded: bool,
 }
 
+fn stored_network_response_body(
+    body: &[u8],
+    content_type: Option<&str>,
+    body_base64: &str,
+) -> StoredNetworkResponseBody {
+    if let Some(body) = decode_devtools_response_body(body, content_type) {
+        StoredNetworkResponseBody {
+            body,
+            base64_encoded: false,
+        }
+    } else {
+        StoredNetworkResponseBody {
+            body: body_base64.to_string(),
+            base64_encoded: true,
+        }
+    }
+}
+
+/// Apply Chromium's CDP response-body text policy without exposing it through
+/// obscura-net's public API. A body is text only when its MIME type has a text
+/// decoder and decoding is lossless; otherwise CDP returns the original bytes
+/// as base64. Empty bodies are textual even when Content-Type is absent.
+fn decode_devtools_response_body(body: &[u8], content_type: Option<&str>) -> Option<String> {
+    if body.is_empty() {
+        return Some(String::new());
+    }
+
+    let content_type = content_type?;
+    let mime = content_type
+        .split(';')
+        .next()
+        .unwrap_or(content_type)
+        .trim()
+        .to_ascii_lowercase();
+    let decoder = devtools_text_decoder(&mime)?;
+
+    let explicit_charset = content_type.split(';').skip(1).find_map(|parameter| {
+        let (name, value) = parameter.split_once('=')?;
+        if !name.trim().eq_ignore_ascii_case("charset") {
+            return None;
+        }
+        let value = value.trim().trim_matches(|c| c == '"' || c == '\'');
+        (!value.is_empty()).then_some(value)
+    });
+    let encoding = if let Some(charset) = explicit_charset {
+        charset
+    } else if matches!(decoder, DevtoolsTextDecoder::Html) {
+        obscura_net::encoding::detect_encoding(body, Some(content_type)).0.name()
+    } else if matches!(decoder, DevtoolsTextDecoder::Utf8) {
+        "utf-8"
+    } else {
+        // Chromium classifies the remaining text/* family as plain text and
+        // defaults it to ISO-8859-1, whose WHATWG decoder is Windows-1252.
+        "windows-1252"
+    };
+    obscura_net::decode_with_label(encoding, body, true, false)
+}
+
+#[derive(Clone, Copy)]
+enum DevtoolsTextDecoder {
+    Html,
+    Utf8,
+    Plain,
+}
+
+fn devtools_text_decoder(mime: &str) -> Option<DevtoolsTextDecoder> {
+    if mime == "text/html" {
+        return Some(DevtoolsTextDecoder::Html);
+    }
+    if matches!(
+        mime,
+        "application/javascript"
+            | "application/ecmascript"
+            | "application/x-ecmascript"
+            | "application/x-javascript"
+            | "text/ecmascript"
+            | "text/javascript"
+            | "text/javascript1.0"
+            | "text/javascript1.1"
+            | "text/javascript1.2"
+            | "text/javascript1.3"
+            | "text/javascript1.4"
+            | "text/javascript1.5"
+            | "text/jscript"
+            | "text/livescript"
+            | "text/x-ecmascript"
+            | "text/x-javascript"
+    ) || matches!(mime, "application/json" | "text/json")
+        || mime.ends_with("+json")
+        || matches!(mime, "application/xml" | "text/xml")
+        || (mime.starts_with("application/") && mime.ends_with("+xml"))
+    {
+        return Some(DevtoolsTextDecoder::Utf8);
+    }
+    (mime.starts_with("text/") && mime != "text/xsl")
+        .then_some(DevtoolsTextDecoder::Plain)
+}
+
 /// A network request made from page JS (fetch()/XHR/dynamic resource) recorded
 /// so the CDP layer can emit Network.requestWillBeSent / responseReceived for
 /// it. Static navigation subresources go through Page::record_network_event;
@@ -2831,10 +2929,11 @@ async fn op_fetch_url(
         if max_entries > 0 && max_bytes > 0 && resp_bytes.len() <= max_bytes {
             gs.network_response_bodies.insert(
                 request_id.clone(),
-                StoredNetworkResponseBody {
-                    body: resp_body.clone(),
-                    base64_encoded: false,
-                },
+                stored_network_response_body(
+                    &resp_bytes,
+                    resp_headers.get("content-type").map(String::as_str),
+                    &resp_body_base64,
+                ),
             );
             gs.network_response_body_order.push_back(request_id.clone());
             while gs.network_response_body_order.len() > max_entries {
@@ -3102,7 +3201,8 @@ fn glob_match(pattern: &str, url: &str) -> bool {
 #[cfg(test)]
 mod tests {
     use super::{
-        cors_response_allows, glob_match, validate_fetch_url, FetchCredentials, ObscuraState,
+        cors_response_allows, decode_devtools_response_body, glob_match, validate_fetch_url,
+        FetchCredentials, ObscuraState,
     };
     use crate::runtime::ObscuraJsRuntime;
     use obscura_dom::parse_html;
@@ -3134,6 +3234,58 @@ mod tests {
             vec!["u6", "u7", "u8", "u9"],
             "the newest entries must be kept, oldest evicted",
         );
+    }
+
+    #[test]
+    fn devtools_body_matches_chromium_text_decoding_boundaries() {
+        assert_eq!(decode_devtools_response_body(b"", None), Some(String::new()));
+        assert_eq!(decode_devtools_response_body(b"ABC", None), None);
+        assert_eq!(
+            decode_devtools_response_body(b"ABC", Some("application/octet-stream")),
+            None,
+        );
+        assert_eq!(
+            decode_devtools_response_body(&[0xff], Some("text/plain")),
+            Some("ÿ".to_string()),
+        );
+        assert_eq!(
+            decode_devtools_response_body(&[0xff], Some("application/json")),
+            None,
+        );
+        assert_eq!(
+            decode_devtools_response_body(&[0x80], Some("text/plain; charset=windows-1252")),
+            Some("€".to_string()),
+        );
+        assert_eq!(
+            decode_devtools_response_body(&[0xff], Some("text/css")),
+            Some("ÿ".to_string()),
+        );
+        assert_eq!(
+            decode_devtools_response_body(&[0xff], Some("text/javascript")),
+            None,
+        );
+        for content_type in [
+            "application/x-ecmascript",
+            "text/javascript1.5",
+            "text/json",
+        ] {
+            assert_eq!(
+                decode_devtools_response_body(&[0xff], Some(content_type)),
+                None,
+                "{content_type} must use Chromium's UTF-8 decoder",
+            );
+        }
+        assert_eq!(
+            decode_devtools_response_body(b"<html/>", Some("application/xhtml+xml")),
+            Some("<html/>".to_string()),
+        );
+        for content_type in ["image/svg+xml", "text/xsl", "foo/bar+xml"] {
+            assert_eq!(
+                decode_devtools_response_body(b"<xml/>", Some(content_type)),
+                None,
+                "{content_type} has no Chromium raw-resource text decoder",
+            );
+        }
     }
 
     // SEC-006 / #580 — PBKDF2 parameters arrive straight from page JS. Without

--- a/crates/obscura-net/src/encoding.rs
+++ b/crates/obscura-net/src/encoding.rs
@@ -33,7 +33,8 @@ pub fn decode_with_label(label: &str, bytes: &[u8], fatal: bool, ignore_bom: boo
         enc.new_decoder()
     };
     if fatal {
-        let mut out = String::with_capacity(bytes.len() + 1);
+        let capacity = dec.max_utf8_buffer_length_without_replacement(bytes.len())?;
+        let mut out = String::with_capacity(capacity);
         let (res, _) = dec.decode_to_string_without_replacement(bytes, &mut out, true);
         match res {
             DecoderResult::InputEmpty => Some(out),


### PR DESCRIPTION
## What changed

- preserve binary JavaScript fetch response bodies for CDP Network events
- apply Chromium-compatible charset decoding to main-document response bodies
- return opaque or non-decodable bodies through `Network.getResponseBody` with `base64Encoded: true`
- retain request-ID correlation through response and body lookup
- leave XHR response decoding to the separate #755 change

Chromium returns recognized non-UTF-8 text, including GBK, as decoded Unicode with `base64Encoded: false`. This branch follows that boundary instead of treating every non-UTF-8 byte sequence as binary.

This is required by the Obscura 0.2.1 Google Flights, CDP, and Booking report and is a follow-up to #394. It does not close #394 because the live Aviasales selection response and readable-body gate has not passed.

## Validation

- browser release nextest: 81/81 passed
- affected CDP network/body release nextest: 5/5 passed
- full workspace release nextest: 1552 passed, 3 failed, 4 skipped
  - the robots timeout reproduced unchanged at the original PR head
  - the MCP snapshot test passed on rerun and at the original PR head
  - the intersection observer test passed in isolation and is covered by prerequisite #786
- all four documented release builds passed
- obstacle course at this head: 32/33, only `observer-intersection` failed
- obstacle course with prerequisite #786 applied in a disposable integration worktree: 33/33
- independent correctness and KISS/duality reviews: passed

## Performance

Interleaved release runs used identical local documents and discarded warmups. The repository noise band is +/-10%.

- UTF-8 fast path: CPU unchanged; median latency 92.661 to 83.123 ms; peak RSS 29.594 to 29.930 MiB (+1.1%)
- opaque invalid-UTF-8 path: CPU unchanged; median latency 77.968 to 80.168 ms (+2.8%); peak RSS 27.875 to 27.547 MiB (-1.2%)
- GBK document: the candidate completed with 27.578 MiB median peak RSS; the original PR head timed out on the same deterministic fixture, so no like-for-like latency ratio is reported

The response-store entry and raw-byte caps are checked before decoding or base64 allocation. Store capacity and ownership are unchanged.

## Rendering

Not applicable. This does not change layout, paint, screenshots, screencast, or PDF output.

## Checklist

- [x] The change is focused and does not remove existing behavior without justification.
- [x] Tests cover the failure and Chromium boundary behavior.
- [x] Render, stealth, and no-default build configurations pass.
- [x] CPU, latency, and memory were compared against the original PR head.
- [x] No public Rust API changed.
