### PR TITLE
fix(js): reflect HTMLInputElement.accept content attribute

### DIFF
--- a/crates/obscura-browser/tests/input_accept.rs
+++ b/crates/obscura-browser/tests/input_accept.rs
@@ -1,0 +1,41 @@
+use std::sync::Arc;
+
+use obscura_browser::{BrowserContext, Page};
+
+#[tokio::test(flavor = "current_thread")]
+async fn input_accept_reflects_the_content_attribute() {
+    let context = Arc::new(BrowserContext::with_storage_and_network(
+        "input-accept".to_owned(),
+        None,
+        false,
+        None,
+        None,
+        true,
+    ));
+    let mut page = Page::new("input-accept-page".to_owned(), context);
+    page.navigate("data:text/html,<input id=upload type=file accept='image/png,image/jpeg'>")
+        .await
+        .unwrap();
+
+    assert_eq!(
+        page.evaluate(
+            r#"
+            (() => {
+                const input = document.getElementById('upload');
+                const initial = input.accept;
+                input.accept = 'image/webp';
+                return {
+                    initial,
+                    property: input.accept,
+                    attribute: input.getAttribute('accept'),
+                };
+            })()
+            "#,
+        ),
+        serde_json::json!({
+            "initial": "image/png,image/jpeg",
+            "property": "image/webp",
+            "attribute": "image/webp",
+        })
+    );
+}

--- a/crates/obscura-js/js/bootstrap.js
+++ b/crates/obscura-js/js/bootstrap.js
@@ -4055,6 +4055,8 @@ class Element extends Node {
   set name(v) { this.setAttribute("name", v); }
   get placeholder() { return this.getAttribute("placeholder") || ""; }
   set placeholder(v) { this.setAttribute("placeholder", v); }
+  get accept() { return this.getAttribute("accept") || ""; }
+  set accept(v) { this.setAttribute("accept", v); }
   // For <a>/<area>, href returns the resolved absolute URL (the spec behavior,
   // and what scrapers want). It uses op_url_resolve, which returns just the
   // resolved string, rather than the full-component op the decomposition


### PR DESCRIPTION
## Problem

`HTMLInputElement.accept` was missing from the DOM shim. File inputs could expose an `accept` content attribute while the corresponding IDL property was undefined, and assigning the property did not update the attribute.

## Fix

- add `Element.accept` getter and setter using the existing attribute reflection path
- cover initial attribute reflection and setter-to-attribute synchronization with a browser integration test

Fixes #795.

## Validation

- `cargo nextest run --offline -p obscura-browser --test input_accept`
- result: 1 passed

The change is limited to the JavaScript DOM shim and its focused business-behavior test.
