### PR TITLE
fix(cdp): stream navigation lifecycle after DOMContentLoaded

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1901,6 +1901,7 @@ dependencies = [
  "tokio",
  "tokio-tungstenite",
  "tracing",
+ "tracing-subscriber",
  "url",
  "uuid",
 ]

--- a/crates/obscura-browser/Cargo.toml
+++ b/crates/obscura-browser/Cargo.toml
@@ -7,6 +7,8 @@ repository.workspace = true
 
 [features]
 default = []
+# Unstable bridge used only by obscura-cdp; not part of the embeddable API.
+internal-cdp = ["obscura-js/internal-cdp"]
 stealth = ["obscura-net/stealth", "obscura-js/stealth"]
 render = ["obscura-js/render", "dep:image"]
 

--- a/crates/obscura-browser/src/lib.rs
+++ b/crates/obscura-browser/src/lib.rs
@@ -1,6 +1,9 @@
 pub mod context;
 mod fork_virtual_url;
 pub mod lifecycle;
+#[cfg(feature = "internal-cdp")]
+#[doc(hidden)]
+pub mod navigation;
 pub mod page;
 #[cfg(feature = "render")]
 pub mod pdf;

--- a/crates/obscura-browser/src/navigation.rs
+++ b/crates/obscura-browser/src/navigation.rs
@@ -1,0 +1,195 @@
+use std::sync::{
+    atomic::{AtomicBool, Ordering},
+    Arc, Mutex,
+};
+
+use obscura_js::runtime::IsolateHandle;
+
+struct RegisteredIsolate {
+    generation: u64,
+    handle: IsolateHandle,
+}
+
+struct IsolateSlot {
+    next_generation: u64,
+    registered: Option<RegisteredIsolate>,
+}
+
+struct NavigationControlInner {
+    cancelled: AtomicBool,
+    isolate: Mutex<IsolateSlot>,
+    notify: tokio::sync::Notify,
+}
+
+/// Internal cancellation handle used by protocol navigation owners.
+///
+/// This is not part of the stable embeddable browser API. Cancellation is
+/// sticky: a runtime registered after cancellation is terminated immediately.
+#[doc(hidden)]
+#[derive(Clone)]
+pub struct NavigationControl {
+    inner: Arc<NavigationControlInner>,
+}
+
+impl NavigationControl {
+    #[doc(hidden)]
+    pub fn new() -> Self {
+        Self {
+            inner: Arc::new(NavigationControlInner {
+                cancelled: AtomicBool::new(false),
+                isolate: Mutex::new(IsolateSlot {
+                    next_generation: 0,
+                    registered: None,
+                }),
+                notify: tokio::sync::Notify::new(),
+            }),
+        }
+    }
+
+    #[doc(hidden)]
+    pub fn cancel(&self) {
+        let first = !self.inner.cancelled.swap(true, Ordering::AcqRel);
+        if first {
+            self.inner.notify.notify_waiters();
+        }
+        let slot = self
+            .inner
+            .isolate
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        // Keep registration, termination, and registration drop linearized.
+        // IsolateHandle::terminate_execution only requests termination; the
+        // owner thread unwinds and drops its registration after this returns.
+        if let Some(registered) = slot.registered.as_ref() {
+            registered.handle.terminate_execution();
+        }
+    }
+
+    #[doc(hidden)]
+    pub fn is_cancelled(&self) -> bool {
+        self.inner.cancelled.load(Ordering::Acquire)
+    }
+
+    #[doc(hidden)]
+    pub async fn cancelled(&self) {
+        let notified = self.inner.notify.notified();
+        tokio::pin!(notified);
+        // Register the waiter before checking the sticky bit, closing the gap
+        // between an AtomicBool check and Notify subscription.
+        notified.as_mut().enable();
+        if self.is_cancelled() {
+            return;
+        }
+        notified.await;
+    }
+
+    pub(crate) fn register_runtime(&self, handle: IsolateHandle) -> RuntimeRegistration {
+        let mut slot = self
+            .inner
+            .isolate
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        slot.next_generation = slot
+            .next_generation
+            .checked_add(1)
+            .expect("navigation isolate generation overflow");
+        let generation = slot.next_generation;
+        slot.registered = Some(RegisteredIsolate {
+            generation,
+            handle: handle.clone(),
+        });
+        if self.is_cancelled() {
+            handle.terminate_execution();
+        }
+        drop(slot);
+        RuntimeRegistration {
+            inner: self.inner.clone(),
+            generation,
+        }
+    }
+
+    #[cfg(test)]
+    fn registered_generation(&self) -> Option<u64> {
+        self.inner
+            .isolate
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .registered
+            .as_ref()
+            .map(|registered| registered.generation)
+    }
+}
+
+impl Default for NavigationControl {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+pub(crate) struct RuntimeRegistration {
+    inner: Arc<NavigationControlInner>,
+    generation: u64,
+}
+
+impl Drop for RuntimeRegistration {
+    fn drop(&mut self) {
+        let mut slot = self
+            .inner
+            .isolate
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        if slot
+            .registered
+            .as_ref()
+            .is_some_and(|registered| registered.generation == self.generation)
+        {
+            slot.registered = None;
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::NavigationControl;
+    use obscura_js::runtime::ObscuraJsRuntime;
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn cancellation_is_sticky_for_existing_and_late_waiters() {
+        let control = NavigationControl::new();
+        control.cancel();
+        control.cancel();
+        assert!(control.is_cancelled());
+        control.cancelled().await;
+    }
+
+    #[test]
+    fn cancellation_before_registration_terminates_the_runtime() {
+        let control = NavigationControl::new();
+        control.cancel();
+        let mut runtime = ObscuraJsRuntime::new();
+        let _registration = control.register_runtime(runtime.isolate_handle());
+        assert!(runtime.execute_script("<cancelled>", "globalThis.ran = true;").is_err());
+        runtime.cancel_termination();
+        assert!(runtime.execute_script("<recovered>", "globalThis.ran = true;").is_ok());
+    }
+
+    #[test]
+    fn stale_registration_cannot_clear_replacement() {
+        let control = NavigationControl::new();
+        let runtime_a = ObscuraJsRuntime::new();
+        let mut runtime_b = ObscuraJsRuntime::new();
+        let registration_a = control.register_runtime(runtime_a.isolate_handle());
+        let generation_a = control.registered_generation().unwrap();
+        let registration_b = control.register_runtime(runtime_b.isolate_handle());
+        let generation_b = control.registered_generation().unwrap();
+        assert!(generation_b > generation_a);
+        drop(registration_a);
+        assert_eq!(control.registered_generation(), Some(generation_b));
+        control.cancel();
+        control.cancel();
+        assert!(runtime_b.execute_script("<new>", "globalThis.newRan = true;").is_err());
+        runtime_b.cancel_termination();
+        drop(registration_b);
+        assert_eq!(control.registered_generation(), None);
+    }
+}

--- a/crates/obscura-browser/src/page.rs
+++ b/crates/obscura-browser/src/page.rs
@@ -14,7 +14,9 @@ use crate::context::BrowserContext;
 use crate::lifecycle::LifecycleState;
 
 const DOCUMENT_LOAD_TASK_TIMEOUT: &str =
-    "document load event task exceeded its one-second budget";
+    "document load event task exceeded its synchronous budget";
+const FINAL_DOCUMENT_LOAD_TASK_BUDGET: std::time::Duration =
+    std::time::Duration::from_secs(1);
 
 fn document_load_error_is_terminal(error: &str) -> bool {
     error == DOCUMENT_LOAD_TASK_TIMEOUT
@@ -2038,15 +2040,25 @@ impl Page {
             .ok()
             .and_then(|value| value.as_bool())
             .unwrap_or(false);
-        let watchdog = load_task_ready
-            .then(|| js.arm_watchdog(std::time::Duration::from_secs(1)));
+        if !load_task_ready {
+            // The autonomous pump arms its watchdog only while V8 is running
+            // and disarms it while the event loop is parked on timer/network
+            // I/O. Wrapping this whole await would both reject valid slow
+            // resources and churn one watchdog thread per 25 ms outer poll.
+            return js.run_autonomous_event_loop_turn().await;
+        }
+
+        // The final load task runs outside the ordinary autonomous queue, so
+        // retain its short synchronous V8 backstop here.
+        let watchdog = js.arm_watchdog(FINAL_DOCUMENT_LOAD_TASK_BUDGET);
         let result = js.run_load_delaying_event_loop_tick().await;
-        let watchdog_fired = watchdog.is_some_and(|token| js.disarm_watchdog(token));
+        let watchdog_fired = js.disarm_watchdog(watchdog);
         if watchdog_fired {
             js.cancel_termination();
-            return Err(DOCUMENT_LOAD_TASK_TIMEOUT.into());
+            Err(DOCUMENT_LOAD_TASK_TIMEOUT.into())
+        } else {
+            result
         }
-        result
     }
 
     fn capture_pending_replacement(&mut self) -> bool {
@@ -6552,6 +6564,61 @@ mod tests {
                 .unwrap(),
             serde_json::json!(false),
             "a terminated onload handler must not be reported as a completed load task",
+        );
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn post_dom_content_loaded_non_load_task_is_watchdog_bounded() {
+        let (base, _requests) = spawn_delayed_classic_script_server(
+            std::time::Duration::from_secs(10),
+            "globalThis.__slowDynamicRan = true;",
+        );
+        let html = format!(
+            "<html><body><script>\
+             globalThis.__lateLoadListener = false;\
+             const script = document.createElement('script');\
+             script.src = '{base}/slow.js';\
+             document.head.appendChild(script);\
+             setTimeout(() => {{ while (true) {{}} }}, 0);\
+             window.addEventListener('load', () => {{ globalThis.__lateLoadListener = true; }});\
+             </script></body></html>",
+        );
+        let mut page = import_map_test_page(
+            "bounded-post-dcl-task",
+            &format!("{base}/"),
+            &html,
+        );
+        page.execute_scripts_until_dom_content_loaded(None).await;
+        let js = page.js.as_mut().unwrap();
+        assert!(
+            js.has_pending_load_delaying_scripts(),
+            "the dynamic script must keep document load blocked",
+        );
+        assert_eq!(
+            js.evaluate("globalThis.__obscura_documentLoadTaskReady?.() === true")
+                .unwrap(),
+            serde_json::json!(false),
+            "the infinite timer must run through the non-final autonomous path",
+        );
+
+        tokio::time::timeout(
+            std::time::Duration::from_secs(7),
+            page.run_autonomous_event_loop_turn(),
+        )
+        .await
+        .expect("a post-DCL browser task escaped the synchronous watchdog")
+        .unwrap();
+
+        assert_eq!(page.lifecycle, super::LifecycleState::Failed);
+        assert!(page.pending_document_load.is_none());
+        assert_eq!(
+            page.js
+                .as_mut()
+                .unwrap()
+                .evaluate("globalThis.__lateLoadListener")
+                .unwrap(),
+            serde_json::json!(false),
+            "a terminated post-DCL task must not publish load",
         );
     }
 

--- a/crates/obscura-browser/src/page.rs
+++ b/crates/obscura-browser/src/page.rs
@@ -13,6 +13,14 @@ use url::Url;
 use crate::context::BrowserContext;
 use crate::lifecycle::LifecycleState;
 
+const DOCUMENT_LOAD_TASK_TIMEOUT: &str =
+    "document load event task exceeded its one-second budget";
+
+fn document_load_error_is_terminal(error: &str) -> bool {
+    error == DOCUMENT_LOAD_TASK_TIMEOUT
+        || obscura_js::runtime::is_fatal_event_loop_error(error)
+}
+
 /// Parse `OBSCURA_GEOLOCATION="lat,lon"` for the navigator.geolocation shim.
 /// Returns None when unset or malformed, leaving the built-in default in place.
 /// Lets a deployment align the reported coordinates with the region its exit IP
@@ -84,6 +92,16 @@ fn truncate_on_char_boundary(s: &str, max: usize) -> &str {
         end -= 1;
     }
     &s[..end]
+}
+
+/// HTML's document-title getter collapses runs of ASCII whitespace. Keep the
+/// native Page snapshot aligned with the DOM op used by `document.title`.
+fn normalize_document_title(title: &str) -> String {
+    title
+        .split(|ch| matches!(ch, '\t' | '\n' | '\u{000C}' | '\r' | ' '))
+        .filter(|part| !part.is_empty())
+        .collect::<Vec<_>>()
+        .join(" ")
 }
 
 #[cfg(feature = "render")]
@@ -214,6 +232,12 @@ struct DeviceMetricsBaseline {
     device_scale_factor: f32,
 }
 
+struct PendingDocumentLoad {
+    deadline: tokio::time::Instant,
+    #[cfg(feature = "render")]
+    resources_prepared: bool,
+}
+
 pub struct Page {
     pub id: String,
     pub frame_id: String,
@@ -288,6 +312,8 @@ pub struct Page {
     /// Page-owned so the subscription survives replacement of the JS runtime
     /// during navigation.
     runtime_events_enabled: std::cell::Cell<bool>,
+    pending_document_load: Option<PendingDocumentLoad>,
+    deferred_navigation: std::cell::RefCell<Option<(String, String, String)>>,
     /// Document-owned HTML script preparation flags saved while the V8 realm
     /// is suspended for CDP/MCP tab switching.  These are restored only when
     /// the same surviving DomTree is resumed; navigation clears them.
@@ -1133,6 +1159,8 @@ impl Page {
             intercept_tx: None,
             preload_scripts: Vec::new(),
             runtime_events_enabled: std::cell::Cell::new(false),
+            pending_document_load: None,
+            deferred_navigation: std::cell::RefCell::new(None),
             suspended_started_script_ids: Vec::new(),
             callbacks: Arc::new(CallbackRegistry::new()),
             #[cfg(feature = "stealth")]
@@ -1946,6 +1974,7 @@ impl Page {
             .collect()
     }
 
+    #[cfg(test)]
     async fn execute_scripts(&mut self) {
         self.execute_scripts_with_module_budget(None).await;
     }
@@ -1970,7 +1999,7 @@ impl Page {
             let poll_budget = remaining.min(tokio::time::Duration::from_millis(25));
             match tokio::time::timeout(
                 poll_budget,
-                js.run_load_delaying_event_loop_tick(),
+                Self::run_document_load_event_loop_tick(js),
             )
             .await
             {
@@ -1980,7 +2009,7 @@ impl Page {
                     }
                 }
                 Ok(Err(error)) => {
-                    if obscura_js::runtime::is_fatal_event_loop_error(&error) {
+                    if document_load_error_is_terminal(&error) {
                         tracing::warn!("load-delaying dynamic script event loop failed: {error}");
                         return false;
                     }
@@ -2001,7 +2030,156 @@ impl Page {
         true
     }
 
+    async fn run_document_load_event_loop_tick(
+        js: &mut ObscuraJsRuntime,
+    ) -> Result<bool, String> {
+        let load_task_ready = js
+            .evaluate("globalThis.__obscura_documentLoadTaskReady?.() === true")
+            .ok()
+            .and_then(|value| value.as_bool())
+            .unwrap_or(false);
+        let watchdog = load_task_ready
+            .then(|| js.arm_watchdog(std::time::Duration::from_secs(1)));
+        let result = js.run_load_delaying_event_loop_tick().await;
+        let watchdog_fired = watchdog.is_some_and(|token| js.disarm_watchdog(token));
+        if watchdog_fired {
+            js.cancel_termination();
+            return Err(DOCUMENT_LOAD_TASK_TIMEOUT.into());
+        }
+        result
+    }
+
+    fn capture_pending_replacement(&mut self) -> bool {
+        if self.deferred_navigation.borrow().is_none() {
+            let replacement = self
+                .js
+                .as_ref()
+                .and_then(ObscuraJsRuntime::take_pending_navigation);
+            if replacement.is_some() {
+                self.deferred_navigation.replace(replacement);
+            }
+        }
+        if self.deferred_navigation.borrow().is_some() {
+            self.pending_document_load = None;
+            true
+        } else {
+            false
+        }
+    }
+
+    fn reset_navigation_continuation(&mut self) {
+        self.pending_document_load = None;
+        self.deferred_navigation.replace(None);
+    }
+
+    fn fail_pending_document_load(&mut self) {
+        if let Some(js) = self.js.as_mut() {
+            let _ = js.execute_script_with_timeout(
+                "<abort-document-load>",
+                "globalThis.__obscura_abortDocumentLoad?.();",
+                std::time::Duration::from_millis(100),
+            );
+        }
+        self.pending_document_load = None;
+        self.lifecycle = LifecycleState::Failed;
+    }
+
+    fn finalize_pending_document_load(&mut self) -> bool {
+        if self.pending_document_load.is_none() {
+            return false;
+        }
+        if self.capture_pending_replacement() {
+            return false;
+        }
+        self.pending_document_load = None;
+        self.title = self
+            .with_dom(|dom| {
+                dom.query_selector("title")
+                    .ok()
+                    .flatten()
+                    .map(|title_id| normalize_document_title(&dom.text_content(title_id)))
+                    .unwrap_or_default()
+            })
+            .unwrap_or_default();
+        self.lifecycle = LifecycleState::Loaded;
+        true
+    }
+
+    #[cfg(feature = "render")]
+    async fn prepare_post_script_render_resources(&mut self) {
+        let warmup_ms = std::env::var("OBSCURA_RENDER_RESOURCE_POST_SCRIPT_WARMUP_MS")
+            .ok()
+            .and_then(|value| value.parse::<u64>().ok())
+            .unwrap_or(1_000);
+        let _ = self.prepare_screenshot_resources(warmup_ms).await;
+    }
+
+    async fn prepare_resources_frames_and_finalize_load(&mut self) -> bool {
+        #[cfg(feature = "render")]
+        if !self
+            .pending_document_load
+            .as_ref()
+            .is_some_and(|pending| pending.resources_prepared)
+        {
+            self.prepare_post_script_render_resources().await;
+            if let Some(pending) = self.pending_document_load.as_mut() {
+                pending.resources_prepared = true;
+            }
+        }
+        self.build_document_frames().await;
+        self.finalize_pending_document_load()
+    }
+
+    async fn complete_pending_document_load_inline(&mut self) -> bool {
+        let Some(deadline) = self.pending_document_load.as_ref().map(|state| state.deadline) else {
+            // A client-side replacement intentionally suppresses the old
+            // document's load event. It is successful continuation work, not
+            // a failed attempt to complete that discarded document.
+            return self.lifecycle == LifecycleState::Loaded
+                || self.deferred_navigation.borrow().is_some();
+        };
+        let completed = match self.js.as_mut() {
+            Some(js) => Self::drive_load_delaying_scripts(js, deadline).await,
+            None => true,
+        };
+        if !completed {
+            tracing::warn!(
+                "script deadline reached with load-delaying dynamic scripts still pending"
+            );
+            self.fail_pending_document_load();
+            return false;
+        }
+        self.prepare_resources_frames_and_finalize_load().await
+    }
+
+    #[cfg(test)]
     async fn execute_scripts_with_module_budget(&mut self, module_budget_override: Option<u64>) {
+        self.execute_scripts_until_dom_content_loaded(module_budget_override).await;
+        #[cfg(feature = "render")]
+        if let Some(pending) = self.pending_document_load.as_mut() {
+            // These test helpers historically exercised script/load behavior
+            // without navigation's post-script render-resource warmup.
+            pending.resources_prepared = true;
+        }
+        let _ = self.complete_pending_document_load_inline().await;
+    }
+
+    async fn execute_scripts_until_dom_content_loaded(
+        &mut self,
+        module_budget_override: Option<u64>,
+    ) {
+        self.execute_scripts_until_dom_content_loaded_with_deadline(
+            module_budget_override,
+            None,
+        )
+        .await;
+    }
+
+    async fn execute_scripts_until_dom_content_loaded_with_deadline(
+        &mut self,
+        module_budget_override: Option<u64>,
+        script_deadline_override: Option<u64>,
+    ) {
         let scripts_started = std::time::Instant::now();
         tracing::info!(
             "execute_scripts called, js runtime exists: {}",
@@ -2020,10 +2198,12 @@ impl Page {
         // synchronous hang. Raise it further with OBSCURA_SCRIPT_DEADLINE_MS=<ms>
         // for very heavy SPAs on slow networks (pair it with a matching client
         // navigation timeout).
-        let script_deadline_ms: u64 = std::env::var("OBSCURA_SCRIPT_DEADLINE_MS")
-            .ok()
-            .and_then(|s| s.parse().ok())
-            .unwrap_or(30_000);
+        let script_deadline_ms: u64 = script_deadline_override.unwrap_or_else(|| {
+            std::env::var("OBSCURA_SCRIPT_DEADLINE_MS")
+                .ok()
+                .and_then(|s| s.parse().ok())
+                .unwrap_or(30_000)
+        });
         let script_deadline =
             tokio::time::Instant::now() + tokio::time::Duration::from_millis(script_deadline_ms);
 
@@ -2725,30 +2905,31 @@ impl Page {
             // dynamic script elements do not gate it. They do remain in the
             // document's load-event delay set, including scripts inserted by
             // a DOMContentLoaded listener.
+            let load_deadline_ms = script_deadline
+                .saturating_duration_since(tokio::time::Instant::now())
+                .as_millis()
+                .min(u64::MAX as u128) as u64;
+            // Queue the deadline fallback just before the Rust-side guard so
+            // its load task gets one event-loop turn before the owner stops
+            // driving the document.
+            let load_deadline_ms = load_deadline_ms.saturating_sub(25);
+            let lifecycle_script = format!(
+                "try {{ document.dispatchEvent(new Event('DOMContentLoaded', {{bubbles:false,cancelable:false}})); }} catch(e) {{}}\n\
+                 try {{ window.dispatchEvent(new Event('DOMContentLoaded', {{bubbles:false,cancelable:false}})); }} catch(e) {{}}\n\
+                 globalThis.__obscura_requestDocumentLoad?.({load_deadline_ms});"
+            );
             let _ = js.execute_script(
                 "<dom-content-loaded>",
-                "try { document.dispatchEvent(new Event('DOMContentLoaded', {bubbles:false,cancelable:false})); } catch(e) {}\n\
-                 try { window.dispatchEvent(new Event('DOMContentLoaded', {bubbles:false,cancelable:false})); } catch(e) {}",
-            );
-
-            let load_blockers_finished =
-                Self::drive_load_delaying_scripts(js, script_deadline).await;
-            if !load_blockers_finished {
-                tracing::warn!(
-                    "script deadline reached with load-delaying dynamic scripts still pending"
-                );
-            }
-
-            // readyState becomes complete before the load event. A script
-            // inserted by an onload handler is therefore post-load work and
-            // remains pending until an explicit caller settle/wait.
-            let _ = js.execute_script(
-                "<load-event>",
-                "globalThis.__documentReadyState__ = 'complete';\n\
-                 if (typeof window.onload === 'function') { try { window.onload(); } catch(e) {} }\n\
-                 try { window.dispatchEvent(new Event('load', {bubbles:false,cancelable:false})); } catch(e) {}",
+                &lifecycle_script,
             );
         }
+        self.lifecycle = LifecycleState::DomContentLoaded;
+        self.pending_document_load = Some(PendingDocumentLoad {
+            deadline: script_deadline,
+            #[cfg(feature = "render")]
+            resources_prepared: false,
+        });
+        self.capture_pending_replacement();
         if let Some(token) = exec_wd {
             if let Some(js) = self.js.as_mut() {
                 js.disarm_watchdog(token);
@@ -2803,6 +2984,7 @@ impl Page {
         {
             Ok(r) => r,
             Err(_) => {
+                self.reset_navigation_continuation();
                 self.lifecycle = crate::lifecycle::LifecycleState::Failed;
                 Err(PageError::NetworkError(format!(
                     "navigation exceeded {nav_timeout_ms}ms deadline"
@@ -2827,6 +3009,7 @@ impl Page {
             return;
         }
         let settle_started = std::time::Instant::now();
+        self.finish_pending_document_load_within(max_ms).await;
         // Pump, then give any frame document that finished fetching a realm of
         // its own. Attaching one runs its scripts, which can start timers,
         // fetches and further frames, so keep alternating until no new frame
@@ -2882,8 +3065,11 @@ impl Page {
         if duration_ms == 0 {
             return;
         }
+        let started = tokio::time::Instant::now();
+        self.finish_pending_document_load_within(duration_ms).await;
+        let remaining_ms = duration_ms.saturating_sub(started.elapsed().as_millis() as u64);
         if let Some(js) = &mut self.js {
-            Self::settle_runtime_for_duration(js, duration_ms).await;
+            Self::settle_runtime_for_duration(js, remaining_ms).await;
         }
         // A fixed wait must retain its full wall clock, so frames get their
         // realms once at the end instead of being interleaved as in `settle`.
@@ -2892,22 +3078,110 @@ impl Page {
         self.advance_frames().await;
     }
 
+    async fn finish_pending_document_load_within(&mut self, max_ms: u64) {
+        let deadline = tokio::time::Instant::now()
+            + tokio::time::Duration::from_millis(max_ms);
+        loop {
+            let pending = self.pending_document_load.is_some();
+            if !pending {
+                break;
+            }
+            let Some(remaining) = deadline.checked_duration_since(tokio::time::Instant::now())
+            else {
+                break;
+            };
+            if remaining.is_zero() {
+                break;
+            }
+            match tokio::time::timeout(remaining, self.run_autonomous_event_loop_turn()).await {
+                Ok(Ok(_)) => {}
+                Ok(Err(error)) => {
+                    tracing::warn!("document load continuation failed during settle: {error}");
+                    break;
+                }
+                Err(_) => break,
+            }
+        }
+    }
+
     /// Advance one wake-driven browser task for a continuously owned page.
     /// `true` means deno_core reached full idle; `false` means one wake/task was
     /// delivered and the owner should offer another turn after servicing any
     /// higher-priority automation commands.
     #[doc(hidden)]
     pub async fn run_autonomous_event_loop_turn(&mut self) -> Result<bool, String> {
-        let reached_idle = match self.js.as_mut() {
-            Some(js) => js.run_autonomous_event_loop_turn().await,
-            None => Ok(true),
-        }?;
+        let mut completed_document_load = false;
+        let reached_idle = if self.pending_document_load.is_some() {
+            if self.capture_pending_replacement() {
+                true
+            } else {
+                let deadline = self
+                    .pending_document_load
+                    .as_ref()
+                    .map(|state| state.deadline)
+                    .unwrap();
+                let has_blockers = self
+                    .js
+                    .as_mut()
+                    .is_some_and(ObscuraJsRuntime::has_pending_load_delaying_scripts);
+                let mut idle = !has_blockers;
+                if has_blockers && tokio::time::Instant::now() < deadline {
+                    let turn = match self.js.as_mut() {
+                        Some(js) => tokio::select! {
+                            result = Self::run_document_load_event_loop_tick(js) => result,
+                            _ = tokio::time::sleep_until(deadline) => Ok(false),
+                        },
+                        None => Ok(true),
+                    };
+                    match turn {
+                        Ok(turn_idle) => idle = turn_idle,
+                        Err(error) if document_load_error_is_terminal(&error) => {
+                            tracing::warn!("document load task failed: {error}");
+                            self.fail_pending_document_load();
+                            return Ok(true);
+                        }
+                        Err(error) => {
+                            tracing::warn!(
+                                "document load task error, continuing the event loop: {error}"
+                            );
+                            idle = false;
+                            tokio::task::yield_now().await;
+                        }
+                    }
+                }
+                if !self.capture_pending_replacement() {
+                    let has_blockers = self
+                        .js
+                        .as_mut()
+                        .is_some_and(ObscuraJsRuntime::has_pending_load_delaying_scripts);
+                    if !has_blockers {
+                        completed_document_load =
+                            self.prepare_resources_frames_and_finalize_load().await;
+                    } else if tokio::time::Instant::now() >= deadline {
+                        tracing::warn!(
+                            "script deadline reached before the document load task completed"
+                        );
+                        self.fail_pending_document_load();
+                        idle = true;
+                    }
+                }
+                idle && self.pending_document_load.is_none()
+            }
+        } else {
+            match self.js.as_mut() {
+                Some(js) => js.run_autonomous_event_loop_turn().await,
+                None => Ok(true),
+            }?
+        };
         // Dynamic iframe fetches finish on the page event loop, but their
         // realms must be built by Page between turns. Keep the autonomous CDP
         // pump on the same generic frame path as settle(), so a client that
         // stays attached can observe and run child documents as they arrive.
         let frame_work = self.advance_frames().await;
-        Ok(reached_idle && !frame_work)
+        Ok(reached_idle
+            && !completed_document_load
+            && !frame_work
+            && self.pending_document_load.is_none())
     }
 
     async fn settle_runtime_for_duration(js: &mut ObscuraJsRuntime, duration_ms: u64) {
@@ -3026,6 +3300,7 @@ impl Page {
         let url = Url::parse(url_str).map_err(|e| PageError::InvalidUrl(e.to_string()))?;
 
         self.lifecycle = LifecycleState::Loading;
+        self.reset_navigation_continuation();
         self.referrer = referrer.to_string();
         self.url = Some(url.clone());
         self.network_events.clear();
@@ -3217,45 +3492,20 @@ impl Page {
         // listeners never registered, frameworks never bootstrapped,
         // page.click() handlers were no-ops. Now scripts run regardless
         // of waitUntil and DCL means "DOM parsed AND scripts executed".
-        self.execute_scripts().await;
-
-        #[cfg(feature = "render")]
-        {
-            // Page scripts and their bounded post-script event-loop pass can
-            // create responsive images, inline styles, and @font-face rules
-            // that did not exist during the parser warmup above. Discover them
-            // before navigation becomes capture-ready. Known parser resources
-            // are filtered by the render cache, so ordinary pages pay only the
-            // inexpensive scan on this second pass.
-            let warmup_ms = std::env::var("OBSCURA_RENDER_RESOURCE_POST_SCRIPT_WARMUP_MS")
-                .ok()
-                .and_then(|value| value.parse::<u64>().ok())
-                .unwrap_or(1_000);
-            let _ = self.prepare_screenshot_resources(warmup_ms).await;
-        }
-
-        self.lifecycle = LifecycleState::DomContentLoaded;
-
-        // Before any `wait_until` can return, because the frames belong to the
-        // document rather than to one readiness level. Puppeteer and Playwright
-        // send `Page.navigate` with no `waitUntil`, which lands here and returns
-        // on the next line, so building frames further down left every real CDP
-        // client seeing a page with no frames at all.
-        self.build_document_frames().await;
+        self.execute_scripts_until_dom_content_loaded(None).await;
 
         if wait_until == crate::lifecycle::WaitUntil::DomContentLoaded {
+            // Frames belong to the parsed document and must exist before a DCL
+            // waiter can inspect them.
+            self.build_document_frames().await;
             return Ok(());
         }
 
-        if let Some(js) = &mut self.js {
-            if let Ok(new_title) = js.evaluate("document.title") {
-                if let Some(t) = new_title.as_str() {
-                    self.title = t.to_string();
-                }
-            }
+        if !self.complete_pending_document_load_inline().await {
+            return Err(PageError::NetworkError(
+                "document load task did not complete before the script deadline".into(),
+            ));
         }
-
-        self.lifecycle = LifecycleState::Loaded;
 
         if matches!(
             wait_until,
@@ -3266,7 +3516,6 @@ impl Page {
                 crate::lifecycle::WaitUntil::NetworkIdle2 => 2,
                 _ => 0,
             };
-
             // Same hazard as the post-script settle: a synchronous poll can pin
             // the thread past the 5s network-idle deadline, so arm a watchdog
             // that terminates the isolate ~500ms past it.
@@ -4225,6 +4474,9 @@ impl Page {
     }
 
     pub fn take_pending_navigation(&self) -> Option<(String, String, String)> {
+        if let Some(navigation) = self.deferred_navigation.borrow_mut().take() {
+            return Some(navigation);
+        }
         if let Some(js) = &self.js {
             js.take_pending_navigation()
         } else {
@@ -4325,7 +4577,7 @@ impl Page {
                 .unwrap_or_default();
             let nav_timeout = self.navigation_timeout();
             let nav_timeout_ms = duration_millis_u64(nav_timeout);
-            let result = tokio::time::timeout(
+            let result = match tokio::time::timeout(
                 nav_timeout,
                 self.navigate_with_wait_post_inner(
                     &url,
@@ -4335,11 +4587,16 @@ impl Page {
                     &source_url,
                 ),
             )
-            .await
-            .map_err(|_| {
-                self.lifecycle = crate::lifecycle::LifecycleState::Failed;
-                PageError::NetworkError(format!("navigation exceeded {nav_timeout_ms}ms deadline"))
-            })?;
+            .await {
+                Ok(result) => result,
+                Err(_) => {
+                    self.reset_navigation_continuation();
+                    self.lifecycle = crate::lifecycle::LifecycleState::Failed;
+                    Err(PageError::NetworkError(format!(
+                        "navigation exceeded {nav_timeout_ms}ms deadline"
+                    )))
+                }
+            };
             result?;
             self.push_history(self.url_string());
             Ok(true)
@@ -5248,6 +5505,58 @@ mod tests {
         (format!("http://{address}"), request_rx)
     }
 
+    fn spawn_gated_document_script_server() -> (
+        String,
+        std::sync::mpsc::Receiver<String>,
+        std::sync::mpsc::Sender<()>,
+    ) {
+        use std::io::{Read as _, Write as _};
+
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+        let address = listener.local_addr().unwrap();
+        let (request_tx, request_rx) = std::sync::mpsc::channel();
+        let (release_tx, release_rx) = std::sync::mpsc::channel();
+        std::thread::spawn(move || {
+            let (mut document, _) = listener.accept().unwrap();
+            let mut request = [0u8; 2048];
+            let _ = document.read(&mut request).unwrap();
+            let body = format!(
+                r#"<html><body><script>
+                    globalThis.__order = [];
+                    document.addEventListener('DOMContentLoaded', () => __order.push('dcl'));
+                    window.onload = () => __order.push('onload');
+                    const script = document.createElement('script');
+                    script.src = 'http://{address}/gated.js';
+                    script.onload = () => __order.push('script-load');
+                    document.head.appendChild(script);
+                </script></body></html>"#,
+            );
+            let response = format!(
+                "HTTP/1.1 200 OK\r\nContent-Type: text/html\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{body}",
+                body.len(),
+            );
+            document.write_all(response.as_bytes()).unwrap();
+
+            let (mut script, _) = listener.accept().unwrap();
+            let length = script.read(&mut request).unwrap();
+            let path = String::from_utf8_lossy(&request[..length])
+                .lines()
+                .next()
+                .and_then(|line| line.split_ascii_whitespace().nth(1))
+                .unwrap_or("/")
+                .to_string();
+            request_tx.send(path).unwrap();
+            release_rx.recv().unwrap();
+            let body = "globalThis.__dynamicRan = true; __order.push('dynamic');";
+            let response = format!(
+                "HTTP/1.1 200 OK\r\nContent-Type: application/javascript\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{body}",
+                body.len(),
+            );
+            script.write_all(response.as_bytes()).unwrap();
+        });
+        (format!("http://{address}/"), request_rx, release_tx)
+    }
+
     fn spawn_script_resource_cache_server(
         distinct: bool,
     ) -> (String, std::sync::Arc<std::sync::atomic::AtomicUsize>) {
@@ -6027,6 +6336,322 @@ mod tests {
             serde_json::json!(1.0),
             "window.onload must fire exactly once",
         );
+        assert_eq!(page.lifecycle, super::LifecycleState::Loaded);
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn cdp_lifecycle_handoff_keeps_the_runtime_live_until_exactly_one_load() {
+        let (url, requests, release) = spawn_gated_document_script_server();
+        let context = std::sync::Arc::new(crate::BrowserContext::with_storage_and_network(
+            "lifecycle-handoff".to_string(),
+            None,
+            false,
+            None,
+            None,
+            true,
+        ));
+        let mut page = super::Page::new("lifecycle-handoff".to_string(), context);
+
+        page.navigate_with_wait(&url, crate::lifecycle::WaitUntil::DomContentLoaded)
+            .await
+            .unwrap();
+        assert_eq!(page.lifecycle, super::LifecycleState::DomContentLoaded);
+        assert!(page.pending_document_load.is_some());
+        assert_eq!(
+            page.js
+                .as_mut()
+                .unwrap()
+                .evaluate("[document.readyState, __order, globalThis.__dynamicRan === true]")
+                .unwrap(),
+            serde_json::json!(["interactive", ["dcl"], false]),
+            "the DCL-returned runtime must remain immediately evaluable",
+        );
+        release.send(()).unwrap();
+        page.settle(2_000).await;
+        assert_eq!(
+            requests
+                .recv_timeout(std::time::Duration::from_secs(1))
+                .unwrap(),
+            "/gated.js",
+        );
+        assert_eq!(page.lifecycle, super::LifecycleState::Loaded);
+        assert_eq!(
+            page.js
+                .as_mut()
+                .unwrap()
+                .evaluate("[document.readyState, __order]")
+                .unwrap(),
+            serde_json::json!([
+                "complete",
+                ["dcl", "dynamic", "script-load", "onload"]
+            ]),
+        );
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn replacement_suppresses_old_load() {
+        let mut replacement = import_map_test_page(
+            "replacement-before-load",
+            "http://127.0.0.1:9",
+            r#"<html><body><script>
+                globalThis.__oldLoad = 0;
+                window.onload = () => globalThis.__oldLoad++;
+                document.addEventListener('DOMContentLoaded', () => {
+                    location.href = 'data:text/html,replacement';
+                });
+            </script></body></html>"#,
+        );
+        replacement.execute_scripts_until_dom_content_loaded(None).await;
+        assert!(replacement.pending_document_load.is_none());
+        assert_eq!(
+            replacement
+                .js
+                .as_mut()
+                .unwrap()
+                .evaluate("globalThis.__oldLoad")
+                .unwrap(),
+            serde_json::json!(0.0),
+        );
+        assert!(replacement.take_pending_navigation().is_some());
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn real_script_deadline_completes_the_load_task_before_publication() {
+        use std::io::Read as _;
+
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+        let address = listener.local_addr().unwrap();
+        std::thread::spawn(move || {
+            let (mut stream, _) = listener.accept().unwrap();
+            let mut request = [0u8; 1024];
+            let _ = stream.read(&mut request);
+            std::thread::sleep(std::time::Duration::from_secs(1));
+        });
+
+        let mut deadline = import_map_test_page(
+            "lifecycle-deadline",
+            &format!("http://{address}"),
+            &format!(r#"<html><body><script>
+                globalThis.__deadlineEvents = [];
+                window.onload = () => {{
+                    globalThis.__deadlineEvents.push('onload');
+                    document.body.setAttribute('data-load-sync', 'complete');
+                }};
+                window.addEventListener('load', () => {{
+                    globalThis.__deadlineEvents.push('listener');
+                    Promise.resolve().then(() => {{
+                        globalThis.__deadlineEvents.push('microtask');
+                        document.body.setAttribute('data-load-microtask', 'complete');
+                    }});
+                }});
+                const script = document.createElement('script');
+                script.src = 'http://{address}/never.js';
+                document.head.appendChild(script);
+            </script></body></html>"#),
+        );
+        deadline
+            .execute_scripts_until_dom_content_loaded_with_deadline(None, Some(150))
+            .await;
+        assert!(
+            deadline
+                .js
+                .as_mut()
+                .unwrap()
+                .has_pending_load_delaying_scripts(),
+            "the stalled external script must hold the document load task",
+        );
+        assert!(deadline.complete_pending_document_load_inline().await);
+        assert_eq!(deadline.lifecycle, super::LifecycleState::Loaded);
+        assert!(deadline.pending_document_load.is_none());
+        assert_eq!(
+            deadline
+                .js
+                .as_mut()
+                .unwrap()
+                .evaluate("globalThis.__deadlineEvents")
+                .unwrap(),
+            serde_json::json!(["onload", "listener", "microtask"]),
+        );
+        let native_load_state = deadline.with_dom(|dom| {
+            let body = dom.query_selector("body").unwrap().unwrap();
+            let node = dom.get_node(body).unwrap();
+            (
+                node.get_attribute("data-load-sync").map(str::to_owned),
+                node.get_attribute("data-load-microtask").map(str::to_owned),
+            )
+        });
+        assert_eq!(
+            native_load_state,
+            Some((Some("complete".into()), Some("complete".into()))),
+        );
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn expired_deadline_never_claims_load_before_the_js_task_runs() {
+        let mut page = import_map_test_page(
+            "expired-load-deadline",
+            "http://127.0.0.1:9",
+            "<html><body><script>window.onload = () => { globalThis.__lateLoad = true; };</script></body></html>",
+        );
+        page.execute_scripts_until_dom_content_loaded_with_deadline(None, Some(0))
+            .await;
+
+        assert!(!page.complete_pending_document_load_inline().await);
+        assert_eq!(page.lifecycle, super::LifecycleState::Failed);
+        assert_eq!(
+            page.js.as_mut().unwrap().evaluate("document.readyState").unwrap(),
+            serde_json::json!("interactive"),
+        );
+        assert_ne!(
+            page.js.as_mut().unwrap().evaluate("globalThis.__lateLoad === true").unwrap(),
+            serde_json::json!(true),
+        );
+        page.js
+            .as_mut()
+            .unwrap()
+            .run_event_loop_bounded(50)
+            .await
+            .unwrap();
+        assert_eq!(
+            page.js
+                .as_mut()
+                .unwrap()
+                .evaluate("[document.readyState, globalThis.__lateLoad === true]")
+                .unwrap(),
+            serde_json::json!(["interactive", false]),
+            "a failed load must cancel its queued fallback instead of firing late",
+        );
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn post_dom_content_loaded_load_handler_is_watchdog_bounded() {
+        let mut page = import_map_test_page(
+            "bounded-load-handler",
+            "http://127.0.0.1:9",
+            "<html><body><script>\
+             globalThis.__lateLoadListener = false;\
+             window.onload = () => { while (true) {} };\
+             window.addEventListener('load', () => { globalThis.__lateLoadListener = true; });\
+             </script></body></html>",
+        );
+        page.execute_scripts_until_dom_content_loaded(None).await;
+        tokio::time::timeout(
+            std::time::Duration::from_secs(2),
+            page.run_autonomous_event_loop_turn(),
+        )
+        .await
+        .expect("the load handler watchdog did not terminate synchronous V8 work")
+        .unwrap();
+        assert_eq!(page.lifecycle, super::LifecycleState::Failed);
+        assert!(page.pending_document_load.is_none());
+        assert_eq!(
+            page.js
+                .as_mut()
+                .unwrap()
+                .evaluate("globalThis.__lateLoadListener")
+                .unwrap(),
+            serde_json::json!(false),
+            "a terminated onload handler must not be reported as a completed load task",
+        );
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn autonomous_load_continues_after_a_page_local_task_error() {
+        let mut page = import_map_test_page(
+            "load-after-task-error",
+            "http://127.0.0.1:9",
+            "<html><body><script>\
+             setTimeout(() => { throw new Error('page-local'); }, 0);\
+             window.onload = () => document.body.setAttribute('data-loaded', 'true');\
+             </script></body></html>",
+        );
+        page.execute_scripts_until_dom_content_loaded(None).await;
+
+        for _ in 0..3 {
+            page.run_autonomous_event_loop_turn().await.unwrap();
+            if page.lifecycle == super::LifecycleState::Loaded {
+                break;
+            }
+        }
+
+        assert_eq!(page.lifecycle, super::LifecycleState::Loaded);
+        assert_eq!(
+            page.js
+                .as_mut()
+                .unwrap()
+                .evaluate("document.body.getAttribute('data-loaded')")
+                .unwrap(),
+            serde_json::json!("true"),
+        );
+    }
+
+    #[test]
+    fn inline_and_autonomous_load_paths_share_terminal_error_classification() {
+        assert!(super::document_load_error_is_terminal(
+            super::DOCUMENT_LOAD_TASK_TIMEOUT,
+        ));
+        assert!(super::document_load_error_is_terminal(
+            "JavaScript heap limit exceeded; execution terminated",
+        ));
+        assert!(super::document_load_error_is_terminal(
+            "autonomous browser task exceeded its task budget",
+        ));
+        assert!(!super::document_load_error_is_terminal(
+            "Event loop error: Uncaught Error: page-local",
+        ));
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn dynamic_iframe_is_attached_before_load_finalizes() {
+        use std::io::{Read as _, Write as _};
+
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+        let address = listener.local_addr().unwrap();
+        let (requested_tx, requested_rx) = std::sync::mpsc::channel();
+        let (release_tx, release_rx) = std::sync::mpsc::channel();
+        std::thread::spawn(move || {
+            let (mut stream, _) = listener.accept().unwrap();
+            let mut request = [0_u8; 1024];
+            let _ = stream.read(&mut request);
+            requested_tx.send(()).unwrap();
+            release_rx.recv().unwrap();
+            let body = "<html><body>child</body></html>";
+            let response = format!(
+                "HTTP/1.1 200 OK\r\nContent-Type: text/html\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{body}",
+                body.len(),
+            );
+            stream.write_all(response.as_bytes()).unwrap();
+        });
+        let html = format!(
+            r#"<html><body><script>
+                document.addEventListener('DOMContentLoaded', () => {{
+                    const frame = document.createElement('iframe');
+                    frame.src = 'http://{address}/child';
+                    document.body.appendChild(frame);
+                }});
+            </script></body></html>"#,
+        );
+        let mut page = import_map_test_page(
+            "dynamic-frame-before-load",
+            &format!("http://{address}/"),
+            &html,
+        );
+
+        page.execute_scripts_until_dom_content_loaded(None).await;
+        assert_eq!(page.lifecycle, super::LifecycleState::DomContentLoaded);
+        assert!(page.frames.is_empty());
+        release_tx.send(()).unwrap();
+        tokio::time::timeout(std::time::Duration::from_secs(2), async {
+            while page.lifecycle != super::LifecycleState::Loaded {
+                page.run_autonomous_event_loop_turn().await.unwrap();
+            }
+        })
+        .await
+        .expect("dynamic iframe load continuation");
+        requested_rx
+            .recv_timeout(std::time::Duration::from_secs(1))
+            .expect("dynamic iframe request");
+        assert_eq!(page.frames.len(), 1, "load published before the child realm attached");
     }
 
     #[tokio::test(flavor = "current_thread")]
@@ -6282,6 +6907,12 @@ mod tests {
             "lazy-module-readiness",
             &base,
             r#"<html><body><script>
+                window.addEventListener("load", () => {
+                    document.body.setAttribute("data-load-state", "loaded");
+                    Promise.resolve().then(() => {
+                        document.body.setAttribute("data-load-microtask", "complete");
+                    });
+                });
                 import("./lazy.js").then(module => {
                     document.body.setAttribute("data-lazy-state", module.ready);
                 });
@@ -6294,13 +6925,32 @@ mod tests {
             started.elapsed() < std::time::Duration::from_millis(500),
             "dynamic import() must not become an implicit navigation settle",
         );
+        let native_load_state = page.with_dom(|dom| {
+            let body = dom.query_selector("body").unwrap().unwrap();
+            let node = dom.get_node(body).unwrap();
+            (
+                node.get_attribute("data-load-state").map(str::to_owned),
+                node.get_attribute("data-load-microtask").map(str::to_owned),
+                node.get_attribute("data-lazy-state").map(str::to_owned),
+            )
+        });
+        assert_eq!(
+            native_load_state,
+            Some((Some("loaded".into()), Some("complete".into()), None)),
+            "the load task and its microtask checkpoint must finish before load is published",
+        );
         assert_eq!(
             page.js
                 .as_mut()
                 .unwrap()
-                .evaluate("document.body.getAttribute('data-lazy-state')")
+                .evaluate(
+                    "[document.readyState, \
+                      document.body.getAttribute('data-load-state'), \
+                      document.body.getAttribute('data-lazy-state')]",
+                )
                 .unwrap(),
-            serde_json::Value::Null,
+            serde_json::json!(["complete", "loaded", null]),
+            "load must publish without waiting for an unrelated lazy module graph",
         );
 
         page.settle_for_duration(1_000).await;
@@ -6313,6 +6963,25 @@ mod tests {
                 .unwrap(),
             serde_json::json!("lazy-ready"),
             "an explicit caller settle must drive the lazy module graph",
+        );
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn load_snapshot_normalizes_mutated_document_title() {
+        let mut page = import_map_test_page(
+            "load-title-normalization",
+            "http://127.0.0.1:9",
+            "<html><head><title> Before\n  Title </title></head><body><script>\
+             window.onload = () => { document.title = ' After\\t  Title '; };\
+             </script></body></html>",
+        );
+
+        page.execute_scripts().await;
+
+        assert_eq!(page.title, "After Title");
+        assert_eq!(
+            page.js.as_mut().unwrap().evaluate("document.title").unwrap(),
+            serde_json::json!("After Title"),
         );
     }
 

--- a/crates/obscura-browser/src/page.rs
+++ b/crates/obscura-browser/src/page.rs
@@ -234,11 +234,21 @@ struct PendingDocumentLoad {
     resources_prepared: bool,
 }
 
+#[cfg(feature = "internal-cdp")]
+struct NavigationOwner {
+    runtime: Option<crate::navigation::RuntimeRegistration>,
+    control: crate::navigation::NavigationControl,
+}
+
 pub struct Page {
     pub id: String,
     pub frame_id: String,
     pub url: Option<Url>,
     pub dom: Option<DomTree>,
+    /// Declared before frame/runtime owners so cancellation unregisters its V8
+    /// handle before either kind of isolate-backed state is dropped.
+    #[cfg(feature = "internal-cdp")]
+    navigation_owner: Option<NavigationOwner>,
     /// Live child frame realms, in creation order. Declared before `js` on
     /// purpose: a realm holds a V8 handle into that isolate, and fields drop in
     /// declaration order, so the frames must go first.
@@ -299,6 +309,8 @@ pub struct Page {
     pub intercept_block_patterns: Vec<String>,
     pub blocked_url_patterns: Vec<String>,
     intercept_tx: Option<tokio::sync::mpsc::UnboundedSender<obscura_js::ops::InterceptedRequest>>,
+    #[cfg(feature = "internal-cdp")]
+    intercept_runtime_generation: u64,
     // Scripts to execute in the page's JS context BEFORE any of the page's
     // own scripts run — the CDP `Page.addScriptToEvaluateOnNewDocument`
     // contract. Includes `Runtime.addBinding` shims so puppeteer's
@@ -1126,6 +1138,8 @@ impl Page {
             frame_id,
             url: None,
             dom: None,
+            #[cfg(feature = "internal-cdp")]
+            navigation_owner: None,
             frames: Vec::new(),
             js: None,
             lifecycle: LifecycleState::Idle,
@@ -1153,6 +1167,8 @@ impl Page {
             intercept_block_patterns: Vec::new(),
             blocked_url_patterns: Vec::new(),
             intercept_tx: None,
+            #[cfg(feature = "internal-cdp")]
+            intercept_runtime_generation: 0,
             preload_scripts: Vec::new(),
             runtime_events_enabled: std::cell::Cell::new(false),
             pending_document_load: None,
@@ -1175,6 +1191,51 @@ impl Page {
     pub fn navigation_timeout(&self) -> std::time::Duration {
         self.navigation_timeout
             .unwrap_or_else(default_navigation_timeout)
+    }
+
+    /// Install the internal control used by the current protocol navigation.
+    /// Existing public navigation entry points remain unchanged.
+    #[cfg(feature = "internal-cdp")]
+    #[doc(hidden)]
+    pub fn set_navigation_control(&mut self, control: crate::navigation::NavigationControl) {
+        let previous = self.navigation_owner.take();
+        drop(previous);
+        let runtime = self
+            .js
+            .as_ref()
+            .map(|js| control.register_runtime(js.isolate_handle()));
+        self.navigation_owner = Some(NavigationOwner { runtime, control });
+    }
+
+    /// Retire the current navigation control after the owner-thread navigation
+    /// future has unwound. This is the only point that clears V8 termination;
+    /// doing so from the cancelling thread could let synchronous JS resume.
+    #[cfg(feature = "internal-cdp")]
+    #[doc(hidden)]
+    pub fn finish_navigation_control(&mut self) {
+        if self.navigation_owner.is_none() {
+            return;
+        }
+        if let Some(js) = self.js.as_mut() {
+            js.cancel_termination();
+        }
+        let owner = self.navigation_owner.take();
+        drop(owner);
+    }
+
+    #[cfg(feature = "internal-cdp")]
+    fn unregister_navigation_runtime(&mut self) {
+        if let Some(owner) = self.navigation_owner.as_mut() {
+            let registration = owner.runtime.take();
+            drop(registration);
+        }
+    }
+
+    #[cfg(feature = "internal-cdp")]
+    fn register_navigation_runtime(&mut self, runtime: &ObscuraJsRuntime) {
+        if let Some(owner) = self.navigation_owner.as_mut() {
+            owner.runtime = Some(owner.control.register_runtime(runtime.isolate_handle()));
+        }
     }
 
     /// Takes precedence over `OBSCURA_NAV_CHAIN_LIMIT`. A limit of 0 is
@@ -1638,6 +1699,8 @@ impl Page {
         // attacker-controlled state, trigger a navigation, and then
         // run code in the next document's context.
         if self.js.is_some() {
+            #[cfg(feature = "internal-cdp")]
+            self.unregister_navigation_runtime();
             // Every frame realm holds a V8 handle into this isolate, so the
             // frames of the outgoing document must go before the runtime does.
             self.frames.clear();
@@ -1709,6 +1772,14 @@ impl Page {
         if let Some(tx) = &self.intercept_tx {
             rt.set_intercept_tx(tx.clone());
         }
+        #[cfg(feature = "internal-cdp")]
+        {
+            self.intercept_runtime_generation = self.intercept_runtime_generation.saturating_add(1);
+            rt.set_intercept_owner(
+                self.id.clone(),
+                format!("{}@{}", self.id, self.intercept_runtime_generation),
+            );
+        }
         // Re-apply intercept_enabled: enable_interception()/enable_intercept()
         // called before the first navigation sets this on the Page while the
         // runtime does not exist yet, so the new runtime would otherwise start
@@ -1720,6 +1791,10 @@ impl Page {
             rt.set_dom(dom);
         }
 
+        // All engine configuration is installed. Register before bootstrap or
+        // author code can enter V8, so cancellation always reaches this isolate.
+        #[cfg(feature = "internal-cdp")]
+        self.register_navigation_runtime(&rt);
         rt.run_page_init();
         let _ = rt.execute_script(
             "<device-metrics>",
@@ -3626,6 +3701,8 @@ impl Page {
     }
 
     pub fn navigate_blank(&mut self) {
+        #[cfg(feature = "internal-cdp")]
+        self.unregister_navigation_runtime();
         self.frames.clear();
         self.js = None;
         self.url = Some(Url::parse("about:blank").unwrap());
@@ -4461,6 +4538,8 @@ impl Page {
         // document. Suspending is a teardown of the realm the frames live in,
         // and a realm cannot be suspended and resumed the way the page's DOM
         // can, so they are rebuilt when the page next loads a document.
+        #[cfg(feature = "internal-cdp")]
+        self.unregister_navigation_runtime();
         self.frames.clear();
         self.js = None;
     }
@@ -4627,6 +4706,11 @@ impl Page {
         self.intercept_tx = Some(tx.clone());
         if let Some(js) = &self.js {
             js.set_intercept_tx(tx);
+            #[cfg(feature = "internal-cdp")]
+            js.set_intercept_owner(
+                self.id.clone(),
+                format!("{}@{}", self.id, self.intercept_runtime_generation),
+            );
         }
     }
 

--- a/crates/obscura-browser/src/page.rs
+++ b/crates/obscura-browser/src/page.rs
@@ -13,14 +13,8 @@ use url::Url;
 use crate::context::BrowserContext;
 use crate::lifecycle::LifecycleState;
 
-const DOCUMENT_LOAD_TASK_TIMEOUT: &str =
-    "document load event task exceeded its synchronous budget";
-const FINAL_DOCUMENT_LOAD_TASK_BUDGET: std::time::Duration =
-    std::time::Duration::from_secs(1);
-
 fn document_load_error_is_terminal(error: &str) -> bool {
-    error == DOCUMENT_LOAD_TASK_TIMEOUT
-        || obscura_js::runtime::is_fatal_event_loop_error(error)
+    obscura_js::runtime::is_fatal_event_loop_error(error)
 }
 
 /// Parse `OBSCURA_GEOLOCATION="lat,lon"` for the navigator.geolocation shim.
@@ -2048,17 +2042,10 @@ impl Page {
             return js.run_autonomous_event_loop_turn().await;
         }
 
-        // The final load task runs outside the ordinary autonomous queue, so
-        // retain its short synchronous V8 backstop here.
-        let watchdog = js.arm_watchdog(FINAL_DOCUMENT_LOAD_TASK_BUDGET);
-        let result = js.run_load_delaying_event_loop_tick().await;
-        let watchdog_fired = js.disarm_watchdog(watchdog);
-        if watchdog_fired {
-            js.cancel_termination();
-            Err(DOCUMENT_LOAD_TASK_TIMEOUT.into())
-        } else {
-            result
-        }
+        // The runtime retains the one-second synchronous budget but arms it
+        // only around each V8 poll. It must be disarmed while this future is
+        // parked on timer or network I/O.
+        js.run_load_delaying_event_loop_tick().await
     }
 
     fn capture_pending_replacement(&mut self) -> bool {
@@ -3106,7 +3093,11 @@ impl Page {
                 break;
             }
             match tokio::time::timeout(remaining, self.run_autonomous_event_loop_turn()).await {
-                Ok(Ok(_)) => {}
+                Ok(Ok(reached_idle)) => {
+                    if !reached_idle {
+                        tokio::task::yield_now().await;
+                    }
+                }
                 Ok(Err(error)) => {
                     tracing::warn!("document load continuation failed during settle: {error}");
                     break;
@@ -3146,7 +3137,17 @@ impl Page {
                         None => Ok(true),
                     };
                     match turn {
-                        Ok(turn_idle) => idle = turn_idle,
+                        Ok(turn_idle) => {
+                            idle = turn_idle;
+                            if !turn_idle {
+                                // The load-specific runtime path intentionally
+                                // performs one V8 poll. Yield here so every
+                                // owner, including MCP's current-thread pump,
+                                // gives timer and network drivers a chance to
+                                // wake the next turn.
+                                tokio::task::yield_now().await;
+                            }
+                        }
                         Err(error) if document_load_error_is_terminal(&error) => {
                             tracing::warn!("document load task failed: {error}");
                             self.fail_pending_document_load();
@@ -6547,13 +6548,14 @@ mod tests {
              </script></body></html>",
         );
         page.execute_scripts_until_dom_content_loaded(None).await;
-        tokio::time::timeout(
-            std::time::Duration::from_secs(2),
-            page.run_autonomous_event_loop_turn(),
-        )
+        tokio::time::timeout(std::time::Duration::from_secs(2), async {
+            while page.lifecycle == super::LifecycleState::DomContentLoaded {
+                page.run_autonomous_event_loop_turn().await.unwrap();
+                tokio::task::yield_now().await;
+            }
+        })
         .await
-        .expect("the load handler watchdog did not terminate synchronous V8 work")
-        .unwrap();
+        .expect("the load handler watchdog did not terminate synchronous V8 work");
         assert_eq!(page.lifecycle, super::LifecycleState::Failed);
         assert!(page.pending_document_load.is_none());
         assert_eq!(
@@ -6634,11 +6636,12 @@ mod tests {
         );
         page.execute_scripts_until_dom_content_loaded(None).await;
 
-        for _ in 0..3 {
+        for _ in 0..8 {
             page.run_autonomous_event_loop_turn().await.unwrap();
             if page.lifecycle == super::LifecycleState::Loaded {
                 break;
             }
+            tokio::task::yield_now().await;
         }
 
         assert_eq!(page.lifecycle, super::LifecycleState::Loaded);
@@ -6654,9 +6657,6 @@ mod tests {
 
     #[test]
     fn inline_and_autonomous_load_paths_share_terminal_error_classification() {
-        assert!(super::document_load_error_is_terminal(
-            super::DOCUMENT_LOAD_TASK_TIMEOUT,
-        ));
         assert!(super::document_load_error_is_terminal(
             "JavaScript heap limit exceeded; execution terminated",
         ));

--- a/crates/obscura-browser/src/page.rs
+++ b/crates/obscura-browser/src/page.rs
@@ -13,6 +13,14 @@ use url::Url;
 use crate::context::BrowserContext;
 use crate::lifecycle::LifecycleState;
 
+const DOCUMENT_LOAD_TASK_TIMEOUT: &str =
+    "document load event task exceeded its one-second budget";
+
+fn document_load_error_is_terminal(error: &str) -> bool {
+    error == DOCUMENT_LOAD_TASK_TIMEOUT
+        || obscura_js::runtime::is_fatal_event_loop_error(error)
+}
+
 /// Parse `OBSCURA_GEOLOCATION="lat,lon"` for the navigator.geolocation shim.
 /// Returns None when unset or malformed, leaving the built-in default in place.
 /// Lets a deployment align the reported coordinates with the region its exit IP
@@ -84,6 +92,16 @@ fn truncate_on_char_boundary(s: &str, max: usize) -> &str {
         end -= 1;
     }
     &s[..end]
+}
+
+/// HTML's document-title getter collapses runs of ASCII whitespace. Keep the
+/// native Page snapshot aligned with the DOM op used by `document.title`.
+fn normalize_document_title(title: &str) -> String {
+    title
+        .split(|ch| matches!(ch, '\t' | '\n' | '\u{000C}' | '\r' | ' '))
+        .filter(|part| !part.is_empty())
+        .collect::<Vec<_>>()
+        .join(" ")
 }
 
 #[cfg(feature = "render")]
@@ -242,6 +260,12 @@ impl PendingFrameWork {
     }
 }
 
+struct PendingDocumentLoad {
+    deadline: tokio::time::Instant,
+    #[cfg(feature = "render")]
+    resources_prepared: bool,
+}
+
 pub struct Page {
     pub id: String,
     pub frame_id: String,
@@ -317,6 +341,8 @@ pub struct Page {
     /// during navigation.
     runtime_events_enabled: std::cell::Cell<bool>,
     pending_frame_work: std::collections::VecDeque<PendingFrameWork>,
+    pending_document_load: Option<PendingDocumentLoad>,
+    deferred_navigation: std::cell::RefCell<Option<(String, String, String)>>,
     /// Document-owned HTML script preparation flags saved while the V8 realm
     /// is suspended for CDP/MCP tab switching.  These are restored only when
     /// the same surviving DomTree is resumed; navigation clears them.
@@ -1168,6 +1194,8 @@ impl Page {
             preload_scripts: Vec::new(),
             runtime_events_enabled: std::cell::Cell::new(false),
             pending_frame_work: std::collections::VecDeque::new(),
+            pending_document_load: None,
+            deferred_navigation: std::cell::RefCell::new(None),
             suspended_started_script_ids: Vec::new(),
             suspended_cdp_object_state: obscura_js::runtime::CdpObjectState::default(),
             callbacks: Arc::new(CallbackRegistry::new()),
@@ -2121,6 +2149,7 @@ impl Page {
             .collect()
     }
 
+    #[cfg(test)]
     async fn execute_scripts(&mut self) {
         self.execute_scripts_with_module_budget(None).await;
     }
@@ -2145,7 +2174,7 @@ impl Page {
             let poll_budget = remaining.min(tokio::time::Duration::from_millis(25));
             match tokio::time::timeout(
                 poll_budget,
-                js.run_load_delaying_event_loop_tick(),
+                Self::run_document_load_event_loop_tick(js),
             )
             .await
             {
@@ -2155,7 +2184,7 @@ impl Page {
                     }
                 }
                 Ok(Err(error)) => {
-                    if obscura_js::runtime::is_fatal_event_loop_error(&error) {
+                    if document_load_error_is_terminal(&error) {
                         tracing::warn!("load-delaying dynamic script event loop failed: {error}");
                         return false;
                     }
@@ -2176,7 +2205,156 @@ impl Page {
         true
     }
 
+    async fn run_document_load_event_loop_tick(
+        js: &mut ObscuraJsRuntime,
+    ) -> Result<bool, String> {
+        let load_task_ready = js
+            .evaluate("globalThis.__obscura_documentLoadTaskReady?.() === true")
+            .ok()
+            .and_then(|value| value.as_bool())
+            .unwrap_or(false);
+        let watchdog = load_task_ready
+            .then(|| js.arm_watchdog(std::time::Duration::from_secs(1)));
+        let result = js.run_load_delaying_event_loop_tick().await;
+        let watchdog_fired = watchdog.is_some_and(|token| js.disarm_watchdog(token));
+        if watchdog_fired {
+            js.cancel_termination();
+            return Err(DOCUMENT_LOAD_TASK_TIMEOUT.into());
+        }
+        result
+    }
+
+    fn capture_pending_replacement(&mut self) -> bool {
+        if self.deferred_navigation.borrow().is_none() {
+            let replacement = self
+                .js
+                .as_ref()
+                .and_then(ObscuraJsRuntime::take_pending_navigation);
+            if replacement.is_some() {
+                self.deferred_navigation.replace(replacement);
+            }
+        }
+        if self.deferred_navigation.borrow().is_some() {
+            self.pending_document_load = None;
+            true
+        } else {
+            false
+        }
+    }
+
+    fn reset_navigation_continuation(&mut self) {
+        self.pending_document_load = None;
+        self.deferred_navigation.replace(None);
+    }
+
+    fn fail_pending_document_load(&mut self) {
+        if let Some(js) = self.js.as_mut() {
+            let _ = js.execute_script_with_timeout(
+                "<abort-document-load>",
+                "globalThis.__obscura_abortDocumentLoad?.();",
+                std::time::Duration::from_millis(100),
+            );
+        }
+        self.pending_document_load = None;
+        self.lifecycle = LifecycleState::Failed;
+    }
+
+    fn finalize_pending_document_load(&mut self) -> bool {
+        if self.pending_document_load.is_none() {
+            return false;
+        }
+        if self.capture_pending_replacement() {
+            return false;
+        }
+        self.pending_document_load = None;
+        self.title = self
+            .with_dom(|dom| {
+                dom.query_selector("title")
+                    .ok()
+                    .flatten()
+                    .map(|title_id| normalize_document_title(&dom.text_content(title_id)))
+                    .unwrap_or_default()
+            })
+            .unwrap_or_default();
+        self.lifecycle = LifecycleState::Loaded;
+        true
+    }
+
+    #[cfg(feature = "render")]
+    async fn prepare_post_script_render_resources(&mut self) {
+        let warmup_ms = std::env::var("OBSCURA_RENDER_RESOURCE_POST_SCRIPT_WARMUP_MS")
+            .ok()
+            .and_then(|value| value.parse::<u64>().ok())
+            .unwrap_or(1_000);
+        let _ = self.prepare_screenshot_resources(warmup_ms).await;
+    }
+
+    async fn prepare_resources_frames_and_finalize_load(&mut self) -> bool {
+        #[cfg(feature = "render")]
+        if !self
+            .pending_document_load
+            .as_ref()
+            .is_some_and(|pending| pending.resources_prepared)
+        {
+            self.prepare_post_script_render_resources().await;
+            if let Some(pending) = self.pending_document_load.as_mut() {
+                pending.resources_prepared = true;
+            }
+        }
+        self.build_document_frames().await;
+        self.finalize_pending_document_load()
+    }
+
+    async fn complete_pending_document_load_inline(&mut self) -> bool {
+        let Some(deadline) = self.pending_document_load.as_ref().map(|state| state.deadline) else {
+            // A client-side replacement intentionally suppresses the old
+            // document's load event. It is successful continuation work, not
+            // a failed attempt to complete that discarded document.
+            return self.lifecycle == LifecycleState::Loaded
+                || self.deferred_navigation.borrow().is_some();
+        };
+        let completed = match self.js.as_mut() {
+            Some(js) => Self::drive_load_delaying_scripts(js, deadline).await,
+            None => true,
+        };
+        if !completed {
+            tracing::warn!(
+                "script deadline reached with load-delaying dynamic scripts still pending"
+            );
+            self.fail_pending_document_load();
+            return false;
+        }
+        self.prepare_resources_frames_and_finalize_load().await
+    }
+
+    #[cfg(test)]
     async fn execute_scripts_with_module_budget(&mut self, module_budget_override: Option<u64>) {
+        self.execute_scripts_until_dom_content_loaded(module_budget_override).await;
+        #[cfg(feature = "render")]
+        if let Some(pending) = self.pending_document_load.as_mut() {
+            // These test helpers historically exercised script/load behavior
+            // without navigation's post-script render-resource warmup.
+            pending.resources_prepared = true;
+        }
+        let _ = self.complete_pending_document_load_inline().await;
+    }
+
+    async fn execute_scripts_until_dom_content_loaded(
+        &mut self,
+        module_budget_override: Option<u64>,
+    ) {
+        self.execute_scripts_until_dom_content_loaded_with_deadline(
+            module_budget_override,
+            None,
+        )
+        .await;
+    }
+
+    async fn execute_scripts_until_dom_content_loaded_with_deadline(
+        &mut self,
+        module_budget_override: Option<u64>,
+        script_deadline_override: Option<u64>,
+    ) {
         let scripts_started = std::time::Instant::now();
         tracing::info!(
             "execute_scripts called, js runtime exists: {}",
@@ -2195,10 +2373,12 @@ impl Page {
         // synchronous hang. Raise it further with OBSCURA_SCRIPT_DEADLINE_MS=<ms>
         // for very heavy SPAs on slow networks (pair it with a matching client
         // navigation timeout).
-        let script_deadline_ms: u64 = std::env::var("OBSCURA_SCRIPT_DEADLINE_MS")
-            .ok()
-            .and_then(|s| s.parse().ok())
-            .unwrap_or(30_000);
+        let script_deadline_ms: u64 = script_deadline_override.unwrap_or_else(|| {
+            std::env::var("OBSCURA_SCRIPT_DEADLINE_MS")
+                .ok()
+                .and_then(|s| s.parse().ok())
+                .unwrap_or(30_000)
+        });
         let script_deadline =
             tokio::time::Instant::now() + tokio::time::Duration::from_millis(script_deadline_ms);
 
@@ -2900,35 +3080,31 @@ impl Page {
             // dynamic script elements do not gate it. They do remain in the
             // document's load-event delay set, including scripts inserted by
             // a DOMContentLoaded listener.
+            let load_deadline_ms = script_deadline
+                .saturating_duration_since(tokio::time::Instant::now())
+                .as_millis()
+                .min(u64::MAX as u128) as u64;
+            // Queue the deadline fallback just before the Rust-side guard so
+            // its load task gets one event-loop turn before the owner stops
+            // driving the document.
+            let load_deadline_ms = load_deadline_ms.saturating_sub(25);
+            let lifecycle_script = format!(
+                "try {{ document.dispatchEvent(new Event('DOMContentLoaded', {{bubbles:false,cancelable:false}})); }} catch(e) {{}}\n\
+                 try {{ window.dispatchEvent(new Event('DOMContentLoaded', {{bubbles:false,cancelable:false}})); }} catch(e) {{}}\n\
+                 globalThis.__obscura_requestDocumentLoad?.({load_deadline_ms});"
+            );
             let _ = js.execute_script(
                 "<dom-content-loaded>",
-                "try { document.dispatchEvent(new Event('DOMContentLoaded', {bubbles:false,cancelable:false})); } catch(e) {}\n\
-                 try { window.dispatchEvent(new Event('DOMContentLoaded', {bubbles:false,cancelable:false})); } catch(e) {}",
-            );
-
-            let load_blockers_finished =
-                Self::drive_load_delaying_scripts(js, script_deadline).await;
-            if !load_blockers_finished {
-                tracing::warn!(
-                    "script deadline reached with load-delaying dynamic scripts still pending"
-                );
-            }
-
-            // readyState becomes complete before the load event. A script
-            // inserted by an onload handler is therefore post-load work and
-            // remains pending until an explicit caller settle/wait.
-            let _ = js.execute_script(
-                "<load-event>",
-                "globalThis.__documentReadyState__ = 'complete';\n\
-                 try {\n\
-                   const loadEvent = new Event('load', {bubbles:false,cancelable:false});\n\
-                   if (typeof window.onload === 'function') {\n\
-                     try { window.onload.call(window, loadEvent); } catch(e) {}\n\
-                   }\n\
-                   try { window.dispatchEvent(loadEvent); } catch(e) {}\n\
-                 } catch(e) {}",
+                &lifecycle_script,
             );
         }
+        self.lifecycle = LifecycleState::DomContentLoaded;
+        self.pending_document_load = Some(PendingDocumentLoad {
+            deadline: script_deadline,
+            #[cfg(feature = "render")]
+            resources_prepared: false,
+        });
+        self.capture_pending_replacement();
         if let Some(token) = exec_wd {
             if let Some(js) = self.js.as_mut() {
                 js.disarm_watchdog(token);
@@ -2983,6 +3159,7 @@ impl Page {
         {
             Ok(r) => r,
             Err(_) => {
+                self.reset_navigation_continuation();
                 self.lifecycle = crate::lifecycle::LifecycleState::Failed;
                 Err(PageError::NetworkError(format!(
                     "navigation exceeded {nav_timeout_ms}ms deadline"
@@ -3007,6 +3184,7 @@ impl Page {
             return;
         }
         let settle_started = std::time::Instant::now();
+        self.finish_pending_document_load_within(max_ms).await;
         // Pump, then give any frame document that finished fetching a realm of
         // its own. Attaching one runs its scripts, which can start timers,
         // fetches and further frames, so keep alternating until no new frame
@@ -3062,8 +3240,11 @@ impl Page {
         if duration_ms == 0 {
             return;
         }
+        let started = tokio::time::Instant::now();
+        self.finish_pending_document_load_within(duration_ms).await;
+        let remaining_ms = duration_ms.saturating_sub(started.elapsed().as_millis() as u64);
         if let Some(js) = &mut self.js {
-            Self::settle_runtime_for_duration(js, duration_ms).await;
+            Self::settle_runtime_for_duration(js, remaining_ms).await;
         }
         // A fixed wait must retain its full wall clock, so frames get their
         // realms once at the end instead of being interleaved as in `settle`.
@@ -3072,22 +3253,110 @@ impl Page {
         self.advance_frames().await;
     }
 
+    async fn finish_pending_document_load_within(&mut self, max_ms: u64) {
+        let deadline = tokio::time::Instant::now()
+            + tokio::time::Duration::from_millis(max_ms);
+        loop {
+            let pending = self.pending_document_load.is_some();
+            if !pending {
+                break;
+            }
+            let Some(remaining) = deadline.checked_duration_since(tokio::time::Instant::now())
+            else {
+                break;
+            };
+            if remaining.is_zero() {
+                break;
+            }
+            match tokio::time::timeout(remaining, self.run_autonomous_event_loop_turn()).await {
+                Ok(Ok(_)) => {}
+                Ok(Err(error)) => {
+                    tracing::warn!("document load continuation failed during settle: {error}");
+                    break;
+                }
+                Err(_) => break,
+            }
+        }
+    }
+
     /// Advance one wake-driven browser task for a continuously owned page.
     /// `true` means deno_core reached full idle; `false` means one wake/task was
     /// delivered and the owner should offer another turn after servicing any
     /// higher-priority automation commands.
     #[doc(hidden)]
     pub async fn run_autonomous_event_loop_turn(&mut self) -> Result<bool, String> {
-        let reached_idle = match self.js.as_mut() {
-            Some(js) => js.run_autonomous_event_loop_turn().await,
-            None => Ok(true),
-        }?;
+        let mut completed_document_load = false;
+        let reached_idle = if self.pending_document_load.is_some() {
+            if self.capture_pending_replacement() {
+                true
+            } else {
+                let deadline = self
+                    .pending_document_load
+                    .as_ref()
+                    .map(|state| state.deadline)
+                    .unwrap();
+                let has_blockers = self
+                    .js
+                    .as_mut()
+                    .is_some_and(ObscuraJsRuntime::has_pending_load_delaying_scripts);
+                let mut idle = !has_blockers;
+                if has_blockers && tokio::time::Instant::now() < deadline {
+                    let turn = match self.js.as_mut() {
+                        Some(js) => tokio::select! {
+                            result = Self::run_document_load_event_loop_tick(js) => result,
+                            _ = tokio::time::sleep_until(deadline) => Ok(false),
+                        },
+                        None => Ok(true),
+                    };
+                    match turn {
+                        Ok(turn_idle) => idle = turn_idle,
+                        Err(error) if document_load_error_is_terminal(&error) => {
+                            tracing::warn!("document load task failed: {error}");
+                            self.fail_pending_document_load();
+                            return Ok(true);
+                        }
+                        Err(error) => {
+                            tracing::warn!(
+                                "document load task error, continuing the event loop: {error}"
+                            );
+                            idle = false;
+                            tokio::task::yield_now().await;
+                        }
+                    }
+                }
+                if !self.capture_pending_replacement() {
+                    let has_blockers = self
+                        .js
+                        .as_mut()
+                        .is_some_and(ObscuraJsRuntime::has_pending_load_delaying_scripts);
+                    if !has_blockers {
+                        completed_document_load =
+                            self.prepare_resources_frames_and_finalize_load().await;
+                    } else if tokio::time::Instant::now() >= deadline {
+                        tracing::warn!(
+                            "script deadline reached before the document load task completed"
+                        );
+                        self.fail_pending_document_load();
+                        idle = true;
+                    }
+                }
+                idle && self.pending_document_load.is_none()
+            }
+        } else {
+            match self.js.as_mut() {
+                Some(js) => js.run_autonomous_event_loop_turn().await,
+                None => Ok(true),
+            }?
+        };
         // Dynamic iframe fetches finish on the page event loop, but their
         // realms must be built by Page between turns. Keep the autonomous CDP
         // pump on the same generic frame path as settle(), so a client that
         // stays attached can observe and run child documents as they arrive.
         let frame_work = self.advance_frames().await;
-        Ok(reached_idle && !frame_work)
+        Ok(reached_idle
+            && !completed_document_load
+            && !frame_work
+            && self.pending_document_load.is_none())
     }
 
     async fn settle_runtime_for_duration(js: &mut ObscuraJsRuntime, duration_ms: u64) {
@@ -3206,6 +3475,7 @@ impl Page {
         let url = Url::parse(url_str).map_err(|e| PageError::InvalidUrl(e.to_string()))?;
 
         self.lifecycle = LifecycleState::Loading;
+        self.reset_navigation_continuation();
         self.referrer = referrer.to_string();
         self.url = Some(url.clone());
         self.network_events.clear();
@@ -3397,45 +3667,20 @@ impl Page {
         // listeners never registered, frameworks never bootstrapped,
         // page.click() handlers were no-ops. Now scripts run regardless
         // of waitUntil and DCL means "DOM parsed AND scripts executed".
-        self.execute_scripts().await;
-
-        #[cfg(feature = "render")]
-        {
-            // Page scripts and their bounded post-script event-loop pass can
-            // create responsive images, inline styles, and @font-face rules
-            // that did not exist during the parser warmup above. Discover them
-            // before navigation becomes capture-ready. Known parser resources
-            // are filtered by the render cache, so ordinary pages pay only the
-            // inexpensive scan on this second pass.
-            let warmup_ms = std::env::var("OBSCURA_RENDER_RESOURCE_POST_SCRIPT_WARMUP_MS")
-                .ok()
-                .and_then(|value| value.parse::<u64>().ok())
-                .unwrap_or(1_000);
-            let _ = self.prepare_screenshot_resources(warmup_ms).await;
-        }
-
-        self.lifecycle = LifecycleState::DomContentLoaded;
-
-        // Before any `wait_until` can return, because the frames belong to the
-        // document rather than to one readiness level. Puppeteer and Playwright
-        // send `Page.navigate` with no `waitUntil`, which lands here and returns
-        // on the next line, so building frames further down left every real CDP
-        // client seeing a page with no frames at all.
-        self.build_document_frames().await;
+        self.execute_scripts_until_dom_content_loaded(None).await;
 
         if wait_until == crate::lifecycle::WaitUntil::DomContentLoaded {
+            // Frames belong to the parsed document and must exist before a DCL
+            // waiter can inspect them.
+            self.build_document_frames().await;
             return Ok(());
         }
 
-        if let Some(js) = &mut self.js {
-            if let Ok(new_title) = js.evaluate("document.title") {
-                if let Some(t) = new_title.as_str() {
-                    self.title = t.to_string();
-                }
-            }
+        if !self.complete_pending_document_load_inline().await {
+            return Err(PageError::NetworkError(
+                "document load task did not complete before the script deadline".into(),
+            ));
         }
-
-        self.lifecycle = LifecycleState::Loaded;
 
         if matches!(
             wait_until,
@@ -3446,7 +3691,6 @@ impl Page {
                 crate::lifecycle::WaitUntil::NetworkIdle2 => 2,
                 _ => 0,
             };
-
             // Same hazard as the post-script settle: a synchronous poll can pin
             // the thread past the 5s network-idle deadline, so arm a watchdog
             // that terminates the isolate ~500ms past it.
@@ -4415,6 +4659,9 @@ impl Page {
     }
 
     pub fn take_pending_navigation(&self) -> Option<(String, String, String)> {
+        if let Some(navigation) = self.deferred_navigation.borrow_mut().take() {
+            return Some(navigation);
+        }
         if let Some(js) = &self.js {
             js.take_pending_navigation()
         } else {
@@ -4515,7 +4762,7 @@ impl Page {
                 .unwrap_or_default();
             let nav_timeout = self.navigation_timeout();
             let nav_timeout_ms = duration_millis_u64(nav_timeout);
-            let result = tokio::time::timeout(
+            let result = match tokio::time::timeout(
                 nav_timeout,
                 self.navigate_with_wait_post_inner(
                     &url,
@@ -4525,11 +4772,16 @@ impl Page {
                     &source_url,
                 ),
             )
-            .await
-            .map_err(|_| {
-                self.lifecycle = crate::lifecycle::LifecycleState::Failed;
-                PageError::NetworkError(format!("navigation exceeded {nav_timeout_ms}ms deadline"))
-            })?;
+            .await {
+                Ok(result) => result,
+                Err(_) => {
+                    self.reset_navigation_continuation();
+                    self.lifecycle = crate::lifecycle::LifecycleState::Failed;
+                    Err(PageError::NetworkError(format!(
+                        "navigation exceeded {nav_timeout_ms}ms deadline"
+                    )))
+                }
+            };
             result?;
             self.push_history(self.url_string());
             Ok(true)
@@ -5436,6 +5688,58 @@ mod tests {
             stream.write_all(response.as_bytes()).unwrap();
         });
         (format!("http://{address}"), request_rx)
+    }
+
+    fn spawn_gated_document_script_server() -> (
+        String,
+        std::sync::mpsc::Receiver<String>,
+        std::sync::mpsc::Sender<()>,
+    ) {
+        use std::io::{Read as _, Write as _};
+
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+        let address = listener.local_addr().unwrap();
+        let (request_tx, request_rx) = std::sync::mpsc::channel();
+        let (release_tx, release_rx) = std::sync::mpsc::channel();
+        std::thread::spawn(move || {
+            let (mut document, _) = listener.accept().unwrap();
+            let mut request = [0u8; 2048];
+            let _ = document.read(&mut request).unwrap();
+            let body = format!(
+                r#"<html><body><script>
+                    globalThis.__order = [];
+                    document.addEventListener('DOMContentLoaded', () => __order.push('dcl'));
+                    window.onload = () => __order.push('onload');
+                    const script = document.createElement('script');
+                    script.src = 'http://{address}/gated.js';
+                    script.onload = () => __order.push('script-load');
+                    document.head.appendChild(script);
+                </script></body></html>"#,
+            );
+            let response = format!(
+                "HTTP/1.1 200 OK\r\nContent-Type: text/html\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{body}",
+                body.len(),
+            );
+            document.write_all(response.as_bytes()).unwrap();
+
+            let (mut script, _) = listener.accept().unwrap();
+            let length = script.read(&mut request).unwrap();
+            let path = String::from_utf8_lossy(&request[..length])
+                .lines()
+                .next()
+                .and_then(|line| line.split_ascii_whitespace().nth(1))
+                .unwrap_or("/")
+                .to_string();
+            request_tx.send(path).unwrap();
+            release_rx.recv().unwrap();
+            let body = "globalThis.__dynamicRan = true; __order.push('dynamic');";
+            let response = format!(
+                "HTTP/1.1 200 OK\r\nContent-Type: application/javascript\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{body}",
+                body.len(),
+            );
+            script.write_all(response.as_bytes()).unwrap();
+        });
+        (format!("http://{address}/"), request_rx, release_tx)
     }
 
     fn spawn_script_resource_cache_server(
@@ -6696,6 +7000,322 @@ mod tests {
             serde_json::json!(1.0),
             "window.onload must fire exactly once",
         );
+        assert_eq!(page.lifecycle, super::LifecycleState::Loaded);
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn cdp_lifecycle_handoff_keeps_the_runtime_live_until_exactly_one_load() {
+        let (url, requests, release) = spawn_gated_document_script_server();
+        let context = std::sync::Arc::new(crate::BrowserContext::with_storage_and_network(
+            "lifecycle-handoff".to_string(),
+            None,
+            false,
+            None,
+            None,
+            true,
+        ));
+        let mut page = super::Page::new("lifecycle-handoff".to_string(), context);
+
+        page.navigate_with_wait(&url, crate::lifecycle::WaitUntil::DomContentLoaded)
+            .await
+            .unwrap();
+        assert_eq!(page.lifecycle, super::LifecycleState::DomContentLoaded);
+        assert!(page.pending_document_load.is_some());
+        assert_eq!(
+            page.js
+                .as_mut()
+                .unwrap()
+                .evaluate("[document.readyState, __order, globalThis.__dynamicRan === true]")
+                .unwrap(),
+            serde_json::json!(["interactive", ["dcl"], false]),
+            "the DCL-returned runtime must remain immediately evaluable",
+        );
+        release.send(()).unwrap();
+        page.settle(2_000).await;
+        assert_eq!(
+            requests
+                .recv_timeout(std::time::Duration::from_secs(1))
+                .unwrap(),
+            "/gated.js",
+        );
+        assert_eq!(page.lifecycle, super::LifecycleState::Loaded);
+        assert_eq!(
+            page.js
+                .as_mut()
+                .unwrap()
+                .evaluate("[document.readyState, __order]")
+                .unwrap(),
+            serde_json::json!([
+                "complete",
+                ["dcl", "dynamic", "script-load", "onload"]
+            ]),
+        );
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn replacement_suppresses_old_load() {
+        let mut replacement = import_map_test_page(
+            "replacement-before-load",
+            "http://127.0.0.1:9",
+            r#"<html><body><script>
+                globalThis.__oldLoad = 0;
+                window.onload = () => globalThis.__oldLoad++;
+                document.addEventListener('DOMContentLoaded', () => {
+                    location.href = 'data:text/html,replacement';
+                });
+            </script></body></html>"#,
+        );
+        replacement.execute_scripts_until_dom_content_loaded(None).await;
+        assert!(replacement.pending_document_load.is_none());
+        assert_eq!(
+            replacement
+                .js
+                .as_mut()
+                .unwrap()
+                .evaluate("globalThis.__oldLoad")
+                .unwrap(),
+            serde_json::json!(0.0),
+        );
+        assert!(replacement.take_pending_navigation().is_some());
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn real_script_deadline_completes_the_load_task_before_publication() {
+        use std::io::Read as _;
+
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+        let address = listener.local_addr().unwrap();
+        std::thread::spawn(move || {
+            let (mut stream, _) = listener.accept().unwrap();
+            let mut request = [0u8; 1024];
+            let _ = stream.read(&mut request);
+            std::thread::sleep(std::time::Duration::from_secs(1));
+        });
+
+        let mut deadline = import_map_test_page(
+            "lifecycle-deadline",
+            &format!("http://{address}"),
+            &format!(r#"<html><body><script>
+                globalThis.__deadlineEvents = [];
+                window.onload = () => {{
+                    globalThis.__deadlineEvents.push('onload');
+                    document.body.setAttribute('data-load-sync', 'complete');
+                }};
+                window.addEventListener('load', () => {{
+                    globalThis.__deadlineEvents.push('listener');
+                    Promise.resolve().then(() => {{
+                        globalThis.__deadlineEvents.push('microtask');
+                        document.body.setAttribute('data-load-microtask', 'complete');
+                    }});
+                }});
+                const script = document.createElement('script');
+                script.src = 'http://{address}/never.js';
+                document.head.appendChild(script);
+            </script></body></html>"#),
+        );
+        deadline
+            .execute_scripts_until_dom_content_loaded_with_deadline(None, Some(150))
+            .await;
+        assert!(
+            deadline
+                .js
+                .as_mut()
+                .unwrap()
+                .has_pending_load_delaying_scripts(),
+            "the stalled external script must hold the document load task",
+        );
+        assert!(deadline.complete_pending_document_load_inline().await);
+        assert_eq!(deadline.lifecycle, super::LifecycleState::Loaded);
+        assert!(deadline.pending_document_load.is_none());
+        assert_eq!(
+            deadline
+                .js
+                .as_mut()
+                .unwrap()
+                .evaluate("globalThis.__deadlineEvents")
+                .unwrap(),
+            serde_json::json!(["onload", "listener", "microtask"]),
+        );
+        let native_load_state = deadline.with_dom(|dom| {
+            let body = dom.query_selector("body").unwrap().unwrap();
+            let node = dom.get_node(body).unwrap();
+            (
+                node.get_attribute("data-load-sync").map(str::to_owned),
+                node.get_attribute("data-load-microtask").map(str::to_owned),
+            )
+        });
+        assert_eq!(
+            native_load_state,
+            Some((Some("complete".into()), Some("complete".into()))),
+        );
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn expired_deadline_never_claims_load_before_the_js_task_runs() {
+        let mut page = import_map_test_page(
+            "expired-load-deadline",
+            "http://127.0.0.1:9",
+            "<html><body><script>window.onload = () => { globalThis.__lateLoad = true; };</script></body></html>",
+        );
+        page.execute_scripts_until_dom_content_loaded_with_deadline(None, Some(0))
+            .await;
+
+        assert!(!page.complete_pending_document_load_inline().await);
+        assert_eq!(page.lifecycle, super::LifecycleState::Failed);
+        assert_eq!(
+            page.js.as_mut().unwrap().evaluate("document.readyState").unwrap(),
+            serde_json::json!("interactive"),
+        );
+        assert_ne!(
+            page.js.as_mut().unwrap().evaluate("globalThis.__lateLoad === true").unwrap(),
+            serde_json::json!(true),
+        );
+        page.js
+            .as_mut()
+            .unwrap()
+            .run_event_loop_bounded(50)
+            .await
+            .unwrap();
+        assert_eq!(
+            page.js
+                .as_mut()
+                .unwrap()
+                .evaluate("[document.readyState, globalThis.__lateLoad === true]")
+                .unwrap(),
+            serde_json::json!(["interactive", false]),
+            "a failed load must cancel its queued fallback instead of firing late",
+        );
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn post_dom_content_loaded_load_handler_is_watchdog_bounded() {
+        let mut page = import_map_test_page(
+            "bounded-load-handler",
+            "http://127.0.0.1:9",
+            "<html><body><script>\
+             globalThis.__lateLoadListener = false;\
+             window.onload = () => { while (true) {} };\
+             window.addEventListener('load', () => { globalThis.__lateLoadListener = true; });\
+             </script></body></html>",
+        );
+        page.execute_scripts_until_dom_content_loaded(None).await;
+        tokio::time::timeout(
+            std::time::Duration::from_secs(2),
+            page.run_autonomous_event_loop_turn(),
+        )
+        .await
+        .expect("the load handler watchdog did not terminate synchronous V8 work")
+        .unwrap();
+        assert_eq!(page.lifecycle, super::LifecycleState::Failed);
+        assert!(page.pending_document_load.is_none());
+        assert_eq!(
+            page.js
+                .as_mut()
+                .unwrap()
+                .evaluate("globalThis.__lateLoadListener")
+                .unwrap(),
+            serde_json::json!(false),
+            "a terminated onload handler must not be reported as a completed load task",
+        );
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn autonomous_load_continues_after_a_page_local_task_error() {
+        let mut page = import_map_test_page(
+            "load-after-task-error",
+            "http://127.0.0.1:9",
+            "<html><body><script>\
+             setTimeout(() => { throw new Error('page-local'); }, 0);\
+             window.onload = () => document.body.setAttribute('data-loaded', 'true');\
+             </script></body></html>",
+        );
+        page.execute_scripts_until_dom_content_loaded(None).await;
+
+        for _ in 0..3 {
+            page.run_autonomous_event_loop_turn().await.unwrap();
+            if page.lifecycle == super::LifecycleState::Loaded {
+                break;
+            }
+        }
+
+        assert_eq!(page.lifecycle, super::LifecycleState::Loaded);
+        assert_eq!(
+            page.js
+                .as_mut()
+                .unwrap()
+                .evaluate("document.body.getAttribute('data-loaded')")
+                .unwrap(),
+            serde_json::json!("true"),
+        );
+    }
+
+    #[test]
+    fn inline_and_autonomous_load_paths_share_terminal_error_classification() {
+        assert!(super::document_load_error_is_terminal(
+            super::DOCUMENT_LOAD_TASK_TIMEOUT,
+        ));
+        assert!(super::document_load_error_is_terminal(
+            "JavaScript heap limit exceeded; execution terminated",
+        ));
+        assert!(super::document_load_error_is_terminal(
+            "autonomous browser task exceeded its task budget",
+        ));
+        assert!(!super::document_load_error_is_terminal(
+            "Event loop error: Uncaught Error: page-local",
+        ));
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn dynamic_iframe_is_attached_before_load_finalizes() {
+        use std::io::{Read as _, Write as _};
+
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+        let address = listener.local_addr().unwrap();
+        let (requested_tx, requested_rx) = std::sync::mpsc::channel();
+        let (release_tx, release_rx) = std::sync::mpsc::channel();
+        std::thread::spawn(move || {
+            let (mut stream, _) = listener.accept().unwrap();
+            let mut request = [0_u8; 1024];
+            let _ = stream.read(&mut request);
+            requested_tx.send(()).unwrap();
+            release_rx.recv().unwrap();
+            let body = "<html><body>child</body></html>";
+            let response = format!(
+                "HTTP/1.1 200 OK\r\nContent-Type: text/html\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{body}",
+                body.len(),
+            );
+            stream.write_all(response.as_bytes()).unwrap();
+        });
+        let html = format!(
+            r#"<html><body><script>
+                document.addEventListener('DOMContentLoaded', () => {{
+                    const frame = document.createElement('iframe');
+                    frame.src = 'http://{address}/child';
+                    document.body.appendChild(frame);
+                }});
+            </script></body></html>"#,
+        );
+        let mut page = import_map_test_page(
+            "dynamic-frame-before-load",
+            &format!("http://{address}/"),
+            &html,
+        );
+
+        page.execute_scripts_until_dom_content_loaded(None).await;
+        assert_eq!(page.lifecycle, super::LifecycleState::DomContentLoaded);
+        assert!(page.frames.is_empty());
+        release_tx.send(()).unwrap();
+        tokio::time::timeout(std::time::Duration::from_secs(2), async {
+            while page.lifecycle != super::LifecycleState::Loaded {
+                page.run_autonomous_event_loop_turn().await.unwrap();
+            }
+        })
+        .await
+        .expect("dynamic iframe load continuation");
+        requested_rx
+            .recv_timeout(std::time::Duration::from_secs(1))
+            .expect("dynamic iframe request");
+        assert_eq!(page.frames.len(), 1, "load published before the child realm attached");
     }
 
     #[tokio::test(flavor = "current_thread")]
@@ -7018,6 +7638,12 @@ mod tests {
             "lazy-module-readiness",
             &base,
             r#"<html><body><script>
+                window.addEventListener("load", () => {
+                    document.body.setAttribute("data-load-state", "loaded");
+                    Promise.resolve().then(() => {
+                        document.body.setAttribute("data-load-microtask", "complete");
+                    });
+                });
                 import("./lazy.js").then(module => {
                     document.body.setAttribute("data-lazy-state", module.ready);
                 });
@@ -7030,13 +7656,32 @@ mod tests {
             started.elapsed() < std::time::Duration::from_millis(500),
             "dynamic import() must not become an implicit navigation settle",
         );
+        let native_load_state = page.with_dom(|dom| {
+            let body = dom.query_selector("body").unwrap().unwrap();
+            let node = dom.get_node(body).unwrap();
+            (
+                node.get_attribute("data-load-state").map(str::to_owned),
+                node.get_attribute("data-load-microtask").map(str::to_owned),
+                node.get_attribute("data-lazy-state").map(str::to_owned),
+            )
+        });
+        assert_eq!(
+            native_load_state,
+            Some((Some("loaded".into()), Some("complete".into()), None)),
+            "the load task and its microtask checkpoint must finish before load is published",
+        );
         assert_eq!(
             page.js
                 .as_mut()
                 .unwrap()
-                .evaluate("document.body.getAttribute('data-lazy-state')")
+                .evaluate(
+                    "[document.readyState, \
+                      document.body.getAttribute('data-load-state'), \
+                      document.body.getAttribute('data-lazy-state')]",
+                )
                 .unwrap(),
-            serde_json::Value::Null,
+            serde_json::json!(["complete", "loaded", null]),
+            "load must publish without waiting for an unrelated lazy module graph",
         );
 
         page.settle_for_duration(1_000).await;
@@ -7049,6 +7694,25 @@ mod tests {
                 .unwrap(),
             serde_json::json!("lazy-ready"),
             "an explicit caller settle must drive the lazy module graph",
+        );
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn load_snapshot_normalizes_mutated_document_title() {
+        let mut page = import_map_test_page(
+            "load-title-normalization",
+            "http://127.0.0.1:9",
+            "<html><head><title> Before\n  Title </title></head><body><script>\
+             window.onload = () => { document.title = ' After\\t  Title '; };\
+             </script></body></html>",
+        );
+
+        page.execute_scripts().await;
+
+        assert_eq!(page.title, "After Title");
+        assert_eq!(
+            page.js.as_mut().unwrap().evaluate("document.title").unwrap(),
+            serde_json::json!("After Title"),
         );
     }
 

--- a/crates/obscura-browser/src/page.rs
+++ b/crates/obscura-browser/src/page.rs
@@ -13,14 +13,8 @@ use url::Url;
 use crate::context::BrowserContext;
 use crate::lifecycle::LifecycleState;
 
-const DOCUMENT_LOAD_TASK_TIMEOUT: &str =
-    "document load event task exceeded its synchronous budget";
-const FINAL_DOCUMENT_LOAD_TASK_BUDGET: std::time::Duration =
-    std::time::Duration::from_secs(1);
-
 fn document_load_error_is_terminal(error: &str) -> bool {
-    error == DOCUMENT_LOAD_TASK_TIMEOUT
-        || obscura_js::runtime::is_fatal_event_loop_error(error)
+    obscura_js::runtime::is_fatal_event_loop_error(error)
 }
 
 /// Parse `OBSCURA_GEOLOCATION="lat,lon"` for the navigator.geolocation shim.
@@ -2223,17 +2217,10 @@ impl Page {
             return js.run_autonomous_event_loop_turn().await;
         }
 
-        // The final load task runs outside the ordinary autonomous queue, so
-        // retain its short synchronous V8 backstop here.
-        let watchdog = js.arm_watchdog(FINAL_DOCUMENT_LOAD_TASK_BUDGET);
-        let result = js.run_load_delaying_event_loop_tick().await;
-        let watchdog_fired = js.disarm_watchdog(watchdog);
-        if watchdog_fired {
-            js.cancel_termination();
-            Err(DOCUMENT_LOAD_TASK_TIMEOUT.into())
-        } else {
-            result
-        }
+        // The runtime retains the one-second synchronous budget but arms it
+        // only around each V8 poll. It must be disarmed while this future is
+        // parked on timer or network I/O.
+        js.run_load_delaying_event_loop_tick().await
     }
 
     fn capture_pending_replacement(&mut self) -> bool {
@@ -3281,7 +3268,11 @@ impl Page {
                 break;
             }
             match tokio::time::timeout(remaining, self.run_autonomous_event_loop_turn()).await {
-                Ok(Ok(_)) => {}
+                Ok(Ok(reached_idle)) => {
+                    if !reached_idle {
+                        tokio::task::yield_now().await;
+                    }
+                }
                 Ok(Err(error)) => {
                     tracing::warn!("document load continuation failed during settle: {error}");
                     break;
@@ -3321,7 +3312,17 @@ impl Page {
                         None => Ok(true),
                     };
                     match turn {
-                        Ok(turn_idle) => idle = turn_idle,
+                        Ok(turn_idle) => {
+                            idle = turn_idle;
+                            if !turn_idle {
+                                // The load-specific runtime path intentionally
+                                // performs one V8 poll. Yield here so every
+                                // owner, including MCP's current-thread pump,
+                                // gives timer and network drivers a chance to
+                                // wake the next turn.
+                                tokio::task::yield_now().await;
+                            }
+                        }
                         Err(error) if document_load_error_is_terminal(&error) => {
                             tracing::warn!("document load task failed: {error}");
                             self.fail_pending_document_load();
@@ -7211,13 +7212,14 @@ mod tests {
              </script></body></html>",
         );
         page.execute_scripts_until_dom_content_loaded(None).await;
-        tokio::time::timeout(
-            std::time::Duration::from_secs(2),
-            page.run_autonomous_event_loop_turn(),
-        )
+        tokio::time::timeout(std::time::Duration::from_secs(2), async {
+            while page.lifecycle == super::LifecycleState::DomContentLoaded {
+                page.run_autonomous_event_loop_turn().await.unwrap();
+                tokio::task::yield_now().await;
+            }
+        })
         .await
-        .expect("the load handler watchdog did not terminate synchronous V8 work")
-        .unwrap();
+        .expect("the load handler watchdog did not terminate synchronous V8 work");
         assert_eq!(page.lifecycle, super::LifecycleState::Failed);
         assert!(page.pending_document_load.is_none());
         assert_eq!(
@@ -7298,11 +7300,12 @@ mod tests {
         );
         page.execute_scripts_until_dom_content_loaded(None).await;
 
-        for _ in 0..3 {
+        for _ in 0..8 {
             page.run_autonomous_event_loop_turn().await.unwrap();
             if page.lifecycle == super::LifecycleState::Loaded {
                 break;
             }
+            tokio::task::yield_now().await;
         }
 
         assert_eq!(page.lifecycle, super::LifecycleState::Loaded);
@@ -7318,9 +7321,6 @@ mod tests {
 
     #[test]
     fn inline_and_autonomous_load_paths_share_terminal_error_classification() {
-        assert!(super::document_load_error_is_terminal(
-            super::DOCUMENT_LOAD_TASK_TIMEOUT,
-        ));
         assert!(super::document_load_error_is_terminal(
             "JavaScript heap limit exceeded; execution terminated",
         ));

--- a/crates/obscura-browser/src/page.rs
+++ b/crates/obscura-browser/src/page.rs
@@ -14,7 +14,9 @@ use crate::context::BrowserContext;
 use crate::lifecycle::LifecycleState;
 
 const DOCUMENT_LOAD_TASK_TIMEOUT: &str =
-    "document load event task exceeded its one-second budget";
+    "document load event task exceeded its synchronous budget";
+const FINAL_DOCUMENT_LOAD_TASK_BUDGET: std::time::Duration =
+    std::time::Duration::from_secs(1);
 
 fn document_load_error_is_terminal(error: &str) -> bool {
     error == DOCUMENT_LOAD_TASK_TIMEOUT
@@ -2213,15 +2215,25 @@ impl Page {
             .ok()
             .and_then(|value| value.as_bool())
             .unwrap_or(false);
-        let watchdog = load_task_ready
-            .then(|| js.arm_watchdog(std::time::Duration::from_secs(1)));
+        if !load_task_ready {
+            // The autonomous pump arms its watchdog only while V8 is running
+            // and disarms it while the event loop is parked on timer/network
+            // I/O. Wrapping this whole await would both reject valid slow
+            // resources and churn one watchdog thread per 25 ms outer poll.
+            return js.run_autonomous_event_loop_turn().await;
+        }
+
+        // The final load task runs outside the ordinary autonomous queue, so
+        // retain its short synchronous V8 backstop here.
+        let watchdog = js.arm_watchdog(FINAL_DOCUMENT_LOAD_TASK_BUDGET);
         let result = js.run_load_delaying_event_loop_tick().await;
-        let watchdog_fired = watchdog.is_some_and(|token| js.disarm_watchdog(token));
+        let watchdog_fired = js.disarm_watchdog(watchdog);
         if watchdog_fired {
             js.cancel_termination();
-            return Err(DOCUMENT_LOAD_TASK_TIMEOUT.into());
+            Err(DOCUMENT_LOAD_TASK_TIMEOUT.into())
+        } else {
+            result
         }
-        result
     }
 
     fn capture_pending_replacement(&mut self) -> bool {
@@ -7216,6 +7228,61 @@ mod tests {
                 .unwrap(),
             serde_json::json!(false),
             "a terminated onload handler must not be reported as a completed load task",
+        );
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn post_dom_content_loaded_non_load_task_is_watchdog_bounded() {
+        let (base, _requests) = spawn_delayed_classic_script_server(
+            std::time::Duration::from_secs(10),
+            "globalThis.__slowDynamicRan = true;",
+        );
+        let html = format!(
+            "<html><body><script>\
+             globalThis.__lateLoadListener = false;\
+             const script = document.createElement('script');\
+             script.src = '{base}/slow.js';\
+             document.head.appendChild(script);\
+             setTimeout(() => {{ while (true) {{}} }}, 0);\
+             window.addEventListener('load', () => {{ globalThis.__lateLoadListener = true; }});\
+             </script></body></html>",
+        );
+        let mut page = import_map_test_page(
+            "bounded-post-dcl-task",
+            &format!("{base}/"),
+            &html,
+        );
+        page.execute_scripts_until_dom_content_loaded(None).await;
+        let js = page.js.as_mut().unwrap();
+        assert!(
+            js.has_pending_load_delaying_scripts(),
+            "the dynamic script must keep document load blocked",
+        );
+        assert_eq!(
+            js.evaluate("globalThis.__obscura_documentLoadTaskReady?.() === true")
+                .unwrap(),
+            serde_json::json!(false),
+            "the infinite timer must run through the non-final autonomous path",
+        );
+
+        tokio::time::timeout(
+            std::time::Duration::from_secs(7),
+            page.run_autonomous_event_loop_turn(),
+        )
+        .await
+        .expect("a post-DCL browser task escaped the synchronous watchdog")
+        .unwrap();
+
+        assert_eq!(page.lifecycle, super::LifecycleState::Failed);
+        assert!(page.pending_document_load.is_none());
+        assert_eq!(
+            page.js
+                .as_mut()
+                .unwrap()
+                .evaluate("globalThis.__lateLoadListener")
+                .unwrap(),
+            serde_json::json!(false),
+            "a terminated post-DCL task must not publish load",
         );
     }
 

--- a/crates/obscura-browser/src/page.rs
+++ b/crates/obscura-browser/src/page.rs
@@ -262,11 +262,21 @@ struct PendingDocumentLoad {
     resources_prepared: bool,
 }
 
+#[cfg(feature = "internal-cdp")]
+struct NavigationOwner {
+    runtime: Option<crate::navigation::RuntimeRegistration>,
+    control: crate::navigation::NavigationControl,
+}
+
 pub struct Page {
     pub id: String,
     pub frame_id: String,
     pub url: Option<Url>,
     pub dom: Option<DomTree>,
+    /// Declared before frame/runtime owners so cancellation unregisters its V8
+    /// handle before either kind of isolate-backed state is dropped.
+    #[cfg(feature = "internal-cdp")]
+    navigation_owner: Option<NavigationOwner>,
     /// Live child frame realms, in creation order. Declared before `js` on
     /// purpose: a realm holds a V8 handle into that isolate, and fields drop in
     /// declaration order, so the frames must go first.
@@ -327,6 +337,8 @@ pub struct Page {
     pub intercept_block_patterns: Vec<String>,
     pub blocked_url_patterns: Vec<String>,
     intercept_tx: Option<tokio::sync::mpsc::UnboundedSender<obscura_js::ops::InterceptedRequest>>,
+    #[cfg(feature = "internal-cdp")]
+    intercept_runtime_generation: u64,
     // Scripts to execute in the page's JS context BEFORE any of the page's
     // own scripts run — the CDP `Page.addScriptToEvaluateOnNewDocument`
     // contract. Includes `Runtime.addBinding` shims so puppeteer's
@@ -1160,6 +1172,8 @@ impl Page {
             frame_id,
             url: None,
             dom: None,
+            #[cfg(feature = "internal-cdp")]
+            navigation_owner: None,
             frames: Vec::new(),
             js: None,
             lifecycle: LifecycleState::Idle,
@@ -1187,6 +1201,8 @@ impl Page {
             intercept_block_patterns: Vec::new(),
             blocked_url_patterns: Vec::new(),
             intercept_tx: None,
+            #[cfg(feature = "internal-cdp")]
+            intercept_runtime_generation: 0,
             preload_scripts: Vec::new(),
             runtime_events_enabled: std::cell::Cell::new(false),
             pending_frame_work: std::collections::VecDeque::new(),
@@ -1211,6 +1227,51 @@ impl Page {
     pub fn navigation_timeout(&self) -> std::time::Duration {
         self.navigation_timeout
             .unwrap_or_else(default_navigation_timeout)
+    }
+
+    /// Install the internal control used by the current protocol navigation.
+    /// Existing public navigation entry points remain unchanged.
+    #[cfg(feature = "internal-cdp")]
+    #[doc(hidden)]
+    pub fn set_navigation_control(&mut self, control: crate::navigation::NavigationControl) {
+        let previous = self.navigation_owner.take();
+        drop(previous);
+        let runtime = self
+            .js
+            .as_ref()
+            .map(|js| control.register_runtime(js.isolate_handle()));
+        self.navigation_owner = Some(NavigationOwner { runtime, control });
+    }
+
+    /// Retire the current navigation control after the owner-thread navigation
+    /// future has unwound. This is the only point that clears V8 termination;
+    /// doing so from the cancelling thread could let synchronous JS resume.
+    #[cfg(feature = "internal-cdp")]
+    #[doc(hidden)]
+    pub fn finish_navigation_control(&mut self) {
+        if self.navigation_owner.is_none() {
+            return;
+        }
+        if let Some(js) = self.js.as_mut() {
+            js.cancel_termination();
+        }
+        let owner = self.navigation_owner.take();
+        drop(owner);
+    }
+
+    #[cfg(feature = "internal-cdp")]
+    fn unregister_navigation_runtime(&mut self) {
+        if let Some(owner) = self.navigation_owner.as_mut() {
+            let registration = owner.runtime.take();
+            drop(registration);
+        }
+    }
+
+    #[cfg(feature = "internal-cdp")]
+    fn register_navigation_runtime(&mut self, runtime: &ObscuraJsRuntime) {
+        if let Some(owner) = self.navigation_owner.as_mut() {
+            owner.runtime = Some(owner.control.register_runtime(runtime.isolate_handle()));
+        }
     }
 
     /// Takes precedence over `OBSCURA_NAV_CHAIN_LIMIT`. A limit of 0 is
@@ -1813,6 +1874,8 @@ impl Page {
         // run code in the next document's context.
         self.pending_frame_work.clear();
         if self.js.is_some() {
+            #[cfg(feature = "internal-cdp")]
+            self.unregister_navigation_runtime();
             // Every frame realm holds a V8 handle into this isolate, so the
             // frames of the outgoing document must go before the runtime does.
             self.frames.clear();
@@ -1884,6 +1947,14 @@ impl Page {
         if let Some(tx) = &self.intercept_tx {
             rt.set_intercept_tx(tx.clone());
         }
+        #[cfg(feature = "internal-cdp")]
+        {
+            self.intercept_runtime_generation = self.intercept_runtime_generation.saturating_add(1);
+            rt.set_intercept_owner(
+                self.id.clone(),
+                format!("{}@{}", self.id, self.intercept_runtime_generation),
+            );
+        }
         // Re-apply intercept_enabled: enable_interception()/enable_intercept()
         // called before the first navigation sets this on the Page while the
         // runtime does not exist yet, so the new runtime would otherwise start
@@ -1895,6 +1966,10 @@ impl Page {
             rt.set_dom(dom);
         }
 
+        // All engine configuration is installed. Register before bootstrap or
+        // author code can enter V8, so cancellation always reaches this isolate.
+        #[cfg(feature = "internal-cdp")]
+        self.register_navigation_runtime(&rt);
         rt.run_page_init();
         let _ = rt.execute_script(
             "<device-metrics>",
@@ -3802,6 +3877,8 @@ impl Page {
 
     pub fn navigate_blank(&mut self) {
         self.pending_frame_work.clear();
+        #[cfg(feature = "internal-cdp")]
+        self.unregister_navigation_runtime();
         self.frames.clear();
         self.js = None;
         self.url = Some(Url::parse("about:blank").unwrap());
@@ -4644,6 +4721,8 @@ impl Page {
         // and a realm cannot be suspended and resumed the way the page's DOM
         // can, so they are rebuilt when the page next loads a document.
         self.pending_frame_work.clear();
+        #[cfg(feature = "internal-cdp")]
+        self.unregister_navigation_runtime();
         self.frames.clear();
         self.js = None;
     }
@@ -4812,6 +4891,11 @@ impl Page {
         self.intercept_tx = Some(tx.clone());
         if let Some(js) = &self.js {
             js.set_intercept_tx(tx);
+            #[cfg(feature = "internal-cdp")]
+            js.set_intercept_owner(
+                self.id.clone(),
+                format!("{}@{}", self.id, self.intercept_runtime_generation),
+            );
         }
     }
 

--- a/crates/obscura-cdp/Cargo.toml
+++ b/crates/obscura-cdp/Cargo.toml
@@ -14,7 +14,7 @@ render = ["obscura-browser/render", "dep:image", "dep:png"]
 
 [dependencies]
 obscura-dom = { workspace = true }
-obscura-browser = { workspace = true }
+obscura-browser = { workspace = true, features = ["internal-cdp"] }
 obscura-js = { workspace = true }
 tokio = { workspace = true }
 tokio-tungstenite = { workspace = true }
@@ -37,3 +37,4 @@ libc = "0.2"
 [dev-dependencies]
 tokio-tungstenite = { workspace = true }
 futures-util = "0.3"
+tracing-subscriber = { workspace = true }

--- a/crates/obscura-cdp/src/dispatch.rs
+++ b/crates/obscura-cdp/src/dispatch.rs
@@ -282,7 +282,6 @@ impl CdpContext {
         if self.browser_contexts.remove(id).is_none() {
             return Err(format!("Browser context not found: {}", id));
         }
-
         let page_ids: Vec<String> = self
             .pages
             .iter()
@@ -336,6 +335,81 @@ impl CdpContext {
             self.runtime_enabled_sessions.remove(session_id);
         }
         self.sessions.retain(|_, v| v != id);
+    }
+
+    /// Destroy a target through the single ownership-cleanup path used by both
+    /// ordinary Target commands and navigation cancellation. A task-owned page
+    /// is temporarily absent from `pages`, but its sessions still identify it.
+    pub(crate) fn destroy_target(&mut self, id: &str) -> bool {
+        let removed_sessions: Vec<String> = self
+            .sessions
+            .iter()
+            .filter(|(_, page_id)| page_id.as_str() == id)
+            .map(|(session_id, _)| session_id.clone())
+            .collect();
+        let existed = !removed_sessions.is_empty() || self.pages.iter().any(|page| page.id == id);
+        if !existed {
+            return false;
+        }
+        for session_id in &removed_sessions {
+            self.pending_events.push(CdpEvent::new(
+                "Target.detachedFromTarget",
+                json!({"sessionId": session_id, "targetId": id}),
+            ));
+        }
+        self.pending_events.push(CdpEvent::new(
+            "Target.targetDestroyed",
+            json!({"targetId": id}),
+        ));
+        self.remove_page(id);
+        true
+    }
+
+    /// Dispose a context, including a page currently owned by an in-flight
+    /// navigation task and therefore absent from `pages`.
+    pub(crate) fn destroy_browser_context(
+        &mut self,
+        id: &str,
+        task_owned_page: Option<&str>,
+    ) -> Result<(), String> {
+        let mut page_ids: Vec<String> = self
+            .pages
+            .iter()
+            .filter(|page| page.context.id == id)
+            .map(|page| page.id.clone())
+            .collect();
+        if let Some(page_id) = task_owned_page {
+            if self.pages.iter().any(|page| page.id == page_id)
+                || self.sessions.values().any(|owner| owner == page_id)
+            {
+                page_ids.push(page_id.to_string());
+            }
+        }
+        page_ids.sort_unstable();
+        page_ids.dedup();
+        let removed_sessions: Vec<(String, String)> = self
+            .sessions
+            .iter()
+            .filter(|(_, owner)| page_ids.contains(owner))
+            .map(|(session, owner)| (session.clone(), owner.clone()))
+            .collect();
+        self.dispose_browser_context(id)?;
+        if let Some(page_id) = task_owned_page {
+            self.remove_page(page_id);
+        }
+        for (session_id, page_id) in removed_sessions {
+            self.pending_events.push(CdpEvent::new(
+                "Target.detachedFromTarget",
+                json!({"sessionId": session_id, "targetId": page_id}),
+            ));
+        }
+        for page_id in page_ids {
+            self.pending_events.push(CdpEvent::new(
+                "Target.targetDestroyed",
+                json!({"targetId": page_id}),
+            ));
+        }
+        Ok(())
     }
 
     #[cfg(feature = "render")]

--- a/crates/obscura-cdp/src/dispatch.rs
+++ b/crates/obscura-cdp/src/dispatch.rs
@@ -1,6 +1,7 @@
 use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 
+use obscura_browser::lifecycle::LifecycleState;
 use obscura_browser::{BrowserContext, Page};
 use obscura_js::ops::InterceptedRequest;
 use serde_json::json;
@@ -44,6 +45,8 @@ pub struct CdpContext {
     /// script-initiated Network events must share this id; inventing a loader
     /// for each fetch breaks DevTools request grouping.
     pub current_loader_ids: HashMap<String, String>,
+    pub(crate) emitted_document_lifecycle: HashMap<String, LifecycleState>,
+    pub(crate) navigation_sessions: HashMap<String, Option<String>>,
     /// Child frame ids already reported to the client, per page, so each frame
     /// is announced once and a frame that goes away can be retracted.
     pub announced_frames: HashMap<String, Vec<String>>,
@@ -167,6 +170,8 @@ impl CdpContext {
             pages: Vec::new(),
             sessions: HashMap::new(),
             current_loader_ids: HashMap::new(),
+            emitted_document_lifecycle: HashMap::new(),
+            navigation_sessions: HashMap::new(),
             announced_frames: HashMap::new(),
             pending_events: Vec::new(),
             #[cfg(feature = "render")]
@@ -318,6 +323,8 @@ impl CdpContext {
             .collect();
         self.pages.retain(|p| p.id != id);
         self.current_loader_ids.remove(id);
+        self.emitted_document_lifecycle.remove(id);
+        self.navigation_sessions.remove(id);
         self.announced_frames.remove(id);
         #[cfg(feature = "render")]
         {

--- a/crates/obscura-cdp/src/dispatch.rs
+++ b/crates/obscura-cdp/src/dispatch.rs
@@ -300,7 +300,6 @@ impl CdpContext {
         if self.browser_contexts.remove(id).is_none() {
             return Err(format!("Browser context not found: {}", id));
         }
-
         let page_ids: Vec<String> = self
             .pages
             .iter()
@@ -341,6 +340,7 @@ impl CdpContext {
             .collect();
         self.pages.retain(|p| p.id != id);
         self.current_loader_ids.remove(id);
+        self.nav_events_emitted.remove(id);
         self.emitted_document_lifecycle.remove(id);
         self.navigation_sessions.remove(id);
         self.announced_frames.remove(id);
@@ -509,6 +509,81 @@ impl CdpContext {
         sessions
     }
 
+    /// Destroy a target through the single ownership-cleanup path used by both
+    /// ordinary Target commands and navigation cancellation. A task-owned page
+    /// is temporarily absent from `pages`, but its sessions still identify it.
+    pub(crate) fn destroy_target(&mut self, id: &str) -> bool {
+        let removed_sessions: Vec<String> = self
+            .sessions
+            .iter()
+            .filter(|(_, page_id)| page_id.as_str() == id)
+            .map(|(session_id, _)| session_id.clone())
+            .collect();
+        let existed = !removed_sessions.is_empty() || self.pages.iter().any(|page| page.id == id);
+        if !existed {
+            return false;
+        }
+        for session_id in &removed_sessions {
+            self.pending_events.push(CdpEvent::new(
+                "Target.detachedFromTarget",
+                json!({"sessionId": session_id, "targetId": id}),
+            ));
+        }
+        self.pending_events.push(CdpEvent::new(
+            "Target.targetDestroyed",
+            json!({"targetId": id}),
+        ));
+        self.remove_page(id);
+        true
+    }
+
+    /// Dispose a context, including a page currently owned by an in-flight
+    /// navigation task and therefore absent from `pages`.
+    pub(crate) fn destroy_browser_context(
+        &mut self,
+        id: &str,
+        task_owned_page: Option<&str>,
+    ) -> Result<(), String> {
+        let mut page_ids: Vec<String> = self
+            .pages
+            .iter()
+            .filter(|page| page.context.id == id)
+            .map(|page| page.id.clone())
+            .collect();
+        if let Some(page_id) = task_owned_page {
+            if self.pages.iter().any(|page| page.id == page_id)
+                || self.sessions.values().any(|owner| owner == page_id)
+            {
+                page_ids.push(page_id.to_string());
+            }
+        }
+        page_ids.sort_unstable();
+        page_ids.dedup();
+        let removed_sessions: Vec<(String, String)> = self
+            .sessions
+            .iter()
+            .filter(|(_, owner)| page_ids.contains(owner))
+            .map(|(session, owner)| (session.clone(), owner.clone()))
+            .collect();
+        self.dispose_browser_context(id)?;
+        if let Some(page_id) = task_owned_page {
+            self.remove_page(page_id);
+        }
+        for (session_id, page_id) in removed_sessions {
+            self.pending_events.push(CdpEvent::new(
+                "Target.detachedFromTarget",
+                json!({"sessionId": session_id, "targetId": page_id}),
+            ));
+        }
+        for page_id in page_ids {
+            self.pending_events.push(CdpEvent::new(
+                "Target.targetDestroyed",
+                json!({"targetId": page_id}),
+            ));
+        }
+        Ok(())
+    }
+
     #[cfg(feature = "render")]
     pub(crate) fn next_screencast_session(&mut self) -> i64 {
         // Never wrap a delayed acknowledgement onto a replacement stream.
@@ -564,6 +639,11 @@ mod context_ownership_tests {
                 &format!("world-{cycle}"),
                 true,
             );
+            ctx.nav_events_emitted.insert(page_id.clone());
+            ctx.emitted_document_lifecycle
+                .insert(page_id.clone(), LifecycleState::Loaded);
+            ctx.navigation_sessions
+                .insert(page_id.clone(), Some(session_id));
             ctx.remove_page(&page_id);
 
             assert!(ctx.execution_contexts.is_empty());
@@ -572,6 +652,9 @@ mod context_ownership_tests {
             assert!(ctx.valid_context_ids.is_empty());
             assert!(ctx.runtime_enabled_sessions.is_empty());
             assert!(ctx.sessions.is_empty());
+            assert!(ctx.nav_events_emitted.is_empty());
+            assert!(ctx.emitted_document_lifecycle.is_empty());
+            assert!(ctx.navigation_sessions.is_empty());
         }
     }
 

--- a/crates/obscura-cdp/src/dispatch.rs
+++ b/crates/obscura-cdp/src/dispatch.rs
@@ -1,6 +1,7 @@
 use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 
+use obscura_browser::lifecycle::LifecycleState;
 use obscura_browser::{BrowserContext, Page};
 use obscura_js::ops::InterceptedRequest;
 use serde_json::json;
@@ -60,6 +61,8 @@ pub struct CdpContext {
     /// events when the client attaches; Page.enable emits them once per page
     /// so clients waiting on the initial load (chromiumoxide, #833) unblock.
     pub nav_events_emitted: std::collections::HashSet<String>,
+    pub(crate) emitted_document_lifecycle: HashMap<String, LifecycleState>,
+    pub(crate) navigation_sessions: HashMap<String, Option<String>>,
     /// Child frame ids already reported to the client, per page, so each frame
     /// is announced once and a frame that goes away can be retracted.
     pub announced_frames: HashMap<String, Vec<String>>,
@@ -174,6 +177,8 @@ impl CdpContext {
             sessions: HashMap::new(),
             current_loader_ids: HashMap::new(),
             nav_events_emitted: std::collections::HashSet::new(),
+            emitted_document_lifecycle: HashMap::new(),
+            navigation_sessions: HashMap::new(),
             announced_frames: HashMap::new(),
             pending_events: Vec::new(),
             #[cfg(feature = "render")]
@@ -336,6 +341,8 @@ impl CdpContext {
             .collect();
         self.pages.retain(|p| p.id != id);
         self.current_loader_ids.remove(id);
+        self.emitted_document_lifecycle.remove(id);
+        self.navigation_sessions.remove(id);
         self.announced_frames.remove(id);
         #[cfg(feature = "render")]
         {

--- a/crates/obscura-cdp/src/domains/page.rs
+++ b/crates/obscura-cdp/src/domains/page.rs
@@ -1,4 +1,5 @@
 use obscura_browser::lifecycle::WaitUntil;
+use obscura_browser::lifecycle::LifecycleState;
 use serde_json::{json, Value};
 
 use crate::dispatch::CdpContext;
@@ -845,11 +846,18 @@ pub fn emit_navigation_events(
     page_url: &str,
     page_id: &str,
     network_events: &[obscura_browser::NetworkEvent],
-    wait_until: WaitUntil,
-    reached_network_idle: bool,
+    _wait_until: WaitUntil,
+    _reached_network_idle: bool,
 ) {
+    // The final two arguments remain for downstream callers of this public
+    // helper. Lifecycle emission now derives solely from Page state so a
+    // requested wait mode cannot fabricate a transition.
     ctx.current_loader_ids
         .insert(page_id.to_string(), loader_id.to_string());
+    ctx.navigation_sessions
+        .insert(page_id.to_string(), session_id.clone());
+    ctx.emitted_document_lifecycle
+        .insert(page_id.to_string(), LifecycleState::Loading);
     let es = session_id.clone();
     let ts = timestamp();
 
@@ -997,38 +1005,18 @@ pub fn emit_navigation_events(
         });
     }
 
-    let mut phase3 = vec![
-        CdpEvent {
-            method: "Page.lifecycleEvent".into(),
-            params: json!({"frameId": frame_id, "loaderId": loader_id, "name": "DOMContentLoaded", "timestamp": ts}),
-            session_id: es.clone(),
-        },
-        CdpEvent {
-            method: "Page.domContentEventFired".into(),
-            params: json!({"timestamp": ts}),
-            session_id: es.clone(),
-        },
-        CdpEvent {
-            method: "Page.lifecycleEvent".into(),
-            params: json!({"frameId": frame_id, "loaderId": loader_id, "name": "load", "timestamp": ts}),
-            session_id: es.clone(),
-        },
-        CdpEvent {
-            method: "Page.loadEventFired".into(),
-            params: json!({"timestamp": ts}),
-            session_id: es.clone(),
-        },
-    ];
-    if reached_network_idle || matches!(wait_until, WaitUntil::Load | WaitUntil::DomContentLoaded) {
-        let idle_ts = timestamp();
-        phase3.push(CdpEvent { method: "Page.lifecycleEvent".into(), params: json!({"frameId": frame_id, "loaderId": loader_id, "name": "networkIdle", "timestamp": idle_ts}), session_id: es.clone() });
-    }
-    phase3.push(CdpEvent {
-        method: "Page.frameStoppedLoading".into(),
-        params: json!({"frameId": frame_id}),
-        session_id: es,
-    });
-    ctx.pending_events.extend(phase3);
+    let lifecycle_state = ctx
+        .get_page(page_id)
+        .map(|page| page.lifecycle)
+        .unwrap_or(LifecycleState::Failed);
+    emit_document_lifecycle_state(
+        ctx,
+        session_id,
+        frame_id,
+        loader_id,
+        page_id,
+        lifecycle_state,
+    );
 
     // Target.targetInfoChanged: strict CDP clients (browser-use, and
     // Puppeteer/Playwright `page.url()` tracking) cache the TargetInfo from
@@ -1053,6 +1041,74 @@ pub fn emit_navigation_events(
             }
         }),
     ));
+}
+
+pub(crate) fn emit_document_lifecycle_state(
+    ctx: &mut CdpContext,
+    session_id: &Option<String>,
+    frame_id: &str,
+    loader_id: &str,
+    page_id: &str,
+    state: LifecycleState,
+) {
+    let last = ctx
+        .emitted_document_lifecycle
+        .get(page_id)
+        .copied()
+        .unwrap_or(LifecycleState::Loading);
+    let emit_dom_content_loaded = matches!(
+        state,
+        LifecycleState::DomContentLoaded | LifecycleState::Loaded | LifecycleState::NetworkIdle
+    ) && !matches!(
+        last,
+        LifecycleState::DomContentLoaded | LifecycleState::Loaded | LifecycleState::NetworkIdle
+    );
+    let emit_load = matches!(state, LifecycleState::Loaded | LifecycleState::NetworkIdle)
+        && !matches!(last, LifecycleState::Loaded | LifecycleState::NetworkIdle);
+    let emit_network_idle = state == LifecycleState::NetworkIdle
+        && last != LifecycleState::NetworkIdle;
+
+    if emit_dom_content_loaded {
+        let timestamp = timestamp();
+        ctx.pending_events.push(CdpEvent {
+            method: "Page.domContentEventFired".into(),
+            params: json!({"timestamp": timestamp}),
+            session_id: session_id.clone(),
+        });
+        ctx.pending_events.push(CdpEvent {
+            method: "Page.lifecycleEvent".into(),
+            params: json!({"frameId": frame_id, "loaderId": loader_id, "name": "DOMContentLoaded", "timestamp": timestamp}),
+            session_id: session_id.clone(),
+        });
+    }
+    if emit_load {
+        let timestamp = timestamp();
+        ctx.pending_events.push(CdpEvent {
+            method: "Page.loadEventFired".into(),
+            params: json!({"timestamp": timestamp}),
+            session_id: session_id.clone(),
+        });
+        ctx.pending_events.push(CdpEvent {
+            method: "Page.lifecycleEvent".into(),
+            params: json!({"frameId": frame_id, "loaderId": loader_id, "name": "load", "timestamp": timestamp}),
+            session_id: session_id.clone(),
+        });
+        ctx.pending_events.push(CdpEvent {
+            method: "Page.frameStoppedLoading".into(),
+            params: json!({"frameId": frame_id}),
+            session_id: session_id.clone(),
+        });
+    }
+    if emit_network_idle {
+        let timestamp = timestamp();
+        ctx.pending_events.push(CdpEvent {
+            method: "Page.lifecycleEvent".into(),
+            params: json!({"frameId": frame_id, "loaderId": loader_id, "name": "networkIdle", "timestamp": timestamp}),
+            session_id: session_id.clone(),
+        });
+    }
+    ctx.emitted_document_lifecycle
+        .insert(page_id.to_string(), state);
 }
 
 /// Emit completed script-initiated requests after the document lifecycle has
@@ -1171,6 +1227,15 @@ async fn do_navigate(
     session_id: &Option<String>,
 ) -> Result<Value, String> {
     let wait_until = parse_wait_until(params);
+    // The public in-process dispatcher has no autonomous owner to preserve a
+    // post-DCL runtime across a command targeting another page. Keep its
+    // historical fully-loaded contract; the WebSocket server owns the real
+    // DCL handoff and continuation pump.
+    let navigation_wait = if wait_until == WaitUntil::DomContentLoaded {
+        WaitUntil::Load
+    } else {
+        wait_until
+    };
 
     // Block CDP-initiated file:// navigation by default.
     // Anyone who can reach the CDP port (default localhost,
@@ -1190,7 +1255,14 @@ async fn do_navigate(
 
     let preload_scripts: Vec<String> = ctx.preload_scripts.iter().map(|(_, s)| s.clone()).collect();
 
-    let (frame_id, loader_id, network_events, page_url, page_id, reached_network_idle) = {
+    let (
+        frame_id,
+        loader_id,
+        network_events,
+        page_url,
+        page_id,
+        reached_network_idle,
+    ) = {
         let page = ctx
             .get_session_page_mut(session_id)
             .ok_or("No page for session")?;
@@ -1208,11 +1280,11 @@ async fn do_navigate(
             .unwrap_or("GET");
         let nav_body = params.get("__body").and_then(|v| v.as_str()).unwrap_or("");
         if nav_method == "POST" && !nav_body.is_empty() {
-            page.navigate_with_wait_post(url, wait_until, nav_method, nav_body)
+            page.navigate_with_wait_post(url, navigation_wait, nav_method, nav_body)
                 .await
                 .map_err(|e| e.to_string())?;
         } else {
-            page.navigate_with_wait(url, wait_until)
+            page.navigate_with_wait(url, navigation_wait)
                 .await
                 .map_err(|e| e.to_string())?;
         }
@@ -1475,11 +1547,17 @@ pub async fn handle(
                         .ok_or("No page for session")?;
                     (page.history.clone(), page.history_index)
                 };
-                let (frame_id, page_id, network_events, page_url, reached_idle) = {
+                let (
+                    frame_id,
+                    page_id,
+                    network_events,
+                    page_url,
+                    reached_idle,
+                ) = {
                     let page = ctx
                         .get_session_page_mut(session_id)
                         .ok_or("No page for session")?;
-                    page.navigate_with_wait(&url, WaitUntil::DomContentLoaded)
+                    page.navigate_with_wait(&url, WaitUntil::Load)
                         .await
                         .map_err(|e| e.to_string())?;
                     page.history = stash.0;
@@ -1729,6 +1807,31 @@ fn timestamp() -> f64 {
 mod tests {
     use super::*;
     use crate::dispatch::CdpContext;
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn in_process_navigation_finishes_load_before_returning() {
+        let mut ctx = CdpContext::new();
+        let page_id = ctx.create_page();
+        let session_id = Some(format!("{page_id}-session"));
+        ctx.sessions
+            .insert(session_id.clone().unwrap(), page_id);
+
+        handle(
+            "navigate",
+            &json!({
+                "url": "data:text/html,<script>window.addEventListener('load',()=>globalThis.__loadSeen=true)</script>",
+                "waitUntil": "domcontentloaded",
+            }),
+            &mut ctx,
+            &session_id,
+        )
+        .await
+        .expect("in-process navigation");
+
+        let page = ctx.get_session_page_mut(&session_id).expect("page");
+        assert_eq!(page.lifecycle, LifecycleState::Loaded);
+        assert_eq!(page.evaluate("globalThis.__loadSeen === true"), json!(true));
+    }
 
     #[test]
     fn runtime_network_events_reuse_the_document_loader_without_lifecycle_replay() {

--- a/crates/obscura-cdp/src/domains/page.rs
+++ b/crates/obscura-cdp/src/domains/page.rs
@@ -1,4 +1,5 @@
 use obscura_browser::lifecycle::WaitUntil;
+use obscura_browser::lifecycle::LifecycleState;
 use serde_json::{json, Value};
 
 use crate::dispatch::CdpContext;
@@ -845,12 +846,19 @@ pub fn emit_navigation_events(
     page_url: &str,
     page_id: &str,
     network_events: &[obscura_browser::NetworkEvent],
-    wait_until: WaitUntil,
-    reached_network_idle: bool,
+    _wait_until: WaitUntil,
+    _reached_network_idle: bool,
 ) {
+    // The final two arguments remain for downstream callers of this public
+    // helper. Lifecycle emission now derives solely from Page state so a
+    // requested wait mode cannot fabricate a transition.
     ctx.current_loader_ids
         .insert(page_id.to_string(), loader_id.to_string());
     ctx.nav_events_emitted.insert(page_id.to_string());
+    ctx.navigation_sessions
+        .insert(page_id.to_string(), session_id.clone());
+    ctx.emitted_document_lifecycle
+        .insert(page_id.to_string(), LifecycleState::Loading);
     let es = session_id.clone();
     let ts = timestamp();
 
@@ -979,38 +987,18 @@ pub fn emit_navigation_events(
         });
     }
 
-    let mut phase3 = vec![
-        CdpEvent {
-            method: "Page.lifecycleEvent".into(),
-            params: json!({"frameId": frame_id, "loaderId": loader_id, "name": "DOMContentLoaded", "timestamp": ts}),
-            session_id: es.clone(),
-        },
-        CdpEvent {
-            method: "Page.domContentEventFired".into(),
-            params: json!({"timestamp": ts}),
-            session_id: es.clone(),
-        },
-        CdpEvent {
-            method: "Page.lifecycleEvent".into(),
-            params: json!({"frameId": frame_id, "loaderId": loader_id, "name": "load", "timestamp": ts}),
-            session_id: es.clone(),
-        },
-        CdpEvent {
-            method: "Page.loadEventFired".into(),
-            params: json!({"timestamp": ts}),
-            session_id: es.clone(),
-        },
-    ];
-    if reached_network_idle || matches!(wait_until, WaitUntil::Load | WaitUntil::DomContentLoaded) {
-        let idle_ts = timestamp();
-        phase3.push(CdpEvent { method: "Page.lifecycleEvent".into(), params: json!({"frameId": frame_id, "loaderId": loader_id, "name": "networkIdle", "timestamp": idle_ts}), session_id: es.clone() });
-    }
-    phase3.push(CdpEvent {
-        method: "Page.frameStoppedLoading".into(),
-        params: json!({"frameId": frame_id}),
-        session_id: es,
-    });
-    ctx.pending_events.extend(phase3);
+    let lifecycle_state = ctx
+        .get_page(page_id)
+        .map(|page| page.lifecycle)
+        .unwrap_or(LifecycleState::Failed);
+    emit_document_lifecycle_state(
+        ctx,
+        session_id,
+        frame_id,
+        loader_id,
+        page_id,
+        lifecycle_state,
+    );
 
     // Target.targetInfoChanged: strict CDP clients (browser-use, and
     // Puppeteer/Playwright `page.url()` tracking) cache the TargetInfo from
@@ -1035,6 +1023,74 @@ pub fn emit_navigation_events(
             }
         }),
     ));
+}
+
+pub(crate) fn emit_document_lifecycle_state(
+    ctx: &mut CdpContext,
+    session_id: &Option<String>,
+    frame_id: &str,
+    loader_id: &str,
+    page_id: &str,
+    state: LifecycleState,
+) {
+    let last = ctx
+        .emitted_document_lifecycle
+        .get(page_id)
+        .copied()
+        .unwrap_or(LifecycleState::Loading);
+    let emit_dom_content_loaded = matches!(
+        state,
+        LifecycleState::DomContentLoaded | LifecycleState::Loaded | LifecycleState::NetworkIdle
+    ) && !matches!(
+        last,
+        LifecycleState::DomContentLoaded | LifecycleState::Loaded | LifecycleState::NetworkIdle
+    );
+    let emit_load = matches!(state, LifecycleState::Loaded | LifecycleState::NetworkIdle)
+        && !matches!(last, LifecycleState::Loaded | LifecycleState::NetworkIdle);
+    let emit_network_idle = state == LifecycleState::NetworkIdle
+        && last != LifecycleState::NetworkIdle;
+
+    if emit_dom_content_loaded {
+        let timestamp = timestamp();
+        ctx.pending_events.push(CdpEvent {
+            method: "Page.domContentEventFired".into(),
+            params: json!({"timestamp": timestamp}),
+            session_id: session_id.clone(),
+        });
+        ctx.pending_events.push(CdpEvent {
+            method: "Page.lifecycleEvent".into(),
+            params: json!({"frameId": frame_id, "loaderId": loader_id, "name": "DOMContentLoaded", "timestamp": timestamp}),
+            session_id: session_id.clone(),
+        });
+    }
+    if emit_load {
+        let timestamp = timestamp();
+        ctx.pending_events.push(CdpEvent {
+            method: "Page.loadEventFired".into(),
+            params: json!({"timestamp": timestamp}),
+            session_id: session_id.clone(),
+        });
+        ctx.pending_events.push(CdpEvent {
+            method: "Page.lifecycleEvent".into(),
+            params: json!({"frameId": frame_id, "loaderId": loader_id, "name": "load", "timestamp": timestamp}),
+            session_id: session_id.clone(),
+        });
+        ctx.pending_events.push(CdpEvent {
+            method: "Page.frameStoppedLoading".into(),
+            params: json!({"frameId": frame_id}),
+            session_id: session_id.clone(),
+        });
+    }
+    if emit_network_idle {
+        let timestamp = timestamp();
+        ctx.pending_events.push(CdpEvent {
+            method: "Page.lifecycleEvent".into(),
+            params: json!({"frameId": frame_id, "loaderId": loader_id, "name": "networkIdle", "timestamp": timestamp}),
+            session_id: session_id.clone(),
+        });
+    }
+    ctx.emitted_document_lifecycle
+        .insert(page_id.to_string(), state);
 }
 
 /// Emit completed script-initiated requests after the document lifecycle has
@@ -1153,6 +1209,15 @@ async fn do_navigate(
     session_id: &Option<String>,
 ) -> Result<Value, String> {
     let wait_until = parse_wait_until(params);
+    // The public in-process dispatcher has no autonomous owner to preserve a
+    // post-DCL runtime across a command targeting another page. Keep its
+    // historical fully-loaded contract; the WebSocket server owns the real
+    // DCL handoff and continuation pump.
+    let navigation_wait = if wait_until == WaitUntil::DomContentLoaded {
+        WaitUntil::Load
+    } else {
+        wait_until
+    };
 
     // Block CDP-initiated file:// navigation by default.
     // Anyone who can reach the CDP port (default localhost,
@@ -1172,7 +1237,14 @@ async fn do_navigate(
 
     let preload_scripts: Vec<String> = ctx.preload_scripts.iter().map(|(_, s)| s.clone()).collect();
 
-    let (frame_id, loader_id, network_events, page_url, page_id, reached_network_idle) = {
+    let (
+        frame_id,
+        loader_id,
+        network_events,
+        page_url,
+        page_id,
+        reached_network_idle,
+    ) = {
         let page = ctx
             .get_session_page_mut(session_id)
             .ok_or("No page for session")?;
@@ -1190,11 +1262,11 @@ async fn do_navigate(
             .unwrap_or("GET");
         let nav_body = params.get("__body").and_then(|v| v.as_str()).unwrap_or("");
         if nav_method == "POST" && !nav_body.is_empty() {
-            page.navigate_with_wait_post(url, wait_until, nav_method, nav_body)
+            page.navigate_with_wait_post(url, navigation_wait, nav_method, nav_body)
                 .await
                 .map_err(|e| e.to_string())?;
         } else {
-            page.navigate_with_wait(url, wait_until)
+            page.navigate_with_wait(url, navigation_wait)
                 .await
                 .map_err(|e| e.to_string())?;
         }
@@ -1492,11 +1564,17 @@ pub async fn handle(
                         .ok_or("No page for session")?;
                     (page.history.clone(), page.history_index)
                 };
-                let (frame_id, page_id, network_events, page_url, reached_idle) = {
+                let (
+                    frame_id,
+                    page_id,
+                    network_events,
+                    page_url,
+                    reached_idle,
+                ) = {
                     let page = ctx
                         .get_session_page_mut(session_id)
                         .ok_or("No page for session")?;
-                    page.navigate_with_wait(&url, WaitUntil::DomContentLoaded)
+                    page.navigate_with_wait(&url, WaitUntil::Load)
                         .await
                         .map_err(|e| e.to_string())?;
                     page.history = stash.0;
@@ -1796,6 +1874,31 @@ mod tests {
             ctx.pending_events.is_empty(),
             "the initial sequence must not replay on a second enable"
         );
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn in_process_navigation_finishes_load_before_returning() {
+        let mut ctx = CdpContext::new();
+        let page_id = ctx.create_page();
+        let session_id = Some(format!("{page_id}-session"));
+        ctx.sessions
+            .insert(session_id.clone().unwrap(), page_id);
+
+        handle(
+            "navigate",
+            &json!({
+                "url": "data:text/html,<script>window.addEventListener('load',()=>globalThis.__loadSeen=true)</script>",
+                "waitUntil": "domcontentloaded",
+            }),
+            &mut ctx,
+            &session_id,
+        )
+        .await
+        .expect("in-process navigation");
+
+        let page = ctx.get_session_page_mut(&session_id).expect("page");
+        assert_eq!(page.lifecycle, LifecycleState::Loaded);
+        assert_eq!(page.evaluate("globalThis.__loadSeen === true"), json!(true));
     }
 
     #[test]

--- a/crates/obscura-cdp/src/domains/target.rs
+++ b/crates/obscura-cdp/src/domains/target.rs
@@ -207,22 +207,7 @@ pub async fn handle(
                 .get("targetId")
                 .and_then(|v| v.as_str())
                 .ok_or("targetId required")?;
-            let session_id = format!("{}-session", target_id);
-
-            ctx.pending_events.push(CdpEvent::new(
-                "Target.detachedFromTarget",
-                json!({
-                    "sessionId": session_id,
-                    "targetId": target_id,
-                }),
-            ));
-            ctx.pending_events.push(CdpEvent::new(
-                "Target.targetDestroyed",
-                json!({ "targetId": target_id }),
-            ));
-
-            ctx.remove_page(target_id);
-            Ok(json!({ "success": true }))
+            Ok(json!({ "success": ctx.destroy_target(target_id) }))
         }
         "setAutoAttach" => Ok(json!({})),
         // No multi-target lifecycle to manage: obscura runs one page per session.
@@ -271,28 +256,7 @@ pub async fn handle(
                 .get("browserContextId")
                 .and_then(|v| v.as_str())
                 .ok_or("browserContextId required")?;
-            let sessions: Vec<(String, String)> = ctx
-                .sessions
-                .iter()
-                .filter_map(|(session_id, page_id)| {
-                    ctx.get_page(page_id)
-                        .filter(|page| page.context.id == context_id)
-                        .map(|_| (session_id.clone(), page_id.clone()))
-                })
-                .collect();
-            let page_ids = ctx.dispose_browser_context(context_id)?;
-            for (session_id, page_id) in sessions {
-                ctx.pending_events.push(CdpEvent::new(
-                    "Target.detachedFromTarget",
-                    json!({ "sessionId": session_id, "targetId": page_id }),
-                ));
-            }
-            for page_id in page_ids {
-                ctx.pending_events.push(CdpEvent::new(
-                    "Target.targetDestroyed",
-                    json!({ "targetId": page_id }),
-                ));
-            }
+            ctx.destroy_browser_context(context_id, None)?;
             Ok(json!({}))
         }
         "getTargetInfo" => {

--- a/crates/obscura-cdp/src/domains/target.rs
+++ b/crates/obscura-cdp/src/domains/target.rs
@@ -233,6 +233,22 @@ pub async fn handle(
                 ctx.sessions.remove(session_id);
                 ctx.runtime_enabled_sessions.remove(session_id);
                 if let Some(page_id) = page_id {
+                    if ctx
+                        .navigation_sessions
+                        .get(&page_id)
+                        .is_some_and(|owner| owner.as_deref() == Some(session_id))
+                    {
+                        let replacement = ctx
+                            .sessions
+                            .iter()
+                            .find(|(_, owner)| *owner == &page_id)
+                            .map(|(remaining, _)| remaining.clone());
+                        if replacement.is_some() {
+                            ctx.navigation_sessions.insert(page_id.clone(), replacement);
+                        } else {
+                            ctx.navigation_sessions.remove(&page_id);
+                        }
+                    }
                     ctx.refresh_runtime_event_collection(&page_id);
                 }
                 #[cfg(feature = "render")]
@@ -367,6 +383,32 @@ mod tests {
         assert!(ctx.get_page(&isolated_page).is_none());
         assert!(ctx.get_page(&default_page).is_some());
         assert!(ctx.browser_contexts.is_empty());
+    }
+
+    #[tokio::test]
+    async fn detaching_navigation_session_clears_lifecycle_route() {
+        let mut ctx = CdpContext::new();
+        let page_id = ctx.create_page();
+        let session_id = "explicit-session".to_string();
+        ctx.sessions.insert(session_id.clone(), page_id.clone());
+        ctx.sessions
+            .insert("remaining-session".to_string(), page_id.clone());
+        ctx.navigation_sessions
+            .insert(page_id.clone(), Some(session_id.clone()));
+
+        handle(
+            "detachFromTarget",
+            &json!({"sessionId": session_id}),
+            &mut ctx,
+            &None,
+        )
+        .await
+        .expect("detach should succeed");
+
+        assert_eq!(
+            ctx.navigation_sessions.get(&page_id),
+            Some(&Some("remaining-session".to_string())),
+        );
     }
 
     #[tokio::test]

--- a/crates/obscura-cdp/src/domains/target.rs
+++ b/crates/obscura-cdp/src/domains/target.rs
@@ -246,6 +246,22 @@ pub async fn handle(
                 ctx.sessions.remove(session_id);
                 ctx.runtime_enabled_sessions.remove(session_id);
                 if let Some(page_id) = page_id {
+                    if ctx
+                        .navigation_sessions
+                        .get(&page_id)
+                        .is_some_and(|owner| owner.as_deref() == Some(session_id))
+                    {
+                        let replacement = ctx
+                            .sessions
+                            .iter()
+                            .find(|(_, owner)| *owner == &page_id)
+                            .map(|(remaining, _)| remaining.clone());
+                        if replacement.is_some() {
+                            ctx.navigation_sessions.insert(page_id.clone(), replacement);
+                        } else {
+                            ctx.navigation_sessions.remove(&page_id);
+                        }
+                    }
                     ctx.refresh_runtime_event_collection(&page_id);
                 }
                 #[cfg(feature = "render")]
@@ -380,6 +396,32 @@ mod tests {
         assert!(ctx.get_page(&isolated_page).is_none());
         assert!(ctx.get_page(&default_page).is_some());
         assert!(ctx.browser_contexts.is_empty());
+    }
+
+    #[tokio::test]
+    async fn detaching_navigation_session_clears_lifecycle_route() {
+        let mut ctx = CdpContext::new();
+        let page_id = ctx.create_page();
+        let session_id = "explicit-session".to_string();
+        ctx.sessions.insert(session_id.clone(), page_id.clone());
+        ctx.sessions
+            .insert("remaining-session".to_string(), page_id.clone());
+        ctx.navigation_sessions
+            .insert(page_id.clone(), Some(session_id.clone()));
+
+        handle(
+            "detachFromTarget",
+            &json!({"sessionId": session_id}),
+            &mut ctx,
+            &None,
+        )
+        .await
+        .expect("detach should succeed");
+
+        assert_eq!(
+            ctx.navigation_sessions.get(&page_id),
+            Some(&Some("remaining-session".to_string())),
+        );
     }
 
     #[tokio::test]

--- a/crates/obscura-cdp/src/domains/target.rs
+++ b/crates/obscura-cdp/src/domains/target.rs
@@ -215,27 +215,7 @@ pub async fn handle(
                 .get("targetId")
                 .and_then(|v| v.as_str())
                 .ok_or("targetId required")?;
-            let mut sessions = ctx.sessions.iter()
-                .filter(|(_, page_id)| page_id.as_str() == target_id)
-                .map(|(session_id, _)| session_id.clone())
-                .collect::<Vec<_>>();
-            sessions.sort_unstable();
-            for session_id in sessions {
-                ctx.pending_events.push(CdpEvent::new(
-                    "Target.detachedFromTarget",
-                    json!({
-                        "sessionId": session_id,
-                        "targetId": target_id,
-                    }),
-                ));
-            }
-            ctx.pending_events.push(CdpEvent::new(
-                "Target.targetDestroyed",
-                json!({ "targetId": target_id }),
-            ));
-
-            ctx.remove_page(target_id);
-            Ok(json!({ "success": true }))
+            Ok(json!({ "success": ctx.destroy_target(target_id) }))
         }
         "setAutoAttach" => Ok(json!({})),
         // No multi-target lifecycle to manage: obscura runs one page per session.
@@ -284,28 +264,7 @@ pub async fn handle(
                 .get("browserContextId")
                 .and_then(|v| v.as_str())
                 .ok_or("browserContextId required")?;
-            let sessions: Vec<(String, String)> = ctx
-                .sessions
-                .iter()
-                .filter_map(|(session_id, page_id)| {
-                    ctx.get_page(page_id)
-                        .filter(|page| page.context.id == context_id)
-                        .map(|_| (session_id.clone(), page_id.clone()))
-                })
-                .collect();
-            let page_ids = ctx.dispose_browser_context(context_id)?;
-            for (session_id, page_id) in sessions {
-                ctx.pending_events.push(CdpEvent::new(
-                    "Target.detachedFromTarget",
-                    json!({ "sessionId": session_id, "targetId": page_id }),
-                ));
-            }
-            for page_id in page_ids {
-                ctx.pending_events.push(CdpEvent::new(
-                    "Target.targetDestroyed",
-                    json!({ "targetId": page_id }),
-                ));
-            }
+            ctx.destroy_browser_context(context_id, None)?;
             Ok(json!({}))
         }
         "getTargetInfo" => {

--- a/crates/obscura-cdp/src/server.rs
+++ b/crates/obscura-cdp/src/server.rs
@@ -65,6 +65,70 @@ enum ServerMessage {
     },
 }
 
+fn enqueue_deferred_cdp(
+    queue: &mut std::collections::VecDeque<ServerMessage>,
+    queued_elsewhere: usize,
+    message: CdpMessage,
+    full_reason: &str,
+) {
+    if queue.len().saturating_add(queued_elsewhere) < MAX_DEFERRED_MESSAGES {
+        queue.push_back(ServerMessage::Cdp(message));
+        return;
+    }
+    if let Ok(request) = serde_json::from_str::<CdpRequest>(&message.text) {
+        let response = crate::types::CdpResponse::error(
+            request.id,
+            -32000,
+            full_reason.to_string(),
+            request.session_id,
+        );
+        if let Ok(json) = serde_json::to_string(&response) {
+            let _ = message.reply_tx.send(json);
+        }
+    }
+}
+
+fn reclassify_deferred_for_lifecycle(
+    deferred: &mut std::collections::VecDeque<ServerMessage>,
+    post_load_deferred: &mut std::collections::VecDeque<ServerMessage>,
+    ctx: &CdpContext,
+    lifecycle_page_id: &str,
+) -> bool {
+    let should_reclassify = deferred.front().is_some_and(|message| match message {
+        ServerMessage::Cdp(cdp) => {
+            command_targets_other_page(&cdp.text, ctx, lifecycle_page_id)
+        }
+        ServerMessage::NewConnection { .. } => false,
+    });
+    if !should_reclassify {
+        return false;
+    }
+    let Some(ServerMessage::Cdp(message)) = deferred.pop_front() else {
+        unreachable!("only CDP messages are reclassified")
+    };
+    enqueue_deferred_cdp(
+        post_load_deferred,
+        deferred.len(),
+        message,
+        "Server busy: another page is completing navigation",
+    );
+    true
+}
+
+fn pop_deferred_for_lifecycle_state(
+    deferred: &mut std::collections::VecDeque<ServerMessage>,
+    post_load_deferred: &mut std::collections::VecDeque<ServerMessage>,
+    lifecycle_active: bool,
+) -> Option<ServerMessage> {
+    if lifecycle_active {
+        deferred.pop_front()
+    } else {
+        post_load_deferred
+            .pop_front()
+            .or_else(|| deferred.pop_front())
+    }
+}
+
 pub async fn start(port: u16) -> anyhow::Result<()> {
     start_with_options(port, None, false).await
 }
@@ -888,6 +952,7 @@ async fn cdp_processor(
                 &mut intercept_rx,
                 &mut intercepted_paused,
                 &mut deferred,
+                post_load_deferred.len(),
                 false,
             )
             .await;
@@ -911,13 +976,21 @@ async fn cdp_processor(
         // before pulling new ones off the wire. Each is processed with no
         // nav-task spawn_local in flight, so this connection's only entered
         // Isolate is the one dispatch is about to touch.
-        let msg = if let Some(d) = deferred.pop_front() {
-            Some(d)
-        } else if lifecycle_continuation_page.is_none() {
-            post_load_deferred.pop_front()
-        } else {
-            None
-        };
+        if lifecycle_continuation_page.as_ref().is_some_and(|page_id| {
+            reclassify_deferred_for_lifecycle(
+                &mut deferred,
+                &mut post_load_deferred,
+                &ctx,
+                page_id,
+            )
+        }) {
+            continue;
+        }
+        let msg = pop_deferred_for_lifecycle_state(
+            &mut deferred,
+            &mut post_load_deferred,
+            lifecycle_continuation_page.is_some(),
+        );
         let msg = if msg.is_some() {
             msg
         } else {
@@ -963,31 +1036,11 @@ async fn cdp_processor(
                     lifecycle_continuation_page.as_deref(),
                 ), if runtime_pump_armed => {
                     let mut completed_lifecycle = false;
-                    match pump_result {
+                    let reached_idle = match pump_result {
                         Ok(reached_idle) => {
                             runtime_pump_error_streak = 0;
                             runtime_pump_armed = !reached_idle;
-                            let terminal_lifecycle = lifecycle_continuation_page
-                                .as_ref()
-                                .and_then(|page_id| ctx.get_page(page_id))
-                                .is_some_and(|page| {
-                                    matches!(
-                                        page.lifecycle,
-                                        obscura_browser::lifecycle::LifecycleState::Loaded
-                                            | obscura_browser::lifecycle::LifecycleState::NetworkIdle
-                                            | obscura_browser::lifecycle::LifecycleState::Failed
-                                    )
-                                });
-                            if terminal_lifecycle {
-                                if reached_idle {
-                                    completed_lifecycle = true;
-                                } else {
-                                    lifecycle_release_deadline.get_or_insert_with(|| {
-                                        tokio::time::Instant::now()
-                                            + POST_LOAD_DRAIN_TIMEOUT
-                                    });
-                                }
-                            }
+                            Some(reached_idle)
                         }
                         Err(error) => {
                             runtime_pump_error_streak = runtime_pump_error_streak.saturating_add(1);
@@ -1036,6 +1089,27 @@ async fn cdp_processor(
                                 runtime_pump_armed = ctx.pages.iter().any(|page| page.has_js());
                                 tokio::task::yield_now().await;
                             }
+                            None
+                        }
+                    };
+                    let terminal_lifecycle = lifecycle_continuation_page
+                        .as_ref()
+                        .and_then(|page_id| ctx.get_page(page_id))
+                        .is_some_and(|page| {
+                            matches!(
+                                page.lifecycle,
+                                obscura_browser::lifecycle::LifecycleState::Loaded
+                                    | obscura_browser::lifecycle::LifecycleState::NetworkIdle
+                                    | obscura_browser::lifecycle::LifecycleState::Failed
+                            )
+                        });
+                    if terminal_lifecycle {
+                        if reached_idle == Some(true) {
+                            completed_lifecycle = true;
+                        } else {
+                            lifecycle_release_deadline.get_or_insert_with(|| {
+                                tokio::time::Instant::now() + POST_LOAD_DRAIN_TIMEOUT
+                            });
                         }
                     }
                     sync_live_page_network_events(
@@ -1113,21 +1187,12 @@ async fn cdp_processor(
                 if lifecycle_continuation_page.as_ref().is_some_and(|page_id| {
                     command_targets_other_page(&cdp_msg.text, &ctx, page_id)
                 }) {
-                    if post_load_deferred.len() >= MAX_DEFERRED_MESSAGES {
-                        if let Ok(req) = serde_json::from_str::<CdpRequest>(&cdp_msg.text) {
-                            let response = crate::types::CdpResponse::error(
-                                req.id,
-                                -32000,
-                                "Server busy: another page is completing navigation".to_string(),
-                                req.session_id,
-                            );
-                            if let Ok(json) = serde_json::to_string(&response) {
-                                let _ = cdp_msg.reply_tx.send(json);
-                            }
-                        }
-                    } else {
-                        post_load_deferred.push_back(ServerMessage::Cdp(cdp_msg));
-                    }
+                    enqueue_deferred_cdp(
+                        &mut post_load_deferred,
+                        deferred.len(),
+                        cdp_msg,
+                        "Server busy: another page is completing navigation",
+                    );
                     continue;
                 }
                 // Route every Page.navigate through the spawn-and-defer path,
@@ -1147,7 +1212,7 @@ async fn cdp_processor(
                     process_with_interception(
                         &cdp_msg.text, &mut ctx, &cdp_msg.reply_tx, &mut rx,
                         &mut intercept_rx, &mut intercepted_paused,
-                        &mut deferred, true,
+                        &mut deferred, post_load_deferred.len(), true,
                     ).await;
                     lifecycle_continuation_page = navigation_page_id.filter(|page_id| {
                         ctx.get_page(page_id).is_some_and(|page| {
@@ -1524,6 +1589,7 @@ async fn process_with_interception(
     intercept_rx: &mut Option<mpsc::UnboundedReceiver<obscura_js::ops::InterceptedRequest>>,
     intercepted_paused: &mut HashMap<String, tokio::sync::oneshot::Sender<obscura_js::ops::InterceptResolution>>,
     deferred: &mut std::collections::VecDeque<ServerMessage>,
+    queued_after_navigation: usize,
     send_command_response: bool,
 ) {
     let req: CdpRequest = match serde_json::from_str(text) {
@@ -1691,23 +1757,13 @@ async fn process_with_interception(
                             // pushed to the outer `cdp_processor` queue so
                             // it's processed sequentially with no nav task
                             // in flight.
-                            if deferred.len() >= MAX_DEFERRED_MESSAGES {
-                                tracing::warn!("INTERCEPTION: deferred queue full ({}), returning error to client", MAX_DEFERRED_MESSAGES);
-                                if let Ok(req) = serde_json::from_str::<CdpRequest>(&msg.text) {
-                                    let resp = crate::types::CdpResponse::error(
-                                        req.id,
-                                        -32000,
-                                        "Server busy: navigation in progress, try again later".to_string(),
-                                        req.session_id,
-                                    );
-                                    if let Ok(json) = serde_json::to_string(&resp) {
-                                        let _ = msg.reply_tx.send(json);
-                                    }
-                                }
-                            } else {
-                                tracing::info!("INTERCEPTION: deferring CDP message until nav completes");
-                                deferred.push_back(ServerMessage::Cdp(msg));
-                            }
+                            tracing::info!("INTERCEPTION: deferring CDP message until nav completes");
+                            enqueue_deferred_cdp(
+                                deferred,
+                                queued_after_navigation,
+                                msg,
+                                "Server busy: navigation in progress, try again later",
+                            );
                         }
                     }
                 }
@@ -1984,14 +2040,16 @@ async fn handle_connection_ws(
 #[cfg(test)]
 mod tests {
     use super::{
-        handle_fetch_resolution, is_navigate_method, merge_cookie_delta, parse_cdp_headers,
-        request_page_id, take_live_pending_navigation,
+        enqueue_deferred_cdp, handle_fetch_resolution, is_navigate_method,
+        merge_cookie_delta, parse_cdp_headers, pop_deferred_for_lifecycle_state,
+        reclassify_deferred_for_lifecycle, request_page_id, take_live_pending_navigation,
+        CdpMessage, ServerMessage, MAX_DEFERRED_MESSAGES,
     };
     #[cfg(feature = "render")]
     use super::{pump_and_forward_screencast_frames, pump_live_page_event_loop};
     use obscura_net::{CookieInfo, CookieJar};
     use serde_json::json;
-    use std::collections::HashMap;
+    use std::collections::{HashMap, VecDeque};
 
     fn cookie(name: &str, value: &str) -> CookieInfo {
         CookieInfo {
@@ -2004,6 +2062,160 @@ mod tests {
             same_site: "Lax".to_string(),
             expires: None,
         }
+    }
+
+    #[test]
+    fn lifecycle_reclassification_preserves_fifo_and_the_shared_queue_bound() {
+        let mut ctx = crate::dispatch::CdpContext::new();
+        let lifecycle_page = ctx.create_page();
+        let foreign_page = ctx.create_page();
+        ctx.sessions
+            .insert("lifecycle-session".to_string(), lifecycle_page.clone());
+        ctx.sessions
+            .insert("foreign-session".to_string(), foreign_page);
+        let (reply_tx, mut reply_rx) = tokio::sync::mpsc::unbounded_channel();
+        let message = |id: i64| CdpMessage {
+            text: json!({
+                "id": id,
+                "method": "Runtime.evaluate",
+                "sessionId": "foreign-session",
+                "params": {"expression": id.to_string()},
+            })
+            .to_string(),
+            reply_tx: reply_tx.clone(),
+        };
+        let mut deferred = VecDeque::from([
+            ServerMessage::Cdp(message(1)),
+            ServerMessage::Cdp(message(2)),
+        ]);
+        let mut post_load = VecDeque::new();
+
+        assert!(reclassify_deferred_for_lifecycle(
+            &mut deferred,
+            &mut post_load,
+            &ctx,
+            &lifecycle_page,
+        ));
+        assert!(reclassify_deferred_for_lifecycle(
+            &mut deferred,
+            &mut post_load,
+            &ctx,
+            &lifecycle_page,
+        ));
+        enqueue_deferred_cdp(&mut post_load, deferred.len(), message(3), "full");
+        let ids = post_load
+            .iter()
+            .map(|entry| match entry {
+                ServerMessage::Cdp(message) => {
+                    serde_json::from_str::<serde_json::Value>(&message.text).unwrap()["id"]
+                        .as_i64()
+                        .unwrap()
+                }
+                ServerMessage::NewConnection { .. } => unreachable!(),
+            })
+            .collect::<Vec<_>>();
+        assert_eq!(ids, vec![1, 2, 3]);
+
+        deferred = VecDeque::from([
+            ServerMessage::Cdp(message(11)),
+            ServerMessage::Cdp(CdpMessage {
+                text: json!({
+                    "id": 12,
+                    "method": "Target.closeTarget",
+                    "params": {"targetId": lifecycle_page},
+                })
+                .to_string(),
+                reply_tx: reply_tx.clone(),
+            }),
+            ServerMessage::Cdp(message(13)),
+        ]);
+        post_load.clear();
+        assert!(reclassify_deferred_for_lifecycle(
+            &mut deferred,
+            &mut post_load,
+            &ctx,
+            &lifecycle_page,
+        ));
+        let owner_close = pop_deferred_for_lifecycle_state(
+            &mut deferred,
+            &mut post_load,
+            true,
+        )
+        .expect("the owner close remains actionable during lifecycle");
+        let ServerMessage::Cdp(owner_close) = owner_close else {
+            unreachable!()
+        };
+        assert_eq!(
+            serde_json::from_str::<serde_json::Value>(&owner_close.text).unwrap()["id"],
+            12,
+        );
+        let first_foreign = pop_deferred_for_lifecycle_state(
+            &mut deferred,
+            &mut post_load,
+            false,
+        )
+        .unwrap();
+        let second_foreign = pop_deferred_for_lifecycle_state(
+            &mut deferred,
+            &mut post_load,
+            false,
+        )
+        .unwrap();
+        let ids = [first_foreign, second_foreign].map(|entry| match entry {
+            ServerMessage::Cdp(message) => {
+                serde_json::from_str::<serde_json::Value>(&message.text).unwrap()["id"]
+                    .as_i64()
+                    .unwrap()
+            }
+            ServerMessage::NewConnection { .. } => unreachable!(),
+        });
+        assert_eq!(ids, [11, 13]);
+
+        post_load.clear();
+        for id in 0..MAX_DEFERRED_MESSAGES {
+            post_load.push_back(ServerMessage::Cdp(message(id as i64)));
+        }
+        deferred.push_back(ServerMessage::Cdp(message(999)));
+        assert!(reclassify_deferred_for_lifecycle(
+            &mut deferred,
+            &mut post_load,
+            &ctx,
+            &lifecycle_page,
+        ));
+        assert_eq!(post_load.len(), MAX_DEFERRED_MESSAGES);
+        let rejected: serde_json::Value = serde_json::from_str(
+            &reply_rx.try_recv().expect("the overflow command must receive an error"),
+        )
+        .unwrap();
+        assert_eq!(rejected["id"], 999);
+        assert_eq!(rejected["error"]["code"], -32000);
+
+        deferred.clear();
+        post_load.clear();
+        for id in 0..(MAX_DEFERRED_MESSAGES - 1) {
+            post_load.push_back(ServerMessage::Cdp(message(id as i64)));
+        }
+        enqueue_deferred_cdp(
+            &mut deferred,
+            post_load.len(),
+            message(1_000),
+            "full",
+        );
+        enqueue_deferred_cdp(
+            &mut deferred,
+            post_load.len(),
+            message(1_001),
+            "full",
+        );
+        assert_eq!(deferred.len() + post_load.len(), MAX_DEFERRED_MESSAGES);
+        let rejected: serde_json::Value = serde_json::from_str(
+            &reply_rx.try_recv().expect(
+                "a navigation-time enqueue must include the existing post-load queue",
+            ),
+        )
+        .unwrap();
+        assert_eq!(rejected["id"], 1_001);
+        assert_eq!(rejected["error"]["code"], -32000);
     }
 
     #[tokio::test(flavor = "current_thread")]

--- a/crates/obscura-cdp/src/server.rs
+++ b/crates/obscura-cdp/src/server.rs
@@ -18,6 +18,8 @@ use crate::dispatch::{self, CdpContext};
 // is reached we return an explicit error response rather than silently dropping.
 const MAX_DEFERRED_MESSAGES: usize = 256;
 const POST_LOAD_DRAIN_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(1);
+const FIRST_LIFECYCLE_PUMP_GRACE: std::time::Duration =
+    std::time::Duration::from_millis(5);
 
 // The WS-stream forwarding channel must also be bounded: if the LocalSet
 // (CDP processor + nav tasks) stalls, the accept thread keeps pushing
@@ -929,8 +931,14 @@ async fn cdp_processor(
     let mut runtime_pump_error_streak = 0_u8;
     let mut lifecycle_continuation_page: Option<String> = None;
     let mut lifecycle_release_deadline: Option<tokio::time::Instant> = None;
+    let mut lifecycle_first_pump_not_before: Option<tokio::time::Instant> = None;
 
     loop {
+        if lifecycle_first_pump_not_before
+            .is_some_and(|deadline| tokio::time::Instant::now() >= deadline)
+        {
+            lifecycle_first_pump_not_before = None;
+        }
         // A DOMContentLoaded listener may have queued a replacement before the
         // old runtime parked. Navigation wins over pumping that old document.
         if let (Some(reply_tx), Some((session_id, url, method, body))) = (
@@ -968,6 +976,9 @@ async fn cdp_processor(
                     )
                 })
                 .map(|page| page.id.clone());
+            lifecycle_first_pump_not_before = lifecycle_continuation_page
+                .as_ref()
+                .map(|_| tokio::time::Instant::now() + FIRST_LIFECYCLE_PUMP_GRACE);
             lifecycle_release_deadline = None;
             runtime_pump_armed = ctx.pages.iter().any(|page| page.has_js());
             continue;
@@ -994,7 +1005,11 @@ async fn cdp_processor(
         let msg = if msg.is_some() {
             msg
         } else {
-            let screencast_active = has_active_screencast(&ctx);
+            // Give the first foreground command after navigation the same
+            // opportunity ahead of compositor work as it has ahead of V8
+            // page tasks. Rasterization can also run synchronously.
+            let screencast_active = lifecycle_first_pump_not_before.is_none()
+                && has_active_screencast(&ctx);
             let live_page_route = if let Some(page_id) = lifecycle_continuation_page.as_ref() {
                 (|| {
                     let page = ctx.get_page(page_id)?;
@@ -1012,6 +1027,7 @@ async fn cdp_processor(
                 })
             };
             let has_intercept_rx = intercept_rx.is_some();
+            let first_pump_not_before = lifecycle_first_pump_not_before;
             tokio::select! {
                 msg = rx.recv() => match msg {
                     Some(m) => Some(m),
@@ -1028,13 +1044,20 @@ async fn cdp_processor(
                 }, if lifecycle_release_deadline.is_some() => {
                     lifecycle_continuation_page = None;
                     lifecycle_release_deadline = None;
+                    lifecycle_first_pump_not_before = None;
                     runtime_pump_armed = ctx.pages.iter().any(|page| page.has_js());
                     None
                 },
-                pump_result = pump_live_page_event_loop(
-                    &mut ctx,
-                    lifecycle_continuation_page.as_deref(),
-                ), if runtime_pump_armed => {
+                pump_result = async {
+                    if let Some(deadline) = first_pump_not_before {
+                        tokio::time::sleep_until(deadline).await;
+                    }
+                    pump_live_page_event_loop(
+                        &mut ctx,
+                        lifecycle_continuation_page.as_deref(),
+                    ).await
+                }, if runtime_pump_armed => {
+                    lifecycle_first_pump_not_before = None;
                     let mut completed_lifecycle = false;
                     let reached_idle = match pump_result {
                         Ok(reached_idle) => {
@@ -1082,6 +1105,7 @@ async fn cdp_processor(
                                     {
                                         lifecycle_continuation_page = None;
                                         lifecycle_release_deadline = None;
+                                        lifecycle_first_pump_not_before = None;
                                     }
                                 }
                                 runtime_pump_armed = false;
@@ -1129,6 +1153,7 @@ async fn cdp_processor(
                     if completed_lifecycle {
                         lifecycle_continuation_page = None;
                         lifecycle_release_deadline = None;
+                        lifecycle_first_pump_not_before = None;
                     }
                     // A continuously ready page task must still yield to the
                     // WebSocket reader/writer and to shutdown/deadline arms.
@@ -1223,6 +1248,9 @@ async fn cdp_processor(
                             )
                         })
                     });
+                    lifecycle_first_pump_not_before = lifecycle_continuation_page
+                        .as_ref()
+                        .map(|_| tokio::time::Instant::now() + FIRST_LIFECYCLE_PUMP_GRACE);
                     lifecycle_release_deadline = None;
                 } else {
                     let fetch_was_resolved = cdp_msg.text.contains("Fetch.")
@@ -1245,6 +1273,7 @@ async fn cdp_processor(
         {
             lifecycle_continuation_page = None;
             lifecycle_release_deadline = None;
+            lifecycle_first_pump_not_before = None;
         }
 
         // Dispatch may have created a page or scheduled new asynchronous work.

--- a/crates/obscura-cdp/src/server.rs
+++ b/crates/obscura-cdp/src/server.rs
@@ -53,11 +53,195 @@ const SHUTDOWN_DRAIN_MS: u64 = 3_000;
 const CONNECTION_LIMIT_RESPONSE: &str = "HTTP/1.1 503 Service Unavailable\r\n\
     Content-Length: 0\r\nConnection: close\r\n\
     X-Obscura-Reason: max-connections\r\n\r\n";
+const MAX_TEARDOWN_REQUEST_BYTES: usize = 256 * 1024;
 use crate::types::CdpRequest;
 
 struct CdpMessage {
     text: String,
     reply_tx: mpsc::UnboundedSender<String>,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum ConnectionEnd {
+    Open = 0,
+    Closed = 1,
+    Shutdown = 2,
+}
+
+struct ActiveNavigation {
+    generation: u64,
+    page_id: String,
+    context_id: String,
+    disposable_context: bool,
+    control: obscura_browser::navigation::NavigationControl,
+    teardown_requests: std::collections::VecDeque<String>,
+    teardown_request_bytes: usize,
+}
+
+struct ConnectionControl {
+    end: std::sync::atomic::AtomicU8,
+    end_notify: Notify,
+    next_generation: std::sync::atomic::AtomicU64,
+    active: std::sync::Mutex<Option<ActiveNavigation>>,
+}
+
+impl ConnectionControl {
+    fn new() -> Self {
+        Self {
+            end: std::sync::atomic::AtomicU8::new(ConnectionEnd::Open as u8),
+            end_notify: Notify::new(),
+            next_generation: std::sync::atomic::AtomicU64::new(0),
+            active: std::sync::Mutex::new(None),
+        }
+    }
+
+    fn end(&self) -> ConnectionEnd {
+        match self.end.load(Ordering::Acquire) {
+            1 => ConnectionEnd::Closed,
+            2 => ConnectionEnd::Shutdown,
+            _ => ConnectionEnd::Open,
+        }
+    }
+
+    fn signal_end(&self, end: ConnectionEnd) {
+        let _ = self.end.compare_exchange(
+            ConnectionEnd::Open as u8,
+            end as u8,
+            Ordering::AcqRel,
+            Ordering::Acquire,
+        );
+        let control = self
+            .active
+            .lock()
+            .unwrap_or_else(|error| error.into_inner())
+            .as_ref()
+            .map(|active| active.control.clone());
+        if let Some(control) = control {
+            control.cancel();
+        }
+        self.end_notify.notify_waiters();
+    }
+
+    async fn ended(&self) -> ConnectionEnd {
+        loop {
+            let notified = self.end_notify.notified();
+            let end = self.end();
+            if end != ConnectionEnd::Open {
+                return end;
+            }
+            notified.await;
+        }
+    }
+
+    fn activate(
+        &self,
+        page_id: String,
+        context_id: String,
+        disposable_context: bool,
+        control: obscura_browser::navigation::NavigationControl,
+    ) -> u64 {
+        let generation = self
+            .next_generation
+            .fetch_add(1, Ordering::AcqRel)
+            .saturating_add(1);
+        let mut active = self
+            .active
+            .lock()
+            .unwrap_or_else(|error| error.into_inner());
+        *active = Some(ActiveNavigation {
+            generation,
+            page_id,
+            context_id,
+            disposable_context,
+            control: control.clone(),
+            teardown_requests: std::collections::VecDeque::new(),
+            teardown_request_bytes: 0,
+        });
+        drop(active);
+        if self.end() != ConnectionEnd::Open {
+            control.cancel();
+        }
+        generation
+    }
+
+    fn signal_teardown_request(&self, text: &str) -> bool {
+        if !text.contains("\"Target.closeTarget\"")
+            && !text.contains("\"Target.disposeBrowserContext\"")
+        {
+            return false;
+        }
+        if self
+            .active
+            .lock()
+            .unwrap_or_else(|error| error.into_inner())
+            .is_none()
+        {
+            return false;
+        }
+        let Ok(request) = serde_json::from_str::<CdpRequest>(text) else {
+            return false;
+        };
+        let mut active_guard = self
+            .active
+            .lock()
+            .unwrap_or_else(|error| error.into_inner());
+        let Some(active) = active_guard.as_mut() else {
+            return false;
+        };
+        let matches = match request.method.as_str() {
+            "Target.closeTarget" => request
+                .params
+                .get("targetId")
+                .and_then(|value| value.as_str())
+                == Some(active.page_id.as_str()),
+            "Target.disposeBrowserContext" => request
+                .params
+                .get("browserContextId")
+                .and_then(|value| value.as_str())
+                == Some(active.context_id.as_str())
+                && active.disposable_context,
+            _ => false,
+        };
+        if !matches {
+            return false;
+        }
+        // Once full, let the normal processor/deferred-queue path own the
+        // command. That path is also bounded and returns an explicit busy
+        // error instead of silently swallowing an unbounded duplicate flood.
+        if active.teardown_requests.len() >= MAX_DEFERRED_MESSAGES
+            || active.teardown_request_bytes.saturating_add(text.len()) > MAX_TEARDOWN_REQUEST_BYTES
+        {
+            return false;
+        }
+        active.teardown_request_bytes += text.len();
+        active.teardown_requests.push_back(text.to_string());
+        let control = active.control.clone();
+        drop(active_guard);
+        control.cancel();
+        true
+    }
+
+    fn finish_navigation(&self, generation: u64) -> Vec<String> {
+        let mut active = self
+            .active
+            .lock()
+            .unwrap_or_else(|error| error.into_inner());
+        if active
+            .as_ref()
+            .is_some_and(|navigation| navigation.generation == generation)
+        {
+            return active
+                .take()
+                .map(|navigation| navigation.teardown_requests.into_iter().collect())
+                .unwrap_or_default();
+        }
+        Vec::new()
+    }
+}
+
+struct PausedInterception {
+    page_id: String,
+    resolver: tokio::sync::oneshot::Sender<obscura_js::ops::InterceptResolution>,
 }
 
 enum ServerMessage {
@@ -442,17 +626,27 @@ pub async fn start_with_serve_options_and_limit(
     let live_connections = Arc::new(AtomicUsize::new(0));
     info!("Connection limit: {}", max_connections);
 
-    // Accept loop: hand each WebSocket connection to its own OS thread so its
-    // pages' isolates live on a dedicated thread.
+    // Accept loop: each connection's page processor gets a dedicated OS thread,
+    // while WebSocket I/O stays on this runtime. Keeping ingress off the V8
+    // thread lets target close, connection loss, and shutdown signal a
+    // synchronous navigation without entering its isolate concurrently.
+    let mut server_shutdown = Box::pin(shutdown_notify.notified());
+    server_shutdown.as_mut().enable();
     loop {
         let stream = tokio::select! {
             stream = ws_rx.recv() => stream,
-            _ = shutdown_notify.notified() => None,
+            _ = &mut server_shutdown => None,
         };
         let stream = match stream {
             Some(s) => s,
             None => break,
         };
+        // `select!` is fair when a handoff and shutdown become ready together.
+        // The atomic is the sticky authority: never start a connection after
+        // the one-shot notification has already fired.
+        if shutdown_flag.load(Ordering::Acquire) {
+            break;
+        }
         // Nagle off + nonblocking on the std socket before it moves to the
         // connection thread. CDP exchanges many small (~100-byte) frames during
         // newPage()/navigate; with Nagle on, each small write waits on an ACK or
@@ -481,14 +675,43 @@ pub async fn start_with_serve_options_and_limit(
             refuse_connection(stream);
             continue;
         }
-        run_connection(
-            stream,
+        let tokio_stream = match TcpStream::from_std(stream) {
+            Ok(stream) => stream,
+            Err(error) => {
+                error!("TcpStream::from_std failed: {}", error);
+                live_connections.fetch_sub(1, Ordering::AcqRel);
+                continue;
+            }
+        };
+        let (msg_tx, msg_rx) = mpsc::unbounded_channel::<ServerMessage>();
+        let connection_control = Arc::new(ConnectionControl::new());
+        if !run_connection(
+            msg_rx,
             shared_ctx.clone(),
             persistence_ctx.clone(),
             persistence_lock.clone(),
             shutdown_notify.clone(),
             live_connections.clone(),
-        );
+            connection_control.clone(),
+        ) {
+            continue;
+        }
+        let ws_shutdown = shutdown_notify.clone();
+        let ws_shutdown_flag = shutdown_flag.clone();
+        tokio::spawn(async move {
+            if let Err(error) = handle_connection_ws(
+                tokio_stream,
+                msg_tx,
+                connection_control.clone(),
+                ws_shutdown,
+                ws_shutdown_flag,
+            )
+            .await
+            {
+                error!("WebSocket connection error: {}", error);
+            }
+            connection_control.signal_end(ConnectionEnd::Closed);
+        });
     }
 
     // Server is shutting down. Connection threads are detached, so saving the
@@ -563,20 +786,19 @@ fn cap_malloc_arenas() {
     }
 }
 
-/// Run one WebSocket connection on its own OS thread: a `current_thread` tokio
-/// runtime + `LocalSet` hosting this connection's `cdp_processor` (with its own
-/// `CdpContext` and pages) and its frame reader. Confining a connection's pages
-/// to one thread is what removes the #430 abort; the interception handshake and
-/// the nav `spawn_local` all stay on this one thread, so no cross-thread V8
-/// plumbing is needed.
+/// Run one connection's page processor on its own OS thread. WebSocket I/O
+/// remains on the server runtime and communicates only through channels and
+/// [`ConnectionControl`]; all Page/V8 ownership, interception work, and local
+/// navigation futures stay confined to this thread (#430).
 fn run_connection(
-    std_stream: std::net::TcpStream,
+    msg_rx: mpsc::UnboundedReceiver<ServerMessage>,
     context_template: Arc<obscura_browser::BrowserContext>,
     persistence_context: Arc<obscura_browser::BrowserContext>,
     persistence_lock: Arc<std::sync::Mutex<()>>,
     shutdown_notify: Arc<Notify>,
     live_connections: Arc<AtomicUsize>,
-) {
+    connection_control: Arc<ConnectionControl>,
+) -> bool {
     // Releases the slot reserved by the accept loop when the thread unwinds,
     // however it exits — clean close, error return, or panic. A plain
     // decrement at the end of the closure would leak slots on the early
@@ -610,26 +832,13 @@ fn run_connection(
             };
             let local = tokio::task::LocalSet::new();
             local.block_on(&rt, async move {
-                let tokio_stream = match TcpStream::from_std(std_stream) {
-                    Ok(s) => s,
-                    Err(e) => {
-                        error!("TcpStream::from_std failed: {}", e);
-                        return;
-                    }
-                };
-                let (msg_tx, msg_rx) = mpsc::unbounded_channel::<ServerMessage>();
-                let processor = tokio::task::spawn_local(cdp_processor(
+                cdp_processor(
                     msg_rx,
                     default_context,
                     shutdown_notify,
-                ));
-                if let Err(e) = handle_connection_ws(tokio_stream, msg_tx).await {
-                    error!("WebSocket connection error: {}", e);
-                }
-                // Connection closed (or shutting down): stop this connection's
-                // processor so the thread can exit.
-                processor.abort();
-                let _ = processor.await;
+                    connection_control,
+                )
+                .await;
             });
 
             // Apply only this connection's cookie changes to the persistence
@@ -651,7 +860,9 @@ fn run_connection(
     if let Err(e) = spawned {
         error!("connection thread spawn failed: {}", e);
         live_connections.fetch_sub(1, Ordering::AcqRel);
+        return false;
     }
+    true
 }
 
 fn cookie_key(cookie: &obscura_net::CookieInfo) -> (String, String, String) {
@@ -892,12 +1103,24 @@ async fn cdp_processor(
     mut rx: mpsc::UnboundedReceiver<ServerMessage>,
     default_context: Arc<obscura_browser::BrowserContext>,
     shutdown_notify: Arc<Notify>,
+    connection_control: Arc<ConnectionControl>,
 ) {
+    // Keep shutdown cancellation live even while the main processor future is
+    // inside `process_with_interception`. This waiter performs no page/V8 work;
+    // it only flips the sticky connection control and terminates the currently
+    // registered isolate through NavigationControl.
+    let shutdown_signal = shutdown_notify.clone();
+    let shutdown_control = connection_control.clone();
+    let shutdown_watcher = tokio::task::spawn_local(async move {
+        shutdown_signal.notified().await;
+        shutdown_control.signal_end(ConnectionEnd::Shutdown);
+    });
     let mut ctx = CdpContext::new_with_shared_context(default_context);
     let (itx, irx) = mpsc::unbounded_channel::<obscura_js::ops::InterceptedRequest>();
     ctx.intercept_tx = Some(itx);
     let mut intercept_rx: Option<mpsc::UnboundedReceiver<obscura_js::ops::InterceptedRequest>> = Some(irx);
-    let mut intercepted_paused: HashMap<String, tokio::sync::oneshot::Sender<obscura_js::ops::InterceptResolution>> = HashMap::new();
+    let mut pending_interceptions = std::collections::VecDeque::new();
+    let mut intercepted_paused: HashMap<String, PausedInterception> = HashMap::new();
 
     // Issue #19 follow-up: messages deferred from inside
     // `process_with_interception` because routing them through
@@ -915,6 +1138,7 @@ async fn cdp_processor(
     // registers and stays registered across iterations, so a later
     // `notify_waiters()` wakes this processor even while it is mid-dispatch.
     let mut shutdown = Box::pin(shutdown_notify.notified());
+    shutdown.as_mut().enable();
     // Chromium's PageHandler receives compositor video frames continuously.
     // Obscura has no separate compositor thread yet, so active screencasts get
     // a bounded 30 Hz opportunity on this connection's owning LocalSet.
@@ -945,6 +1169,15 @@ async fn cdp_processor(
             connection_reply_tx.as_ref(),
             take_live_pending_navigation(&ctx),
         ) {
+            if let Some(page_id) = ctx.sessions.get(&session_id).cloned() {
+                let replaced_page = std::collections::HashSet::from([page_id]);
+                fail_paused_interceptions(&replaced_page, &mut intercepted_paused);
+                fail_queued_interceptions(
+                    &replaced_page,
+                    &mut pending_interceptions,
+                    &mut intercept_rx,
+                );
+            }
             let navigation = json!({
                 "id": 0,
                 "method": "Page.navigate",
@@ -958,10 +1191,12 @@ async fn cdp_processor(
                 reply_tx,
                 &mut rx,
                 &mut intercept_rx,
+                &mut pending_interceptions,
                 &mut intercepted_paused,
                 &mut deferred,
-                post_load_deferred.len(),
+                &mut post_load_deferred,
                 false,
+                &connection_control,
             )
             .await;
             lifecycle_continuation_page = ctx
@@ -1010,31 +1245,19 @@ async fn cdp_processor(
             // page tasks. Rasterization can also run synchronously.
             let screencast_active = lifecycle_first_pump_not_before.is_none()
                 && has_active_screencast(&ctx);
-            let live_page_route = if let Some(page_id) = lifecycle_continuation_page.as_ref() {
-                (|| {
-                    let page = ctx.get_page(page_id)?;
-                    ctx.sessions
-                        .iter()
-                        .find(|(_, owner)| *owner == page_id)
-                        .map(|(session_id, _)| (session_id.clone(), page.frame_id.clone()))
-                })()
-            } else {
-                ctx.pages.iter().find_map(|page| {
-                        ctx.sessions
-                            .iter()
-                            .find(|(_, owner)| *owner == &page.id)
-                            .map(|(session_id, _)| (session_id.clone(), page.frame_id.clone()))
-                })
-            };
             let has_intercept_rx = intercept_rx.is_some();
             let first_pump_not_before = lifecycle_first_pump_not_before;
             tokio::select! {
                 msg = rx.recv() => match msg {
                     Some(m) => Some(m),
-                    None => break,
+                    None => {
+                        connection_control.signal_end(ConnectionEnd::Closed);
+                        break;
+                    }
                 },
                 _ = &mut shutdown => {
                     tracing::info!("Shutdown signal received (connection processor)");
+                    connection_control.signal_end(ConnectionEnd::Shutdown);
                     break;
                 },
                 _ = async {
@@ -1160,20 +1383,16 @@ async fn cdp_processor(
                     tokio::task::yield_now().await;
                     None
                 },
-                Some(intercepted) = async {
-                    if let Some(ref mut receiver) = intercept_rx {
-                        receiver.recv().await
-                    } else {
-                        std::future::pending().await
-                    }
-                }, if has_intercept_rx => {
-                    if let (Some((session_id, frame_id)), Some(reply_tx)) =
-                        (live_page_route.as_ref(), connection_reply_tx.as_ref())
+                Some(intercepted) = receive_interception(&mut pending_interceptions, &mut intercept_rx), if has_intercept_rx => {
+                    let route = interception_route(&ctx, &intercepted.owner_page_id);
+                    if let (Some((page_id, session_id, frame_id)), Some(reply_tx)) =
+                        (route, connection_reply_tx.as_ref())
                     {
                         emit_intercepted_request(
                             intercepted,
-                            frame_id,
-                            Some(session_id.clone()),
+                            &page_id,
+                            &frame_id,
+                            Some(session_id),
                             reply_tx,
                             &mut intercepted_paused,
                         );
@@ -1234,10 +1453,21 @@ async fn cdp_processor(
                     let navigation_page_id = serde_json::from_str::<CdpRequest>(&cdp_msg.text)
                         .ok()
                         .and_then(|request| request_page_id(&request, &ctx));
+                    if let Some(page_id) = navigation_page_id.as_ref() {
+                        let replaced_page = std::collections::HashSet::from([page_id.clone()]);
+                        fail_paused_interceptions(&replaced_page, &mut intercepted_paused);
+                        fail_queued_interceptions(
+                            &replaced_page,
+                            &mut pending_interceptions,
+                            &mut intercept_rx,
+                        );
+                    }
                     process_with_interception(
                         &cdp_msg.text, &mut ctx, &cdp_msg.reply_tx, &mut rx,
-                        &mut intercept_rx, &mut intercepted_paused,
-                        &mut deferred, post_load_deferred.len(), true,
+                        &mut intercept_rx, &mut pending_interceptions,
+                        &mut intercepted_paused,
+                        &mut deferred, &mut post_load_deferred, true,
+                        &connection_control,
                     ).await;
                     lifecycle_continuation_page = navigation_page_id.filter(|page_id| {
                         ctx.get_page(page_id).is_some_and(|page| {
@@ -1253,6 +1483,28 @@ async fn cdp_processor(
                         .map(|_| tokio::time::Instant::now() + FIRST_LIFECYCLE_PUMP_GRACE);
                     lifecycle_release_deadline = None;
                 } else {
+                    if let Some((destroyed_pages, disposed_context)) =
+                        teardown_owners_for_request(&cdp_msg.text, &ctx)
+                    {
+                        fail_paused_interceptions(&destroyed_pages, &mut intercepted_paused);
+                        fail_queued_interceptions(
+                            &destroyed_pages,
+                            &mut pending_interceptions,
+                            &mut intercept_rx,
+                        );
+                        discard_destroyed_target_commands(
+                            &mut deferred,
+                            &ctx,
+                            &destroyed_pages,
+                            disposed_context.as_deref(),
+                        );
+                        discard_destroyed_target_commands(
+                            &mut post_load_deferred,
+                            &ctx,
+                            &destroyed_pages,
+                            disposed_context.as_deref(),
+                        );
+                    }
                     let fetch_was_resolved = cdp_msg.text.contains("Fetch.")
                         && handle_fetch_resolution(
                             &cdp_msg.text,
@@ -1290,6 +1542,7 @@ async fn cdp_processor(
 
     // The connection thread merges this context's cookie delta into the
     // persistence template after the processor stops.
+    shutdown_watcher.abort();
     let _ = &ctx;
 }
 
@@ -1327,15 +1580,60 @@ fn command_targets_other_page(
     request_page_id(&request, ctx).is_some_and(|page_id| page_id != lifecycle_page_id)
 }
 
+fn teardown_owners_for_request(
+    text: &str,
+    ctx: &CdpContext,
+) -> Option<(std::collections::HashSet<String>, Option<String>)> {
+    let request = serde_json::from_str::<CdpRequest>(text).ok()?;
+    match request.method.as_str() {
+        "Target.closeTarget" => {
+            let target_id = request.params.get("targetId")?.as_str()?;
+            Some((std::collections::HashSet::from([target_id.to_string()]), None))
+        }
+        "Target.disposeBrowserContext" => {
+            let context_id = request.params.get("browserContextId")?.as_str()?.to_string();
+            let pages = ctx.pages
+                .iter()
+                .filter(|page| page.context.id == context_id)
+                .map(|page| page.id.clone())
+                .collect();
+            Some((pages, Some(context_id)))
+        }
+        _ => None,
+    }
+}
+
+async fn receive_interception(
+    pending: &mut std::collections::VecDeque<obscura_js::ops::InterceptedRequest>,
+    receiver: &mut Option<mpsc::UnboundedReceiver<obscura_js::ops::InterceptedRequest>>,
+) -> Option<obscura_js::ops::InterceptedRequest> {
+    if let Some(intercepted) = pending.pop_front() {
+        return Some(intercepted);
+    }
+    match receiver {
+        Some(receiver) => receiver.recv().await,
+        None => std::future::pending().await,
+    }
+}
+
+fn interception_route(
+    ctx: &CdpContext,
+    page_id: &str,
+) -> Option<(String, String, String)> {
+    let page = ctx.get_page(page_id)?;
+    ctx.sessions
+        .iter()
+        .find(|(_, owner)| owner.as_str() == page_id)
+        .map(|(session_id, _)| (page_id.to_string(), session_id.clone(), page.frame_id.clone()))
+}
+
 fn emit_intercepted_request(
     intercepted: obscura_js::ops::InterceptedRequest,
+    page_id: &str,
     frame_id: &str,
     session_id: Option<String>,
     reply_tx: &mpsc::UnboundedSender<String>,
-    intercepted_paused: &mut HashMap<
-        String,
-        tokio::sync::oneshot::Sender<obscura_js::ops::InterceptResolution>,
-    >,
+    intercepted_paused: &mut HashMap<String, PausedInterception>,
 ) {
     tracing::info!(
         "INTERCEPTION: requestPaused for {} {} (sending to client)",
@@ -1385,7 +1683,10 @@ fn emit_intercepted_request(
         "sessionId": session_id,
     });
     let _ = reply_tx.send(request_paused.to_string());
-    intercepted_paused.insert(intercepted.request_id, intercepted.resolver);
+    intercepted_paused.insert(intercepted.request_id, PausedInterception {
+        page_id: page_id.to_string(),
+        resolver: intercepted.resolver,
+    });
 }
 
 async fn pump_live_page_event_loop(
@@ -1559,16 +1860,25 @@ fn parse_cdp_headers(params: &serde_json::Value) -> Option<HashMap<String, Strin
 
 fn handle_fetch_resolution(
     text: &str,
-    _ctx: &mut CdpContext,
+    ctx: &mut CdpContext,
     reply_tx: &mpsc::UnboundedSender<String>,
-    intercepted_paused: &mut HashMap<String, tokio::sync::oneshot::Sender<obscura_js::ops::InterceptResolution>>,
+    intercepted_paused: &mut HashMap<String, PausedInterception>,
 ) -> bool {
     if let Ok(req) = serde_json::from_str::<CdpRequest>(text) {
         let method = req.method.as_str();
         let request_id = req.params.get("requestId").and_then(|v| v.as_str()).unwrap_or("");
         tracing::info!("INTERCEPTION resolution: {} for {}, paused_count={}", method, request_id, intercepted_paused.len());
 
-        if let Some(resolver) = intercepted_paused.remove(request_id) {
+        let session_matches_owner = intercepted_paused.get(request_id).is_some_and(|paused| {
+            req.session_id
+                .as_ref()
+                .and_then(|session_id| ctx.sessions.get(session_id))
+                .is_none_or(|page_id| page_id == &paused.page_id)
+        });
+        if session_matches_owner {
+            let Some(paused) = intercepted_paused.remove(request_id) else {
+                return false;
+            };
             tracing::info!("INTERCEPTION resolved: {}", request_id);
             let resolution = match method {
                 "Fetch.continueRequest" => obscura_js::ops::InterceptResolution::Continue {
@@ -1599,9 +1909,24 @@ fn handle_fetch_resolution(
                 }
                 _ => return false,
             };
-            let _ = resolver.send(resolution);
+            let _ = paused.resolver.send(resolution);
             let resp = crate::types::CdpResponse::success(req.id, json!({}), req.session_id);
             if let Ok(json) = serde_json::to_string(&resp) {
+                let _ = reply_tx.send(json);
+            }
+            return true;
+        }
+        // Internal JS fetch interceptions have owner/generation-qualified IDs.
+        // Once their owner is replaced or destroyed, do not let the legacy
+        // static Fetch handler acknowledge the stale ID as if it still existed.
+        if request_id.contains(":intercept-") {
+            let response = crate::types::CdpResponse::error(
+                req.id,
+                -32000,
+                "Invalid InterceptionId".to_string(),
+                req.session_id,
+            );
+            if let Ok(json) = serde_json::to_string(&response) {
                 let _ = reply_tx.send(json);
             }
             return true;
@@ -1610,16 +1935,142 @@ fn handle_fetch_resolution(
     false
 }
 
+fn fail_paused_interceptions(
+    destroyed_pages: &std::collections::HashSet<String>,
+    intercepted_paused: &mut HashMap<String, PausedInterception>,
+) {
+    let request_ids: Vec<String> = intercepted_paused
+        .iter()
+        .filter(|(_, paused)| destroyed_pages.contains(&paused.page_id))
+        .map(|(request_id, _)| request_id.clone())
+        .collect();
+    for request_id in request_ids {
+        let Some(paused) = intercepted_paused.remove(&request_id) else { continue };
+        let _ = paused.resolver.send(obscura_js::ops::InterceptResolution::Fail {
+            reason: "Aborted".into(),
+        });
+    }
+}
+
+fn fail_queued_interceptions(
+    destroyed_pages: &std::collections::HashSet<String>,
+    pending: &mut std::collections::VecDeque<obscura_js::ops::InterceptedRequest>,
+    intercept_rx: &mut Option<mpsc::UnboundedReceiver<obscura_js::ops::InterceptedRequest>>,
+) {
+    if let Some(receiver) = intercept_rx.as_mut() {
+        while let Ok(intercepted) = receiver.try_recv() {
+            pending.push_back(intercepted);
+        }
+    }
+    let mut retained = std::collections::VecDeque::with_capacity(pending.len());
+    while let Some(intercepted) = pending.pop_front() {
+        if destroyed_pages.contains(&intercepted.owner_page_id) {
+            let _ = intercepted.resolver.send(obscura_js::ops::InterceptResolution::Fail {
+                reason: "Aborted".into(),
+            });
+        } else {
+            retained.push_back(intercepted);
+        }
+    }
+    *pending = retained;
+}
+
+fn discard_destroyed_target_commands(
+    deferred: &mut std::collections::VecDeque<ServerMessage>,
+    ctx: &CdpContext,
+    destroyed_pages: &std::collections::HashSet<String>,
+    disposed_context: Option<&str>,
+) {
+    let mut retained = std::collections::VecDeque::with_capacity(deferred.len());
+    while let Some(message) = deferred.pop_front() {
+        let discard = match &message {
+            ServerMessage::Cdp(message) => serde_json::from_str::<CdpRequest>(&message.text)
+                .ok()
+                .is_some_and(|request| {
+                    request_page_id(&request, ctx)
+                        .is_some_and(|page_id| destroyed_pages.contains(&page_id))
+                        || request.params.get("targetId").and_then(|value| value.as_str())
+                            .is_some_and(|page_id| destroyed_pages.contains(page_id))
+                        || disposed_context.is_some_and(|context_id| {
+                            request.params.get("browserContextId").and_then(|value| value.as_str())
+                                == Some(context_id)
+                        })
+                }),
+            ServerMessage::NewConnection { .. } => false,
+        };
+        if discard {
+            if let ServerMessage::Cdp(message) = message {
+                if let Ok(request) = serde_json::from_str::<CdpRequest>(&message.text) {
+                    let response = crate::types::CdpResponse::error(
+                        request.id,
+                        -32000,
+                        "Target closed".to_string(),
+                        request.session_id,
+                    );
+                    if let Ok(json) = serde_json::to_string(&response) {
+                        let _ = message.reply_tx.send(json);
+                    }
+                }
+            }
+        } else {
+            retained.push_back(message);
+        }
+    }
+    *deferred = retained;
+}
+
+fn finish_inflight_teardown(
+    text: &str,
+    ctx: &mut CdpContext,
+    page_id: &str,
+    context_id: &str,
+    reply_tx: &mpsc::UnboundedSender<String>,
+) {
+    let Ok(request) = serde_json::from_str::<CdpRequest>(text) else {
+        return;
+    };
+    let result = match request.method.as_str() {
+        "Target.closeTarget" => Ok(json!({"success": ctx.destroy_target(page_id)})),
+        "Target.disposeBrowserContext" => ctx
+            .destroy_browser_context(context_id, Some(page_id))
+            .map(|_| json!({})),
+        _ => return,
+    };
+    for event in ctx.pending_events.drain(..) {
+        if let Ok(json) = serde_json::to_string(&event) {
+            let _ = reply_tx.send(json);
+        }
+    }
+    let response = match result {
+        Ok(result) => crate::types::CdpResponse::success(
+            request.id,
+            result,
+            request.session_id,
+        ),
+        Err(error) => crate::types::CdpResponse::error(
+            request.id,
+            -32000,
+            error,
+            request.session_id,
+        ),
+    };
+    if let Ok(json) = serde_json::to_string(&response) {
+        let _ = reply_tx.send(json);
+    }
+}
+
 async fn process_with_interception(
     text: &str,
     ctx: &mut CdpContext,
     reply_tx: &mpsc::UnboundedSender<String>,
     rx: &mut mpsc::UnboundedReceiver<ServerMessage>,
     intercept_rx: &mut Option<mpsc::UnboundedReceiver<obscura_js::ops::InterceptedRequest>>,
-    intercepted_paused: &mut HashMap<String, tokio::sync::oneshot::Sender<obscura_js::ops::InterceptResolution>>,
+    pending_interceptions: &mut std::collections::VecDeque<obscura_js::ops::InterceptedRequest>,
+    intercepted_paused: &mut HashMap<String, PausedInterception>,
     deferred: &mut std::collections::VecDeque<ServerMessage>,
-    queued_after_navigation: usize,
+    post_load_deferred: &mut std::collections::VecDeque<ServerMessage>,
     send_command_response: bool,
+    connection_control: &Arc<ConnectionControl>,
 ) {
     let req: CdpRequest = match serde_json::from_str(text) {
         Ok(r) => r,
@@ -1682,12 +2133,20 @@ async fn process_with_interception(
     let session_for_events = req.session_id.clone();
     let frame_id = page.frame_id.clone();
     let loader_id = format!("loader-{}", uuid::Uuid::new_v4());
+    let navigation_context_id = page.context.id.clone();
+    let navigation_control = obscura_browser::navigation::NavigationControl::new();
+    page.set_navigation_control(navigation_control.clone());
+    let navigation_generation = connection_control.activate(
+        page_id.clone(),
+        navigation_context_id.clone(),
+        navigation_context_id != ctx.default_context.id,
+        navigation_control.clone(),
+    );
 
-    let (nav_done_tx, mut nav_done_rx) = mpsc::channel::<(obscura_browser::Page, Result<(), String>)>(1);
     let url_owned = url.to_string();
     let nav_v8_lock = ctx.v8_lock.clone();
 
-    tokio::task::spawn_local(async move {
+    let mut navigation_task = tokio::task::spawn_local(async move {
         // Issue #19: serialize this connection's V8 work across its pages. This
         // nav task runs while the connection's processor keeps pumping other CDP
         // messages via `dispatch` (which takes the same per-connection lock), so
@@ -1698,21 +2157,30 @@ async fn process_with_interception(
         // must run BEFORE the page's own scripts (CDP contract). Hand them
         // to the page so navigate_single can inject them at the right point.
         page.set_preload_scripts(preload_scripts);
-        let result = page
-            .navigate_with_wait_post(
+        let result = {
+            let navigation = page.navigate_with_wait_post(
                 &url_owned,
                 obscura_browser::lifecycle::WaitUntil::DomContentLoaded,
                 &nav_method,
                 &nav_body,
-            )
-            .await
-        .map_err(|e| e.to_string());
+            );
+            tokio::pin!(navigation);
+            tokio::select! {
+                result = &mut navigation => result.map_err(|error| error.to_string()),
+                _ = navigation_control.cancelled() => {
+                    Err("Navigation cancelled".to_string())
+                }
+            }
+        };
+        page.finish_navigation_control();
         drop(_v8_guard);
-        let _ = nav_done_tx.send((page, result)).await;
+        (page, result)
     });
 
     let navigate_result: Result<(), String>;
     let page_back: Option<obscura_browser::Page>;
+    let mut task_failed = false;
+    let mut rx_open = true;
 
     // Issue #19 follow-up (PR #36 maintainer's fetch-intercept repro):
     // While the spawned nav task is executing V8 (potentially parked on
@@ -1738,28 +2206,49 @@ async fn process_with_interception(
         let has_irx = intercept_rx.is_some();
 
         tokio::select! {
-            Some((returned_page, result)) = nav_done_rx.recv() => {
-                page_back = Some(returned_page);
-                navigate_result = result;
+            result = &mut navigation_task => {
+                match result {
+                    Ok((returned_page, result)) => {
+                        page_back = Some(returned_page);
+                        navigate_result = result;
+                    }
+                    Err(error) => {
+                        tracing::error!("navigation task failed: {error}");
+                        page_back = None;
+                        navigate_result = Err(format!("navigation task failed: {error}"));
+                        task_failed = true;
+                    }
+                }
                 break;
             }
-            Some(intercepted) = async {
-                if let Some(ref mut irx) = intercept_rx {
-                    irx.recv().await
+            Some(intercepted) = receive_interception(pending_interceptions, intercept_rx), if has_irx => {
+                let owner_page_id = intercepted.owner_page_id.clone();
+                let (owner_session, owner_frame) = if owner_page_id == page_id {
+                    (session_for_events.clone(), frame_id.clone())
+                } else if let Some((_, session, frame)) = interception_route(ctx, &owner_page_id) {
+                    (Some(session), frame)
                 } else {
-                    std::future::pending().await
-                }
-            }, if has_irx => {
+                    let _ = intercepted.resolver.send(obscura_js::ops::InterceptResolution::Fail {
+                        reason: "Aborted".into(),
+                    });
+                    continue;
+                };
                 emit_intercepted_request(
                     intercepted,
-                    &frame_id,
-                    session_for_events.clone(),
+                    &owner_page_id,
+                    &owner_frame,
+                    owner_session,
                     reply_tx,
                     intercepted_paused,
                 );
                 tokio::time::sleep(tokio::time::Duration::from_millis(50)).await;
             }
-            Some(msg) = rx.recv() => {
+            msg = rx.recv(), if rx_open => {
+                let Some(msg) = msg else {
+                    rx_open = false;
+                    connection_control.signal_end(ConnectionEnd::Closed);
+                    continue;
+                };
                 tracing::info!("INTERCEPTION select: received CDP message during navigation");
                 match msg {
                     ServerMessage::NewConnection { reply_tx: new_tx } => {
@@ -1770,7 +2259,12 @@ async fn process_with_interception(
                         let _ = new_tx.send(json!({"__init": true, "pageId": pid, "sessionId": sid}).to_string());
                     }
                     ServerMessage::Cdp(msg) => {
-                        if msg.text.contains("Fetch.continueRequest")
+                        if connection_control.signal_teardown_request(&msg.text) {
+                            // The transport normally recognizes teardown first,
+                            // but a close queued immediately behind navigate may
+                            // arrive before the processor registers ownership.
+                            // Recheck here to close that ordering window.
+                        } else if msg.text.contains("Fetch.continueRequest")
                             || msg.text.contains("Fetch.fulfillRequest")
                             || msg.text.contains("Fetch.failRequest")
                         {
@@ -1789,7 +2283,7 @@ async fn process_with_interception(
                             tracing::info!("INTERCEPTION: deferring CDP message until nav completes");
                             enqueue_deferred_cdp(
                                 deferred,
-                                queued_after_navigation,
+                                post_load_deferred.len(),
                                 msg,
                                 "Server busy: navigation in progress, try again later",
                             );
@@ -1803,7 +2297,74 @@ async fn process_with_interception(
     // Deferred messages are handled by the outer `cdp_processor` loop
     // (it drains `deferred` before pulling the next message off `rx`).
 
-    let mut page = page_back.expect("navigation task should return the page");
+    let teardown_requests = connection_control.finish_navigation(navigation_generation);
+    let connection_end = connection_control.end();
+    if !teardown_requests.is_empty() || connection_end != ConnectionEnd::Open || task_failed {
+        let disposing_context = teardown_requests.iter().any(|text| {
+            serde_json::from_str::<CdpRequest>(text)
+                .ok()
+                .is_some_and(|request| request.method == "Target.disposeBrowserContext")
+        });
+        let mut destroyed_pages = std::collections::HashSet::from([page_id.clone()]);
+        if connection_end != ConnectionEnd::Open {
+            destroyed_pages.extend(ctx.pages.iter().map(|page| page.id.clone()));
+        } else if disposing_context {
+            destroyed_pages.extend(
+                ctx.pages
+                    .iter()
+                    .filter(|page| page.context.id == navigation_context_id)
+                    .map(|page| page.id.clone()),
+            );
+        }
+        fail_paused_interceptions(&destroyed_pages, intercepted_paused);
+        fail_queued_interceptions(
+            &destroyed_pages,
+            pending_interceptions,
+            intercept_rx,
+        );
+        discard_destroyed_target_commands(
+            deferred,
+            ctx,
+            &destroyed_pages,
+            disposing_context.then_some(navigation_context_id.as_str()),
+        );
+        discard_destroyed_target_commands(
+            post_load_deferred,
+            ctx,
+            &destroyed_pages,
+            disposing_context.then_some(navigation_context_id.as_str()),
+        );
+        drop(page_back);
+        if !teardown_requests.is_empty() {
+            for teardown_request in teardown_requests {
+                finish_inflight_teardown(
+                    &teardown_request,
+                    ctx,
+                    &page_id,
+                    &navigation_context_id,
+                    reply_tx,
+                );
+            }
+        } else {
+            ctx.remove_page(&page_id);
+        }
+        if task_failed && connection_end == ConnectionEnd::Open {
+            let response = crate::types::CdpResponse::error(
+                req.id,
+                -32000,
+                navigate_result.err().unwrap_or_else(|| "navigation task failed".into()),
+                req.session_id.clone(),
+            );
+            if send_command_response {
+                if let Ok(json) = serde_json::to_string(&response) {
+                    let _ = reply_tx.send(json);
+                }
+            }
+        }
+        return;
+    }
+
+    let mut page = page_back.expect("completed navigation should return the page");
 
     // Fold in network events for script-initiated requests (fetch/XHR/dynamic
     // resource) so they emit as Network.requestWillBeSent / responseReceived
@@ -1990,6 +2551,9 @@ fn check_pending_navigation(ctx: &CdpContext, session_id: &Option<String>) -> Op
 async fn handle_connection_ws(
     stream: TcpStream,
     msg_tx: mpsc::UnboundedSender<ServerMessage>,
+    connection_control: Arc<ConnectionControl>,
+    shutdown_notify: Arc<Notify>,
+    shutdown_flag: Arc<AtomicBool>,
 ) -> anyhow::Result<()> {
     // tokio_tungstenite wraps the stream in a 128 KiB write BufWriter by
     // default. CDP traffic is many small (~100-byte) frames, and that buffer
@@ -2000,7 +2564,19 @@ async fn handle_connection_ws(
     let mut cfg = WebSocketConfig::default();
     cfg.write_buffer_size = 0;
     cfg.max_write_buffer_size = 64 << 20;
-    let ws_stream = tokio_tungstenite::accept_async_with_config(stream, Some(cfg)).await?;
+    let mut websocket_shutdown = Box::pin(shutdown_notify.notified());
+    websocket_shutdown.as_mut().enable();
+    if shutdown_flag.load(Ordering::Acquire) {
+        connection_control.signal_end(ConnectionEnd::Shutdown);
+        return Ok(());
+    }
+    let ws_stream = tokio::select! {
+        result = tokio_tungstenite::accept_async_with_config(stream, Some(cfg)) => result?,
+        _ = &mut websocket_shutdown => {
+            connection_control.signal_end(ConnectionEnd::Shutdown);
+            return Ok(());
+        }
+    };
     info!("WebSocket connected");
     let (mut ws_sender, mut ws_receiver) = ws_stream.split();
 
@@ -2013,18 +2589,36 @@ async fn handle_connection_ws(
         tracing::debug!("Connection init: {}", &init_msg[..init_msg.len().min(100)]);
     }
 
-    let send_task = tokio::task::spawn_local(async move {
+    let send_control = connection_control.clone();
+    let mut send_task = tokio::spawn(async move {
         while let Some(msg) = reply_rx.recv().await {
             if msg.contains("\"__init\"") {
                 continue;
             }
             if ws_sender.send(Message::Text(msg.into())).await.is_err() {
+                send_control.signal_end(ConnectionEnd::Closed);
                 break;
             }
         }
     });
 
-    while let Some(msg) = ws_receiver.next().await {
+    loop {
+        let msg = tokio::select! {
+            msg = ws_receiver.next() => msg,
+            end = connection_control.ended() => {
+                if end != ConnectionEnd::Open {
+                    break;
+                }
+                continue;
+            }
+            _ = &mut websocket_shutdown => {
+                connection_control.signal_end(ConnectionEnd::Shutdown);
+                break;
+            }
+        };
+        let Some(msg) = msg else {
+            break;
+        };
         let msg = match msg {
             Ok(m) => m,
             Err(e) => {
@@ -2042,7 +2636,12 @@ async fn handle_connection_ws(
                             let _ = reply_tx.send(json);
                         }
                     }
+                    connection_control.signal_end(ConnectionEnd::Closed);
                     break;
+                }
+
+                if connection_control.signal_teardown_request(&text) {
+                    continue;
                 }
 
                 if let Some(resp) = fast_path_response(&text) {
@@ -2062,7 +2661,15 @@ async fn handle_connection_ws(
         }
     }
 
-    send_task.abort();
+    connection_control.signal_end(ConnectionEnd::Closed);
+    drop(reply_tx);
+    drop(msg_tx);
+    if tokio::time::timeout(tokio::time::Duration::from_secs(1), &mut send_task)
+        .await
+        .is_err()
+    {
+        send_task.abort();
+    }
     Ok(())
 }
 
@@ -2070,15 +2677,232 @@ async fn handle_connection_ws(
 mod tests {
     use super::{
         enqueue_deferred_cdp, handle_fetch_resolution, is_navigate_method,
+        fail_paused_interceptions, fail_queued_interceptions,
         merge_cookie_delta, parse_cdp_headers, pop_deferred_for_lifecycle_state,
         reclassify_deferred_for_lifecycle, request_page_id, take_live_pending_navigation,
-        CdpMessage, ServerMessage, MAX_DEFERRED_MESSAGES,
+        CdpMessage, PausedInterception, ServerMessage, MAX_DEFERRED_MESSAGES,
+        cdp_processor, ConnectionControl, ConnectionEnd,
+        finish_inflight_teardown,
     };
     #[cfg(feature = "render")]
     use super::{pump_and_forward_screencast_frames, pump_live_page_event_loop};
     use obscura_net::{CookieInfo, CookieJar};
     use serde_json::json;
     use std::collections::{HashMap, VecDeque};
+
+    #[test]
+    fn interception_cleanup_is_scoped_to_destroyed_page_owners() {
+        let (a_paused_tx, mut a_paused_rx) = tokio::sync::oneshot::channel();
+        let (b_paused_tx, mut b_paused_rx) = tokio::sync::oneshot::channel();
+        let mut paused = HashMap::from([
+            ("a-paused".to_string(), PausedInterception {
+                page_id: "page-a".to_string(),
+                resolver: a_paused_tx,
+            }),
+            ("b-paused".to_string(), PausedInterception {
+                page_id: "page-b".to_string(),
+                resolver: b_paused_tx,
+            }),
+        ]);
+        let destroyed = std::collections::HashSet::from(["page-b".to_string()]);
+        fail_paused_interceptions(&destroyed, &mut paused);
+        assert!(paused.contains_key("a-paused"));
+        assert!(matches!(a_paused_rx.try_recv(), Err(tokio::sync::oneshot::error::TryRecvError::Empty)));
+        assert!(matches!(b_paused_rx.try_recv(), Ok(obscura_js::ops::InterceptResolution::Fail { .. })));
+
+        let (a_queued_tx, mut a_queued_rx) = tokio::sync::oneshot::channel();
+        let (b_queued_tx, mut b_queued_rx) = tokio::sync::oneshot::channel();
+        let (_intercept_tx, intercept_rx) = tokio::sync::mpsc::unbounded_channel();
+        let mut intercept_rx = Some(intercept_rx);
+        let mut queued = VecDeque::from([
+            obscura_js::ops::InterceptedRequest {
+                owner_page_id: "page-a".to_string(),
+                request_id: "a-queued".to_string(),
+                url: "https://example.com/a".to_string(),
+                method: "GET".to_string(),
+                headers: HashMap::new(),
+                resource_type: "Fetch".to_string(),
+                resolver: a_queued_tx,
+            },
+            obscura_js::ops::InterceptedRequest {
+                owner_page_id: "page-b".to_string(),
+                request_id: "b-queued".to_string(),
+                url: "https://example.com/b".to_string(),
+                method: "GET".to_string(),
+                headers: HashMap::new(),
+                resource_type: "Fetch".to_string(),
+                resolver: b_queued_tx,
+            },
+        ]);
+        fail_queued_interceptions(&destroyed, &mut queued, &mut intercept_rx);
+        assert_eq!(queued.len(), 1);
+        assert_eq!(queued.front().unwrap().owner_page_id, "page-a");
+        assert!(matches!(a_queued_rx.try_recv(), Err(tokio::sync::oneshot::error::TryRecvError::Empty)));
+        assert!(matches!(b_queued_rx.try_recv(), Ok(obscura_js::ops::InterceptResolution::Fail { .. })));
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn shutdown_cancels_task_owned_stalled_navigation() {
+        std::env::set_var("OBSCURA_ALLOW_PRIVATE_NETWORK", "1");
+        let fixture = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let fixture_url = format!("http://{}/stalled", fixture.local_addr().unwrap());
+        let (requested_tx, requested_rx) = tokio::sync::oneshot::channel();
+        tokio::spawn(async move {
+            let (mut socket, _) = fixture.accept().await.unwrap();
+            let mut request = [0_u8; 1024];
+            let _ = tokio::io::AsyncReadExt::read(&mut socket, &mut request).await;
+            let _ = requested_tx.send(());
+            tokio::time::sleep(std::time::Duration::from_secs(10)).await;
+        });
+
+        tokio::task::LocalSet::new().run_until(async move {
+            let (msg_tx, msg_rx) = tokio::sync::mpsc::unbounded_channel();
+            let (reply_tx, mut reply_rx) = tokio::sync::mpsc::unbounded_channel();
+            let shutdown = std::sync::Arc::new(tokio::sync::Notify::new());
+            let control = std::sync::Arc::new(ConnectionControl::new());
+            let processor = tokio::task::spawn_local(cdp_processor(
+                msg_rx,
+                std::sync::Arc::new(obscura_browser::BrowserContext::new("default".to_string())),
+                shutdown.clone(),
+                control.clone(),
+            ));
+            msg_tx.send(ServerMessage::NewConnection { reply_tx: reply_tx.clone() }).unwrap();
+            let _ = reply_rx.recv().await.expect("processor init");
+            msg_tx.send(ServerMessage::Cdp(CdpMessage {
+                text: json!({"id": 1, "method": "Target.createTarget", "params": {"url": "about:blank"}}).to_string(),
+                reply_tx: reply_tx.clone(),
+            })).unwrap();
+            let mut target_id = None;
+            let mut session_id = None;
+            while target_id.is_none() || session_id.is_none() {
+                let message: serde_json::Value = serde_json::from_str(&reply_rx.recv().await.unwrap()).unwrap();
+                if message["id"] == 1 {
+                    target_id = message["result"]["targetId"].as_str().map(str::to_string);
+                }
+                if message["method"] == "Target.attachedToTarget" {
+                    session_id = message["params"]["sessionId"].as_str().map(str::to_string);
+                }
+            }
+            msg_tx.send(ServerMessage::Cdp(CdpMessage {
+                text: json!({
+                    "id": 2, "method": "Page.navigate", "sessionId": session_id.unwrap(),
+                    "params": {"url": fixture_url},
+                }).to_string(),
+                reply_tx,
+            })).unwrap();
+            tokio::time::timeout(std::time::Duration::from_secs(2), requested_rx)
+                .await.expect("stalled request was not reached").expect("fixture signal dropped");
+            shutdown.notify_waiters();
+            tokio::time::timeout(std::time::Duration::from_secs(2), processor)
+                .await.expect("shutdown did not cancel navigation").expect("processor task panicked");
+            assert_eq!(control.end(), ConnectionEnd::Shutdown);
+            assert!(control.active.lock().unwrap().is_none());
+            drop(msg_tx);
+            drop(target_id);
+        }).await;
+    }
+
+    #[test]
+    fn duplicate_inflight_close_requests_each_receive_a_response() {
+        let mut ctx = crate::dispatch::CdpContext::new();
+        let page_id = ctx.create_page();
+        let context_id = ctx.default_context.id.clone();
+        let (reply_tx, mut reply_rx) = tokio::sync::mpsc::unbounded_channel();
+        finish_inflight_teardown(
+            &json!({"id": 1, "method": "Target.closeTarget", "params": {"targetId": page_id}}).to_string(),
+            &mut ctx,
+            &page_id,
+            &context_id,
+            &reply_tx,
+        );
+        finish_inflight_teardown(
+            &json!({"id": 2, "method": "Target.closeTarget", "params": {"targetId": page_id}}).to_string(),
+            &mut ctx,
+            &page_id,
+            &context_id,
+            &reply_tx,
+        );
+        let mut responses = HashMap::new();
+        let mut destroyed = 0;
+        while let Ok(text) = reply_rx.try_recv() {
+            let message: serde_json::Value = serde_json::from_str(&text).unwrap();
+            if let Some(id) = message["id"].as_u64() {
+                responses.insert(id, message);
+            } else if message["method"] == "Target.targetDestroyed" {
+                destroyed += 1;
+            }
+        }
+        assert_eq!(responses[&1]["result"]["success"], json!(true));
+        assert_eq!(responses[&2]["result"]["success"], json!(false));
+        assert_eq!(destroyed, 1);
+    }
+
+    #[test]
+    fn mixed_inflight_teardown_batches_destroy_target_once() {
+        fn run(methods: &[&str]) -> (usize, usize) {
+            let mut ctx = crate::dispatch::CdpContext::new();
+            let context_id = ctx.create_browser_context();
+            let page_id = ctx.create_page_in_context(Some(&context_id)).unwrap();
+            let session_id = format!("{page_id}-session");
+            ctx.sessions.insert(session_id, page_id.clone());
+            // Match process_with_interception: the task owns the Page while
+            // CdpContext retains its session/context identity.
+            ctx.pages.retain(|page| page.id != page_id);
+            let (reply_tx, mut reply_rx) = tokio::sync::mpsc::unbounded_channel();
+            for (offset, method) in methods.iter().enumerate() {
+                let params = if *method == "Target.closeTarget" {
+                    json!({"targetId": page_id})
+                } else {
+                    json!({"browserContextId": context_id})
+                };
+                finish_inflight_teardown(
+                    &json!({"id": offset + 1, "method": method, "params": params}).to_string(),
+                    &mut ctx,
+                    &page_id,
+                    &context_id,
+                    &reply_tx,
+                );
+            }
+            let mut destroyed = 0;
+            let mut responses = 0;
+            while let Ok(text) = reply_rx.try_recv() {
+                let message: serde_json::Value = serde_json::from_str(&text).unwrap();
+                destroyed += usize::from(message["method"] == "Target.targetDestroyed");
+                responses += usize::from(message.get("id").is_some());
+            }
+            (destroyed, responses)
+        }
+        for methods in [
+            ["Target.closeTarget", "Target.disposeBrowserContext"],
+            ["Target.disposeBrowserContext", "Target.closeTarget"],
+            ["Target.disposeBrowserContext", "Target.disposeBrowserContext"],
+        ] {
+            let (destroyed, responses) = run(&methods);
+            assert_eq!(destroyed, 1, "{methods:?}");
+            assert_eq!(responses, 2, "{methods:?}");
+        }
+    }
+
+    #[test]
+    fn inflight_teardown_queue_is_bounded() {
+        let control = ConnectionControl::new();
+        let navigation = obscura_browser::navigation::NavigationControl::new();
+        let generation = control.activate(
+            "page-1".to_string(),
+            "default".to_string(),
+            false,
+            navigation,
+        );
+        for id in 0..MAX_DEFERRED_MESSAGES {
+            assert!(control.signal_teardown_request(
+                &json!({"id": id, "method": "Target.closeTarget", "params": {"targetId": "page-1"}}).to_string()
+            ));
+        }
+        assert!(!control.signal_teardown_request(
+            &json!({"id": MAX_DEFERRED_MESSAGES, "method": "Target.closeTarget", "params": {"targetId": "page-1"}}).to_string()
+        ));
+        assert_eq!(control.finish_navigation(generation).len(), MAX_DEFERRED_MESSAGES);
+    }
 
     fn cookie(name: &str, value: &str) -> CookieInfo {
         CookieInfo {
@@ -2256,10 +3080,12 @@ mod tests {
                 let shutdown = std::sync::Arc::new(tokio::sync::Notify::new());
                 let request_shutdown = shutdown.clone();
                 let default_context = crate::dispatch::CdpContext::new().default_context;
+                let connection_control = std::sync::Arc::new(super::ConnectionControl::new());
                 let processor = tokio::task::spawn_local(super::cdp_processor(
                     server_rx,
                     default_context,
                     shutdown,
+                    connection_control,
                 ));
 
                 server_tx
@@ -2547,7 +3373,10 @@ mod tests {
     #[test]
     fn fetch_resolution_is_handled_once_by_the_outer_processor() {
         let (resolution_tx, mut resolution_rx) = tokio::sync::oneshot::channel();
-        let mut paused = HashMap::from([("request-1".to_string(), resolution_tx)]);
+        let mut paused = HashMap::from([("request-1".to_string(), PausedInterception {
+            page_id: "page-1".to_string(),
+            resolver: resolution_tx,
+        })]);
         let (reply_tx, mut reply_rx) = tokio::sync::mpsc::unbounded_channel::<String>();
         let mut ctx = crate::dispatch::CdpContext::new();
 

--- a/crates/obscura-cdp/src/server.rs
+++ b/crates/obscura-cdp/src/server.rs
@@ -1056,6 +1056,9 @@ async fn cdp_processor(
                         lifecycle_continuation_page = None;
                         lifecycle_release_deadline = None;
                     }
+                    // A continuously ready page task must still yield to the
+                    // WebSocket reader/writer and to shutdown/deadline arms.
+                    tokio::task::yield_now().await;
                     None
                 },
                 Some(intercepted) = async {
@@ -1184,6 +1187,10 @@ async fn cdp_processor(
         // pump will park cheaply if its next task is a distant timer.
         runtime_pump_armed = ctx.pages.iter().any(|page| page.has_js());
         runtime_pump_error_streak = 0;
+        // Let the WebSocket writer flush this command's response and the
+        // reader enqueue the client's follow-up before background page work is
+        // offered another V8 turn.
+        tokio::task::yield_now().await;
 
     }
 
@@ -2000,12 +2007,13 @@ mod tests {
     }
 
     #[tokio::test(flavor = "current_thread")]
-    async fn page_runtime_advances_while_cdp_client_is_silent() {
+    async fn page_runtime_and_shutdown_progress_under_silence_and_command_flood() {
         tokio::task::LocalSet::new()
             .run_until(async {
                 let (server_tx, server_rx) = tokio::sync::mpsc::unbounded_channel();
                 let (reply_tx, mut reply_rx) = tokio::sync::mpsc::unbounded_channel();
                 let shutdown = std::sync::Arc::new(tokio::sync::Notify::new());
+                let request_shutdown = shutdown.clone();
                 let default_context = crate::dispatch::CdpContext::new().default_context;
                 let processor = tokio::task::spawn_local(super::cdp_processor(
                     server_rx,
@@ -2114,10 +2122,65 @@ mod tests {
                     }
                 }
 
-                drop(server_tx);
+                send(json!({
+                    "id": 4,
+                    "method": "Runtime.enable",
+                    "sessionId": session_id,
+                    "params": {},
+                }));
+                while serde_json::from_str::<serde_json::Value>(
+                    &reply_rx.recv().await.expect("Runtime.enable response channel"),
+                )
+                .unwrap()["id"] != 4
+                {}
+                send(json!({
+                    "id": 5,
+                    "method": "Runtime.evaluate",
+                    "sessionId": session_id,
+                    "params": {
+                        "expression": "setTimeout(() => console.log('__pump_fairness_marker__'), 0)",
+                    },
+                }));
+                while serde_json::from_str::<serde_json::Value>(
+                    &reply_rx.recv().await.expect("timer response channel"),
+                )
+                .unwrap()["id"] != 5
+                {}
+
+                const FLOOD: i64 = 4_096;
+                for id in 10_000..10_000 + FLOOD {
+                    send(json!({"id": id, "method": "Browser.getVersion", "params": {}}));
+                }
+                let mut saw_last_flood_response = false;
+                tokio::time::timeout(std::time::Duration::from_secs(2), async {
+                    loop {
+                        let value: serde_json::Value = serde_json::from_str(
+                            &reply_rx.recv().await.expect("flood response channel"),
+                        )
+                        .unwrap();
+                        saw_last_flood_response |= value["id"] == 10_000 + FLOOD - 1;
+                        if value["method"] == "Runtime.consoleAPICalled"
+                            && value["params"]["args"][0]["value"]
+                                == "__pump_fairness_marker__"
+                        {
+                            break;
+                        }
+                    }
+                })
+                .await
+                .expect("continuous commands starved the page event loop");
+                assert!(
+                    !saw_last_flood_response,
+                    "the page pump ran only after draining the unbounded command backlog",
+                );
+
+                for id in 20_000..20_000 + FLOOD {
+                    send(json!({"id": id, "method": "Browser.getVersion", "params": {}}));
+                }
+                request_shutdown.notify_one();
                 tokio::time::timeout(std::time::Duration::from_secs(2), processor)
                     .await
-                    .expect("processor shutdown timeout")
+                    .expect("continuous commands starved processor shutdown")
                     .expect("processor task");
             })
             .await;

--- a/crates/obscura-cdp/src/server.rs
+++ b/crates/obscura-cdp/src/server.rs
@@ -17,6 +17,7 @@ use crate::dispatch::{self, CdpContext};
 // must be bounded so a stalled navigation cannot OOM the process. When the cap
 // is reached we return an explicit error response rather than silently dropping.
 const MAX_DEFERRED_MESSAGES: usize = 256;
+const POST_LOAD_DRAIN_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(1);
 
 // The WS-stream forwarding channel must also be bounded: if the LocalSet
 // (CDP processor + nav tasks) stalls, the accept thread keeps pushing
@@ -840,6 +841,8 @@ async fn cdp_processor(
     // in flight.
     let mut deferred: std::collections::VecDeque<ServerMessage> =
         std::collections::VecDeque::new();
+    let mut post_load_deferred: std::collections::VecDeque<ServerMessage> =
+        std::collections::VecDeque::new();
 
     // Graceful shutdown: one signal watcher on the accept side flips the flag
     // and calls `notify_waiters()`. Polled once here (via the select! below) it
@@ -860,29 +863,83 @@ async fn cdp_processor(
     // next command/navigation, so static pages consume no polling budget.
     let mut runtime_pump_armed = false;
     let mut runtime_pump_error_streak = 0_u8;
+    let mut lifecycle_continuation_page: Option<String> = None;
+    let mut lifecycle_release_deadline: Option<tokio::time::Instant> = None;
 
     loop {
+        // A DOMContentLoaded listener may have queued a replacement before the
+        // old runtime parked. Navigation wins over pumping that old document.
+        if let (Some(reply_tx), Some((session_id, url, method, body))) = (
+            connection_reply_tx.as_ref(),
+            take_live_pending_navigation(&ctx),
+        ) {
+            let navigation = json!({
+                "id": 0,
+                "method": "Page.navigate",
+                "params": {"url": url, "__method": method, "__body": body},
+                "sessionId": session_id,
+            })
+            .to_string();
+            process_with_interception(
+                &navigation,
+                &mut ctx,
+                reply_tx,
+                &mut rx,
+                &mut intercept_rx,
+                &mut intercepted_paused,
+                &mut deferred,
+                false,
+            )
+            .await;
+            lifecycle_continuation_page = ctx
+                .sessions
+                .get(&session_id)
+                .and_then(|page_id| ctx.get_page(page_id))
+                .filter(|page| {
+                    matches!(
+                        page.lifecycle,
+                        obscura_browser::lifecycle::LifecycleState::DomContentLoaded
+                            | obscura_browser::lifecycle::LifecycleState::Loaded
+                    )
+                })
+                .map(|page| page.id.clone());
+            lifecycle_release_deadline = None;
+            runtime_pump_armed = ctx.pages.iter().any(|page| page.has_js());
+            continue;
+        }
         // Drain any deferred messages from the previous interception window
         // before pulling new ones off the wire. Each is processed with no
         // nav-task spawn_local in flight, so this connection's only entered
         // Isolate is the one dispatch is about to touch.
         let msg = if let Some(d) = deferred.pop_front() {
             Some(d)
+        } else if lifecycle_continuation_page.is_none() {
+            post_load_deferred.pop_front()
+        } else {
+            None
+        };
+        let msg = if msg.is_some() {
+            msg
         } else {
             let screencast_active = has_active_screencast(&ctx);
-            let live_page_route = ctx
-                .pages
-                .iter()
-                .find(|page| page.has_js())
-                .and_then(|page| {
+            let live_page_route = if let Some(page_id) = lifecycle_continuation_page.as_ref() {
+                (|| {
+                    let page = ctx.get_page(page_id)?;
                     ctx.sessions
                         .iter()
-                        .find(|(_, page_id)| *page_id == &page.id)
+                        .find(|(_, owner)| *owner == page_id)
                         .map(|(session_id, _)| (session_id.clone(), page.frame_id.clone()))
-                });
+                })()
+            } else {
+                ctx.pages.iter().find_map(|page| {
+                        ctx.sessions
+                            .iter()
+                            .find(|(_, owner)| *owner == &page.id)
+                            .map(|(session_id, _)| (session_id.clone(), page.frame_id.clone()))
+                })
+            };
             let has_intercept_rx = intercept_rx.is_some();
             tokio::select! {
-                biased;
                 msg = rx.recv() => match msg {
                     Some(m) => Some(m),
                     None => break,
@@ -891,48 +948,113 @@ async fn cdp_processor(
                     tracing::info!("Shutdown signal received (connection processor)");
                     break;
                 },
-                pump_result = pump_live_page_event_loop(&mut ctx), if runtime_pump_armed => {
+                _ = async {
+                    if let Some(deadline) = lifecycle_release_deadline {
+                        tokio::time::sleep_until(deadline).await;
+                    }
+                }, if lifecycle_release_deadline.is_some() => {
+                    lifecycle_continuation_page = None;
+                    lifecycle_release_deadline = None;
+                    runtime_pump_armed = ctx.pages.iter().any(|page| page.has_js());
+                    None
+                },
+                pump_result = pump_live_page_event_loop(
+                    &mut ctx,
+                    lifecycle_continuation_page.as_deref(),
+                ), if runtime_pump_armed => {
+                    let mut completed_lifecycle = false;
                     match pump_result {
                         Ok(reached_idle) => {
                             runtime_pump_error_streak = 0;
                             runtime_pump_armed = !reached_idle;
+                            let terminal_lifecycle = lifecycle_continuation_page
+                                .as_ref()
+                                .and_then(|page_id| ctx.get_page(page_id))
+                                .is_some_and(|page| {
+                                    matches!(
+                                        page.lifecycle,
+                                        obscura_browser::lifecycle::LifecycleState::Loaded
+                                            | obscura_browser::lifecycle::LifecycleState::NetworkIdle
+                                            | obscura_browser::lifecycle::LifecycleState::Failed
+                                    )
+                                });
+                            if terminal_lifecycle {
+                                if reached_idle {
+                                    completed_lifecycle = true;
+                                } else {
+                                    lifecycle_release_deadline.get_or_insert_with(|| {
+                                        tokio::time::Instant::now()
+                                            + POST_LOAD_DRAIN_TIMEOUT
+                                    });
+                                }
+                            }
                         }
                         Err(error) => {
                             runtime_pump_error_streak = runtime_pump_error_streak.saturating_add(1);
-                            runtime_pump_armed = runtime_pump_error_streak <= 3
-                                && ctx.pages.iter().any(|page| page.has_js());
                             tracing::warn!("autonomous page task failed: {error}");
-                            tokio::task::yield_now().await;
+                            if runtime_pump_error_streak > 3 {
+                                if let Some(page_id) = lifecycle_continuation_page
+                                    .clone()
+                                    .or_else(|| {
+                                        ctx.pages
+                                            .iter()
+                                            .find(|page| page.has_js())
+                                            .map(|page| page.id.clone())
+                                    })
+                                {
+                                    let sessions = ctx
+                                        .sessions
+                                        .iter()
+                                        .filter(|(_, owner)| *owner == &page_id)
+                                        .map(|(session_id, _)| session_id.clone())
+                                        .collect::<Vec<_>>();
+                                    for session_id in &sessions {
+                                        ctx.pending_events.push(crate::types::CdpEvent {
+                                            method: "Inspector.targetCrashed".to_string(),
+                                            params: json!({"status": "crashed", "errorCode": 0}),
+                                            session_id: Some(session_id.clone()),
+                                        });
+                                        ctx.pending_events.push(crate::types::CdpEvent::new(
+                                            "Target.detachedFromTarget",
+                                            json!({"sessionId": session_id, "targetId": &page_id}),
+                                        ));
+                                    }
+                                    ctx.pending_events.push(crate::types::CdpEvent::new(
+                                        "Target.targetDestroyed",
+                                        json!({"targetId": &page_id}),
+                                    ));
+                                    ctx.remove_page(&page_id);
+                                    if lifecycle_continuation_page.as_deref()
+                                        == Some(page_id.as_str())
+                                    {
+                                        lifecycle_continuation_page = None;
+                                        lifecycle_release_deadline = None;
+                                    }
+                                }
+                                runtime_pump_armed = false;
+                            } else {
+                                runtime_pump_armed = ctx.pages.iter().any(|page| page.has_js());
+                                tokio::task::yield_now().await;
+                            }
                         }
                     }
-                    sync_live_page_network_events(&mut ctx);
+                    sync_live_page_network_events(
+                        &mut ctx,
+                        lifecycle_continuation_page.as_deref(),
+                    );
                     dispatch::drain_runtime_events(&mut ctx);
                     dispatch::drain_binding_calls(&mut ctx);
                     dispatch::drain_frame_events(&mut ctx);
+                    // Chromium reports the load-delaying resource completion
+                    // and callbacks caused by that work before document load.
+                    sync_live_page_lifecycle_events(
+                        &mut ctx,
+                        lifecycle_continuation_page.as_deref(),
+                    );
                     forward_pending_events(&mut ctx, connection_reply_tx.as_ref());
-                    if let (Some(reply_tx), Some((session_id, url, method, body))) = (
-                        connection_reply_tx.as_ref(),
-                        take_live_pending_navigation(&ctx),
-                    ) {
-                        let navigation = json!({
-                            "id": 0,
-                            "method": "Page.navigate",
-                            "params": {"url": url, "__method": method, "__body": body},
-                            "sessionId": session_id,
-                        })
-                        .to_string();
-                        process_with_interception(
-                            &navigation,
-                            &mut ctx,
-                            reply_tx,
-                            &mut rx,
-                            &mut intercept_rx,
-                            &mut intercepted_paused,
-                            &mut deferred,
-                            false,
-                        )
-                        .await;
-                        runtime_pump_armed = ctx.pages.iter().any(|page| page.has_js());
+                    if completed_lifecycle {
+                        lifecycle_continuation_page = None;
+                        lifecycle_release_deadline = None;
                     }
                     None
                 },
@@ -985,6 +1107,26 @@ async fn cdp_processor(
                 );
             }
             ServerMessage::Cdp(cdp_msg) => {
+                if lifecycle_continuation_page.as_ref().is_some_and(|page_id| {
+                    command_targets_other_page(&cdp_msg.text, &ctx, page_id)
+                }) {
+                    if post_load_deferred.len() >= MAX_DEFERRED_MESSAGES {
+                        if let Ok(req) = serde_json::from_str::<CdpRequest>(&cdp_msg.text) {
+                            let response = crate::types::CdpResponse::error(
+                                req.id,
+                                -32000,
+                                "Server busy: another page is completing navigation".to_string(),
+                                req.session_id,
+                            );
+                            if let Ok(json) = serde_json::to_string(&response) {
+                                let _ = cdp_msg.reply_tx.send(json);
+                            }
+                        }
+                    } else {
+                        post_load_deferred.push_back(ServerMessage::Cdp(cdp_msg));
+                    }
+                    continue;
+                }
                 // Route every Page.navigate through the spawn-and-defer path,
                 // not just intercepted ones. Holding the V8 lock across a
                 // multi-second navigate inside the regular dispatch wedges the
@@ -996,11 +1138,24 @@ async fn cdp_processor(
                 let is_navigation = is_navigate_method(&cdp_msg.text);
 
                 if is_navigation {
+                    let navigation_page_id = serde_json::from_str::<CdpRequest>(&cdp_msg.text)
+                        .ok()
+                        .and_then(|request| request_page_id(&request, &ctx));
                     process_with_interception(
                         &cdp_msg.text, &mut ctx, &cdp_msg.reply_tx, &mut rx,
                         &mut intercept_rx, &mut intercepted_paused,
                         &mut deferred, true,
                     ).await;
+                    lifecycle_continuation_page = navigation_page_id.filter(|page_id| {
+                        ctx.get_page(page_id).is_some_and(|page| {
+                            matches!(
+                                page.lifecycle,
+                                obscura_browser::lifecycle::LifecycleState::DomContentLoaded
+                                    | obscura_browser::lifecycle::LifecycleState::Loaded
+                            )
+                        })
+                    });
+                    lifecycle_release_deadline = None;
                 } else {
                     let fetch_was_resolved = cdp_msg.text.contains("Fetch.")
                         && handle_fetch_resolution(
@@ -1016,6 +1171,14 @@ async fn cdp_processor(
             }
         }
 
+        if lifecycle_continuation_page
+            .as_ref()
+            .is_some_and(|page_id| ctx.get_page(page_id).is_none())
+        {
+            lifecycle_continuation_page = None;
+            lifecycle_release_deadline = None;
+        }
+
         // Dispatch may have created a page or scheduled new asynchronous work.
         // A single live isolate is the connection's current active target; the
         // pump will park cheaply if its next task is a distant timer.
@@ -1027,6 +1190,40 @@ async fn cdp_processor(
     // The connection thread merges this context's cookie delta into the
     // persistence template after the processor stops.
     let _ = &ctx;
+}
+
+fn request_page_id(request: &CdpRequest, ctx: &CdpContext) -> Option<String> {
+    if request.method == "Target.sendMessageToTarget" {
+        if let Some(page_id) = request
+            .params
+            .get("sessionId")
+            .and_then(|value| value.as_str())
+            .and_then(|session_id| ctx.sessions.get(session_id))
+        {
+            return Some(page_id.clone());
+        }
+        if let Some(inner) = request.params.get("message").and_then(|value| value.as_str()) {
+            if let Ok(inner) = serde_json::from_str::<CdpRequest>(inner) {
+                return request_page_id(&inner, ctx);
+            }
+        }
+    }
+    request
+        .session_id
+        .as_ref()
+        .and_then(|session_id| ctx.sessions.get(session_id))
+        .cloned()
+}
+
+fn command_targets_other_page(
+    text: &str,
+    ctx: &CdpContext,
+    lifecycle_page_id: &str,
+) -> bool {
+    let Ok(request) = serde_json::from_str::<CdpRequest>(text) else {
+        return false;
+    };
+    request_page_id(&request, ctx).is_some_and(|page_id| page_id != lifecycle_page_id)
 }
 
 fn emit_intercepted_request(
@@ -1090,27 +1287,71 @@ fn emit_intercepted_request(
     intercepted_paused.insert(intercepted.request_id, intercepted.resolver);
 }
 
-async fn pump_live_page_event_loop(ctx: &mut CdpContext) -> Result<bool, String> {
-    let Some(page) = ctx.pages.iter_mut().find(|page| page.has_js()) else {
+async fn pump_live_page_event_loop(
+    ctx: &mut CdpContext,
+    lifecycle_page_id: Option<&str>,
+) -> Result<bool, String> {
+    let page_index = lifecycle_page_id
+        .and_then(|page_id| ctx.pages.iter().position(|page| page.id == page_id))
+        .or_else(|| ctx.pages.iter().position(|page| page.has_js()));
+    let Some(page_index) = page_index else {
         return Ok(true);
     };
+    let page = &mut ctx.pages[page_index];
     page.run_autonomous_event_loop_turn().await
 }
 
-fn sync_live_page_network_events(ctx: &mut CdpContext) {
-    let page_route = ctx.pages.iter().find(|page| page.has_js()).and_then(|page| {
-        ctx.sessions
-            .iter()
-            .find(|(_, page_id)| *page_id == &page.id)
-            .map(|(session_id, _)| {
-                (
-                    Some(session_id.clone()),
-                    page.id.clone(),
-                    page.frame_id.clone(),
-                    page.url_string(),
-                )
-            })
-    });
+fn sync_live_page_lifecycle_events(ctx: &mut CdpContext, lifecycle_page_id: Option<&str>) {
+    let route_for = |page: &obscura_browser::Page| {
+        if !page.has_js() {
+            return None;
+        }
+        let loader_id = ctx.current_loader_ids.get(&page.id)?.clone();
+        let session_id = ctx.navigation_sessions.get(&page.id)?.clone();
+        Some((
+            session_id,
+            page.id.clone(),
+            page.frame_id.clone(),
+            loader_id,
+            page.lifecycle,
+        ))
+    };
+    let route = if let Some(page_id) = lifecycle_page_id {
+        ctx.get_page(page_id).and_then(route_for)
+    } else {
+        ctx.pages.iter().find_map(route_for)
+    };
+    let Some((session_id, page_id, frame_id, loader_id, lifecycle)) = route else {
+        return;
+    };
+    crate::domains::page::emit_document_lifecycle_state(
+        ctx,
+        &session_id,
+        &frame_id,
+        &loader_id,
+        &page_id,
+        lifecycle,
+    );
+}
+
+fn sync_live_page_network_events(ctx: &mut CdpContext, lifecycle_page_id: Option<&str>) {
+    let route_for = |page: &obscura_browser::Page| {
+        if !page.has_js() {
+            return None;
+        }
+        let session_id = ctx.navigation_sessions.get(&page.id)?.clone();
+        Some((
+            session_id,
+            page.id.clone(),
+            page.frame_id.clone(),
+            page.url_string(),
+        ))
+    };
+    let page_route = if let Some(page_id) = lifecycle_page_id {
+        ctx.get_page(page_id).and_then(route_for)
+    } else {
+        ctx.pages.iter().find_map(route_for)
+    };
     let Some((session_id, page_id, frame_id, page_url)) = page_route else {
         return;
     };
@@ -1134,14 +1375,17 @@ fn sync_live_page_network_events(ctx: &mut CdpContext) {
 fn take_live_pending_navigation(
     ctx: &CdpContext,
 ) -> Option<(String, String, String, String)> {
-    let page = ctx.pages.iter().find(|page| page.has_js())?;
-    let session_id = ctx
-        .sessions
-        .iter()
-        .find(|(_, page_id)| *page_id == &page.id)
-        .map(|(session_id, _)| session_id.clone())?;
-    let (url, method, body) = page.take_pending_navigation()?;
-    Some((session_id, url, method, body))
+    ctx.pages.iter().find_map(|page| {
+        if !page.has_js() {
+            return None;
+        }
+        let session_id = ctx
+            .navigation_sessions
+            .get(&page.id)
+            .and_then(Clone::clone)?;
+        let (url, method, body) = page.take_pending_navigation()?;
+        Some((session_id, url, method, body))
+    })
 }
 
 fn forward_pending_events(
@@ -1324,7 +1568,6 @@ async fn process_with_interception(
     }
 
     let url = req.params.get("url").and_then(|v| v.as_str()).unwrap_or("");
-    let wait_until = crate::domains::page::parse_wait_until(&req.params);
     let nav_method = req.params.get("__method").and_then(|v| v.as_str()).unwrap_or("GET").to_string();
     let nav_body = req.params.get("__body").and_then(|v| v.as_str()).unwrap_or("").to_string();
 
@@ -1353,11 +1596,14 @@ async fn process_with_interception(
         // must run BEFORE the page's own scripts (CDP contract). Hand them
         // to the page so navigate_single can inject them at the right point.
         page.set_preload_scripts(preload_scripts);
-        let result = if nav_method == "POST" && !nav_body.is_empty() {
-            page.navigate_with_wait_post(&url_owned, wait_until, &nav_method, &nav_body).await
-        } else {
-            page.navigate_with_wait(&url_owned, wait_until).await
-        }
+        let result = page
+            .navigate_with_wait_post(
+                &url_owned,
+                obscura_browser::lifecycle::WaitUntil::DomContentLoaded,
+                &nav_method,
+                &nav_body,
+            )
+            .await
         .map_err(|e| e.to_string());
         drop(_v8_guard);
         let _ = nav_done_tx.send((page, result)).await;
@@ -1508,7 +1754,7 @@ async fn process_with_interception(
         &page_url,
         &page_id_for_events,
         &network_events,
-        wait_until,
+        obscura_browser::lifecycle::WaitUntil::DomContentLoaded,
         reached_network_idle,
     );
     #[cfg(feature = "render")]
@@ -1732,6 +1978,7 @@ async fn handle_connection_ws(
 mod tests {
     use super::{
         handle_fetch_resolution, is_navigate_method, merge_cookie_delta, parse_cdp_headers,
+        request_page_id, take_live_pending_navigation,
     };
     #[cfg(feature = "render")]
     use super::{pump_and_forward_screencast_frames, pump_live_page_event_loop};
@@ -1918,6 +2165,59 @@ mod tests {
         assert!(!is_navigate_method("not json"));
     }
 
+    #[test]
+    fn legacy_send_message_wrapper_resolves_its_effective_page() {
+        let mut ctx = crate::dispatch::CdpContext::new();
+        ctx.sessions
+            .insert("legacy-session".to_string(), "page-2".to_string());
+        let request: crate::types::CdpRequest = serde_json::from_value(json!({
+            "id": 4,
+            "method": "Target.sendMessageToTarget",
+            "params": {
+                "sessionId": "legacy-session",
+                "message": "{\"id\":5,\"method\":\"Runtime.evaluate\",\"params\":{\"expression\":\"1\"}}"
+            }
+        }))
+        .unwrap();
+        assert_eq!(request_page_id(&request, &ctx).as_deref(), Some("page-2"));
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn detached_navigation_owner_retargets_autonomous_navigation() {
+        let mut ctx = crate::dispatch::CdpContext::new();
+        let page_id = ctx.create_page();
+        ctx.get_page_mut(&page_id)
+            .unwrap()
+            .navigate_with_wait(
+                "data:text/html,current",
+                obscura_browser::lifecycle::WaitUntil::Load,
+            )
+            .await
+            .unwrap();
+        ctx.sessions
+            .insert("detached-session".to_string(), page_id.clone());
+        ctx.sessions
+            .insert("remaining-session".to_string(), page_id.clone());
+        ctx.navigation_sessions
+            .insert(page_id.clone(), Some("detached-session".to_string()));
+
+        crate::domains::target::handle(
+            "detachFromTarget",
+            &json!({"sessionId": "detached-session"}),
+            &mut ctx,
+            &None,
+        )
+        .await
+        .unwrap();
+        ctx.get_page_mut(&page_id)
+            .unwrap()
+            .evaluate("location.href = 'data:text/html,replacement'");
+
+        let pending = take_live_pending_navigation(&ctx).expect("autonomous navigation");
+        assert_eq!(pending.0, "remaining-session");
+        assert_eq!(pending.1, "data:text/html,replacement");
+    }
+
     // Issue #365: Fetch.continueRequest header overrides must be parsed from the
     // CDP `[{name, value}]` list so they can be applied to the outgoing request.
     #[test]
@@ -2008,7 +2308,7 @@ mod tests {
             .evaluate(
                 "setTimeout(() => document.body.setAttribute('style', 'margin:0;width:96px;height:64px;background:green'), 0)",
             );
-        pump_live_page_event_loop(&mut ctx).await.unwrap();
+        pump_live_page_event_loop(&mut ctx, None).await.unwrap();
         pump_and_forward_screencast_frames(&mut ctx, Some(&reply_tx)).await;
         let first_update: serde_json::Value = serde_json::from_str(
             &reply_rx.try_recv().expect("timer mutation should emit a frame"),
@@ -2027,7 +2327,7 @@ mod tests {
             .evaluate(
                 "setTimeout(() => document.body.setAttribute('style', 'margin:0;width:96px;height:64px;background:blue'), 0)",
             );
-        pump_live_page_event_loop(&mut ctx).await.unwrap();
+        pump_live_page_event_loop(&mut ctx, None).await.unwrap();
         pump_and_forward_screencast_frames(&mut ctx, Some(&reply_tx)).await;
         assert!(reply_rx.try_recv().is_err());
         assert!(ctx.screencasts[&session_id].autonomous_frame_pending);
@@ -2109,7 +2409,7 @@ mod tests {
                 "requestAnimationFrame(() => document.body.setAttribute('style','margin:0;width:96px;height:64px;background:lime'))",
             );
         tokio::time::sleep(std::time::Duration::from_millis(25)).await;
-        pump_live_page_event_loop(&mut ctx).await.unwrap();
+        pump_live_page_event_loop(&mut ctx, None).await.unwrap();
         pump_and_forward_screencast_frames(&mut ctx, None).await;
         let raf_frame = ctx
             .pending_events

--- a/crates/obscura-cdp/tests/navigation_lifecycle_stream.rs
+++ b/crates/obscura-cdp/tests/navigation_lifecycle_stream.rs
@@ -56,6 +56,16 @@ async fn serve_delayed_load_fixture(
             let _ = socket.write_all(response.as_bytes()).await;
             continue;
         }
+        if request.starts_with("GET /busy-finished ") {
+            let _ = slow_requested.send(());
+            let body = "ok";
+            let response = format!(
+                "HTTP/1.1 200 OK\r\nContent-Type: text/plain\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{body}",
+                body.len(),
+            );
+            let _ = socket.write_all(response.as_bytes()).await;
+            continue;
+        }
         if request.starts_with("GET /after-load ") {
             tokio::time::sleep(Duration::from_millis(150)).await;
             let body = "ok";
@@ -72,6 +82,8 @@ async fn serve_delayed_load_fixture(
         }
         let dcl_script = if request.starts_with("GET /timeout ") {
             "const script = document.createElement('script'); script.src = '/never'; document.head.appendChild(script);"
+        } else if request.starts_with("GET /busy-after-dcl ") {
+            "setTimeout(() => { globalThis.__busyStarted = true; const until = performance.now() + 300; while (performance.now() < until) {} globalThis.__busyDone = true; fetch('/busy-finished'); }, 0);"
         } else if request.starts_with("GET /post-load-timeout ") {
             ""
         } else {
@@ -455,6 +467,113 @@ async fn domcontentloaded_returns_before_a_load_delaying_script() {
                 "params": {"targetId": second_target},
             }))
             .await;
+            let _ = ws.close(None).await;
+        })
+        .await;
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn same_page_command_wins_the_first_post_dcl_pump() {
+    std::env::set_var("OBSCURA_ALLOW_PRIVATE_NETWORK", "1");
+    let fixture = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let fixture_url = format!("http://{}/busy-after-dcl", fixture.local_addr().unwrap());
+    let (slow_requested_tx, mut busy_finished_rx) = mpsc::unbounded_channel();
+    let (_release_tx, release_rx) = oneshot::channel();
+    tokio::spawn(serve_delayed_load_fixture(
+        fixture,
+        slow_requested_tx,
+        release_rx,
+    ));
+
+    let port = pick_port().await;
+    tokio::task::LocalSet::new()
+        .run_until(async move {
+            tokio::task::spawn_local(async move {
+                let _ = obscura_cdp::server::start(port).await;
+            });
+            let mut ws = connect_cdp(port).await;
+            let (target_id, session_id) = create_target(&mut ws, 1, None).await;
+            enable_page_lifecycle(&mut ws, &session_id, 2).await;
+            send(&mut ws, json!({
+                "id": 3,
+                "method": "Page.startScreencast",
+                "sessionId": session_id,
+                "params": {},
+            })).await;
+            loop {
+                let message = next_json(&mut ws).await;
+                if message["id"] == 3 {
+                    break;
+                }
+            }
+
+            send(&mut ws, json!({
+                "id": 4,
+                "method": "Page.navigate",
+                "sessionId": session_id,
+                "params": {"url": fixture_url},
+            })).await;
+            loop {
+                let message = next_json(&mut ws).await;
+                if message["id"] == 4 {
+                    break;
+                }
+            }
+
+            // Playwright's waitUntil=commit returns before DOMContentLoaded.
+            // Queue the follow-up while outer response/event finalization still
+            // owns routing; it must precede the first post-DCL background poll.
+            send(&mut ws, json!({
+                "id": 5,
+                "method": "Runtime.evaluate",
+                "sessionId": session_id,
+                "params": {
+                    "expression": "[globalThis.__busyStarted === true, globalThis.__busyDone === true]",
+                    "returnByValue": true,
+                },
+            })).await;
+            let immediate = tokio::time::timeout(Duration::from_secs(2), async {
+                loop {
+                    let message = next_json(&mut ws).await;
+                    if message["id"] == 5 {
+                        break message;
+                    }
+                }
+            })
+            .await
+            .expect("the same-page command did not complete");
+            assert_eq!(
+                immediate["result"]["result"]["value"],
+                json!([false, false]),
+            );
+
+            // The grace is one-shot. Prove autonomous progress out of band,
+            // before another CDP command can wake the processor.
+            tokio::time::timeout(Duration::from_secs(2), busy_finished_rx.recv())
+                .await
+                .expect("the background task did not progress under silence")
+                .expect("the fixture observation channel closed");
+            send(&mut ws, json!({
+                "id": 6,
+                "method": "Runtime.evaluate",
+                "sessionId": session_id,
+                "params": {
+                    "expression": "globalThis.__busyDone === true",
+                    "returnByValue": true,
+                },
+            })).await;
+            let completed = loop {
+                let message = next_json(&mut ws).await;
+                if message["id"] == 6 {
+                    break message;
+                }
+            };
+            assert_eq!(completed["result"]["result"]["value"], json!(true));
+            send(&mut ws, json!({
+                "id": 7,
+                "method": "Target.closeTarget",
+                "params": {"targetId": target_id},
+            })).await;
             let _ = ws.close(None).await;
         })
         .await;

--- a/crates/obscura-cdp/tests/navigation_lifecycle_stream.rs
+++ b/crates/obscura-cdp/tests/navigation_lifecycle_stream.rs
@@ -1,0 +1,651 @@
+use std::time::Duration;
+
+use futures_util::{SinkExt, StreamExt};
+use serde_json::{json, Value};
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::TcpListener;
+use tokio::sync::{mpsc, oneshot};
+use tokio_tungstenite::{connect_async, tungstenite::Message};
+
+async fn pick_port() -> u16 {
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let port = listener.local_addr().unwrap().port();
+    drop(listener);
+    port
+}
+
+async fn connect_cdp(
+    port: u16,
+) -> tokio_tungstenite::WebSocketStream<
+    tokio_tungstenite::MaybeTlsStream<tokio::net::TcpStream>,
+> {
+    let url = format!("ws://127.0.0.1:{port}/devtools/browser");
+    let mut last_error = None;
+    for _ in 0..100 {
+        match connect_async(&url).await {
+            Ok((ws, _)) => return ws,
+            Err(error) => last_error = Some(error),
+        }
+        tokio::time::sleep(Duration::from_millis(10)).await;
+    }
+    panic!("CDP server did not become ready: {:?}", last_error);
+}
+
+async fn serve_delayed_load_fixture(
+    listener: TcpListener,
+    slow_requested: mpsc::UnboundedSender<()>,
+    mut release_slow: oneshot::Receiver<()>,
+) {
+    let release = async move {
+        let _ = (&mut release_slow).await;
+    };
+    tokio::pin!(release);
+    loop {
+        let (mut socket, _) = listener.accept().await.unwrap();
+        let mut buffer = [0_u8; 2048];
+        let read = socket.read(&mut buffer).await.unwrap_or(0);
+        let request = String::from_utf8_lossy(&buffer[..read]);
+        if request.starts_with("GET /slow.js ") {
+            let _ = slow_requested.send(());
+            release.as_mut().await;
+            let body = "globalThis.__slowScriptDone = true;";
+            let response = format!(
+                "HTTP/1.1 200 OK\r\nContent-Type: application/javascript\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{body}",
+                body.len(),
+            );
+            let _ = socket.write_all(response.as_bytes()).await;
+            continue;
+        }
+        if request.starts_with("GET /after-load ") {
+            tokio::time::sleep(Duration::from_millis(150)).await;
+            let body = "ok";
+            let response = format!(
+                "HTTP/1.1 200 OK\r\nContent-Type: text/plain\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{body}",
+                body.len(),
+            );
+            let _ = socket.write_all(response.as_bytes()).await;
+            continue;
+        }
+        if request.starts_with("GET /never ") {
+            tokio::time::sleep(Duration::from_secs(10)).await;
+            continue;
+        }
+        let dcl_script = if request.starts_with("GET /timeout ") {
+            "const script = document.createElement('script'); script.src = '/never'; document.head.appendChild(script);"
+        } else if request.starts_with("GET /post-load-timeout ") {
+            ""
+        } else {
+            "const script = document.createElement('script'); script.src = '/slow.js'; document.head.appendChild(script);"
+        };
+        let post_load_fetch = if request.starts_with("GET /post-load-timeout ") {
+            "/never"
+        } else {
+            "/after-load"
+        };
+        let onload_extra = if request.starts_with("GET /post-load-timeout ") {
+            "setInterval(() => {}, 0);"
+        } else {
+            ""
+        };
+        let body = r#"<!doctype html><script>
+            document.addEventListener('DOMContentLoaded', () => {
+                globalThis.__dclSeen = (globalThis.__dclSeen || 0) + 1;
+                __DCL_SCRIPT__
+            });
+            window.onload = () => {
+                globalThis.__loadSeen = (globalThis.__loadSeen || 0) + 1;
+                fetch('__POST_LOAD_FETCH__');
+                __ONLOAD_EXTRA__
+            };
+        </script><p>ready</p>"#
+            .replace("__DCL_SCRIPT__", dcl_script)
+            .replace("__POST_LOAD_FETCH__", post_load_fetch)
+            .replace("__ONLOAD_EXTRA__", onload_extra);
+        let response = format!(
+            "HTTP/1.1 200 OK\r\nContent-Type: text/html\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{body}",
+            body.len(),
+        );
+        let _ = socket.write_all(response.as_bytes()).await;
+    }
+}
+
+async fn next_json<S>(ws: &mut tokio_tungstenite::WebSocketStream<S>) -> Value
+where
+    S: tokio::io::AsyncRead + tokio::io::AsyncWrite + Unpin,
+{
+    let message = tokio::time::timeout(Duration::from_secs(7), ws.next())
+        .await
+        .expect("CDP message timeout")
+        .expect("CDP WebSocket closed")
+        .expect("CDP WebSocket error");
+    match message {
+        Message::Text(text) => serde_json::from_str(&text).unwrap(),
+        other => panic!("unexpected WebSocket message: {other:?}"),
+    }
+}
+
+async fn send<S>(
+    ws: &mut tokio_tungstenite::WebSocketStream<S>,
+    value: Value,
+) where
+    S: tokio::io::AsyncRead + tokio::io::AsyncWrite + Unpin,
+{
+    ws.send(Message::Text(value.to_string().into())).await.unwrap();
+}
+
+async fn create_target<S>(
+    ws: &mut tokio_tungstenite::WebSocketStream<S>,
+    id: i64,
+    browser_context_id: Option<&str>,
+) -> (String, String)
+where
+    S: tokio::io::AsyncRead + tokio::io::AsyncWrite + Unpin,
+{
+    let mut params = json!({"url": "about:blank"});
+    if let Some(context_id) = browser_context_id {
+        params["browserContextId"] = json!(context_id);
+    }
+    send(ws, json!({"id": id, "method": "Target.createTarget", "params": params})).await;
+    let mut session_id = None;
+    let mut target_id = None;
+    while session_id.is_none() || target_id.is_none() {
+        let message = next_json(ws).await;
+        if message["method"] == "Target.attachedToTarget" {
+            session_id = message["params"]["sessionId"].as_str().map(str::to_string);
+        }
+        if message["id"] == id {
+            target_id = message["result"]["targetId"].as_str().map(str::to_string);
+        }
+    }
+    (target_id.unwrap(), session_id.unwrap())
+}
+
+async fn enable_page_lifecycle<S>(
+    ws: &mut tokio_tungstenite::WebSocketStream<S>,
+    session_id: &str,
+    first_id: i64,
+) where
+    S: tokio::io::AsyncRead + tokio::io::AsyncWrite + Unpin,
+{
+    send(ws, json!({
+        "id": first_id,
+        "method": "Page.enable",
+        "sessionId": session_id,
+        "params": {},
+    })).await;
+    while next_json(ws).await["id"] != first_id {}
+    send(ws, json!({
+        "id": first_id + 1,
+        "method": "Page.setLifecycleEventsEnabled",
+        "sessionId": session_id,
+        "params": {"enabled": true},
+    })).await;
+    while next_json(ws).await["id"] != first_id + 1 {}
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn domcontentloaded_returns_before_a_load_delaying_script() {
+    std::env::set_var("OBSCURA_ALLOW_PRIVATE_NETWORK", "1");
+    let fixture = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let fixture_url = format!("http://{}/", fixture.local_addr().unwrap());
+    let (slow_requested_tx, mut slow_requested_rx) = mpsc::unbounded_channel();
+    let (release_slow_tx, release_slow_rx) = oneshot::channel();
+    tokio::spawn(serve_delayed_load_fixture(
+        fixture,
+        slow_requested_tx,
+        release_slow_rx,
+    ));
+
+    let port = pick_port().await;
+    tokio::task::LocalSet::new()
+        .run_until(async move {
+            tokio::task::spawn_local(async move {
+                let _ = obscura_cdp::server::start(port).await;
+            });
+            let mut ws = connect_cdp(port).await;
+
+            let (target_id, session_id) = create_target(&mut ws, 1, None).await;
+            enable_page_lifecycle(&mut ws, &session_id, 2).await;
+
+            send(&mut ws, json!({
+                "id": 31,
+                "method": "Network.enable",
+                "sessionId": session_id,
+                "params": {},
+            }))
+            .await;
+            while next_json(&mut ws).await["id"] != 31 {}
+
+            send(&mut ws, json!({
+                "id": 4,
+                "method": "Page.navigate",
+                "sessionId": session_id,
+                "params": {"url": fixture_url},
+            }))
+            .await;
+
+            tokio::time::timeout(Duration::from_secs(2), slow_requested_rx.recv())
+                .await
+                .expect("load-delaying script was not requested")
+                .expect("fixture request channel closed");
+
+            let mut sequence = Vec::new();
+            let mut saw_response = false;
+            let mut saw_dcl = false;
+            while !saw_response || !saw_dcl {
+                let message = next_json(&mut ws).await;
+                if message["id"] == 4 {
+                    saw_response = true;
+                    sequence.push("response");
+                } else if message["method"] == "Page.lifecycleEvent"
+                    && message["params"]["name"] == "init"
+                {
+                    sequence.push("init");
+                } else if message["method"] == "Page.frameNavigated" {
+                    sequence.push("frameNavigated");
+                } else if message["method"] == "Page.domContentEventFired" {
+                    sequence.push("domContentEventFired");
+                } else if message["method"] == "Page.lifecycleEvent"
+                    && message["params"]["name"] == "DOMContentLoaded"
+                {
+                    saw_dcl = true;
+                    sequence.push("DOMContentLoaded");
+                } else if message["method"] == "Page.lifecycleEvent"
+                    && message["params"]["name"] == "load"
+                {
+                    panic!("load fired before the delayed script completed: {message}");
+                }
+            }
+            assert_eq!(
+                sequence,
+                [
+                    "response",
+                    "init",
+                    "frameNavigated",
+                    "domContentEventFired",
+                    "DOMContentLoaded",
+                ],
+            );
+
+            send(&mut ws, json!({
+                "id": 5,
+                "method": "Runtime.evaluate",
+                "sessionId": session_id,
+                "params": {
+                    "expression": "[document.readyState, globalThis.__dclSeen || 0, globalThis.__loadSeen || 0, globalThis.__slowScriptDone === true]",
+                    "returnByValue": true,
+                },
+            }))
+            .await;
+            let evaluated = loop {
+                let message = next_json(&mut ws).await;
+                if message["id"] == 5 {
+                    break message;
+                }
+            };
+            assert_eq!(
+                evaluated["result"]["result"]["value"],
+                json!(["interactive", 1, 0, false]),
+            );
+
+            // A page-owned lifecycle continuation must not head-of-line block
+            // commands for another target on the same connection.
+            send(&mut ws, json!({
+                "id": 50,
+                "method": "Target.createTarget",
+                "params": {"url": "about:blank"},
+            }))
+            .await;
+            let mut second_session = None;
+            let mut second_target = None;
+            let mut saw_after_load_response = false;
+            while second_session.is_none() || second_target.is_none() {
+                let message = next_json(&mut ws).await;
+                if message["method"] == "Network.responseReceived"
+                    && message["params"]["response"]["url"]
+                        .as_str()
+                        .is_some_and(|url| url.ends_with("/after-load"))
+                {
+                    saw_after_load_response = true;
+                }
+                if message["method"] == "Target.attachedToTarget" {
+                    second_session = message["params"]["sessionId"]
+                        .as_str()
+                        .map(str::to_string);
+                }
+                if message["id"] == 50 {
+                    second_target = message["result"]["targetId"]
+                        .as_str()
+                        .map(str::to_string);
+                }
+            }
+            let second_session = second_session.unwrap();
+            let second_target = second_target.unwrap();
+            send(&mut ws, json!({
+                "id": 51,
+                "method": "Runtime.evaluate",
+                "sessionId": second_session,
+                "params": {"expression": "51"},
+            }))
+            .await;
+            release_slow_tx.send(()).unwrap();
+            let mut load_sequence = Vec::new();
+            let mut slow_request_id = None;
+            let mut other_target_response = None;
+            while load_sequence.last() != Some(&"frameStoppedLoading")
+                || !saw_after_load_response
+                || other_target_response.is_none()
+            {
+                let message = next_json(&mut ws).await;
+                if message["id"] == 51 {
+                    assert!(
+                        saw_after_load_response,
+                        "another target suspended work queued by the load handler",
+                    );
+                    other_target_response = Some(message);
+                } else if message["method"] == "Network.responseReceived"
+                    && message["params"]["response"]["url"]
+                        .as_str()
+                        .is_some_and(|url| url.ends_with("/after-load"))
+                {
+                    saw_after_load_response = true;
+                } else if message["method"] == "Network.responseReceived"
+                    && message["params"]["response"]["url"]
+                        .as_str()
+                        .is_some_and(|url| url.ends_with("/slow.js"))
+                {
+                    slow_request_id = message["params"]["requestId"]
+                        .as_str()
+                        .map(str::to_string);
+                    load_sequence.push("slowResponse");
+                } else if message["method"] == "Network.loadingFinished"
+                    && message["params"]["requestId"].as_str() == slow_request_id.as_deref()
+                {
+                    load_sequence.push("slowFinished");
+                } else if message["method"] == "Page.loadEventFired" {
+                    if message["sessionId"].as_str() != Some(session_id.as_str()) {
+                        continue;
+                    }
+                    load_sequence.push("loadEventFired");
+                } else if message["method"] == "Page.lifecycleEvent"
+                    && message["params"]["name"] == "load"
+                    && message["sessionId"].as_str() == Some(session_id.as_str())
+                {
+                    load_sequence.push("load");
+                } else if message["method"] == "Page.frameStoppedLoading"
+                    && message["sessionId"].as_str() == Some(session_id.as_str())
+                {
+                    load_sequence.push("frameStoppedLoading");
+                }
+            }
+            assert_eq!(
+                load_sequence,
+                [
+                    "slowResponse",
+                    "slowFinished",
+                    "loadEventFired",
+                    "load",
+                    "frameStoppedLoading",
+                ],
+            );
+            assert_eq!(
+                other_target_response.unwrap()["result"]["result"]["value"],
+                json!("51"),
+            );
+            send(&mut ws, json!({
+                "id": 60,
+                "method": "Page.navigate",
+                "sessionId": session_id,
+                "params": {"url": format!("{fixture_url}timeout")},
+            }))
+            .await;
+            let mut timeout_page_dcl = false;
+            while !timeout_page_dcl {
+                let message = next_json(&mut ws).await;
+                timeout_page_dcl = message["method"] == "Page.lifecycleEvent"
+                    && message["params"]["name"] == "DOMContentLoaded"
+                    && message["sessionId"].as_str() == Some(session_id.as_str());
+            }
+            send(&mut ws, json!({
+                "id": 61,
+                "method": "Runtime.evaluate",
+                "sessionId": second_session,
+                "params": {"expression": "2"},
+            }))
+            .await;
+            let deferral_deadline = tokio::time::Instant::now() + Duration::from_millis(150);
+            while let Ok(Some(Ok(Message::Text(text)))) =
+                tokio::time::timeout_at(deferral_deadline, ws.next()).await
+            {
+                let message: Value = serde_json::from_str(&text).unwrap();
+                assert_ne!(message["id"], 61,
+                    "another target entered V8 while the lifecycle owner was pending load");
+            }
+            send(&mut ws, json!({
+                "id": 7,
+                "method": "Target.closeTarget",
+                "params": {"targetId": target_id},
+            }))
+            .await;
+            let mut close_acknowledged = false;
+            let mut resumed = None;
+            while !close_acknowledged || resumed.is_none() {
+                let message = next_json(&mut ws).await;
+                close_acknowledged |= message["id"] == 7;
+                if message["id"] == 61 {
+                    resumed = Some(message);
+                }
+            }
+            assert_eq!(resumed.unwrap()["result"]["result"]["value"], json!("2"));
+            send(&mut ws, json!({
+                "id": 62,
+                "method": "Runtime.evaluate",
+                "sessionId": second_session,
+                "params": {"expression": "3"},
+            }))
+            .await;
+            let after_close_started = tokio::time::Instant::now();
+            let after_close = loop {
+                let message = next_json(&mut ws).await;
+                if message["id"] == 62 {
+                    break message;
+                }
+            };
+            assert!(
+                after_close_started.elapsed() < Duration::from_secs(2),
+                "closing the lifecycle owner stranded another target",
+            );
+            assert_eq!(after_close["result"]["result"]["value"], json!("3"));
+            send(&mut ws, json!({
+                "id": 8,
+                "method": "Target.closeTarget",
+                "params": {"targetId": second_target},
+            }))
+            .await;
+            let _ = ws.close(None).await;
+        })
+        .await;
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn disposing_context_during_load_releases_deferred_target() {
+    std::env::set_var("OBSCURA_ALLOW_PRIVATE_NETWORK", "1");
+    let fixture = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let fixture_url = format!("http://{}/timeout", fixture.local_addr().unwrap());
+    let (slow_requested_tx, _slow_requested_rx) = mpsc::unbounded_channel();
+    let (_release_tx, release_rx) = oneshot::channel();
+    tokio::spawn(serve_delayed_load_fixture(
+        fixture,
+        slow_requested_tx,
+        release_rx,
+    ));
+
+    let port = pick_port().await;
+    tokio::task::LocalSet::new()
+        .run_until(async move {
+            tokio::task::spawn_local(async move {
+                let _ = obscura_cdp::server::start(port).await;
+            });
+            let mut ws = connect_cdp(port).await;
+            let (_control_target, control_session) = create_target(&mut ws, 1, None).await;
+
+            send(&mut ws, json!({
+                "id": 2,
+                "method": "Target.createBrowserContext",
+                "params": {},
+            })).await;
+            let context_id = loop {
+                let message = next_json(&mut ws).await;
+                if message["id"] == 2 {
+                    break message["result"]["browserContextId"]
+                        .as_str()
+                        .unwrap()
+                        .to_string();
+                }
+            };
+            let (owned_target, owned_session) =
+                create_target(&mut ws, 3, Some(&context_id)).await;
+            enable_page_lifecycle(&mut ws, &owned_session, 4).await;
+
+            send(&mut ws, json!({
+                "id": 6,
+                "method": "Page.navigate",
+                "sessionId": owned_session,
+                "params": {"url": fixture_url},
+            })).await;
+            send(&mut ws, json!({
+                "id": 7,
+                "method": "Runtime.evaluate",
+                "sessionId": control_session,
+                "params": {"expression": "7"},
+            })).await;
+            loop {
+                let message = next_json(&mut ws).await;
+                assert_ne!(message["id"], 7, "control target entered V8 before DCL");
+                if message["method"] == "Page.lifecycleEvent"
+                    && message["params"]["name"] == "DOMContentLoaded"
+                {
+                    break;
+                }
+            }
+
+            let deferral_deadline = tokio::time::Instant::now() + Duration::from_millis(150);
+            while let Ok(Some(Ok(Message::Text(text)))) =
+                tokio::time::timeout_at(deferral_deadline, ws.next()).await
+            {
+                let message: Value = serde_json::from_str(&text).unwrap();
+                assert_ne!(message["id"], 7, "control target entered V8 before disposal");
+            }
+
+            send(&mut ws, json!({
+                "id": 8,
+                "method": "Target.disposeBrowserContext",
+                "params": {"browserContextId": context_id},
+            })).await;
+            let mut disposed = false;
+            let mut resumed = None;
+            let mut destroyed = false;
+            while !disposed || resumed.is_none() || !destroyed {
+                let message = next_json(&mut ws).await;
+                disposed |= message["id"] == 8;
+                if message["id"] == 7 {
+                    resumed = Some(message.clone());
+                }
+                destroyed |= message["method"] == "Target.targetDestroyed"
+                    && message["params"]["targetId"].as_str() == Some(owned_target.as_str());
+            }
+            assert_eq!(resumed.unwrap()["result"]["result"]["value"], json!("7"));
+            let _ = ws.close(None).await;
+        })
+        .await;
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn post_load_drain_releases_other_target_at_absolute_bound() {
+    std::env::set_var("OBSCURA_ALLOW_PRIVATE_NETWORK", "1");
+    let fixture = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let fixture_url = format!("http://{}/post-load-timeout", fixture.local_addr().unwrap());
+    let (slow_requested_tx, _slow_requested_rx) = mpsc::unbounded_channel();
+    let (_release_tx, release_rx) = oneshot::channel();
+    tokio::spawn(serve_delayed_load_fixture(
+        fixture,
+        slow_requested_tx,
+        release_rx,
+    ));
+
+    let port = pick_port().await;
+    tokio::task::LocalSet::new()
+        .run_until(async move {
+            tokio::task::spawn_local(async move {
+                let _ = obscura_cdp::server::start(port).await;
+            });
+            let mut ws = connect_cdp(port).await;
+            let (owner_target, owner_session) = create_target(&mut ws, 1, None).await;
+            let (other_target, other_session) = create_target(&mut ws, 2, None).await;
+            enable_page_lifecycle(&mut ws, &owner_session, 3).await;
+
+            send(&mut ws, json!({
+                "id": 5,
+                "method": "Page.navigate",
+                "sessionId": owner_session,
+                "params": {"url": fixture_url},
+            })).await;
+            send(&mut ws, json!({
+                "id": 6,
+                "method": "Runtime.evaluate",
+                "sessionId": other_session,
+                "params": {"expression": "6"},
+            })).await;
+
+            let mut load_at = None;
+            let resumed = loop {
+                let message = next_json(&mut ws).await;
+                if message["method"] == "Page.lifecycleEvent"
+                    && message["params"]["name"] == "load"
+                    && message["sessionId"].as_str() == Some(owner_session.as_str())
+                {
+                    load_at = Some(tokio::time::Instant::now());
+                }
+                if message["id"] == 6 {
+                    assert!(load_at.is_some(), "other target resumed before load");
+                    break message;
+                }
+            };
+            let drain_elapsed = load_at.unwrap().elapsed();
+            assert!(
+                drain_elapsed >= Duration::from_millis(800),
+                "post-load drain released too early: {drain_elapsed:?}",
+            );
+            assert!(
+                drain_elapsed < Duration::from_secs(2),
+                "post-load drain exceeded its absolute bound: {drain_elapsed:?}",
+            );
+            assert_eq!(resumed["result"]["result"]["value"], json!("6"));
+
+            send(&mut ws, json!({
+                "id": 7,
+                "method": "Runtime.evaluate",
+                "sessionId": owner_session,
+                "params": {"expression": "7"},
+            })).await;
+            let owner_resumed = loop {
+                let message = next_json(&mut ws).await;
+                if message["id"] == 7 {
+                    break message;
+                }
+            };
+            assert_eq!(owner_resumed["result"]["result"]["value"], json!("7"));
+            send(&mut ws, json!({
+                "id": 8,
+                "method": "Target.closeTarget",
+                "params": {"targetId": owner_target},
+            })).await;
+            send(&mut ws, json!({
+                "id": 9,
+                "method": "Target.closeTarget",
+                "params": {"targetId": other_target},
+            })).await;
+            let _ = ws.close(None).await;
+        })
+        .await;
+}

--- a/crates/obscura-cdp/tests/navigation_lifecycle_stream.rs
+++ b/crates/obscura-cdp/tests/navigation_lifecycle_stream.rs
@@ -1,4 +1,6 @@
 use std::time::Duration;
+use std::io::Write;
+use std::sync::{Arc, Mutex};
 
 use futures_util::{SinkExt, StreamExt};
 use serde_json::{json, Value};
@@ -6,6 +8,17 @@ use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::net::TcpListener;
 use tokio::sync::{mpsc, oneshot};
 use tokio_tungstenite::{connect_async, tungstenite::Message};
+
+struct SharedTraceWriter(Arc<Mutex<Vec<u8>>>);
+
+impl Write for SharedTraceWriter {
+    fn write(&mut self, bytes: &[u8]) -> std::io::Result<usize> {
+        self.0.lock().unwrap().extend_from_slice(bytes);
+        Ok(bytes.len())
+    }
+
+    fn flush(&mut self) -> std::io::Result<()> { Ok(()) }
+}
 
 async fn pick_port() -> u16 {
     let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
@@ -80,6 +93,53 @@ async fn serve_delayed_load_fixture(
             tokio::time::sleep(Duration::from_secs(10)).await;
             continue;
         }
+        if request.starts_with("GET /stalled-primary ") {
+            let _ = slow_requested.send(());
+            tokio::time::sleep(Duration::from_secs(10)).await;
+            continue;
+        }
+        if request.starts_with("GET /stalled-fetch ") {
+            let _ = slow_requested.send(());
+            tokio::time::sleep(Duration::from_secs(10)).await;
+            continue;
+        }
+        if request.starts_with("GET /async-module ") {
+            let body = "<!doctype html><script type=module>await fetch('/stalled-fetch')</script>";
+            let response = format!(
+                "HTTP/1.1 200 OK\r\nContent-Type: text/html\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{body}",
+                body.len(),
+            );
+            let _ = socket.write_all(response.as_bytes()).await;
+            continue;
+        }
+        if request.starts_with("GET /infinite.js ") {
+            let _ = slow_requested.send(());
+            let body = "console.warn('OBSCURA_SYNC_SCRIPT_ENTERED'); while (true) {}";
+            let response = format!(
+                "HTTP/1.1 200 OK\r\nContent-Type: application/javascript\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{body}",
+                body.len(),
+            );
+            let _ = socket.write_all(response.as_bytes()).await;
+            continue;
+        }
+        if request.starts_with("GET /infinite-parser ") {
+            let body = "<!doctype html><script src=\"/infinite.js\"></script>";
+            let response = format!(
+                "HTTP/1.1 200 OK\r\nContent-Type: text/html\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{body}",
+                body.len(),
+            );
+            let _ = socket.write_all(response.as_bytes()).await;
+            continue;
+        }
+        if request.starts_with("GET /intercept-a") {
+            let body = "<!doctype html><script>fetch('/a-data')</script><p>A</p>";
+            let response = format!(
+                "HTTP/1.1 200 OK\r\nContent-Type: text/html\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{body}",
+                body.len(),
+            );
+            let _ = socket.write_all(response.as_bytes()).await;
+            continue;
+        }
         let dcl_script = if request.starts_with("GET /timeout ") {
             "const script = document.createElement('script'); script.src = '/never'; document.head.appendChild(script);"
         } else if request.starts_with("GET /busy-after-dcl ") {
@@ -112,6 +172,522 @@ async fn serve_delayed_load_fixture(
         );
         let _ = socket.write_all(response.as_bytes()).await;
     }
+}
+
+async fn assert_navigation_teardown(
+    path: &str,
+    dispose_context: bool,
+    wait_for_request: bool,
+) {
+    let sync_trace = (path == "/infinite-parser").then(|| {
+        let trace = Arc::new(Mutex::new(Vec::new()));
+        let writer = trace.clone();
+        tracing_subscriber::fmt()
+            .with_ansi(false)
+            .with_writer(move || SharedTraceWriter(writer.clone()))
+            .try_init()
+            .expect("test process must own the tracing subscriber");
+        trace
+    });
+    std::env::set_var("OBSCURA_ALLOW_PRIVATE_NETWORK", "1");
+    let fixture = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let fixture_url = format!("http://{}{path}", fixture.local_addr().unwrap());
+    let (never_requested_tx, mut never_requested_rx) = mpsc::unbounded_channel();
+    let (_release_tx, release_rx) = oneshot::channel();
+    tokio::spawn(serve_delayed_load_fixture(
+        fixture,
+        never_requested_tx,
+        release_rx,
+    ));
+
+    let port = pick_port().await;
+    tokio::task::LocalSet::new()
+        .run_until(async move {
+            tokio::task::spawn_local(async move {
+                let _ = obscura_cdp::server::start(port).await;
+            });
+            let mut ws = connect_cdp(port).await;
+            let context_id = if dispose_context {
+                send(&mut ws, json!({
+                    "id": 1,
+                    "method": "Target.createBrowserContext",
+                    "params": {},
+                })).await;
+                Some(loop {
+                    let message = next_json(&mut ws).await;
+                    if message["id"] == 1 {
+                        break message["result"]["browserContextId"]
+                            .as_str()
+                            .unwrap()
+                            .to_string();
+                    }
+                })
+            } else {
+                None
+            };
+            let (target_id, session_id) =
+                create_target(&mut ws, 2, context_id.as_deref()).await;
+            send(&mut ws, json!({
+                "id": 3,
+                "method": "Page.navigate",
+                "sessionId": session_id,
+                "params": {"url": fixture_url},
+            })).await;
+            if wait_for_request {
+                tokio::time::timeout(Duration::from_secs(7), never_requested_rx.recv())
+                    .await
+                    .expect("navigation fixture request was not observed")
+                    .expect("fixture observation channel closed");
+                if path == "/infinite-parser" {
+                    let trace = sync_trace.as_ref().unwrap();
+                    tokio::time::timeout(Duration::from_secs(2), async {
+                        loop {
+                            if String::from_utf8_lossy(&trace.lock().unwrap())
+                                .contains("OBSCURA_SYNC_SCRIPT_ENTERED")
+                            {
+                                break;
+                            }
+                            tokio::time::sleep(Duration::from_millis(1)).await;
+                        }
+                    }).await.expect("synchronous script never entered V8");
+                }
+            }
+
+            let teardown = if let Some(context_id) = context_id.as_ref() {
+                json!({
+                    "id": 4,
+                    "method": "Target.disposeBrowserContext",
+                    "params": {"browserContextId": context_id},
+                })
+            } else {
+                json!({
+                    "id": 4,
+                    "method": "Target.closeTarget",
+                    "params": {"targetId": target_id},
+                })
+            };
+            send(&mut ws, teardown).await;
+            let close_started = tokio::time::Instant::now();
+            let mut close_acknowledged = false;
+            let mut destroyed = false;
+            while !close_acknowledged || !destroyed {
+                let message = next_json(&mut ws).await;
+                close_acknowledged |= message["id"] == 4
+                    && (dispose_context || message["result"]["success"] == json!(true));
+                destroyed |= message["method"] == "Target.targetDestroyed"
+                    && message["params"]["targetId"].as_str() == Some(target_id.as_str());
+            }
+            assert!(
+                close_started.elapsed() < Duration::from_secs(2),
+                "closing a task-owned target did not cancel navigation promptly",
+            );
+
+            let (_replacement_id, replacement_session) =
+                create_target(&mut ws, 5, None).await;
+            send(&mut ws, json!({
+                "id": 6,
+                "method": "Runtime.evaluate",
+                "sessionId": replacement_session,
+                "params": {"expression": "40 + 2", "returnByValue": true},
+            })).await;
+            let replacement_result = loop {
+                let message = next_json(&mut ws).await;
+                if message["id"] == 6 {
+                    break message;
+                }
+            };
+            assert_eq!(
+                replacement_result["result"]["result"]["value"],
+                json!(42.0),
+            );
+            let _ = ws.close(None).await;
+        })
+        .await;
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn closing_target_cancels_stalled_primary_navigation() {
+    assert_navigation_teardown("/stalled-primary", false, true).await;
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn disposing_context_cancels_stalled_primary_navigation() {
+    assert_navigation_teardown("/stalled-primary", true, true).await;
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn closing_target_terminates_synchronous_navigation_script() {
+    assert_navigation_teardown("/infinite-parser", false, true).await;
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn disposing_context_terminates_synchronous_navigation_script() {
+    assert_navigation_teardown("/infinite-parser", true, true).await;
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn closing_target_cancels_navigation_parked_in_async_module_fetch() {
+    assert_navigation_teardown("/async-module", false, true).await;
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn close_queued_immediately_after_navigate_cancels_registered_owner() {
+    assert_navigation_teardown("/stalled-primary", false, false).await;
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn closing_connection_cancels_stalled_primary_navigation() {
+    std::env::set_var("OBSCURA_ALLOW_PRIVATE_NETWORK", "1");
+    let fixture = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let fixture_url = format!("http://{}/stalled-primary", fixture.local_addr().unwrap());
+    let (request_tx, mut request_rx) = mpsc::unbounded_channel();
+    let (_release_tx, release_rx) = oneshot::channel();
+    tokio::spawn(serve_delayed_load_fixture(fixture, request_tx, release_rx));
+
+    let port = pick_port().await;
+    tokio::task::LocalSet::new()
+        .run_until(async move {
+            tokio::task::spawn_local(async move {
+                let _ = obscura_cdp::server::start_with_serve_options_and_limit(
+                    port,
+                    "127.0.0.1",
+                    None,
+                    false,
+                    None,
+                    false,
+                    None,
+                    true,
+                    1,
+                )
+                .await;
+            });
+            let mut ws = connect_cdp(port).await;
+            let (_target_id, session_id) = create_target(&mut ws, 1, None).await;
+            send(&mut ws, json!({
+                "id": 2,
+                "method": "Page.navigate",
+                "sessionId": session_id,
+                "params": {"url": fixture_url},
+            })).await;
+            tokio::time::timeout(Duration::from_secs(7), request_rx.recv())
+                .await
+                .expect("stalled primary request was not observed")
+                .expect("fixture observation channel closed");
+            let close_started = tokio::time::Instant::now();
+            let _ = ws.close(None).await;
+            drop(ws);
+
+            let mut replacement = connect_cdp(port).await;
+            assert!(
+                close_started.elapsed() < Duration::from_secs(2),
+                "connection slot was not released after cancelling navigation",
+            );
+            let (_replacement_id, replacement_session) =
+                create_target(&mut replacement, 3, None).await;
+            send(&mut replacement, json!({
+                "id": 4,
+                "method": "Runtime.evaluate",
+                "sessionId": replacement_session,
+                "params": {"expression": "6 * 7", "returnByValue": true},
+            })).await;
+            let result = loop {
+                let message = next_json(&mut replacement).await;
+                if message["id"] == 4 {
+                    break message;
+                }
+            };
+            assert_eq!(result["result"]["result"]["value"], json!(42.0));
+            let _ = replacement.close(None).await;
+        })
+        .await;
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn closing_target_fails_paused_navigation_interception() {
+    std::env::set_var("OBSCURA_ALLOW_PRIVATE_NETWORK", "1");
+    let fixture = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let fixture_url = format!("http://{}/intercepted", fixture.local_addr().unwrap());
+    let (request_tx, _request_rx) = mpsc::unbounded_channel();
+    let (_release_tx, release_rx) = oneshot::channel();
+    tokio::spawn(serve_delayed_load_fixture(fixture, request_tx, release_rx));
+
+    let port = pick_port().await;
+    tokio::task::LocalSet::new()
+        .run_until(async move {
+            tokio::task::spawn_local(async move {
+                let _ = obscura_cdp::server::start(port).await;
+            });
+            let mut ws = connect_cdp(port).await;
+            let (target_id, session_id) = create_target(&mut ws, 1, None).await;
+            send(&mut ws, json!({
+                "id": 2,
+                "method": "Fetch.enable",
+                "sessionId": session_id,
+                "params": {"patterns": [{"urlPattern": "*"}]},
+            })).await;
+            loop {
+                if next_json(&mut ws).await["id"] == 2 {
+                    break;
+                }
+            }
+            send(&mut ws, json!({
+                "id": 3,
+                "method": "Page.navigate",
+                "sessionId": session_id,
+                "params": {"url": fixture_url},
+            })).await;
+            loop {
+                let message = next_json(&mut ws).await;
+                if message["method"] == "Fetch.requestPaused" {
+                    break;
+                }
+            }
+            send(&mut ws, json!({
+                "id": 4,
+                "method": "Target.closeTarget",
+                "params": {"targetId": target_id},
+            })).await;
+            let close_started = tokio::time::Instant::now();
+            let mut acknowledged = false;
+            let mut destroyed = false;
+            while !acknowledged || !destroyed {
+                let message = next_json(&mut ws).await;
+                acknowledged |= message["id"] == 4
+                    && message["result"]["success"] == json!(true);
+                destroyed |= message["method"] == "Target.targetDestroyed"
+                    && message["params"]["targetId"].as_str() == Some(target_id.as_str());
+            }
+            assert!(
+                close_started.elapsed() < Duration::from_secs(2),
+                "paused interception prevented target teardown",
+            );
+            let (_replacement_id, replacement_session) =
+                create_target(&mut ws, 5, None).await;
+            send(&mut ws, json!({
+                "id": 6,
+                "method": "Runtime.evaluate",
+                "sessionId": replacement_session,
+                "params": {"expression": "42", "returnByValue": true},
+            })).await;
+            loop {
+                let message = next_json(&mut ws).await;
+                if message["id"] == 6 {
+                    assert_eq!(message["result"]["result"]["value"], json!(42.0));
+                    break;
+                }
+            }
+            let _ = ws.close(None).await;
+        })
+        .await;
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn closing_stalled_target_preserves_sibling_paused_interception() {
+    std::env::set_var("OBSCURA_ALLOW_PRIVATE_NETWORK", "1");
+    let fixture = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let origin = format!("http://{}", fixture.local_addr().unwrap());
+    let (request_tx, mut request_rx) = mpsc::unbounded_channel();
+    let (_release_tx, release_rx) = oneshot::channel();
+    tokio::spawn(serve_delayed_load_fixture(fixture, request_tx, release_rx));
+
+    let port = pick_port().await;
+    tokio::task::LocalSet::new().run_until(async move {
+        tokio::task::spawn_local(async move {
+            let _ = obscura_cdp::server::start(port).await;
+        });
+        let mut ws = connect_cdp(port).await;
+        let (target_a, session_a) = create_target(&mut ws, 1, None).await;
+        send(&mut ws, json!({
+            "id": 2, "method": "Fetch.enable", "sessionId": session_a,
+            "params": {"patterns": [{"urlPattern": "*"}]},
+        })).await;
+        while next_json(&mut ws).await["id"] != 2 {}
+        send(&mut ws, json!({
+            "id": 3, "method": "Page.navigate", "sessionId": session_a,
+            "params": {"url": format!("{origin}/intercept-a")},
+        })).await;
+        let mut request_a = None;
+        let mut navigation_a_done = false;
+        while request_a.is_none() || !navigation_a_done {
+            let message = next_json(&mut ws).await;
+            navigation_a_done |= message["id"] == 3;
+            if message["method"] == "Fetch.requestPaused"
+                && message["sessionId"].as_str() == Some(session_a.as_str())
+                && message["params"]["request"]["url"].as_str().is_some_and(|url| url.ends_with("/a-data"))
+            {
+                request_a = message["params"]["requestId"].as_str().map(str::to_string);
+            }
+        }
+
+        let (target_b, session_b) = create_target(&mut ws, 4, None).await;
+        send(&mut ws, json!({
+            "id": 40, "method": "Fetch.enable", "sessionId": session_b,
+            "params": {"patterns": [{"urlPattern": "*"}]},
+        })).await;
+        while next_json(&mut ws).await["id"] != 40 {}
+        send(&mut ws, json!({
+            "id": 41, "method": "Page.navigate", "sessionId": session_b,
+            "params": {"url": format!("{origin}/intercept-a?b")},
+        })).await;
+        let mut request_b = None;
+        let mut navigation_b_done = false;
+        while request_b.is_none() || !navigation_b_done {
+            let message = next_json(&mut ws).await;
+            navigation_b_done |= message["id"] == 41;
+            if message["method"] == "Fetch.requestPaused"
+                && message["sessionId"].as_str() == Some(session_b.as_str())
+                && message["params"]["request"]["url"].as_str().is_some_and(|url| url.ends_with("/a-data"))
+            {
+                request_b = message["params"]["requestId"].as_str().map(str::to_string);
+            }
+        }
+        assert_ne!(request_a.as_deref(), request_b.as_deref());
+        send(&mut ws, json!({
+            "id": 5, "method": "Page.navigate", "sessionId": session_b,
+            "params": {"url": format!("{origin}/stalled-primary")},
+        })).await;
+        tokio::time::timeout(Duration::from_secs(7), request_rx.recv())
+            .await.expect("stalled B request not observed").expect("fixture channel closed");
+        send(&mut ws, json!({
+            "id": 6, "method": "Target.closeTarget", "params": {"targetId": target_b},
+        })).await;
+        while next_json(&mut ws).await["id"] != 6 {}
+
+        send(&mut ws, json!({
+            "id": 7, "method": "Fetch.continueRequest", "sessionId": session_a,
+            "params": {"requestId": request_a.unwrap()},
+        })).await;
+        let continued = tokio::time::timeout(Duration::from_secs(2), async {
+            loop {
+                let message = next_json(&mut ws).await;
+                if message["id"] == 7 { break message; }
+            }
+        }).await.expect("closing B discarded A's paused interception");
+        assert!(continued.get("error").is_none(), "{continued}");
+        send(&mut ws, json!({
+            "id": 8, "method": "Target.closeTarget", "params": {"targetId": target_a},
+        })).await;
+        let _ = ws.close(None).await;
+    }).await;
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn replacing_runtime_aborts_old_pause_and_uses_new_request_identity() {
+    std::env::set_var("OBSCURA_ALLOW_PRIVATE_NETWORK", "1");
+    let fixture = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let origin = format!("http://{}", fixture.local_addr().unwrap());
+    let (request_tx, _request_rx) = mpsc::unbounded_channel();
+    let (_release_tx, release_rx) = oneshot::channel();
+    tokio::spawn(serve_delayed_load_fixture(fixture, request_tx, release_rx));
+    let port = pick_port().await;
+    tokio::task::LocalSet::new().run_until(async move {
+        tokio::task::spawn_local(async move { let _ = obscura_cdp::server::start(port).await; });
+        let mut ws = connect_cdp(port).await;
+        let (target_id, session_id) = create_target(&mut ws, 1, None).await;
+        send(&mut ws, json!({
+            "id": 2, "method": "Fetch.enable", "sessionId": session_id,
+            "params": {"patterns": [{"urlPattern": "*"}]},
+        })).await;
+        while next_json(&mut ws).await["id"] != 2 {}
+
+        async fn navigate_to_pause<S>(
+            ws: &mut tokio_tungstenite::WebSocketStream<S>,
+            id: i64,
+            session_id: &str,
+            url: &str,
+        ) -> String
+        where S: tokio::io::AsyncRead + tokio::io::AsyncWrite + Unpin {
+            send(ws, json!({
+                "id": id, "method": "Page.navigate", "sessionId": session_id,
+                "params": {"url": url},
+            })).await;
+            let mut request_id = None;
+            let mut navigation_done = false;
+            while request_id.is_none() || !navigation_done {
+                let message = next_json(ws).await;
+                navigation_done |= message["id"] == id;
+                if message["method"] == "Fetch.requestPaused"
+                    && message["sessionId"].as_str() == Some(session_id)
+                    && message["params"]["request"]["url"].as_str().is_some_and(|url| url.ends_with("/a-data"))
+                {
+                    request_id = message["params"]["requestId"].as_str().map(str::to_string);
+                }
+            }
+            request_id.unwrap()
+        }
+
+        let first = navigate_to_pause(&mut ws, 3, &session_id, &format!("{origin}/intercept-a")).await;
+        let second = navigate_to_pause(&mut ws, 4, &session_id, &format!("{origin}/intercept-a?replacement")).await;
+        assert_ne!(first, second, "runtime replacement reused interception identity");
+        send(&mut ws, json!({
+            "id": 5, "method": "Fetch.continueRequest", "sessionId": session_id,
+            "params": {"requestId": first},
+        })).await;
+        let old = loop { let message = next_json(&mut ws).await; if message["id"] == 5 { break message; } };
+        assert!(old.get("error").is_some(), "old document pause remained resolvable: first={first} second={second} response={old}");
+        send(&mut ws, json!({
+            "id": 6, "method": "Fetch.continueRequest", "sessionId": session_id,
+            "params": {"requestId": second},
+        })).await;
+        let new = loop { let message = next_json(&mut ws).await; if message["id"] == 6 { break message; } };
+        assert!(new.get("error").is_none(), "replacement pause was lost: {new}");
+        send(&mut ws, json!({"id": 7, "method": "Target.closeTarget", "params": {"targetId": target_id}})).await;
+        let _ = ws.close(None).await;
+    }).await;
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn closing_loaded_target_aborts_autonomous_paused_request() {
+    std::env::set_var("OBSCURA_ALLOW_PRIVATE_NETWORK", "1");
+    let fixture = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let url = format!("http://{}/intercept-a", fixture.local_addr().unwrap());
+    let (request_tx, _request_rx) = mpsc::unbounded_channel();
+    let (_release_tx, release_rx) = oneshot::channel();
+    tokio::spawn(serve_delayed_load_fixture(fixture, request_tx, release_rx));
+    let port = pick_port().await;
+    tokio::task::LocalSet::new().run_until(async move {
+        tokio::task::spawn_local(async move { let _ = obscura_cdp::server::start(port).await; });
+        let mut ws = connect_cdp(port).await;
+        let (target_id, session_id) = create_target(&mut ws, 1, None).await;
+        send(&mut ws, json!({
+            "id": 2, "method": "Fetch.enable", "sessionId": session_id,
+            "params": {"patterns": [{"urlPattern": "*"}]},
+        })).await;
+        while next_json(&mut ws).await["id"] != 2 {}
+        send(&mut ws, json!({
+            "id": 3, "method": "Page.navigate", "sessionId": session_id,
+            "params": {"url": url},
+        })).await;
+        let mut request_id = None;
+        let mut navigation_done = false;
+        while request_id.is_none() || !navigation_done {
+            let message = next_json(&mut ws).await;
+            navigation_done |= message["id"] == 3;
+            if message["method"] == "Fetch.requestPaused" {
+                if message["params"]["request"]["url"].as_str().is_some_and(|url| url.ends_with("/a-data")) {
+                    request_id = message["params"]["requestId"].as_str().map(str::to_string);
+                }
+            }
+        }
+        send(&mut ws, json!({
+            "id": 4, "method": "Target.closeTarget", "params": {"targetId": target_id},
+        })).await;
+        while next_json(&mut ws).await["id"] != 4 {}
+        send(&mut ws, json!({
+            "id": 5, "method": "Fetch.continueRequest", "sessionId": session_id,
+            "params": {"requestId": request_id.unwrap()},
+        })).await;
+        let stale = loop { let message = next_json(&mut ws).await; if message["id"] == 5 { break message; } };
+        assert!(stale.get("error").is_some(), "closed target retained paused request: {stale}");
+        let (_other, other_session) = create_target(&mut ws, 6, None).await;
+        send(&mut ws, json!({
+            "id": 7, "method": "Runtime.evaluate", "sessionId": other_session,
+            "params": {"expression": "42", "returnByValue": true},
+        })).await;
+        let result = loop { let message = next_json(&mut ws).await; if message["id"] == 7 { break message; } };
+        assert_eq!(result["result"]["result"]["value"], json!(42.0));
+        let _ = ws.close(None).await;
+    }).await;
 }
 
 async fn next_json<S>(ws: &mut tokio_tungstenite::WebSocketStream<S>) -> Value

--- a/crates/obscura-cdp/tests/navigation_lifecycle_stream.rs
+++ b/crates/obscura-cdp/tests/navigation_lifecycle_stream.rs
@@ -82,11 +82,6 @@ async fn serve_delayed_load_fixture(
         } else {
             "/after-load"
         };
-        let onload_extra = if request.starts_with("GET /post-load-timeout ") {
-            "setInterval(() => {}, 10);"
-        } else {
-            ""
-        };
         let body = r#"<!doctype html><script>
             document.addEventListener('DOMContentLoaded', () => {
                 globalThis.__dclSeen = (globalThis.__dclSeen || 0) + 1;
@@ -95,12 +90,10 @@ async fn serve_delayed_load_fixture(
             window.onload = () => {
                 globalThis.__loadSeen = (globalThis.__loadSeen || 0) + 1;
                 fetch('__POST_LOAD_FETCH__');
-                __ONLOAD_EXTRA__
             };
         </script><p>ready</p>"#
             .replace("__DCL_SCRIPT__", dcl_script)
-            .replace("__POST_LOAD_FETCH__", post_load_fetch)
-            .replace("__ONLOAD_EXTRA__", onload_extra);
+            .replace("__POST_LOAD_FETCH__", post_load_fetch);
         let response = format!(
             "HTTP/1.1 200 OK\r\nContent-Type: text/html\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{body}",
             body.len(),

--- a/crates/obscura-cdp/tests/navigation_lifecycle_stream.rs
+++ b/crates/obscura-cdp/tests/navigation_lifecycle_stream.rs
@@ -83,7 +83,7 @@ async fn serve_delayed_load_fixture(
             "/after-load"
         };
         let onload_extra = if request.starts_with("GET /post-load-timeout ") {
-            "setInterval(() => {}, 0);"
+            "setInterval(() => {}, 10);"
         } else {
             ""
         };

--- a/crates/obscura-js/Cargo.toml
+++ b/crates/obscura-js/Cargo.toml
@@ -7,6 +7,8 @@ repository.workspace = true
 
 [features]
 default = []
+# Unstable ownership metadata used only by obscura-cdp.
+internal-cdp = []
 # Builds obscura-net with its stealth (wreq) HTTP client and lets scripted
 # fetch()/XHR be routed through it so JS-level requests carry the same Chrome
 # TLS fingerprint and client hints as stealth navigation.

--- a/crates/obscura-js/js/bootstrap.js
+++ b/crates/obscura-js/js/bootstrap.js
@@ -305,8 +305,15 @@ function __finishDocumentLoad() {
     __documentLoadForceTimer = undefined;
   }
   globalThis.__documentReadyState__ = 'complete';
-  if (typeof window.onload === 'function') { try { window.onload(); } catch(e) {} }
-  try { window.dispatchEvent(new Event('load', {bubbles:false,cancelable:false})); } catch(e) {}
+  // The event-path parity implementation provides the authoritative browser
+  // load dispatcher. Keep the legacy fallback so this change remains
+  // independently mergeable when that implementation is not present yet.
+  if (typeof globalThis.__obscura_dispatchWindowLoad === 'function') {
+    try { globalThis.__obscura_dispatchWindowLoad(); } catch(e) {}
+  } else {
+    if (typeof window.onload === 'function') { try { window.onload(); } catch(e) {} }
+    try { window.dispatchEvent(new Event('load', {bubbles:false,cancelable:false})); } catch(e) {}
+  }
   // This is the authoritative completion bit read by the Rust owner. Set it
   // only after every synchronous load listener returned; the event-loop turn
   // performs their Promise checkpoint before yielding back to that owner.

--- a/crates/obscura-js/js/bootstrap.js
+++ b/crates/obscura-js/js/bootstrap.js
@@ -23,6 +23,9 @@
     '__obscura_isDisabled', '__obscura_labeledControl', '__obscura_interactiveHost',
     '__markParserScripts', '__obscura_hasPendingDynamicScripts',
     '__obscura_hasPendingLoadDelayingScripts',
+    '__obscura_requestDocumentLoad',
+    '__obscura_documentLoadTaskReady',
+    '__obscura_abortDocumentLoad',
     '__obscura_nextPendingTimeoutDelay',
     '__obscura_hw', '__obscura_mem',
     '__documentReadyState__', '__currentUrl',
@@ -250,6 +253,11 @@ let __dynScriptQueue = [];
 let __dynScriptBusy = false;
 let __dynClassicPending = 0;
 let __dynLoadDelayingPending = 0;
+let __documentLoadRequested = false;
+let __documentLoadCompleted = false;
+let __documentLoadNormalTimer;
+let __documentLoadForceTimer;
+let __documentLoadForceDeadline = Infinity;
 Object.defineProperty(globalThis, '__obscura_hasPendingDynamicScripts', {
   value: function() {
     return __dynClassicPending > 0 || __dynScriptBusy || __dynScriptQueue.length > 0;
@@ -264,7 +272,89 @@ Object.defineProperty(globalThis, '__obscura_hasPendingDynamicScripts', {
 // dynamic import() and scripts created by a load handler are post-load work.
 // Keep this bridge hidden for the same reason as the general queue status.
 Object.defineProperty(globalThis, '__obscura_hasPendingLoadDelayingScripts', {
-  value: function() { return __dynLoadDelayingPending > 0; },
+  value: function() {
+    return __dynLoadDelayingPending > 0
+      || (__documentLoadRequested && !__documentLoadCompleted);
+  },
+  writable: false,
+  enumerable: false,
+  configurable: false,
+});
+Object.defineProperty(globalThis, '__obscura_documentLoadTaskReady', {
+  value: function() {
+    return __documentLoadRequested && !__documentLoadCompleted
+      && (__dynLoadDelayingPending === 0
+          || performance.now() >= __documentLoadForceDeadline);
+  },
+  writable: false,
+  enumerable: false,
+  configurable: false,
+});
+function __finishDocumentLoad() {
+  if (__documentLoadCompleted) return;
+  // The script deadline is a browser recovery boundary. Late resource tasks
+  // may still finish, but they no longer participate in this document's load
+  // event after the fallback has fired.
+  __dynLoadDelayingPending = 0;
+  if (__documentLoadNormalTimer !== undefined) {
+    _cancelScheduled(__documentLoadNormalTimer);
+    __documentLoadNormalTimer = undefined;
+  }
+  if (__documentLoadForceTimer !== undefined) {
+    _cancelScheduled(__documentLoadForceTimer);
+    __documentLoadForceTimer = undefined;
+  }
+  globalThis.__documentReadyState__ = 'complete';
+  if (typeof window.onload === 'function') { try { window.onload(); } catch(e) {} }
+  try { window.dispatchEvent(new Event('load', {bubbles:false,cancelable:false})); } catch(e) {}
+  // This is the authoritative completion bit read by the Rust owner. Set it
+  // only after every synchronous load listener returned; the event-loop turn
+  // performs their Promise checkpoint before yielding back to that owner.
+  __documentLoadCompleted = true;
+}
+function __scheduleDocumentLoadIfReady() {
+  if (!__documentLoadRequested || __documentLoadCompleted
+      || __dynLoadDelayingPending > 0 || __documentLoadNormalTimer !== undefined) return;
+  __documentLoadNormalTimer = _scheduleAfter(0, function() {
+    __documentLoadNormalTimer = undefined;
+    if (__dynLoadDelayingPending === 0) __finishDocumentLoad();
+  });
+  // Synchronous-only embedders have no task queue. They cannot preserve the
+  // DCL/load task boundary, but they must not strand readyState indefinitely.
+  if (__documentLoadNormalTimer === undefined && __dynLoadDelayingPending === 0) {
+    __finishDocumentLoad();
+  }
+}
+Object.defineProperty(globalThis, '__obscura_requestDocumentLoad', {
+  value: function(deadlineMs) {
+    if (__documentLoadRequested) return;
+    __documentLoadRequested = true;
+    __scheduleDocumentLoadIfReady();
+    if (__documentLoadCompleted) return;
+    const forceAfter = Math.max(0, Number(deadlineMs) || 0);
+    __documentLoadForceDeadline = performance.now() + forceAfter;
+    __documentLoadForceTimer = _scheduleAfter(forceAfter, function() {
+      __documentLoadForceTimer = undefined;
+      __finishDocumentLoad();
+    });
+  },
+  writable: false,
+  enumerable: false,
+  configurable: false,
+});
+Object.defineProperty(globalThis, '__obscura_abortDocumentLoad', {
+  value: function() {
+    if (__documentLoadNormalTimer !== undefined) {
+      _cancelScheduled(__documentLoadNormalTimer);
+      __documentLoadNormalTimer = undefined;
+    }
+    if (__documentLoadForceTimer !== undefined) {
+      _cancelScheduled(__documentLoadForceTimer);
+      __documentLoadForceTimer = undefined;
+    }
+    __documentLoadRequested = false;
+    __documentLoadCompleted = true;
+  },
   writable: false,
   enumerable: false,
   configurable: false,
@@ -387,6 +477,7 @@ async function __runDynScriptTask(task) {
     if (task.delaysLoad) {
       task.delaysLoad = false;
       __dynLoadDelayingPending = Math.max(0, __dynLoadDelayingPending - 1);
+      __scheduleDocumentLoadIfReady();
     }
   }
 }

--- a/crates/obscura-js/js/bootstrap.js
+++ b/crates/obscura-js/js/bootstrap.js
@@ -305,8 +305,18 @@ function __finishDocumentLoad() {
     __documentLoadForceTimer = undefined;
   }
   globalThis.__documentReadyState__ = 'complete';
-  if (typeof window.onload === 'function') { try { window.onload(); } catch(e) {} }
-  try { window.dispatchEvent(new Event('load', {bubbles:false,cancelable:false})); } catch(e) {}
+  // The event-path parity implementation provides the authoritative browser
+  // load dispatcher. Keep the legacy fallback so this change remains
+  // independently mergeable when that implementation is not present yet.
+  if (typeof globalThis.__obscura_dispatchWindowLoad === 'function') {
+    try { globalThis.__obscura_dispatchWindowLoad(); } catch(e) {}
+  } else {
+    const loadEvent = new Event('load', {bubbles:false,cancelable:false});
+    if (typeof window.onload === 'function') {
+      try { window.onload.call(window, loadEvent); } catch(e) {}
+    }
+    try { window.dispatchEvent(loadEvent); } catch(e) {}
+  }
   // This is the authoritative completion bit read by the Rust owner. Set it
   // only after every synchronous load listener returned; the event-loop turn
   // performs their Promise checkpoint before yielding back to that owner.

--- a/crates/obscura-js/src/ops.rs
+++ b/crates/obscura-js/src/ops.rs
@@ -51,6 +51,9 @@ pub enum InterceptResolution {
 }
 
 pub struct InterceptedRequest {
+    #[cfg(feature = "internal-cdp")]
+    #[doc(hidden)]
+    pub owner_page_id: String,
     pub request_id: String,
     pub url: String,
     pub method: String,
@@ -123,6 +126,10 @@ pub struct ObscuraState {
     pub stealth_client: Option<Arc<StealthHttpClient>>,
     pub pending_navigation: Option<(String, String, String)>,
     pub intercept_tx: Option<tokio::sync::mpsc::UnboundedSender<InterceptedRequest>>,
+    #[cfg(feature = "internal-cdp")]
+    pub intercept_owner_page_id: String,
+    #[cfg(feature = "internal-cdp")]
+    pub intercept_request_scope: String,
     pub intercept_counter: u64,
     pub intercept_enabled: bool,
     // Queue of (binding_name, payload) calls made by page JS via the
@@ -308,6 +315,10 @@ impl ObscuraState {
             stealth_client: None,
             pending_navigation: None,
             intercept_tx: None,
+            #[cfg(feature = "internal-cdp")]
+            intercept_owner_page_id: String::new(),
+            #[cfg(feature = "internal-cdp")]
+            intercept_request_scope: String::new(),
             intercept_counter: 0,
             intercept_enabled: false,
             pending_binding_calls: Vec::new(),
@@ -2339,9 +2350,19 @@ async fn op_fetch_url(
         );
         let itx = if gs.intercept_enabled {
             gs.intercept_counter += 1;
-            gs.intercept_tx
-                .clone()
-                .map(|tx| (tx, format!("intercept-{}", gs.intercept_counter)))
+            #[cfg(feature = "internal-cdp")]
+            let owner_page_id = gs.intercept_owner_page_id.clone();
+            #[cfg(not(feature = "internal-cdp"))]
+            let owner_page_id = String::new();
+            #[cfg(feature = "internal-cdp")]
+            let request_id = if !gs.intercept_request_scope.is_empty() {
+                format!("{}:intercept-{}", gs.intercept_request_scope, gs.intercept_counter)
+            } else {
+                format!("intercept-{}", gs.intercept_counter)
+            };
+            #[cfg(not(feature = "internal-cdp"))]
+            let request_id = format!("intercept-{}", gs.intercept_counter);
+            gs.intercept_tx.clone().map(|tx| (tx, request_id, owner_page_id))
         } else {
             None
         };
@@ -2391,11 +2412,15 @@ async fn op_fetch_url(
     let mut override_headers: Option<HashMap<String, String>> = None;
     let mut override_body: Option<Vec<u8>> = None;
 
-    if let Some((tx, request_id)) = intercept_tx {
+    if let Some((tx, request_id, owner_page_id)) = intercept_tx {
+        #[cfg(not(feature = "internal-cdp"))]
+        let _ = &owner_page_id;
         let custom_headers: HashMap<String, String> =
             serde_json::from_str(&headers_json).unwrap_or_default();
         let (resolve_tx, resolve_rx) = tokio::sync::oneshot::channel();
         let intercepted = InterceptedRequest {
+            #[cfg(feature = "internal-cdp")]
+            owner_page_id,
             request_id: request_id.clone(),
             url: url.clone(),
             method: method.clone(),

--- a/crates/obscura-js/src/ops.rs
+++ b/crates/obscura-js/src/ops.rs
@@ -51,6 +51,9 @@ pub enum InterceptResolution {
 }
 
 pub struct InterceptedRequest {
+    #[cfg(feature = "internal-cdp")]
+    #[doc(hidden)]
+    pub owner_page_id: String,
     pub request_id: String,
     pub url: String,
     pub method: String,
@@ -123,6 +126,10 @@ pub struct ObscuraState {
     pub stealth_client: Option<Arc<StealthHttpClient>>,
     pub pending_navigation: Option<(String, String, String)>,
     pub intercept_tx: Option<tokio::sync::mpsc::UnboundedSender<InterceptedRequest>>,
+    #[cfg(feature = "internal-cdp")]
+    pub intercept_owner_page_id: String,
+    #[cfg(feature = "internal-cdp")]
+    pub intercept_request_scope: String,
     pub intercept_counter: u64,
     pub intercept_enabled: bool,
     // Queue of (binding_name, payload) calls made by page JS via the
@@ -308,6 +315,10 @@ impl ObscuraState {
             stealth_client: None,
             pending_navigation: None,
             intercept_tx: None,
+            #[cfg(feature = "internal-cdp")]
+            intercept_owner_page_id: String::new(),
+            #[cfg(feature = "internal-cdp")]
+            intercept_request_scope: String::new(),
             intercept_counter: 0,
             intercept_enabled: false,
             pending_binding_calls: Vec::new(),
@@ -2355,9 +2366,19 @@ async fn op_fetch_url(
         );
         let itx = if gs.intercept_enabled {
             gs.intercept_counter += 1;
-            gs.intercept_tx
-                .clone()
-                .map(|tx| (tx, format!("intercept-{}", gs.intercept_counter)))
+            #[cfg(feature = "internal-cdp")]
+            let owner_page_id = gs.intercept_owner_page_id.clone();
+            #[cfg(not(feature = "internal-cdp"))]
+            let owner_page_id = String::new();
+            #[cfg(feature = "internal-cdp")]
+            let request_id = if !gs.intercept_request_scope.is_empty() {
+                format!("{}:intercept-{}", gs.intercept_request_scope, gs.intercept_counter)
+            } else {
+                format!("intercept-{}", gs.intercept_counter)
+            };
+            #[cfg(not(feature = "internal-cdp"))]
+            let request_id = format!("intercept-{}", gs.intercept_counter);
+            gs.intercept_tx.clone().map(|tx| (tx, request_id, owner_page_id))
         } else {
             None
         };
@@ -2407,11 +2428,15 @@ async fn op_fetch_url(
     let mut override_headers: Option<HashMap<String, String>> = None;
     let mut override_body: Option<Vec<u8>> = None;
 
-    if let Some((tx, request_id)) = intercept_tx {
+    if let Some((tx, request_id, owner_page_id)) = intercept_tx {
+        #[cfg(not(feature = "internal-cdp"))]
+        let _ = &owner_page_id;
         let custom_headers: HashMap<String, String> =
             serde_json::from_str(&headers_json).unwrap_or_default();
         let (resolve_tx, resolve_rx) = tokio::sync::oneshot::channel();
         let intercepted = InterceptedRequest {
+            #[cfg(feature = "internal-cdp")]
+            owner_page_id,
             request_id: request_id.clone(),
             url: url.clone(),
             method: method.clone(),

--- a/crates/obscura-js/src/runtime.rs
+++ b/crates/obscura-js/src/runtime.rs
@@ -2700,11 +2700,21 @@ impl ObscuraJsRuntime {
         const AUTONOMOUS_TASK_WATCHDOG_MS: u64 =
             SYNCHRONOUS_TASK_FLOOR_MS + WATCHDOG_SCHEDULING_MARGIN_MS;
 
+        self.run_autonomous_event_loop_turn_with_watchdog(
+            std::time::Duration::from_millis(AUTONOMOUS_TASK_WATCHDOG_MS),
+        )
+        .await
+    }
+
+    async fn run_autonomous_event_loop_turn_with_watchdog(
+        &mut self,
+        task_budget: std::time::Duration,
+    ) -> Result<bool, String> {
         self.begin_javascript_task();
 
         let checkpoint_watchdog = crate::cdp_watchdog::arm(
             self.isolate_handle(),
-            std::time::Duration::from_millis(AUTONOMOUS_TASK_WATCHDOG_MS),
+            task_budget,
         );
         self.runtime.v8_isolate().perform_microtask_checkpoint();
         if crate::cdp_watchdog::disarm(checkpoint_watchdog) {
@@ -2720,7 +2730,7 @@ impl ObscuraJsRuntime {
         let result = std::future::poll_fn(|cx| {
             let watchdog = crate::cdp_watchdog::arm(
                 isolate_handle.clone(),
-                std::time::Duration::from_millis(AUTONOMOUS_TASK_WATCHDOG_MS),
+                task_budget,
             );
             let tick = self
                 .runtime
@@ -5911,6 +5921,38 @@ mod tests {
             .unwrap(),
             serde_json::json!("usable"),
             "the per-turn watchdog must leave the isolate reusable",
+        );
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn autonomous_watchdog_excludes_time_parked_on_a_timer() {
+        let mut rt = setup_runtime("<html><body></body></html>");
+        rt.execute_script(
+            "autonomous-parked-timer",
+            "globalThis.__parkedTimerDone = false;\
+             setTimeout(() => { globalThis.__parkedTimerDone = true; }, 100);",
+        )
+        .unwrap();
+
+        let started = std::time::Instant::now();
+        tokio::time::timeout(
+            std::time::Duration::from_secs(1),
+            rt.run_autonomous_event_loop_turn_with_watchdog(
+                std::time::Duration::from_millis(20),
+            ),
+        )
+        .await
+        .expect("autonomous timer turn remained parked")
+        .expect("parked time was incorrectly charged to the synchronous watchdog");
+
+        assert!(
+            started.elapsed() >= std::time::Duration::from_millis(80),
+            "the event loop did not remain parked beyond the test watchdog budget",
+        );
+        assert_eq!(
+            rt.evaluate("globalThis.__parkedTimerDone").unwrap(),
+            serde_json::json!(true),
+            "the isolate must remain reusable after a parked autonomous turn",
         );
     }
 

--- a/crates/obscura-js/src/runtime.rs
+++ b/crates/obscura-js/src/runtime.rs
@@ -2710,6 +2710,14 @@ impl ObscuraJsRuntime {
         &mut self,
         task_budget: std::time::Duration,
     ) -> Result<bool, String> {
+        self.run_event_loop_turn_with_watchdog(task_budget, true).await
+    }
+
+    async fn run_event_loop_turn_with_watchdog(
+        &mut self,
+        task_budget: std::time::Duration,
+        wait_for_wake: bool,
+    ) -> Result<bool, String> {
         self.begin_javascript_task();
 
         let checkpoint_watchdog = crate::cdp_watchdog::arm(
@@ -2756,7 +2764,7 @@ impl ObscuraJsRuntime {
                 std::task::Poll::Ready(Err(error)) => std::task::Poll::Ready(Err(format!(
                     "Event loop error: {error}"
                 ))),
-                std::task::Poll::Pending if waiting_for_wake => {
+                std::task::Poll::Pending if !wait_for_wake || waiting_for_wake => {
                     std::task::Poll::Ready(Ok(false))
                 }
                 std::task::Poll::Pending => {
@@ -2769,12 +2777,13 @@ impl ObscuraJsRuntime {
         self.finish_heap_checked(result)
     }
 
-    /// Drive one cooperative event-loop turn for browser lifecycle code that
-    /// must re-check an external readiness predicate after every wake. The
+    /// Drive one event-loop poll for browser lifecycle code that must re-check
+    /// an external readiness predicate without parking on unrelated I/O. The
     /// boolean is true only when deno_core reached full idle.
     #[doc(hidden)]
     pub async fn run_load_delaying_event_loop_tick(&mut self) -> Result<bool, String> {
-        self.run_cooperative_event_loop_tick().await
+        self.run_event_loop_turn_with_watchdog(std::time::Duration::from_secs(1), false)
+            .await
     }
 
     /// Pump deferred work until deno_core reports true idle, or until the page

--- a/crates/obscura-js/src/runtime.rs
+++ b/crates/obscura-js/src/runtime.rs
@@ -1034,6 +1034,14 @@ impl ObscuraJsRuntime {
         state.intercept_tx = Some(tx);
     }
 
+    #[cfg(feature = "internal-cdp")]
+    #[doc(hidden)]
+    pub fn set_intercept_owner(&self, page_id: String, request_scope: String) {
+        let mut state = self.state.borrow_mut();
+        state.intercept_owner_page_id = page_id;
+        state.intercept_request_scope = request_scope;
+    }
+
     pub fn set_intercept_enabled(&self, enabled: bool) {
         let mut state = self.state.borrow_mut();
         state.intercept_enabled = enabled;

--- a/crates/obscura-js/src/runtime.rs
+++ b/crates/obscura-js/src/runtime.rs
@@ -252,10 +252,7 @@ pub fn spawn_watchdog(handle: IsolateHandle, budget: std::time::Duration) -> Wat
 }
 
 impl WatchdogToken {
-    /// Stop the watchdog. Returns true if it had already fired (terminated the
-    /// isolate). The caller must then clear the termination flag via
-    /// [`ObscuraJsRuntime::cancel_termination`] before the next eval.
-    pub fn stop(mut self) -> bool {
+    fn cancel_and_join(&mut self) {
         {
             let (lock, cvar) = &*self.pair;
             *lock.lock().unwrap() = true;
@@ -264,7 +261,23 @@ impl WatchdogToken {
         if let Some(j) = self.join.take() {
             let _ = j.join();
         }
+    }
+
+    /// Stop the watchdog. Returns true if it had already fired (terminated the
+    /// isolate). The caller must then clear the termination flag via
+    /// [`ObscuraJsRuntime::cancel_termination`] before the next eval.
+    pub fn stop(mut self) -> bool {
+        self.cancel_and_join();
         self.fired.load(std::sync::atomic::Ordering::SeqCst)
+    }
+}
+
+impl Drop for WatchdogToken {
+    fn drop(&mut self) {
+        // Futures which own a watchdog may be cancelled while parked on I/O.
+        // Dropping the token must not leave a detached thread which later
+        // terminates an isolate that has already moved on to another task.
+        self.cancel_and_join();
     }
 }
 
@@ -2482,7 +2495,8 @@ impl ObscuraJsRuntime {
     }
 
     /// Whether a connected dynamic script prepared before the document load
-    /// event still has fetch/evaluation/load-or-error work outstanding.
+    /// event still has work outstanding, or the queued document load task has
+    /// not completed its task-end microtask checkpoint yet.
     ///
     /// This intentionally excludes `import()` and scripts created by a load
     /// handler. Those are ordinary post-load enhancement work and should only
@@ -5898,6 +5912,17 @@ mod tests {
             serde_json::json!("usable"),
             "the per-turn watchdog must leave the isolate reusable",
         );
+    }
+
+    #[test]
+    fn dropping_a_cancelled_watchdog_cannot_terminate_later_work() {
+        let mut rt = setup_runtime("<html><body></body></html>");
+        {
+            let _cancelled = rt.arm_watchdog(std::time::Duration::from_millis(20));
+        }
+        std::thread::sleep(std::time::Duration::from_millis(40));
+
+        assert_eq!(rt.evaluate("1 + 1").unwrap(), serde_json::json!(2.0));
     }
 
     #[tokio::test(flavor = "current_thread")]
@@ -17548,5 +17573,3 @@ mod tests {
         );
     }
 }
-
-

--- a/crates/obscura-js/src/runtime.rs
+++ b/crates/obscura-js/src/runtime.rs
@@ -3010,11 +3010,21 @@ impl ObscuraJsRuntime {
         const AUTONOMOUS_TASK_WATCHDOG_MS: u64 =
             SYNCHRONOUS_TASK_FLOOR_MS + WATCHDOG_SCHEDULING_MARGIN_MS;
 
+        self.run_autonomous_event_loop_turn_with_watchdog(
+            std::time::Duration::from_millis(AUTONOMOUS_TASK_WATCHDOG_MS),
+        )
+        .await
+    }
+
+    async fn run_autonomous_event_loop_turn_with_watchdog(
+        &mut self,
+        task_budget: std::time::Duration,
+    ) -> Result<bool, String> {
         self.begin_javascript_task();
 
         let checkpoint_watchdog = crate::cdp_watchdog::arm(
             self.isolate_handle(),
-            std::time::Duration::from_millis(AUTONOMOUS_TASK_WATCHDOG_MS),
+            task_budget,
         );
         self.runtime().v8_isolate().perform_microtask_checkpoint();
         if crate::cdp_watchdog::disarm(checkpoint_watchdog) {
@@ -3030,7 +3040,7 @@ impl ObscuraJsRuntime {
         let result = std::future::poll_fn(|cx| {
             let watchdog = crate::cdp_watchdog::arm(
                 isolate_handle.clone(),
-                std::time::Duration::from_millis(AUTONOMOUS_TASK_WATCHDOG_MS),
+                task_budget,
             );
             let tick = self
                 .runtime()
@@ -6782,6 +6792,38 @@ mod tests {
             .unwrap(),
             serde_json::json!("usable"),
             "the per-turn watchdog must leave the isolate reusable",
+        );
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn autonomous_watchdog_excludes_time_parked_on_a_timer() {
+        let mut rt = setup_runtime("<html><body></body></html>");
+        rt.execute_script(
+            "autonomous-parked-timer",
+            "globalThis.__parkedTimerDone = false;\
+             setTimeout(() => { globalThis.__parkedTimerDone = true; }, 100);",
+        )
+        .unwrap();
+
+        let started = std::time::Instant::now();
+        tokio::time::timeout(
+            std::time::Duration::from_secs(1),
+            rt.run_autonomous_event_loop_turn_with_watchdog(
+                std::time::Duration::from_millis(20),
+            ),
+        )
+        .await
+        .expect("autonomous timer turn remained parked")
+        .expect("parked time was incorrectly charged to the synchronous watchdog");
+
+        assert!(
+            started.elapsed() >= std::time::Duration::from_millis(80),
+            "the event loop did not remain parked beyond the test watchdog budget",
+        );
+        assert_eq!(
+            rt.evaluate("globalThis.__parkedTimerDone").unwrap(),
+            serde_json::json!(true),
+            "the isolate must remain reusable after a parked autonomous turn",
         );
     }
 

--- a/crates/obscura-js/src/runtime.rs
+++ b/crates/obscura-js/src/runtime.rs
@@ -1277,6 +1277,14 @@ impl ObscuraJsRuntime {
         state.intercept_tx = Some(tx);
     }
 
+    #[cfg(feature = "internal-cdp")]
+    #[doc(hidden)]
+    pub fn set_intercept_owner(&self, page_id: String, request_scope: String) {
+        let mut state = self.state.borrow_mut();
+        state.intercept_owner_page_id = page_id;
+        state.intercept_request_scope = request_scope;
+    }
+
     pub fn set_intercept_enabled(&self, enabled: bool) {
         let mut state = self.state.borrow_mut();
         state.intercept_enabled = enabled;

--- a/crates/obscura-js/src/runtime.rs
+++ b/crates/obscura-js/src/runtime.rs
@@ -2805,7 +2805,8 @@ impl ObscuraJsRuntime {
     }
 
     /// Whether a connected dynamic script prepared before the document load
-    /// event still has fetch/evaluation/load-or-error work outstanding.
+    /// event still has work outstanding, or the queued document load task has
+    /// not completed its task-end microtask checkpoint yet.
     ///
     /// This intentionally excludes `import()` and scripts created by a load
     /// handler. Those are ordinary post-load enhancement work and should only

--- a/crates/obscura-js/src/runtime.rs
+++ b/crates/obscura-js/src/runtime.rs
@@ -3020,6 +3020,14 @@ impl ObscuraJsRuntime {
         &mut self,
         task_budget: std::time::Duration,
     ) -> Result<bool, String> {
+        self.run_event_loop_turn_with_watchdog(task_budget, true).await
+    }
+
+    async fn run_event_loop_turn_with_watchdog(
+        &mut self,
+        task_budget: std::time::Duration,
+        wait_for_wake: bool,
+    ) -> Result<bool, String> {
         self.begin_javascript_task();
 
         let checkpoint_watchdog = crate::cdp_watchdog::arm(
@@ -3066,7 +3074,7 @@ impl ObscuraJsRuntime {
                 std::task::Poll::Ready(Err(error)) => std::task::Poll::Ready(Err(format!(
                     "Event loop error: {error}"
                 ))),
-                std::task::Poll::Pending if waiting_for_wake => {
+                std::task::Poll::Pending if !wait_for_wake || waiting_for_wake => {
                     std::task::Poll::Ready(Ok(false))
                 }
                 std::task::Poll::Pending => {
@@ -3079,12 +3087,13 @@ impl ObscuraJsRuntime {
         self.finish_heap_checked(result)
     }
 
-    /// Drive one cooperative event-loop turn for browser lifecycle code that
-    /// must re-check an external readiness predicate after every wake. The
+    /// Drive one event-loop poll for browser lifecycle code that must re-check
+    /// an external readiness predicate without parking on unrelated I/O. The
     /// boolean is true only when deno_core reached full idle.
     #[doc(hidden)]
     pub async fn run_load_delaying_event_loop_tick(&mut self) -> Result<bool, String> {
-        self.run_cooperative_event_loop_tick().await
+        self.run_event_loop_turn_with_watchdog(std::time::Duration::from_secs(1), false)
+            .await
     }
 
     /// Pump deferred work until deno_core reports true idle, or until the page

--- a/crates/obscura-mcp/src/lib.rs
+++ b/crates/obscura-mcp/src/lib.rs
@@ -933,16 +933,23 @@ async fn tool_navigate(args: &Value, state: &mut BrowserState) -> Result<String,
         .ok_or("Missing url parameter")?;
     let wait_until = args.get("waitUntil").and_then(Value::as_str).unwrap_or("load");
 
-    let condition = obscura_browser::lifecycle::WaitUntil::from_str(wait_until);
+    let condition = match obscura_browser::lifecycle::WaitUntil::from_str(wait_until) {
+        // MCP has no continuously running owner for a live DCL continuation.
+        obscura_browser::lifecycle::WaitUntil::DomContentLoaded => {
+            obscura_browser::lifecycle::WaitUntil::Load
+        }
+        condition => condition,
+    };
     let ua = state.user_agent.clone();
-    let page = state.page_mut();
-    if let Some(ref ua) = ua {
-        page.http_client.set_user_agent(ua).await;
+    {
+        let page = state.page_mut();
+        if let Some(ref ua) = ua {
+            page.http_client.set_user_agent(ua).await;
+        }
+        page.navigate_with_wait(url, condition).await
+            .map_err(|e| e.to_string())?;
     }
-
-    page.navigate_with_wait(url, condition).await
-        .map_err(|e| e.to_string())?;
-
+    let page = state.page_mut();
     let summary = format!("Navigated to {} — \"{}\"", page.url_string(), page.title);
     // DOM changed — invalidate the ref table. Next snapshot will rebuild.
     state.interactive_refs.clear();
@@ -1350,7 +1357,7 @@ async fn tool_back(state: &mut BrowserState) -> Result<String, String> {
     let prev_idx = page.history_index - 1;
     let url = page.history[prev_idx].clone();
     page.set_history_index(prev_idx);
-    let condition = obscura_browser::lifecycle::WaitUntil::DomContentLoaded;
+    let condition = obscura_browser::lifecycle::WaitUntil::Load;
     let stash = (page.history.clone(), page.history_index);
     page.navigate_with_wait(&url, condition).await.map_err(|e| e.to_string())?;
     let page = state.page_mut();
@@ -1368,7 +1375,7 @@ async fn tool_forward(state: &mut BrowserState) -> Result<String, String> {
     let next_idx = page.history_index + 1;
     let url = page.history[next_idx].clone();
     page.set_history_index(next_idx);
-    let condition = obscura_browser::lifecycle::WaitUntil::DomContentLoaded;
+    let condition = obscura_browser::lifecycle::WaitUntil::Load;
     let stash = (page.history.clone(), page.history_index);
     page.navigate_with_wait(&url, condition).await.map_err(|e| e.to_string())?;
     let page = state.page_mut();
@@ -1383,7 +1390,7 @@ async fn tool_reload(state: &mut BrowserState) -> Result<String, String> {
     if url == "about:blank" {
         return Err("Nothing to reload.".to_string());
     }
-    let condition = obscura_browser::lifecycle::WaitUntil::DomContentLoaded;
+    let condition = obscura_browser::lifecycle::WaitUntil::Load;
     state.page_mut().navigate_with_wait(&url, condition).await.map_err(|e| e.to_string())?;
     state.interactive_refs.clear();
     Ok(format!("Reloaded {url}"))
@@ -1772,9 +1779,9 @@ async fn tool_tab_new(args: &Value, state: &mut BrowserState) -> Result<String, 
         if let Some(ref ua) = ua {
             page.http_client.set_user_agent(ua).await;
         }
-        page.navigate_with_wait(u, obscura_browser::lifecycle::WaitUntil::DomContentLoaded)
+        page.navigate_with_wait(u, obscura_browser::lifecycle::WaitUntil::Load)
             .await.map_err(|e| e.to_string())?;
-        Ok(format!("Opened {id} and navigated to {}", page.url_string()))
+        Ok(format!("Opened {id} and navigated to {}", state.page_mut().url_string()))
     } else {
         Ok(format!("Opened {id} (about:blank)."))
     }
@@ -2034,6 +2041,25 @@ fn tool_set_storage_state(args: &Value, state: &mut BrowserState) -> Result<Stri
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn mcp_dcl_navigation_keeps_its_historical_loaded_contract() {
+        let mut state = BrowserState::new(None, None, false);
+        tool_navigate(
+            &json!({
+                "url": "data:text/html,<script>window.addEventListener('load',()=>globalThis.__loadSeen=true)</script>",
+                "waitUntil": "domcontentloaded",
+            }),
+            &mut state,
+        )
+        .await
+        .expect("MCP navigation");
+        assert_eq!(
+            state.page_mut().lifecycle,
+            obscura_browser::lifecycle::LifecycleState::Loaded,
+        );
+        assert_eq!(state.page_mut().evaluate("globalThis.__loadSeen === true"), json!(true));
+    }
 
     fn listed_tools() -> Vec<Value> {
         handle_tools_list(json!(1)).result.expect("tools/list result")

--- a/crates/obscura-mcp/src/lib.rs
+++ b/crates/obscura-mcp/src/lib.rs
@@ -935,16 +935,23 @@ async fn tool_navigate(args: &Value, state: &mut BrowserState) -> Result<String,
         .ok_or("Missing url parameter")?;
     let wait_until = args.get("waitUntil").and_then(Value::as_str).unwrap_or("load");
 
-    let condition = obscura_browser::lifecycle::WaitUntil::from_str(wait_until);
+    let condition = match obscura_browser::lifecycle::WaitUntil::from_str(wait_until) {
+        // MCP has no continuously running owner for a live DCL continuation.
+        obscura_browser::lifecycle::WaitUntil::DomContentLoaded => {
+            obscura_browser::lifecycle::WaitUntil::Load
+        }
+        condition => condition,
+    };
     let ua = state.user_agent.clone();
-    let page = state.page_mut();
-    if let Some(ref ua) = ua {
-        page.http_client.set_user_agent(ua).await;
+    {
+        let page = state.page_mut();
+        if let Some(ref ua) = ua {
+            page.http_client.set_user_agent(ua).await;
+        }
+        page.navigate_with_wait(url, condition).await
+            .map_err(|e| e.to_string())?;
     }
-
-    page.navigate_with_wait(url, condition).await
-        .map_err(|e| e.to_string())?;
-
+    let page = state.page_mut();
     let summary = format!("Navigated to {} — \"{}\"", page.url_string(), page.title);
     // DOM changed — invalidate the ref table. Next snapshot will rebuild.
     state.interactive_refs.clear();
@@ -1352,7 +1359,7 @@ async fn tool_back(state: &mut BrowserState) -> Result<String, String> {
     let prev_idx = page.history_index - 1;
     let url = page.history[prev_idx].clone();
     page.set_history_index(prev_idx);
-    let condition = obscura_browser::lifecycle::WaitUntil::DomContentLoaded;
+    let condition = obscura_browser::lifecycle::WaitUntil::Load;
     let stash = (page.history.clone(), page.history_index);
     page.navigate_with_wait(&url, condition).await.map_err(|e| e.to_string())?;
     let page = state.page_mut();
@@ -1370,7 +1377,7 @@ async fn tool_forward(state: &mut BrowserState) -> Result<String, String> {
     let next_idx = page.history_index + 1;
     let url = page.history[next_idx].clone();
     page.set_history_index(next_idx);
-    let condition = obscura_browser::lifecycle::WaitUntil::DomContentLoaded;
+    let condition = obscura_browser::lifecycle::WaitUntil::Load;
     let stash = (page.history.clone(), page.history_index);
     page.navigate_with_wait(&url, condition).await.map_err(|e| e.to_string())?;
     let page = state.page_mut();
@@ -1385,7 +1392,7 @@ async fn tool_reload(state: &mut BrowserState) -> Result<String, String> {
     if url == "about:blank" {
         return Err("Nothing to reload.".to_string());
     }
-    let condition = obscura_browser::lifecycle::WaitUntil::DomContentLoaded;
+    let condition = obscura_browser::lifecycle::WaitUntil::Load;
     state.page_mut().navigate_with_wait(&url, condition).await.map_err(|e| e.to_string())?;
     state.interactive_refs.clear();
     Ok(format!("Reloaded {url}"))
@@ -1774,9 +1781,9 @@ async fn tool_tab_new(args: &Value, state: &mut BrowserState) -> Result<String, 
         if let Some(ref ua) = ua {
             page.http_client.set_user_agent(ua).await;
         }
-        page.navigate_with_wait(u, obscura_browser::lifecycle::WaitUntil::DomContentLoaded)
+        page.navigate_with_wait(u, obscura_browser::lifecycle::WaitUntil::Load)
             .await.map_err(|e| e.to_string())?;
-        Ok(format!("Opened {id} and navigated to {}", page.url_string()))
+        Ok(format!("Opened {id} and navigated to {}", state.page_mut().url_string()))
     } else {
         Ok(format!("Opened {id} (about:blank)."))
     }
@@ -2078,6 +2085,25 @@ fn tool_set_storage_state(args: &Value, state: &mut BrowserState) -> Result<Stri
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn mcp_dcl_navigation_keeps_its_historical_loaded_contract() {
+        let mut state = BrowserState::new(None, None, false);
+        tool_navigate(
+            &json!({
+                "url": "data:text/html,<script>window.addEventListener('load',()=>globalThis.__loadSeen=true)</script>",
+                "waitUntil": "domcontentloaded",
+            }),
+            &mut state,
+        )
+        .await
+        .expect("MCP navigation");
+        assert_eq!(
+            state.page_mut().lifecycle,
+            obscura_browser::lifecycle::LifecycleState::Loaded,
+        );
+        assert_eq!(state.page_mut().evaluate("globalThis.__loadSeen === true"), json!(true));
+    }
 
     fn listed_tools() -> Vec<Value> {
         handle_tools_list(json!(1)).result.expect("tools/list result")

--- a/docs/Architecture-overview.md
+++ b/docs/Architecture-overview.md
@@ -108,7 +108,25 @@ Lifecycle events are emitted by `obscura-browser/lifecycle.rs` as the page trans
 init → commit → domcontentloaded → load → networkidle2 → networkidle0
 ```
 
-`waitUntil` on `Page.navigate` blocks until the requested level is reached. The Puppeteer / Playwright `goto` resolves on the matching `Page.lifecycleEvent` client-side.
+Puppeteer and Playwright do not send a server-side `waitUntil` with raw
+`Page.navigate`. The WebSocket server therefore returns the navigation result
+at DOMContentLoaded, keeps ownership of the live page runtime, and streams the
+later load transition. Same-page commands may run during
+that continuation. Commands which would activate another page are held in a
+bounded per-connection queue until the active page reaches load or its bounded
+load-script deadline ends, because suspending the single V8 isolate
+earlier would otherwise discard timers, fetches, and dynamic-script jobs.
+After load, a wake-driven drain may retain that ownership for at most one
+second so work queued by a load handler can publish its network/runtime events
+before another target replaces the active isolate.
+
+Load is emitted only after load-delaying scripts and their Network/Runtime
+events have been drained. Lifecycle events are emitted once per document and remain
+routed to the session that initiated the navigation. In-process CDP and MCP do
+not own an autonomous WebSocket pump, so they preserve their historical
+fully-loaded return contract instead of exposing an unowned DCL continuation.
+Puppeteer / Playwright `goto` resolves client-side when its requested lifecycle
+event arrives.
 
 ## Storage
 

--- a/docs/Architecture-overview.md
+++ b/docs/Architecture-overview.md
@@ -56,9 +56,11 @@ viewport, scroll, animation, font, and resource changes. The same geometry
 therefore drives browser APIs and paint instead of maintaining separate
 measurement and screenshot models.
 
-## Single V8 isolate
+## V8 ownership
 
-All pages in a process share one V8 isolate. The isolate is single-threaded by design.
+Each CDP connection owns a dedicated processor thread. Its page runtimes stay
+on that thread and only one page runtime is active at a time. Different
+connections therefore cannot enter each other's V8 isolates.
 
 `obscura_js::v8_lock::global()` is a `tokio::sync::Mutex` that serializes V8 work. A handler that wants to run JS must acquire the lock first:
 
@@ -67,9 +69,17 @@ let _guard = obscura_js::v8_lock::global().lock().await;
 page.evaluate(expr).await
 ```
 
-The dispatcher routes long-running operations (navigation, eval) through `process_with_interception` in `server.rs`, which spawns the work onto the tokio `LocalSet` and releases the dispatcher to keep handling other CDP messages.
+The dispatcher routes navigation through `process_with_interception` in
+`server.rs`, which keeps the task's join handle and continues receiving
+WebSocket control messages without entering V8 concurrently. Commands that
+would activate another page are deferred in a bounded queue.
 
-This is why `Target.createTarget` from many concurrent clients works: each `newPage` returns immediately while the actual navigation runs in a spawned task.
+An internal, feature-gated `NavigationControl` registers the current runtime's
+thread-safe V8 isolate handle. Target close, context disposal, connection loss,
+and shutdown set a sticky cancellation flag and terminate synchronous V8 work
+when necessary. The owner thread then unwinds the navigation future normally,
+clears V8 termination, awaits the task, and drops the page. A canceled page is
+never reinserted.
 
 ## Robustness
 
@@ -98,7 +108,11 @@ Worked example: [Adding a CDP method or Web API](Adding-a-CDP-method-or-Web-API.
 Each CDP client connection gets attached to one or more targets.
 Session IDs are `"{targetId}-session"`. The dispatcher routes by `sessionId` in the incoming frame to the right `Page`.
 
-Targets are created by `Target.createTarget`. Closing the WebSocket detaches all sessions but leaves the pages running.
+Targets are created by `Target.createTarget`. Closing the WebSocket is
+connection-local teardown: in-flight navigation is canceled, paused requests
+are failed, and that connection's pages, sessions, loaders, frame state,
+screencasts, streams, pending events, and deferred commands are dropped.
+Other connections are unaffected.
 
 ## Lifecycle
 

--- a/docs/Architecture-overview.md
+++ b/docs/Architecture-overview.md
@@ -118,7 +118,25 @@ Lifecycle events are emitted by `obscura-browser/lifecycle.rs` as the page trans
 init → commit → domcontentloaded → load → networkidle2 → networkidle0
 ```
 
-`waitUntil` on `Page.navigate` blocks until the requested level is reached. The Puppeteer / Playwright `goto` resolves on the matching `Page.lifecycleEvent` client-side.
+Puppeteer and Playwright do not send a server-side `waitUntil` with raw
+`Page.navigate`. The WebSocket server therefore returns the navigation result
+at DOMContentLoaded, keeps ownership of the live page runtime, and streams the
+later load transition. Same-page commands may run during
+that continuation. Commands which would activate another page are held in a
+bounded per-connection queue until the active page reaches load or its bounded
+load-script deadline ends, because suspending the single V8 isolate
+earlier would otherwise discard timers, fetches, and dynamic-script jobs.
+After load, a wake-driven drain may retain that ownership for at most one
+second so work queued by a load handler can publish its network/runtime events
+before another target replaces the active isolate.
+
+Load is emitted only after load-delaying scripts and their Network/Runtime
+events have been drained. Lifecycle events are emitted once per document and remain
+routed to the session that initiated the navigation. In-process CDP and MCP do
+not own an autonomous WebSocket pump, so they preserve their historical
+fully-loaded return contract instead of exposing an unowned DCL continuation.
+Puppeteer / Playwright `goto` resolves client-side when its requested lifecycle
+event arrives.
 
 ## Storage
 

--- a/docs/Architecture-overview.md
+++ b/docs/Architecture-overview.md
@@ -56,9 +56,11 @@ viewport, scroll, animation, font, and resource changes. The same geometry
 therefore drives browser APIs and paint instead of maintaining separate
 measurement and screenshot models.
 
-## Single V8 isolate
+## V8 ownership
 
-All pages in a process share one V8 isolate. The isolate is single-threaded by design.
+Each CDP connection owns a dedicated processor thread. Its page runtimes stay
+on that thread and only one page runtime is active at a time. Different
+connections therefore cannot enter each other's V8 isolates.
 
 `obscura_js::v8_lock::global()` is a `tokio::sync::Mutex` that serializes V8 work. A handler that wants to run JS must acquire the lock first:
 
@@ -67,9 +69,17 @@ let _guard = obscura_js::v8_lock::global().lock().await;
 page.evaluate(expr).await
 ```
 
-The dispatcher routes long-running operations (navigation, eval) through `process_with_interception` in `server.rs`, which spawns the work onto the tokio `LocalSet` and releases the dispatcher to keep handling other CDP messages.
+The dispatcher routes navigation through `process_with_interception` in
+`server.rs`, which keeps the task's join handle and continues receiving
+WebSocket control messages without entering V8 concurrently. Commands that
+would activate another page are deferred in a bounded queue.
 
-This is why `Target.createTarget` from many concurrent clients works: each `newPage` returns immediately while the actual navigation runs in a spawned task.
+An internal, feature-gated `NavigationControl` registers the current runtime's
+thread-safe V8 isolate handle. Target close, context disposal, connection loss,
+and shutdown set a sticky cancellation flag and terminate synchronous V8 work
+when necessary. The owner thread then unwinds the navigation future normally,
+clears V8 termination, awaits the task, and drops the page. A canceled page is
+never reinserted.
 
 ## Robustness
 
@@ -108,7 +118,11 @@ OS threads. This is not a complete WorkerGlobalScope implementation.
 Each CDP client connection gets attached to one or more targets.
 Session IDs are `"{targetId}-session"`. The dispatcher routes by `sessionId` in the incoming frame to the right `Page`.
 
-Targets are created by `Target.createTarget`. Closing the WebSocket detaches all sessions but leaves the pages running.
+Targets are created by `Target.createTarget`. Closing the WebSocket is
+connection-local teardown: in-flight navigation is canceled, paused requests
+are failed, and that connection's pages, sessions, loaders, frame state,
+screencasts, streams, pending events, and deferred commands are dropped.
+Other connections are unaffected.
 
 ## Lifecycle
 


### PR DESCRIPTION
## Summary

- return raw `Page.navigate` at DOMContentLoaded while load-delaying work continues on the owning page task
- stream DOMContentLoaded and load lifecycle events at their actual transitions
- cancel task-owned navigation on target close, context disposal, connection loss, browser close, and process shutdown
- terminate bounded synchronous V8 work safely, unwind normally, and never reinsert a canceled page
- preserve interception ownership across pages and runtime replacement, including both deferred command queues
- bound unrelated command deferral and keep direct browser and MCP load-waiting behavior

This is the navigation lifecycle and teardown slice from the supplied Obscura 0.2.1 report. It does not close #394, which still requires an observed Aviasales search response and readable response body.

## Verification

- focused `obscura-cdp` release nextest with render: 194 passed, 3 skipped
- affected browser, JS, and CDP release nextest with render: 725 passed, 3 skipped
- full release nextest with render: 1591 passed, 4 skipped
- all four documented release builds passed
- standalone obstacle course: 32/33, with only the pre-existing `observer-intersection` failure fixed independently by #786
- isolated candidate-specific combination with #786: 33/33
- exact pre-fix versus post-fix interleaved CDP benchmark, 5 rounds and 12 cycles per round: 37.63 ms versus 37.56 ms median fast cycle; 20.97 MiB versus 21.16 MiB idle RSS; 29.59 MiB versus 29.94 MiB post-navigation RSS; 26.13 MiB versus 26.47 MiB post-close RSS
- stalled-navigation target close: timed out in all 5 pre-fix rounds; completed in all 5 post-fix rounds in 0.33 to 0.39 ms
- interleaved fetch smoke, 7 rounds: latency changed by +1.6% and +1.9%; peak RSS changed by +0.2% and -2.5%
- two independent adversarial reviews passed after the API, cancellation race, cross-page ownership, duplicate teardown, queue-bound, and KISS findings were addressed

## Compatibility

No stable public Rust API change and no hostname-specific behavior. The navigation control seam is available only through the internal CDP feature. PR #786 applies cleanly; this PR remains based directly on `main` and is not stacked.

The PR remains draft until the final combined help-me-fly Booking and admitted Google acceptance gates complete.
