### PR TITLE
fix(js): new FormData(form) reads the form + keys()/values() are iterable

### DIFF
--- a/crates/obscura-js/js/bootstrap.js
+++ b/crates/obscura-js/js/bootstrap.js
@@ -9881,6 +9881,12 @@ if (typeof File === "undefined") globalThis.File = class File extends Blob {
   }
   get [Symbol.toStringTag]() { return "File"; }
 };
+// A FormData value keeps Blob/File objects as-is (the multipart serializer reads
+// their bytes); every other value is coerced to a string per the Fetch spec.
+function _isFormBlob(v) {
+  return v != null && typeof v === "object" &&
+    (v._bytes !== undefined || (typeof Blob === "function" && v instanceof Blob));
+}
 if (typeof FormData === "undefined") globalThis.FormData = class FormData {
   constructor(form) {
     this._d = [];
@@ -9909,8 +9915,8 @@ if (typeof FormData === "undefined") globalThis.FormData = class FormData {
       }
     }
   }
-  append(k, v) { this._d.push([String(k), String(v)]); }
-  set(k, v) { k = String(k); this._d = this._d.filter(([a]) => a !== k); this._d.push([k, String(v)]); }
+  append(k, v) { this._d.push([String(k), _isFormBlob(v) ? v : String(v)]); }
+  set(k, v) { k = String(k); this._d = this._d.filter(([a]) => a !== k); this._d.push([k, _isFormBlob(v) ? v : String(v)]); }
   delete(k) { k = String(k); this._d = this._d.filter(([a]) => a !== k); }
   get(k) { const e = this._d.find(([a]) => a === k); return e ? e[1] : null; }
   getAll(k) { return this._d.filter(([a]) => a === k).map(([, v]) => v); }

--- a/crates/obscura-js/js/bootstrap.js
+++ b/crates/obscura-js/js/bootstrap.js
@@ -9881,7 +9881,46 @@ if (typeof File === "undefined") globalThis.File = class File extends Blob {
   }
   get [Symbol.toStringTag]() { return "File"; }
 };
-if (typeof FormData === "undefined") globalThis.FormData = class FormData { constructor(){this._d=[];} append(k,v){this._d.push([k,v]);} get(k){const e=this._d.find(([a])=>a===k);return e?e[1]:null;} getAll(k){return this._d.filter(([a])=>a===k).map(([,v])=>v);} has(k){return this._d.some(([a])=>a===k);} entries(){return this._d[Symbol.iterator]();} forEach(cb){this._d.forEach(([k,v])=>cb(v,k));} };
+if (typeof FormData === "undefined") globalThis.FormData = class FormData {
+  constructor(form) {
+    this._d = [];
+    // `new FormData(form)` reads the form's current successful controls (the
+    // spec's "constructing the entry list"): skip disabled controls, buttons,
+    // and unchecked checkboxes/radios; a checkbox with no value submits "on".
+    if (form === undefined || form === null) return;
+    const isForm = form.nodeType === 1 && String(form.tagName || "").toUpperCase() === "FORM";
+    if (!isForm) {
+      throw new TypeError("Failed to construct 'FormData': parameter 1 is not of type 'HTMLFormElement'.");
+    }
+    if (typeof form.querySelectorAll === "function") {
+      const controls = form.querySelectorAll("input,select,textarea");
+      for (let i = 0; i < controls.length; i++) {
+        const el = controls[i];
+        const name = el.getAttribute ? el.getAttribute("name") : el.name;
+        if (!name || el.disabled) continue;
+        const tag = (el.tagName || "").toLowerCase();
+        const type = (((el.getAttribute && el.getAttribute("type")) || el.type || "")).toLowerCase();
+        if (tag === "input" && (type === "checkbox" || type === "radio")) {
+          if (el.checked) this._d.push([name, el.value != null ? String(el.value) : "on"]);
+          continue;
+        }
+        if (type === "submit" || type === "reset" || type === "button" || type === "image" || type === "file") continue;
+        this._d.push([name, el.value != null ? String(el.value) : ""]);
+      }
+    }
+  }
+  append(k, v) { this._d.push([String(k), String(v)]); }
+  set(k, v) { k = String(k); this._d = this._d.filter(([a]) => a !== k); this._d.push([k, String(v)]); }
+  delete(k) { k = String(k); this._d = this._d.filter(([a]) => a !== k); }
+  get(k) { const e = this._d.find(([a]) => a === k); return e ? e[1] : null; }
+  getAll(k) { return this._d.filter(([a]) => a === k).map(([, v]) => v); }
+  has(k) { return this._d.some(([a]) => a === k); }
+  entries() { return this._d[Symbol.iterator](); }
+  keys() { return this._d.map(([k]) => k)[Symbol.iterator](); }
+  values() { return this._d.map(([, v]) => v)[Symbol.iterator](); }
+  forEach(cb) { this._d.forEach(([k, v]) => cb(v, k, this)); }
+  [Symbol.iterator]() { return this.entries(); }
+};
 // application/x-www-form-urlencoded serializer: like encodeURIComponent but
 // space -> '+' and also percent-encoding the chars encodeURIComponent leaves
 // bare ( ! ~ ' ( ) ), keeping the form-urlencoded safe set ( * - . _ ).


### PR DESCRIPTION
closes #788

two bugs in the FormData shim (`js/bootstrap.js`)

1. `new FormData(form)` was a no-op. now it reads the form's successful controls (the spec entry list): skips disabled controls, buttons, and unchecked checkboxes/radios. a bare checkbox submits `on`, a select contributes its selected value.
2. `keys()` and `values()` threw `not iterable`. added both plus `[Symbol.iterator]` so `[...fd]` and `[...fd.keys()]` work. `set()`/`delete()` added while there. `new FormData(nonForm)` now throws `TypeError` like Chrome.

**before**  `new FormData(f).get("a")` -> `null` . `[...fd.keys()]` -> TypeError
**after**   `{a:"x",b:"y"}` . keys `["a","c","s"]` values `["x","1","o2"]`

verified on a render+stealth build: a form-populated FormData POSTs correct `multipart/form-data` (server echoes the fields), disabled/radio/textarea/duplicate-name handled, `entries()`/`has()`/`getAll()`/`forEach` unchanged.