### PR TITLE
fix(js): Chrome-shaped blob URLs + throw on non-Blob input

### DIFF
--- a/crates/obscura-js/js/bootstrap.js
+++ b/crates/obscura-js/js/bootstrap.js
@@ -13282,8 +13282,31 @@ globalThis.Worker = class Worker {
 
 globalThis.__blobStore = globalThis.__blobStore || {};
 URL.createObjectURL = function(blob) {
-  if (blob) {
-    const id = 'blob:obscura/' + Math.random().toString(36).substring(2);
+  // Chrome mints blob:<document-origin>/<v4-uuid> (blob:null/<uuid> on an opaque
+  // origin) and throws a TypeError on missing/non-Blob input. The old code named
+  // the engine ("blob:obscura/") — a one-line anti-bot tell — used a base36 token
+  // no UUID parser accepts, and handed back a well-formed-looking string for
+  // invalid input so the caller only failed later at the fetch (issue #751).
+  if (arguments.length === 0) {
+    throw new TypeError("Failed to execute 'createObjectURL' on 'URL': 1 argument required, but only 0 present.");
+  }
+  const isBlob = blob != null && typeof blob === 'object' &&
+    (blob._bytes !== undefined ||
+     (typeof Blob === 'function' && blob instanceof Blob) ||
+     typeof blob.text === 'function');
+  if (!isBlob) {
+    throw new TypeError("Failed to execute 'createObjectURL' on 'URL': parameter 1 is not of type 'Blob'.");
+  }
+  {
+    let origin = 'null';
+    try { origin = new URL(location.href).origin || 'null'; } catch (e) {}
+    const uuid = (globalThis.crypto && typeof crypto.randomUUID === 'function')
+      ? crypto.randomUUID()
+      : 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, (c) => {
+          const r = (Math.random() * 16) | 0;
+          return (c === 'x' ? r : (r & 0x3) | 0x8).toString(16);
+        });
+    const id = 'blob:' + origin + '/' + uuid;
     // Store synchronously so a Worker built from the blob URL in the same
     // tick sees its source. Blob-URL Worker construction is synchronous in
     // real browsers; the previous async blob.text().then() store raced the
@@ -13302,7 +13325,6 @@ URL.createObjectURL = function(blob) {
     }
     return id;
   }
-  return 'blob:obscura/fallback';
 };
 URL.revokeObjectURL = function(url) {
   delete globalThis.__blobStore[url];


### PR DESCRIPTION
closes #751

`URL.createObjectURL` (`js/bootstrap.js`) deviated from Chrome three ways, all readable from a page:

1. it named the engine: `blob:obscura/`. one `startsWith("blob:obscura")` is a complete anti-bot check.
2. wrong shape: a base36 token with no origin. Chrome mints `blob:<document-origin>/<v4-uuid>` (`blob:null/<uuid>` on an opaque origin).
3. invalid input got a well-formed-looking string instead of a throw.

**fix**: origin at mint time via `new URL(location.href).origin`, a v4 uuid via `crypto.randomUUID` (already in tree), and the exact Chrome `TypeError`s on `0` args / non-Blob input.

**before**  `blob:obscura/mvgx…` . `createObjectURL("nope")` -> `"blob:obscura/fallback"`
**after**   `blob:https://example.com/cb2b13df-…-4…` . `createObjectURL("nope")` -> `TypeError`

single `__blobStore`, so `revokeObjectURL` still covers it. verified on a render+stealth build that Worker construction from a blob URL still runs, `File` works, and each mint is unique.