### PR TITLE
fix: page.fill()/click() timeout via CDP - box model error + Input.insertText

### DIFF
--- a/crates/obscura-cdp/src/domains/dom.rs
+++ b/crates/obscura-cdp/src/domains/dom.rs
@@ -299,10 +299,16 @@ pub async fn handle(
         }
         "getBoxModel" => {
             let page = ctx.get_session_page_mut(session_id).ok_or("No page")?;
-            let node_id = match resolve_node_id(page, params) {
-                Ok(nid) => nid,
-                Err(_) => return Ok(json!(null)),
-            };
+            // A resolution failure here must reach the client as a real CDP
+            // protocol error, matching Chrome (-32000 "Could not compute box
+            // model."). Playwright's actionability polling re-reads the box
+            // model across animation frames to confirm layout stability; a
+            // silent placeholder quad or a bare `null` result never signals
+            // failure, so the box never (dis)stabilizes and the client spins
+            // until its own timeout with no protocol-level error to explain
+            // why (issue #807).
+            let node_id = resolve_node_id(page, params)
+                .map_err(|_| "Could not compute box model.".to_string())?;
             let code = format!(
                 "(function() {{\
                     var el = globalThis._wrap && globalThis._wrap({0});\
@@ -314,16 +320,17 @@ pub async fn handle(
                 node_id
             );
             let val = page.evaluate(&code);
-            let (quad, w, h) = if let Some(arr) = val.as_array() {
-                let nums: Vec<f64> = arr.iter().filter_map(|v| v.as_f64()).collect();
-                if nums.len() >= 10 {
-                    let q: Vec<Value> = nums[..8].iter().map(|n| coord_value(*n)).collect();
-                    (q, nums[8], nums[9])
-                } else {
-                    (vec![json!(8),json!(8),json!(108),json!(8),json!(108),json!(28),json!(8),json!(28)], 100.0, 20.0)
+            let (quad, w, h) = match val.as_array() {
+                Some(arr) => {
+                    let nums: Vec<f64> = arr.iter().filter_map(|v| v.as_f64()).collect();
+                    if nums.len() >= 10 {
+                        let q: Vec<Value> = nums[..8].iter().map(|n| coord_value(*n)).collect();
+                        (q, nums[8], nums[9])
+                    } else {
+                        return Err("Could not compute box model.".to_string());
+                    }
                 }
-            } else {
-                (vec![json!(8),json!(8),json!(108),json!(8),json!(108),json!(28),json!(8),json!(28)], 100.0, 20.0)
+                None => return Err("Could not compute box model.".to_string()),
             };
             Ok(json!({
                 "model": {
@@ -337,10 +344,10 @@ pub async fn handle(
         }
         "getContentQuads" => {
             let page = ctx.get_session_page_mut(session_id).ok_or("No page")?;
-            let node_id = match resolve_node_id(page, params) {
-                Ok(nid) => nid,
-                Err(_) => return Ok(json!(null)),
-            };
+            // See getBoxModel above: a resolution failure must surface as a
+            // real CDP error, not a fake quad or a bare `null`.
+            let node_id = resolve_node_id(page, params)
+                .map_err(|_| "Could not compute box model.".to_string())?;
             let code = format!(
                 "(function() {{\
                     var el = globalThis._wrap && globalThis._wrap({0});\
@@ -351,12 +358,16 @@ pub async fn handle(
                 node_id
             );
             let val = page.evaluate(&code);
-            let quad = if let Some(arr) = val.as_array() {
-                let nums: Vec<f64> = arr.iter().filter_map(|v| v.as_f64()).collect();
-                if nums.len() == 8 { nums.iter().map(|n| coord_value(*n)).collect::<Vec<_>>() }
-                else { vec![json!(8),json!(8),json!(108),json!(8),json!(108),json!(28),json!(8),json!(28)] }
-            } else {
-                vec![json!(8),json!(8),json!(108),json!(8),json!(108),json!(28),json!(8),json!(28)]
+            let quad = match val.as_array() {
+                Some(arr) => {
+                    let nums: Vec<f64> = arr.iter().filter_map(|v| v.as_f64()).collect();
+                    if nums.len() == 8 {
+                        nums.iter().map(|n| coord_value(*n)).collect::<Vec<_>>()
+                    } else {
+                        return Err("Could not compute box model.".to_string());
+                    }
+                }
+                None => return Err("Could not compute box model.".to_string()),
             };
             Ok(json!({ "quads": [quad] }))
         }

--- a/crates/obscura-cdp/src/domains/input.rs
+++ b/crates/obscura-cdp/src/domains/input.rs
@@ -393,6 +393,27 @@ pub async fn handle(
 
             Ok(json!({}))
         }
+        "insertText" => {
+            // Bulk text insertion (paste / IME commit), distinct from
+            // dispatchKeyEvent's per-character path: no keydown/keyup pairs,
+            // just the resulting value change plus the `input` event a
+            // controlled/reactive field listens for. Playwright's
+            // page.fill() calls this directly, so it was previously landing
+            // on the `_ => Err("Unknown Input method")` arm below and timing
+            // out (issue #807): the fix is dispatch, not new JS — the
+            // existing insert_text_js() helper already does the right thing.
+            let text = params.get("text").and_then(|v| v.as_str()).unwrap_or("");
+            if !text.is_empty() {
+                if let Some(page) = ctx.get_session_page_mut(session_id) {
+                    page.evaluate(&insert_text_js(text));
+                    // Give frameworks (React/Vue/Angular) a turn to react to
+                    // the input event before the caller proceeds, matching
+                    // the "char" dispatchKeyEvent path above.
+                    page.settle(50).await;
+                }
+            }
+            Ok(json!({}))
+        }
         "dispatchTouchEvent" => Ok(json!({})),
         "setIgnoreInputEvents" => Ok(json!({})),
         _ => Err(format!("Unknown Input method: {}", method)),


### PR DESCRIPTION
Fixes #807.

Two independent bugs, both surfacing as the same client-side symptom: `page.fill()` times out with no protocol-level error, even though the target element reports visible/enabled/editable via direct queries.

## 1. Silent fake box model on node-resolution failure

`getBoxModel`/`getContentQuads` (`crates/obscura-cdp/src/domains/dom.rs`) returned a hardcoded placeholder quad (`[8,8,108,8,108,28,8,28]`) whenever node resolution failed, instead of a real CDP protocol error. Playwright's actionability polling re-reads an element's box across animation frames to confirm layout stability before acting — a silent fallback quad never signals failure, so the box never (dis)stabilizes and the client spins until its own timeout with nothing to explain why.

Now returns `"Could not compute box model."`, matching Chrome's real behavior on this failure path.

## 2. `Input.insertText` unimplemented

This is what `page.fill()` actually calls under the hood — bulk text insertion (paste / IME commit), distinct from `dispatchKeyEvent`'s per-character path. It was landing on the `_ => Err("Unknown Input method")` arm and timing out. The underlying JS helper (`insert_text_js`) already existed and is used by `dispatchKeyEvent`'s `"char"` case — this just wires up the missing dispatch arm for `insertText`, including the same `settle(50ms)` so reactive frameworks (React/Vue/Angular) get a turn to react to the resulting `input` event before the caller proceeds.

## Verification

Both fixes were tested against a real repro, not just reasoned about:
- **Unpatched build**: `page.fill()` times out (15003ms) — confirmed matches the reported issue exactly.
- **Fix 1 alone**: box-model resolves correctly, but `page.fill()` *still* times out identically — confirmed this alone does not fix the reported bug (see issue comment history).
- **Both fixes together**: `page.fill()` succeeds in 22ms. Verified the `input` event actually fires for a reactive/controlled-component listener (checked via a separate mirror element updated only by a real `input` listener, not just the input's own `.value`) — so this isn't a naive DOM value-set silently bypassing framework state.
- `page.click()` on the same patched build succeeded in 68ms both before and after, confirming box-model/actionability was never broadly broken — this was specifically the two gaps above.

Also checked and ruled out an anti-bot/stealth-mode explanation while investigating: no `isTrusted` checks or bot-detection logic anywhere in the codebase, and `bootstrap.js` deliberately force-marks CDP-dispatched events as trusted to *defeat* anti-bot gating on target pages, not trigger it.

Built and tested via the repo's own multi-stage Dockerfile in an isolated container throughout.