### PR TITLE
fix(browser): thread page callbacks through stealth do_fetch

### DIFF
--- a/crates/obscura-browser/src/page.rs
+++ b/crates/obscura-browser/src/page.rs
@@ -1594,7 +1594,12 @@ impl Page {
     async fn do_fetch(&self, url: &Url) -> Result<Response, ObscuraNetError> {
         #[cfg(feature = "stealth")]
         if let Some(ref stealth) = self.stealth_client {
-            return stealth.fetch(url).await;
+            // Pass the page callbacks so CDP Network events and
+            // page.on('request'/'response') observers fire for stealth-mode
+            // navigations too, matching the non-stealth path below.
+            return stealth
+                .fetch_with_callbacks(url, Some(&self.callbacks))
+                .await;
         }
         self.http_client
             .fetch_with_callbacks(url, Some(&self.callbacks))


### PR DESCRIPTION
In stealth mode `Page::do_fetch` called `stealth.fetch(url)`, which passes `None` for callbacks, so CDP Network events and `page.on('request'/'response')` observers silently missed every stealth-mode navigation. The non-stealth path already passes `Some(&self.callbacks)`.

Call `stealth.fetch_with_callbacks(url, Some(&self.callbacks))` instead, mirroring the non-stealth path; `StealthHttpClient` already exposes that method with the identical signature (`fetch` just delegates to it with `None`).

**Note:** the changed line is `#[cfg(feature = "stealth")]` (wreq/boringssl), which does not build on all dev machines. It is a one-line mirror using an existing method with a matching signature; the default build stays clean, and CI with the stealth feature validates it.

Closes #811