### PR TITLE
fix(js): clamp deeply nested browser timers

### DIFF
--- a/crates/obscura-js/js/bootstrap.js
+++ b/crates/obscura-js/js/bootstrap.js
@@ -928,23 +928,41 @@ const _coerceTimerFn = (fn) => {
   return typeof fn === "function" ? fn : null;
 };
 
+let _timerTaskNestingLevel = 0;
+const _timerDelayForNesting = (delay, nestingLevel) =>
+  nestingLevel > 5 ? Math.max(4, delay) : delay;
+const _runTimerTask = (nestingLevel, fn) => {
+  const previous = _timerTaskNestingLevel;
+  _timerTaskNestingLevel = nestingLevel;
+  try { return fn(); }
+  finally { _timerTaskNestingLevel = previous; }
+};
+
 globalThis.setTimeout = (fn, delay = 0, ...args) => {
   const f = _coerceTimerFn(fn);
   if (f === null) return ++_tid;
   const id = ++_tid;
   const normalizedDelay = Math.max(0, Number(delay) || 0);
+  const parentNestingLevel = _timerTaskNestingLevel;
+  const taskNestingLevel = parentNestingLevel + 1;
+  const scheduledDelay = _timerDelayForNesting(normalizedDelay, parentNestingLevel);
   const state = { cancelled: false };
-  const nativeId = _scheduleAfter(normalizedDelay, () => {
-    _timerStates.delete(id);
-    _nativeTimerIds.delete(id);
-    __obscuraPendingTimeoutDeadlines.delete(id);
-    if (state.cancelled) return;
-    try { f(...args); } catch(e) { console.error("Timer error:", e); }
-  });
+  const nativeId = _scheduleAfter(
+    scheduledDelay,
+    () => {
+      _timerStates.delete(id);
+      _nativeTimerIds.delete(id);
+      __obscuraPendingTimeoutDeadlines.delete(id);
+      if (state.cancelled) return;
+      _runTimerTask(taskNestingLevel, () => {
+        try { f(...args); } catch(e) { console.error("Timer error:", e); }
+      });
+    },
+  );
   if (nativeId !== undefined) {
     _timerStates.set(id, state);
     _nativeTimerIds.set(id, nativeId);
-    __obscuraPendingTimeoutDeadlines.set(id, performance.now() + normalizedDelay);
+    __obscuraPendingTimeoutDeadlines.set(id, performance.now() + scheduledDelay);
   }
   return id;
 };
@@ -965,15 +983,25 @@ globalThis.setInterval = (fn, delay = 0, ...args) => {
   const f = _coerceTimerFn(fn);
   if (f === null) return ++_tid;
   const id = ++_tid;
+  const normalizedDelay = Math.max(0, Number(delay) || 0);
+  const parentNestingLevel = _timerTaskNestingLevel;
+  let taskNestingLevel = parentNestingLevel + 1;
   _intervals.add(id);
   const tick = () => {
     if (!_intervals.has(id)) return;
-    try { f(...args); } catch(e) { console.error("Interval error:", e); }
+    _runTimerTask(taskNestingLevel, () => {
+      try { f(...args); } catch(e) { console.error("Interval error:", e); }
+    });
     if (!_intervals.has(id)) return;
-    const nativeId = _scheduleAfter(delay, tick);
+    const nextDelay = _timerDelayForNesting(normalizedDelay, taskNestingLevel);
+    taskNestingLevel++;
+    const nativeId = _scheduleAfter(nextDelay, tick);
     if (nativeId !== undefined) _nativeTimerIds.set(id, nativeId);
   };
-  const nativeId = _scheduleAfter(delay, tick);
+  const nativeId = _scheduleAfter(
+    _timerDelayForNesting(normalizedDelay, parentNestingLevel),
+    tick,
+  );
   if (nativeId !== undefined) _nativeTimerIds.set(id, nativeId);
   return id;
 };

--- a/crates/obscura-js/src/runtime.rs
+++ b/crates/obscura-js/src/runtime.rs
@@ -5776,6 +5776,132 @@ mod tests {
     }
 
     #[tokio::test(flavor = "current_thread")]
+    async fn zero_delay_interval_created_by_timer_yields_to_embedder() {
+        let mut rt = setup_runtime("<html><body></body></html>");
+        rt.execute_script(
+            "nested-zero-interval",
+            "globalThis.__outerTimerRan = false;\
+             globalThis.__zeroIntervalTicks = 0;\
+             setTimeout(() => {\
+               globalThis.__outerTimerRan = true;\
+               globalThis.__zeroInterval = setInterval(\
+                 () => __zeroIntervalTicks++, 0);\
+             }, 0);",
+        )
+        .unwrap();
+
+        let started = std::time::Instant::now();
+        rt.run_autonomous_event_loop_turn().await.unwrap();
+        let elapsed = started.elapsed();
+
+        assert!(
+            elapsed < std::time::Duration::from_millis(500),
+            "a repeating timer must yield between ticks; elapsed={elapsed:?}",
+        );
+        assert_eq!(
+            rt.evaluate("globalThis.__outerTimerRan").unwrap(),
+            serde_json::json!(true),
+        );
+        rt.run_autonomous_event_loop_turn().await.unwrap();
+        for _ in 0..5 {
+            rt.run_autonomous_event_loop_turn().await.unwrap();
+        }
+        assert_eq!(
+            rt.evaluate("globalThis.__zeroIntervalTicks").unwrap(),
+            serde_json::json!(6.0),
+            "the repeating timer must make one tick of progress per event-loop turn",
+        );
+        rt.execute_script("clear-zero-interval", "clearInterval(globalThis.__zeroInterval)")
+            .unwrap();
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn top_level_zero_delay_interval_clamps_after_six_ticks() {
+        let mut rt = setup_runtime("<html><body></body></html>");
+        rt.execute_script(
+            "top-level-zero-interval",
+            "globalThis.__nestedTimerDelays = [];\
+             globalThis.__topInterval = setInterval(\
+               () => {\
+                 const nested = setTimeout(() => {}, 0);\
+                 __nestedTimerDelays.push(__obscura_nextPendingTimeoutDelay());\
+                 clearTimeout(nested);\
+               }, 0);",
+        )
+        .unwrap();
+
+        for _ in 0..7 {
+            rt.run_autonomous_event_loop_turn().await.unwrap();
+        }
+        assert_eq!(
+            rt.evaluate("globalThis.__nestedTimerDelays.length")
+                .unwrap(),
+            serde_json::json!(7.0),
+            "the interval must continue yielding and making progress",
+        );
+        let observed = rt.evaluate("globalThis.__nestedTimerDelays").unwrap();
+        let delays = observed.as_array().unwrap();
+        assert!(
+            delays[0].as_f64().unwrap() < 2.0,
+            "a shallow nested timer must remain unclamped: {delays:?}",
+        );
+        assert!(
+            delays[4].as_f64().unwrap() < 2.0,
+            "the fifth-level parent must remain below the clamp boundary: {delays:?}",
+        );
+        assert!(
+            delays[5].as_f64().unwrap() >= 2.0,
+            "a timer nested from the sixth interval task must receive the four-millisecond clamp: {delays:?}",
+        );
+        rt.execute_script("clear-top-interval", "clearInterval(globalThis.__topInterval)")
+            .unwrap();
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn deeply_nested_interval_inherits_the_timer_task_nesting() {
+        let mut rt = setup_runtime("<html><body></body></html>");
+        rt.execute_script(
+            "deep-zero-interval",
+            "globalThis.__deepIntervalTicks = 0;\
+             function installDeepInterval(depth) {\
+               if (depth === 0) {\
+                 globalThis.__deepInterval = setInterval(\
+                   () => __deepIntervalTicks++, 0);\
+               } else {\
+                 setTimeout(() => installDeepInterval(depth - 1), 0);\
+               }\
+             }\
+             installDeepInterval(6);",
+        )
+        .unwrap();
+
+        for _ in 0..8 {
+            if rt.evaluate("globalThis.__deepInterval !== undefined")
+                .unwrap()
+                == serde_json::json!(true)
+            {
+                break;
+            }
+            rt.run_autonomous_event_loop_turn().await.unwrap();
+        }
+        assert_eq!(
+            rt.evaluate("globalThis.__deepIntervalTicks").unwrap(),
+            serde_json::json!(0.0),
+            "an interval installed by a level-six timer must clamp before its first tick",
+        );
+        rt.run_autonomous_event_loop_turn().await.unwrap();
+        assert_eq!(
+            rt.evaluate("globalThis.__deepIntervalTicks").unwrap(),
+            serde_json::json!(1.0),
+        );
+        rt.execute_script(
+            "clear-deep-interval",
+            "clearInterval(globalThis.__deepInterval)",
+        )
+        .unwrap();
+    }
+
+    #[tokio::test(flavor = "current_thread")]
     async fn short_observation_deadline_does_not_terminate_the_active_task() {
         let mut rt = setup_runtime("<html><body></body></html>");
         rt.execute_script(
@@ -17548,5 +17674,3 @@ mod tests {
         );
     }
 }
-
-


### PR DESCRIPTION
## Summary

- track one shared task-nesting level across `setTimeout` and `setInterval`
- apply Chromium's 4 ms minimum only after the nesting threshold
- preserve immediate top-level zero-delay intervals and yield between repeated tasks

This is an independent fix found while isolating the navigation lifecycle workload from #799. A zero-delay interval created by timer work could otherwise keep the page runtime continuously runnable and delay unrelated lifecycle work.

## Compatibility

The threshold follows the HTML timer algorithm and current Blink behavior: parent nesting levels through 5 remain unclamped, while a timer scheduled by a level-6 task receives the 4 ms minimum. No public API or browser-visible diagnostic property is added.

## Verification

- focused release nextest: 4/4 passed
- full `obscura-js` release nextest with render: 440/440 passed
- two independent adversarial reviews: passed
- interleaved unchanged-main/candidate timer samples: median wall 0.12 s for both; median peak RSS 30.90 MiB versus 30.77 MiB

References: https://html.spec.whatwg.org/multipage/timers-and-user-prompts.html#timers and https://source.chromium.org/chromium/chromium/src/+/main:third_party/blink/renderer/core/frame/dom_timer.cc