### PR TITLE
fix(js): createObjectURL rejects non-Blob input; blob-ID fallback uses CSPRNG

### DIFF
--- a/crates/obscura-js/js/bootstrap.js
+++ b/crates/obscura-js/js/bootstrap.js
@@ -13358,10 +13358,12 @@ URL.createObjectURL = function(blob) {
   if (arguments.length === 0) {
     throw new TypeError("Failed to execute 'createObjectURL' on 'URL': 1 argument required, but only 0 present.");
   }
+  // Only a real Blob/File (or obscura's Blob, which carries _bytes) is valid —
+  // Chrome throws for anything else. Duck-typing on `.text()` used to accept
+  // Response and other unrelated objects.
   const isBlob = blob != null && typeof blob === 'object' &&
     (blob._bytes !== undefined ||
-     (typeof Blob === 'function' && blob instanceof Blob) ||
-     typeof blob.text === 'function');
+     (typeof Blob === 'function' && blob instanceof Blob));
   if (!isBlob) {
     throw new TypeError("Failed to execute 'createObjectURL' on 'URL': parameter 1 is not of type 'Blob'.");
   }
@@ -13371,7 +13373,10 @@ URL.createObjectURL = function(blob) {
     const uuid = (globalThis.crypto && typeof crypto.randomUUID === 'function')
       ? crypto.randomUUID()
       : 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, (c) => {
-          const r = (Math.random() * 16) | 0;
+          // CSPRNG, not Math.random() — blob IDs must not be predictable.
+          const b = new Uint8Array(1);
+          crypto.getRandomValues(b);
+          const r = b[0] & 0x0f;
           return (c === 'x' ? r : (r & 0x3) | 0x8).toString(16);
         });
     const id = 'blob:' + origin + '/' + uuid;

--- a/crates/obscura-js/src/runtime.rs
+++ b/crates/obscura-js/src/runtime.rs
@@ -3344,6 +3344,33 @@ mod tests {
         rt
     }
 
+    // SEC-503 / #820 — createObjectURL must reject non-Blob input (an object
+    // that merely has a .text() method, e.g. Response) with a TypeError, as
+    // Chrome does; a real Blob is still accepted.
+    #[test]
+    fn create_object_url_rejects_non_blob_input() {
+        let mut rt = setup_runtime("<html><body></body></html>");
+
+        // A real Blob is accepted and yields a blob: URL.
+        let ok = rt
+            .evaluate("URL.createObjectURL(new Blob(['hello'])).startsWith('blob:')")
+            .unwrap();
+        assert_eq!(ok, serde_json::json!(true), "a real Blob must be accepted");
+
+        // A non-Blob object with only .text() must be rejected.
+        let rejected = rt
+            .evaluate(
+                "(function(){ try { URL.createObjectURL({ text: () => Promise.resolve('x') }); return false; }\
+                   catch (e) { return !!(e && e.name === 'TypeError'); } })()",
+            )
+            .unwrap();
+        assert_eq!(
+            rejected,
+            serde_json::json!(true),
+            "createObjectURL must throw TypeError for non-Blob input"
+        );
+    }
+
     // SEC-301 / SEC-302 / #792 — the profile setters must embed values safely.
     // set_platform must not allow a backslash-before-quote to break out of the
     // JS string literal (injection), and set_user_agent must not silently fail


### PR DESCRIPTION
Two blob-URL hygiene fixes in `bootstrap.js`:

- **createObjectURL** accepted any object with a `.text()` method (e.g. `Response`); Chrome throws `TypeError` for non-Blob/File input. Drop the `.text()` duck-type from the `isBlob` gate — accept only obscura's Blob (`_bytes`) or a real `instanceof Blob`. The downstream `.text()` store path stays reachable for `instanceof`-Blob shims without `_bytes`.
- **blob-ID UUID fallback** used `Math.random()` (predictable) when `crypto.randomUUID` is unavailable; use `crypto.getRandomValues` so IDs are never predictable. (Defensive — `randomUUID` is always defined in practice.)

A third scan finding (blob store surviving navigation) turned out **not** to be a real leak: `Page::init_js` drops the whole `ObscuraJsRuntime` and builds a fresh V8 context on every navigation (deliberate isolation), so `__blobStore` starts empty for each new document. No change needed there (see issue thread).

**TDD:** RED accepted a non-Blob `{ text: () => … }`; GREEN rejects it with `TypeError` while a real `Blob` is still accepted.

Closes #820