### PR TITLE
fix(cdp): route domain events to enabled sessions

### DIFF
--- a/crates/obscura-cdp/src/dispatch.rs
+++ b/crates/obscura-cdp/src/dispatch.rs
@@ -55,14 +55,12 @@ pub struct CdpContext {
     /// script-initiated Network events must share this id; inventing a loader
     /// for each fetch breaks DevTools request grouping.
     pub current_loader_ids: HashMap<String, String>,
-    /// Pages whose initial navigation event sequence has been emitted. A page
-    /// is created already loaded (about:blank), but Chrome emits that load's
-    /// events when the client attaches; Page.enable emits them once per page
-    /// so clients waiting on the initial load (chromiumoxide, #833) unblock.
-    pub nav_events_emitted: std::collections::HashSet<String>,
-    /// Child frame ids already reported to the client, per page, so each frame
-    /// is announced once and a frame that goes away can be retracted.
+    /// Child frame ids currently observed per page.
     pub announced_frames: HashMap<String, Vec<String>>,
+    /// Child frame ids reported to each Page-enabled session.
+    pub(crate) page_announced_frames_by_session: HashMap<String, Vec<String>>,
+    /// Sessions that have received the page snapshot emitted by Page.enable.
+    pub(crate) page_initial_events_emitted_sessions: HashSet<String>,
     pub pending_events: Vec<CdpEvent>,
     #[cfg(feature = "render")]
     pub(crate) screencasts: HashMap<String, ScreencastState>,
@@ -75,6 +73,12 @@ pub struct CdpContext {
     target_session_counter: u64,
     pub preload_scripts: Vec<(String, String)>, // (identifier, source)
     pub preload_counter: u32,
+    /// Sessions that called Page.enable.
+    pub(crate) page_enabled_sessions: HashSet<String>,
+    /// Sessions that enabled the optional Page.lifecycleEvent stream.
+    pub(crate) lifecycle_enabled_sessions: HashSet<String>,
+    /// Sessions that called Network.enable.
+    pub(crate) network_enabled_sessions: HashSet<String>,
     // Which sessions asked for each `Runtime.addBinding` name. A binding is a
     // session-scoped subscription in CDP, and a client discards any event whose
     // sessionId is not one it holds, so the call has to go back to the session
@@ -173,8 +177,9 @@ impl CdpContext {
             pages: Vec::new(),
             sessions: HashMap::new(),
             current_loader_ids: HashMap::new(),
-            nav_events_emitted: std::collections::HashSet::new(),
             announced_frames: HashMap::new(),
+            page_announced_frames_by_session: HashMap::new(),
+            page_initial_events_emitted_sessions: HashSet::new(),
             pending_events: Vec::new(),
             #[cfg(feature = "render")]
             screencasts: HashMap::new(),
@@ -187,6 +192,9 @@ impl CdpContext {
             target_session_counter: 0,
             preload_scripts: Vec::new(),
             binding_sessions: HashMap::new(),
+            page_enabled_sessions: HashSet::new(),
+            lifecycle_enabled_sessions: HashSet::new(),
+            network_enabled_sessions: HashSet::new(),
             runtime_enabled_sessions: HashSet::new(),
             preload_counter: 0,
             fetch_intercept: FetchInterceptState::new(),
@@ -344,7 +352,7 @@ impl CdpContext {
             }
         }
         for session_id in &removed_sessions {
-            self.runtime_enabled_sessions.remove(session_id);
+            self.remove_session_subscriptions(session_id);
         }
         if let Some(context_ids) = self.page_contexts.remove(id) {
             for context_id in context_ids {
@@ -502,6 +510,62 @@ impl CdpContext {
         sessions
     }
 
+    pub(crate) fn remove_session_subscriptions(&mut self, session_id: &str) {
+        self.page_announced_frames_by_session.remove(session_id);
+        self.page_initial_events_emitted_sessions.remove(session_id);
+        self.page_enabled_sessions.remove(session_id);
+        self.lifecycle_enabled_sessions.remove(session_id);
+        self.network_enabled_sessions.remove(session_id);
+        self.runtime_enabled_sessions.remove(session_id);
+        for sessions in self.binding_sessions.values_mut() {
+            sessions.retain(|registered| registered != session_id);
+        }
+    }
+
+    pub(crate) fn detach_session(&mut self, session_id: &str) -> Option<String> {
+        let page_id = self.sessions.remove(session_id)?;
+        let had_network_subscription = self.network_enabled_sessions.contains(session_id);
+        self.remove_session_subscriptions(session_id);
+        if had_network_subscription
+            && !self.has_session_for_page(&self.network_enabled_sessions, &page_id)
+        {
+            if let Some(page) = self.get_page_mut(&page_id) {
+                page.clear_response_bodies();
+            }
+        }
+        Some(page_id)
+    }
+
+    pub(crate) fn has_session_for_page(
+        &self,
+        enabled_sessions: &HashSet<String>,
+        page_id: &str,
+    ) -> bool {
+        enabled_sessions.iter().any(|session_id| {
+            self.sessions
+                .get(session_id)
+                .is_some_and(|owner| owner == page_id)
+        })
+    }
+
+    pub(crate) fn sessions_for_page(
+        &self,
+        enabled_sessions: &HashSet<String>,
+        page_id: &str,
+    ) -> Vec<String> {
+        let mut sessions = enabled_sessions
+            .iter()
+            .filter(|session_id| {
+                self.sessions
+                    .get(*session_id)
+                    .is_some_and(|owner| owner == page_id)
+            })
+            .cloned()
+            .collect::<Vec<_>>();
+        sessions.sort();
+        sessions
+    }
+
     #[cfg(feature = "render")]
     pub(crate) fn next_screencast_session(&mut self) -> i64 {
         // Never wrap a delayed acknowledgement onto a replacement stream.
@@ -639,6 +703,38 @@ mod context_ownership_tests {
         assert!(ctx.context_by_id(child.id).is_none());
         assert!(ctx.context_by_id(main.id).is_some());
         assert!(ctx.context_by_id(sibling.id).is_some());
+    }
+
+    #[test]
+    fn detached_frame_contexts_are_pruned_without_a_page_subscriber() {
+        let mut ctx = CdpContext::new();
+        let page = ctx.create_page();
+        let runtime_session = "runtime-session".to_string();
+        ctx.sessions.insert(runtime_session.clone(), page.clone());
+        ctx.runtime_enabled_sessions.insert(runtime_session.clone());
+        let child = ctx.create_isolated_context(
+            &page,
+            "detached-child",
+            "https://example.test/child",
+            "utility",
+            false,
+        ).0;
+        ctx.announced_frames.insert(
+            page,
+            vec!["detached-child".to_string()],
+        );
+
+        drain_frame_events(&mut ctx);
+
+        assert!(ctx.context_by_id(child.id).is_none());
+        assert!(ctx.pending_events.iter().any(|event| {
+            event.method == "Runtime.executionContextDestroyed"
+                && event.session_id.as_deref() == Some(runtime_session.as_str())
+                && event.params["executionContextId"] == child.id
+        }));
+        assert!(ctx.pending_events.iter().all(|event| {
+            event.method != "Page.frameDetached"
+        }));
     }
 
 }
@@ -973,21 +1069,16 @@ pub(crate) fn drain_binding_calls(ctx: &mut CdpContext) {
         let execution_context_id = ctx.default_context_id(&page_id).unwrap_or(1);
         for (name, payload) in calls {
             // The sessions that asked for this binding, narrowed to the page the
-            // call came from. Falling back to every session of the page keeps a
-            // binding that was installed without a session (a preload, or a
-            // direct embedder) deliverable rather than silently dropped.
-            let registered = ctx.binding_sessions.get(&name);
-            let targets: Vec<&str> = page_sessions
-                .iter()
-                .copied()
-                .filter(|session| {
-                    registered.is_none_or(|owners| owners.iter().any(|owner| owner == session))
-                })
-                .collect();
-            let targets = if targets.is_empty() {
-                page_sessions.clone()
-            } else {
-                targets
+            // call came from. A missing registration belongs to an embedder and
+            // is delivered page-wide. An empty registration belonged to a
+            // detached client and must remain silent.
+            let targets: Vec<&str> = match ctx.binding_sessions.get(&name) {
+                Some(owners) => page_sessions
+                    .iter()
+                    .copied()
+                    .filter(|session| owners.iter().any(|owner| owner == session))
+                    .collect(),
+                None => page_sessions.clone(),
             };
             for session_id in targets {
                 events.push(CdpEvent {
@@ -1014,43 +1105,34 @@ pub(crate) fn drain_binding_calls(ctx: &mut CdpContext) {
 // after every dispatch, reports a frame whenever it actually appears instead
 // of only at navigation, and is the same drain point binding calls use.
 pub(crate) fn drain_frame_events(ctx: &mut CdpContext) {
-    // Every session on the page, not just one: a client that reaches a page the
-    // ordinary way holds two of them, because Target.createTarget opens a
-    // session and the Target.attachToTarget that follows opens another. A
-    // client drops any event whose sessionId is not the one it attached with,
-    // so announcing to an arbitrary session is the same as not announcing.
-    let mut page_to_sessions: HashMap<String, Vec<String>> = HashMap::new();
-    for (session_id, page_id) in &ctx.sessions {
-        page_to_sessions
-            .entry(page_id.clone())
-            .or_default()
-            .push(session_id.clone());
-    }
-    // ctx.sessions is a HashMap, so fix an order the events can be asserted in.
-    for sessions in page_to_sessions.values_mut() {
-        sessions.sort();
-    }
-
     let mut events: Vec<CdpEvent> = Vec::new();
-    let mut announced: HashMap<String, Vec<String>> = HashMap::new();
+    let mut frame_detach_events: Vec<CdpEvent> = Vec::new();
+    let mut announced_by_page: HashMap<String, Vec<String>> = HashMap::new();
+    let mut announced_by_session: HashMap<String, Vec<String>> = HashMap::new();
     let mut detached = Vec::new();
     for page in &ctx.pages {
-        let Some(session_ids) = page_to_sessions.get(&page.id) else {
-            continue;
-        };
         let live = crate::domains::page::child_frame_values(page);
-        let known = ctx.announced_frames.get(&page.id);
         let live_ids: Vec<String> = live
             .iter()
             .map(|frame| frame["id"].as_str().unwrap_or_default().to_string())
             .collect();
-
-        for frame in &live {
-            let id = frame["id"].as_str().unwrap_or_default();
-            if known.is_some_and(|ids| ids.iter().any(|seen| seen == id)) {
-                continue;
+        if let Some(known) = ctx.announced_frames.get(&page.id) {
+            for id in known {
+                if !live_ids.contains(id) {
+                    detached.push((page.id.clone(), id.clone()));
+                }
             }
-            for session_id in session_ids {
+        }
+        announced_by_page.insert(page.id.clone(), live_ids.clone());
+        let session_ids = ctx.sessions_for_page(&ctx.page_enabled_sessions, &page.id);
+
+        for session_id in session_ids {
+            let known = ctx.page_announced_frames_by_session.get(&session_id);
+            for frame in &live {
+                let id = frame["id"].as_str().unwrap_or_default();
+                if known.is_some_and(|ids| ids.iter().any(|seen| seen == id)) {
+                    continue;
+                }
                 // Attach before navigate: a client builds its frame from the
                 // attach event and treats a navigation of a frame it has never
                 // seen as a protocol error.
@@ -1075,18 +1157,22 @@ pub(crate) fn drain_frame_events(ctx: &mut CdpContext) {
                     session_id: Some(session_id.clone()),
                 });
             }
-        }
 
-        if let Some(known) = known {
-            for id in known {
-                if !live_ids.contains(id) {
-                    detached.push((page.id.clone(), id.clone(), session_ids.clone()));
+            if let Some(known) = known {
+                for id in known {
+                    if !live_ids.contains(id) {
+                        frame_detach_events.push(CdpEvent {
+                            method: "Page.frameDetached".into(),
+                            params: json!({ "frameId": id, "reason": "remove" }),
+                            session_id: Some(session_id.clone()),
+                        });
+                    }
                 }
             }
+            announced_by_session.insert(session_id, live_ids.clone());
         }
-        announced.insert(page.id.clone(), live_ids);
     }
-    for (page_id, frame_id, page_sessions) in detached {
+    for (page_id, frame_id) in detached {
         let removed = ctx.remove_frame_contexts(&page_id, &frame_id);
         let runtime_sessions = ctx.runtime_sessions_for_page(&page_id);
         for context in removed {
@@ -1101,15 +1187,14 @@ pub(crate) fn drain_frame_events(ctx: &mut CdpContext) {
                 ));
             }
         }
-        for session_id in page_sessions {
-            events.push(CdpEvent {
-                method: "Page.frameDetached".into(),
-                params: json!({ "frameId": frame_id, "reason": "remove" }),
-                session_id: Some(session_id),
-            });
-        }
     }
-    ctx.announced_frames.extend(announced);
+    // A page can be temporarily absent while a navigation task owns it. Keep
+    // its announcement state until explicit page/session teardown so draining
+    // another page cannot make the child frames look new on reinsertion.
+    ctx.announced_frames.extend(announced_by_page);
+    ctx.page_announced_frames_by_session
+        .extend(announced_by_session);
+    events.extend(frame_detach_events);
     ctx.pending_events.extend(events);
 }
 

--- a/crates/obscura-cdp/src/domains/input.rs
+++ b/crates/obscura-cdp/src/domains/input.rs
@@ -256,9 +256,7 @@ pub async fn handle(
                         .get(&page_id)
                         .cloned()
                         .unwrap_or_else(|| format!("loader-blank-{page_id}"));
-                    ctx.pending_events.push(crate::types::CdpEvent {
-                        method: "Page.frameNavigated".into(),
-                        params: json!({
+                    let params = json!({
                             "frame": crate::domains::page::frame_value(
                                 &frame_id,
                                 None,
@@ -267,9 +265,16 @@ pub async fn handle(
                                 "text/html",
                             ),
                             "type": "Navigation",
-                        }),
-                        session_id: Some(session_id.clone().unwrap_or_default()),
-                    });
+                        });
+                    for session_id in
+                        ctx.sessions_for_page(&ctx.page_enabled_sessions, &page_id)
+                    {
+                        ctx.pending_events.push(crate::types::CdpEvent {
+                            method: "Page.frameNavigated".into(),
+                            params: params.clone(),
+                            session_id: Some(session_id),
+                        });
+                    }
                 }
             } else if event_type == "mouseWheel" {
                 let delta_x = params.get("deltaX").and_then(|v| v.as_f64()).unwrap_or(0.0);

--- a/crates/obscura-cdp/src/domains/network.rs
+++ b/crates/obscura-cdp/src/domains/network.rs
@@ -31,13 +31,25 @@ pub async fn handle(
     session_id: &Option<String>,
 ) -> Result<Value, String> {
     match method {
-        "enable" => Ok(json!({})),
+        "enable" => {
+            if let Some(session_id) = session_id {
+                ctx.network_enabled_sessions.insert(session_id.clone());
+            }
+            Ok(json!({}))
+        }
         "disable" => {
-            if let Some(page) = ctx.get_session_page_mut(session_id) {
-                page.clear_response_bodies();
-            } else {
-                for page in &mut ctx.pages {
-                    page.clear_response_bodies();
+            let page_id = session_id
+                .as_ref()
+                .and_then(|session_id| ctx.sessions.get(session_id))
+                .cloned();
+            if let Some(session_id) = session_id {
+                ctx.network_enabled_sessions.remove(session_id);
+            }
+            if let Some(page_id) = page_id {
+                if !ctx.has_session_for_page(&ctx.network_enabled_sessions, &page_id) {
+                    if let Some(page) = ctx.get_page_mut(&page_id) {
+                        page.clear_response_bodies();
+                    }
                 }
             }
             Ok(json!({}))
@@ -400,6 +412,37 @@ mod tests {
         .await
         .unwrap_err();
         assert!(err.contains("No response body found"));
+    }
+
+    #[tokio::test]
+    async fn browser_level_network_disable_preserves_page_session_bodies() {
+        let mut ctx = CdpContext::new();
+        let page_id = ctx.create_page();
+        let session_id = Some("session-1".to_string());
+        ctx.sessions.insert(session_id.clone().unwrap(), page_id.clone());
+        ctx.network_enabled_sessions
+            .insert(session_id.clone().unwrap());
+
+        let page = ctx.get_page_mut(&page_id).unwrap();
+        page.navigate("data:text/html,<html><body>owned body</body></html>")
+            .await
+            .unwrap();
+        let request_id = page.network_events[0].request_id.clone();
+
+        handle("disable", &json!({}), &mut ctx, &None)
+            .await
+            .unwrap();
+        let result = handle(
+            "getResponseBody",
+            &json!({ "requestId": request_id }),
+            &mut ctx,
+            &session_id,
+        )
+        .await
+        .unwrap();
+        assert!(result["body"]
+            .as_str()
+            .is_some_and(|body| body.contains("owned body")));
     }
 }
 

--- a/crates/obscura-cdp/src/domains/page.rs
+++ b/crates/obscura-cdp/src/domains/page.rs
@@ -833,6 +833,42 @@ pub(crate) fn command_can_change_screencast_frame(method: &str) -> bool {
     )
 }
 
+fn emit_to_sessions(
+    ctx: &mut CdpContext,
+    sessions: &[String],
+    method: &str,
+    params: Value,
+) {
+    for session_id in sessions {
+        ctx.pending_events.push(CdpEvent::with_session(
+            method,
+            params.clone(),
+            session_id.clone(),
+        ));
+    }
+}
+
+fn initial_lifecycle_events(
+    frame_id: &str,
+    loader_id: &str,
+    timestamp: f64,
+    session_id: &str,
+) -> Vec<CdpEvent> {
+    ["commit", "DOMContentLoaded", "load", "networkIdle"]
+        .into_iter()
+        .map(|name| CdpEvent::with_session(
+            "Page.lifecycleEvent",
+            json!({
+                "frameId": frame_id,
+                "loaderId": loader_id,
+                "name": name,
+                "timestamp": timestamp,
+            }),
+            session_id.to_string(),
+        ))
+        .collect()
+}
+
 /// Emit the post-navigation event stream into `ctx.pending_events`. Shared
 /// by both the in-process `do_navigate` path and the spawned path in
 /// `server::process_navigation`, so the recent goto-returns-Response /
@@ -850,8 +886,9 @@ pub fn emit_navigation_events(
 ) {
     ctx.current_loader_ids
         .insert(page_id.to_string(), loader_id.to_string());
-    ctx.nav_events_emitted.insert(page_id.to_string());
-    let es = session_id.clone();
+    let page_sessions = ctx.sessions_for_page(&ctx.page_enabled_sessions, page_id);
+    let lifecycle_sessions = ctx.sessions_for_page(&ctx.lifecycle_enabled_sessions, page_id);
+    let network_sessions = ctx.sessions_for_page(&ctx.network_enabled_sessions, page_id);
     let ts = timestamp();
 
     // Real Chrome uses the navigation's loaderId as the main document's
@@ -900,42 +937,32 @@ pub fn emit_navigation_events(
     if let Some(idx) = nav_idx {
         let net_event = &network_events[idx];
         let rid = &nav_request_ids[idx];
-        ctx.pending_events.push(CdpEvent {
-            method: "Network.requestWillBeSent".into(),
-            params: json!({"requestId": rid, "loaderId": loader_id, "documentURL": page_url, "request": {"url": net_event.url, "method": net_event.method, "headers": net_event.headers}, "timestamp": net_event.timestamp, "wallTime": net_event.timestamp, "initiator": {"type": "other"}, "type": net_event.resource_type, "frameId": frame_id}),
-            session_id: es.clone(),
-        });
+        let params = json!({"requestId": rid, "loaderId": loader_id, "documentURL": page_url, "request": {"url": net_event.url, "method": net_event.method, "headers": net_event.headers}, "timestamp": net_event.timestamp, "wallTime": net_event.timestamp, "initiator": {"type": "other"}, "type": net_event.resource_type, "frameId": frame_id});
+        emit_to_sessions(ctx, &network_sessions, "Network.requestWillBeSent", params);
     }
 
     let contexts = ctx.commit_default_context(page_id, frame_id, page_url);
     let runtime_sessions = ctx.runtime_sessions_for_page(page_id);
-    let mut phase1 = vec![CdpEvent {
-        method: "Page.lifecycleEvent".into(),
-        params: json!({"frameId": frame_id, "loaderId": loader_id, "name": "init", "timestamp": ts}),
-        session_id: es.clone(),
-    }];
-    for runtime_session in &runtime_sessions {
-        phase1.push(CdpEvent::with_session(
-            "Runtime.executionContextsCleared",
-            json!({}),
-            runtime_session.clone(),
-        ));
-    }
-    phase1.push(CdpEvent {
-        method: "Page.frameNavigated".into(),
-        params: json!({"frame": frame_value(frame_id, None, loader_id, page_url, &nav_mime), "type": "Navigation"}),
-        session_id: es.clone(),
-    });
+    let init_params = json!({"frameId": frame_id, "loaderId": loader_id, "name": "init", "timestamp": ts});
+    emit_to_sessions(ctx, &lifecycle_sessions, "Page.lifecycleEvent", init_params);
+    emit_to_sessions(
+        ctx,
+        &runtime_sessions,
+        "Runtime.executionContextsCleared",
+        json!({}),
+    );
+    let frame_params = json!({"frame": frame_value(frame_id, None, loader_id, page_url, &nav_mime), "type": "Navigation"});
+    emit_to_sessions(ctx, &page_sessions, "Page.frameNavigated", frame_params);
     for runtime_session in runtime_sessions {
         for context in &contexts {
-            phase1.push(super::runtime::execution_context_created_event(
+            ctx.pending_events.push(super::runtime::execution_context_created_event(
                 context,
                 Some(runtime_session.clone()),
             ));
         }
     }
-    phase1.push(CdpEvent { method: "Page.lifecycleEvent".into(), params: json!({"frameId": frame_id, "loaderId": loader_id, "name": "commit", "timestamp": ts}), session_id: es.clone() });
-    ctx.pending_events.extend(phase1);
+    let commit_params = json!({"frameId": frame_id, "loaderId": loader_id, "name": "commit", "timestamp": ts});
+    emit_to_sessions(ctx, &lifecycle_sessions, "Page.lifecycleEvent", commit_params);
 
     if ctx.fetch_intercept.enabled {
         for (i, net_event) in network_events.iter().enumerate() {
@@ -953,7 +980,7 @@ pub fn emit_navigation_events(
                     "resourceType": net_event.resource_type,
                     "networkId": rid,
                 }),
-                session_id: es.clone(),
+                session_id: session_id.clone(),
             });
         }
     }
@@ -961,56 +988,31 @@ pub fn emit_navigation_events(
     for (i, net_event) in network_events.iter().enumerate() {
         let rid = &nav_request_ids[i];
         if Some(i) != nav_idx {
-            ctx.pending_events.push(CdpEvent {
-                method: "Network.requestWillBeSent".into(),
-                params: json!({"requestId": rid, "loaderId": loader_id, "documentURL": page_url, "request": {"url": net_event.url, "method": net_event.method, "headers": net_event.headers}, "timestamp": net_event.timestamp, "wallTime": net_event.timestamp, "initiator": {"type": "other"}, "type": net_event.resource_type, "frameId": frame_id}),
-                session_id: es.clone(),
-            });
+            let params = json!({"requestId": rid, "loaderId": loader_id, "documentURL": page_url, "request": {"url": net_event.url, "method": net_event.method, "headers": net_event.headers}, "timestamp": net_event.timestamp, "wallTime": net_event.timestamp, "initiator": {"type": "other"}, "type": net_event.resource_type, "frameId": frame_id});
+            emit_to_sessions(ctx, &network_sessions, "Network.requestWillBeSent", params);
         }
-        ctx.pending_events.push(CdpEvent {
-            method: "Network.responseReceived".into(),
-            params: json!({"requestId": rid, "loaderId": loader_id, "timestamp": net_event.timestamp, "type": net_event.resource_type, "response": {"url": net_event.url, "status": net_event.status, "statusText": "", "headers": &*net_event.response_headers, "mimeType": net_event.response_headers.get("content-type").cloned().unwrap_or_default()}, "frameId": frame_id}),
-            session_id: es.clone(),
-        });
-        ctx.pending_events.push(CdpEvent {
-            method: "Network.loadingFinished".into(),
-            params: json!({"requestId": rid, "timestamp": net_event.timestamp, "encodedDataLength": net_event.body_size}),
-            session_id: es.clone(),
-        });
+        let response_params = json!({"requestId": rid, "loaderId": loader_id, "timestamp": net_event.timestamp, "type": net_event.resource_type, "response": {"url": net_event.url, "status": net_event.status, "statusText": "", "headers": &*net_event.response_headers, "mimeType": net_event.response_headers.get("content-type").cloned().unwrap_or_default()}, "frameId": frame_id});
+        let finished_params = json!({"requestId": rid, "timestamp": net_event.timestamp, "encodedDataLength": net_event.body_size});
+        emit_to_sessions(ctx, &network_sessions, "Network.responseReceived", response_params);
+        emit_to_sessions(ctx, &network_sessions, "Network.loadingFinished", finished_params);
     }
 
-    let mut phase3 = vec![
-        CdpEvent {
-            method: "Page.lifecycleEvent".into(),
-            params: json!({"frameId": frame_id, "loaderId": loader_id, "name": "DOMContentLoaded", "timestamp": ts}),
-            session_id: es.clone(),
-        },
-        CdpEvent {
-            method: "Page.domContentEventFired".into(),
-            params: json!({"timestamp": ts}),
-            session_id: es.clone(),
-        },
-        CdpEvent {
-            method: "Page.lifecycleEvent".into(),
-            params: json!({"frameId": frame_id, "loaderId": loader_id, "name": "load", "timestamp": ts}),
-            session_id: es.clone(),
-        },
-        CdpEvent {
-            method: "Page.loadEventFired".into(),
-            params: json!({"timestamp": ts}),
-            session_id: es.clone(),
-        },
-    ];
+    for (name, method) in [
+        ("DOMContentLoaded", "Page.domContentEventFired"),
+        ("load", "Page.loadEventFired"),
+    ] {
+        let lifecycle_params = json!({"frameId": frame_id, "loaderId": loader_id, "name": name, "timestamp": ts});
+        emit_to_sessions(ctx, &lifecycle_sessions, "Page.lifecycleEvent", lifecycle_params);
+        let page_params = json!({"timestamp": ts});
+        emit_to_sessions(ctx, &page_sessions, method, page_params);
+    }
     if reached_network_idle || matches!(wait_until, WaitUntil::Load | WaitUntil::DomContentLoaded) {
         let idle_ts = timestamp();
-        phase3.push(CdpEvent { method: "Page.lifecycleEvent".into(), params: json!({"frameId": frame_id, "loaderId": loader_id, "name": "networkIdle", "timestamp": idle_ts}), session_id: es.clone() });
+        let params = json!({"frameId": frame_id, "loaderId": loader_id, "name": "networkIdle", "timestamp": idle_ts});
+        emit_to_sessions(ctx, &lifecycle_sessions, "Page.lifecycleEvent", params);
     }
-    phase3.push(CdpEvent {
-        method: "Page.frameStoppedLoading".into(),
-        params: json!({"frameId": frame_id}),
-        session_id: es,
-    });
-    ctx.pending_events.extend(phase3);
+    let stopped_params = json!({"frameId": frame_id});
+    emit_to_sessions(ctx, &page_sessions, "Page.frameStoppedLoading", stopped_params);
 
     // Target.targetInfoChanged: strict CDP clients (browser-use, and
     // Puppeteer/Playwright `page.url()` tracking) cache the TargetInfo from
@@ -1042,7 +1044,7 @@ pub fn emit_navigation_events(
 /// must not replay frame navigation or load lifecycle events.
 pub(crate) fn emit_runtime_network_events(
     ctx: &mut CdpContext,
-    session_id: &Option<String>,
+    _session_id: &Option<String>,
     frame_id: &str,
     page_url: &str,
     page_id: &str,
@@ -1056,11 +1058,10 @@ pub(crate) fn emit_runtime_network_events(
         .get(page_id)
         .cloned()
         .unwrap_or_else(|| format!("loader-blank-{page_id}"));
+    let sessions = ctx.sessions_for_page(&ctx.network_enabled_sessions, page_id);
     for network_event in network_events {
         let request_id = &network_event.request_id;
-        ctx.pending_events.push(CdpEvent {
-            method: "Network.requestWillBeSent".into(),
-            params: json!({
+        let request_params = json!({
                 "requestId": request_id,
                 "loaderId": loader_id,
                 "documentURL": page_url,
@@ -1074,12 +1075,8 @@ pub(crate) fn emit_runtime_network_events(
                 "initiator": {"type": "script"},
                 "type": network_event.resource_type,
                 "frameId": frame_id,
-            }),
-            session_id: session_id.clone(),
-        });
-        ctx.pending_events.push(CdpEvent {
-            method: "Network.responseReceived".into(),
-            params: json!({
+            });
+        let response_params = json!({
                 "requestId": request_id,
                 "loaderId": loader_id,
                 "timestamp": network_event.timestamp,
@@ -1095,18 +1092,29 @@ pub(crate) fn emit_runtime_network_events(
                         .unwrap_or_default(),
                 },
                 "frameId": frame_id,
-            }),
-            session_id: session_id.clone(),
-        });
-        ctx.pending_events.push(CdpEvent {
-            method: "Network.loadingFinished".into(),
-            params: json!({
+            });
+        let finished_params = json!({
                 "requestId": request_id,
                 "timestamp": network_event.timestamp,
                 "encodedDataLength": network_event.body_size,
-            }),
-            session_id: session_id.clone(),
-        });
+            });
+        for session_id in &sessions {
+            ctx.pending_events.push(CdpEvent::with_session(
+                "Network.requestWillBeSent",
+                request_params.clone(),
+                session_id.clone(),
+            ));
+            ctx.pending_events.push(CdpEvent::with_session(
+                "Network.responseReceived",
+                response_params.clone(),
+                session_id.clone(),
+            ));
+            ctx.pending_events.push(CdpEvent::with_session(
+                "Network.loadingFinished",
+                finished_params.clone(),
+                session_id.clone(),
+            ));
+        }
     }
 }
 
@@ -1242,43 +1250,91 @@ pub async fn handle(
 ) -> Result<Value, String> {
     match method {
         "enable" => {
+            if let Some(session_id) = session_id {
+                ctx.page_enabled_sessions.insert(session_id.clone());
+            }
             // Chrome loads a new target's initial about:blank right after
             // createTarget, so by the time a client attaches and calls
             // Page.enable the page has already produced its load events.
             // obscura creates pages silently, which starves clients that wait
             // for the initial load: chromiumoxide's new_page blocks until the
-            // main frame's "load" lifecycle event arrives (#833). Emit those
-            // events once, the first time a session enables the page domain
-            // on a page that has not emitted a navigation. This is not a
-            // document change, so there is no execution-context churn: the
-            // existing context announced by Runtime.enable stays valid.
-            let initial = ctx.get_session_page(session_id).and_then(|page| {
-                if ctx.nav_events_emitted.contains(&page.id) {
+            // main frame's load event arrives (#833). Emit Page-domain events
+            // once for each enabling session. Lifecycle events remain behind
+            // Page.setLifecycleEventsEnabled and are emitted there if it is
+            // enabled after this snapshot.
+            let initial = session_id.as_ref().and_then(|enabled_session| {
+                if ctx.page_initial_events_emitted_sessions.contains(enabled_session) {
                     return None;
                 }
-                Some((page.id.clone(), page.frame_id.clone(), page.url_string()))
+                ctx.get_session_page(session_id).map(|page| {
+                    (
+                        enabled_session.clone(),
+                        page.id.clone(),
+                        page.frame_id.clone(),
+                        page.url_string(),
+                    )
+                })
             });
-            if let Some((page_id, frame_id, url)) = initial {
-                ctx.nav_events_emitted.insert(page_id.clone());
+            if let Some((enabled_session, page_id, frame_id, url)) = initial {
+                ctx.page_initial_events_emitted_sessions
+                    .insert(enabled_session.clone());
                 let ts = timestamp();
-                let loader_id = format!("loader-blank-{page_id}");
-                let es = session_id.clone();
+                let loader_id = ctx.current_loader_ids
+                    .get(&page_id)
+                    .cloned()
+                    .unwrap_or_else(|| format!("loader-blank-{page_id}"));
+                let es = Some(enabled_session.clone());
                 // Build the frame through the schema-complete helper: generated
                 // CDP clients (chromiumoxide) reject a frameNavigated payload
                 // missing secureContextType/crossOriginIsolatedContextType and
                 // drop the whole connection (#833).
                 let frame = frame_value(&frame_id, None, &loader_id, &url, "text/html");
-                let events = vec![
-                    CdpEvent { method: "Page.frameNavigated".into(), params: json!({"frame": frame, "type": "Navigation"}), session_id: es.clone() },
-                    CdpEvent { method: "Page.lifecycleEvent".into(), params: json!({"frameId": frame_id, "loaderId": loader_id, "name": "commit", "timestamp": ts}), session_id: es.clone() },
-                    CdpEvent { method: "Page.lifecycleEvent".into(), params: json!({"frameId": frame_id, "loaderId": loader_id, "name": "DOMContentLoaded", "timestamp": ts}), session_id: es.clone() },
-                    CdpEvent { method: "Page.domContentEventFired".into(), params: json!({"timestamp": ts}), session_id: es.clone() },
-                    CdpEvent { method: "Page.lifecycleEvent".into(), params: json!({"frameId": frame_id, "loaderId": loader_id, "name": "load", "timestamp": ts}), session_id: es.clone() },
-                    CdpEvent { method: "Page.loadEventFired".into(), params: json!({"timestamp": ts}), session_id: es.clone() },
-                    CdpEvent { method: "Page.lifecycleEvent".into(), params: json!({"frameId": frame_id, "loaderId": loader_id, "name": "networkIdle", "timestamp": ts}), session_id: es.clone() },
-                    CdpEvent { method: "Page.frameStoppedLoading".into(), params: json!({"frameId": frame_id, "timestamp": ts}), session_id: es },
-                ];
+                let lifecycle_enabled = ctx.lifecycle_enabled_sessions
+                    .contains(&enabled_session);
+                let mut events = vec![CdpEvent {
+                    method: "Page.frameNavigated".into(),
+                    params: json!({"frame": frame, "type": "Navigation"}),
+                    session_id: es.clone(),
+                }];
+                let mut lifecycle = initial_lifecycle_events(
+                    &frame_id,
+                    &loader_id,
+                    ts,
+                    &enabled_session,
+                ).into_iter();
+                if lifecycle_enabled {
+                    events.extend(lifecycle.by_ref().take(2));
+                }
+                events.push(CdpEvent {
+                    method: "Page.domContentEventFired".into(),
+                    params: json!({"timestamp": ts}),
+                    session_id: es.clone(),
+                });
+                if lifecycle_enabled {
+                    events.push(lifecycle.next().expect("load lifecycle event"));
+                }
+                events.push(CdpEvent {
+                    method: "Page.loadEventFired".into(),
+                    params: json!({"timestamp": ts}),
+                    session_id: es.clone(),
+                });
+                if lifecycle_enabled {
+                    events.push(lifecycle.next().expect("network-idle lifecycle event"));
+                }
+                events.push(CdpEvent {
+                    method: "Page.frameStoppedLoading".into(),
+                    params: json!({"frameId": frame_id, "timestamp": ts}),
+                    session_id: es,
+                });
                 ctx.pending_events.extend(events);
+            }
+            Ok(json!({}))
+        }
+        "disable" => {
+            if let Some(session_id) = session_id {
+                ctx.page_enabled_sessions.remove(session_id);
+                ctx.lifecycle_enabled_sessions.remove(session_id);
+                ctx.page_announced_frames_by_session.remove(session_id);
             }
             Ok(json!({}))
         }
@@ -1360,7 +1416,37 @@ pub async fn handle(
 
             Ok(json!({ "executionContextId": context.id }))
         }
-        "setLifecycleEventsEnabled" => Ok(json!({})),
+        "setLifecycleEventsEnabled" => {
+            if let Some(session_id) = session_id {
+                if params.get("enabled").and_then(Value::as_bool).unwrap_or(false) {
+                    let newly_enabled = ctx.lifecycle_enabled_sessions
+                        .insert(session_id.clone());
+                    let needs_snapshot = newly_enabled
+                        && ctx.page_enabled_sessions.contains(session_id)
+                        && ctx.page_initial_events_emitted_sessions.contains(session_id);
+                    if needs_snapshot {
+                        let snapshot = ctx.get_session_page(&Some(session_id.clone())).map(|page| {
+                            let loader_id = ctx.current_loader_ids
+                                .get(&page.id)
+                                .cloned()
+                                .unwrap_or_else(|| format!("loader-blank-{}", page.id));
+                            (page.frame_id.clone(), loader_id)
+                        });
+                        if let Some((frame_id, loader_id)) = snapshot {
+                            ctx.pending_events.extend(initial_lifecycle_events(
+                                &frame_id,
+                                &loader_id,
+                                timestamp(),
+                                session_id,
+                            ));
+                        }
+                    }
+                } else {
+                    ctx.lifecycle_enabled_sessions.remove(session_id);
+                }
+            }
+            Ok(json!({}))
+        }
         "addScriptToEvaluateOnNewDocument" => {
             let source = params.get("source").and_then(|v| v.as_str()).unwrap_or("");
             ctx.preload_counter += 1;
@@ -1749,14 +1835,15 @@ mod tests {
 
     // #833: chromiumoxide's new_page waits for the initial target's "load"
     // lifecycle event before returning. Page.enable on a freshly created
-    // (silently loaded) page must emit the initial load sequence once, with a
-    // schema-complete frame, and must not replay it on a second enable.
+    // (silently loaded) page must emit the initial load sequence once per CDP
+    // session, with a schema-complete frame, and must not replay it when that
+    // same session enables the domain again.
     #[tokio::test(flavor = "current_thread")]
-    async fn page_enable_emits_the_initial_load_events_once() {
+    async fn page_enable_emits_the_initial_load_events_once_per_session() {
         let mut ctx = CdpContext::new();
         let page_id = ctx.create_page();
         let session = Some(format!("{page_id}-session"));
-        ctx.sessions.insert(session.clone().unwrap(), page_id);
+        ctx.sessions.insert(session.clone().unwrap(), page_id.clone());
 
         handle("enable", &json!({}), &mut ctx, &session)
             .await
@@ -1787,6 +1874,13 @@ mod tests {
             );
         }
         assert!(ctx.pending_events.is_empty() == false);
+        assert_eq!(
+            ctx.pending_events.iter()
+                .filter(|event| event.method == "Page.lifecycleEvent")
+                .count(),
+            0,
+            "Page.enable must not bypass lifecycle opt-in",
+        );
 
         ctx.pending_events.clear();
         handle("enable", &json!({}), &mut ctx, &session)
@@ -1796,6 +1890,122 @@ mod tests {
             ctx.pending_events.is_empty(),
             "the initial sequence must not replay on a second enable"
         );
+
+        handle(
+            "setLifecycleEventsEnabled",
+            &json!({"enabled": true}),
+            &mut ctx,
+            &session,
+        )
+        .await
+        .expect("lifecycle enable must succeed");
+        assert_eq!(
+            ctx.pending_events.iter()
+                .filter(|event| event.method == "Page.lifecycleEvent")
+                .count(),
+            4,
+        );
+        ctx.pending_events.clear();
+
+        handle(
+            "setLifecycleEventsEnabled",
+            &json!({"enabled": false}),
+            &mut ctx,
+            &session,
+        )
+        .await
+        .expect("lifecycle disable must succeed");
+        handle(
+            "setLifecycleEventsEnabled",
+            &json!({"enabled": true}),
+            &mut ctx,
+            &session,
+        )
+        .await
+        .expect("lifecycle re-enable must succeed");
+        assert_eq!(
+            ctx.pending_events.iter()
+                .filter(|event| event.method == "Page.lifecycleEvent")
+                .count(),
+            4,
+            "false-to-true lifecycle opt-in must emit the current snapshot",
+        );
+        ctx.pending_events.clear();
+
+        handle("disable", &json!({}), &mut ctx, &session)
+            .await
+            .expect("page disable must succeed");
+        handle("enable", &json!({}), &mut ctx, &session)
+            .await
+            .expect("page re-enable must succeed");
+        assert!(
+            ctx.pending_events.is_empty(),
+            "Page re-enable must not replay the Page-domain initial sequence",
+        );
+        handle(
+            "setLifecycleEventsEnabled",
+            &json!({"enabled": true}),
+            &mut ctx,
+            &session,
+        )
+        .await
+        .expect("lifecycle opt-in after Page re-enable must succeed");
+        assert_eq!(
+            ctx.pending_events.iter()
+                .filter(|event| event.method == "Page.lifecycleEvent")
+                .count(),
+            4,
+            "Page disable must reset the lifecycle snapshot state",
+        );
+        ctx.pending_events.clear();
+
+        let current_loader_id = "loader-after-navigation";
+        ctx.current_loader_ids
+            .insert(page_id.clone(), current_loader_id.to_string());
+        let second_session = Some("attached-session".to_string());
+        ctx.sessions
+            .insert(second_session.clone().unwrap(), page_id);
+        handle("enable", &json!({}), &mut ctx, &second_session)
+            .await
+            .expect("enable on a second session must succeed");
+        assert!(!ctx.pending_events.is_empty());
+        assert!(ctx.pending_events.iter().all(|event| {
+            event.session_id.as_ref() == second_session.as_ref()
+        }));
+        assert!(ctx.pending_events.iter().all(|event| {
+            event.method != "Page.lifecycleEvent"
+        }));
+        let late_frame = ctx.pending_events.iter()
+            .find(|event| event.method == "Page.frameNavigated")
+            .expect("late-attached session receives the current frame");
+        assert_eq!(late_frame.params["frame"]["loaderId"], current_loader_id);
+
+        ctx.pending_events.clear();
+        handle("enable", &json!({}), &mut ctx, &second_session)
+            .await
+            .expect("repeated second-session enable must succeed");
+        assert!(ctx.pending_events.is_empty());
+
+        handle(
+            "setLifecycleEventsEnabled",
+            &json!({"enabled": true}),
+            &mut ctx,
+            &second_session,
+        )
+        .await
+        .expect("second-session lifecycle enable must succeed");
+        assert_eq!(
+            ctx.pending_events.iter()
+                .filter(|event| event.method == "Page.lifecycleEvent")
+                .count(),
+            4,
+        );
+        assert!(ctx.pending_events.iter()
+            .filter(|event| event.method == "Page.lifecycleEvent")
+            .all(|event| event.params["loaderId"] == current_loader_id));
+        assert!(ctx.pending_events.iter().all(|event| {
+            event.session_id.as_ref() == second_session.as_ref()
+        }));
     }
 
     #[test]
@@ -1805,6 +2015,8 @@ mod tests {
         let session_id = Some(format!("{page_id}-session"));
         ctx.sessions
             .insert(session_id.clone().unwrap(), page_id.clone());
+        ctx.network_enabled_sessions
+            .insert(session_id.clone().unwrap());
         ctx.current_loader_ids
             .insert(page_id.clone(), "loader-current".into());
         let event = obscura_browser::NetworkEvent {

--- a/crates/obscura-cdp/src/domains/target.rs
+++ b/crates/obscura-cdp/src/domains/target.rs
@@ -242,9 +242,7 @@ pub async fn handle(
         // Ack these so Chrome-shaped clients that call them do not warn (issue #340).
         "detachFromTarget" => {
             if let Some(session_id) = params.get("sessionId").and_then(Value::as_str) {
-                let page_id = ctx.sessions.get(session_id).cloned();
-                ctx.sessions.remove(session_id);
-                ctx.runtime_enabled_sessions.remove(session_id);
+                let page_id = ctx.detach_session(session_id);
                 if let Some(page_id) = page_id {
                     ctx.refresh_runtime_event_collection(&page_id);
                 }
@@ -461,6 +459,14 @@ mod tests {
         .await
         .unwrap();
         let session_id = attached["sessionId"].as_str().unwrap().to_string();
+        ctx.page_enabled_sessions.insert(session_id.clone());
+        ctx.lifecycle_enabled_sessions.insert(session_id.clone());
+        ctx.network_enabled_sessions.insert(session_id.clone());
+        ctx.runtime_enabled_sessions.insert(session_id.clone());
+        ctx.page_announced_frames_by_session
+            .insert(session_id.clone(), vec!["frame-1".into()]);
+        ctx.announced_frames
+            .insert(page_id.clone(), vec!["frame-1".into()]);
 
         handle(
             "detachFromTarget",
@@ -471,6 +477,45 @@ mod tests {
         .await
         .expect("detach should succeed");
         assert!(!ctx.sessions.contains_key(&session_id));
+        assert!(!ctx.page_enabled_sessions.contains(&session_id));
+        assert!(!ctx.lifecycle_enabled_sessions.contains(&session_id));
+        assert!(!ctx.network_enabled_sessions.contains(&session_id));
+        assert!(!ctx.runtime_enabled_sessions.contains(&session_id));
+        assert!(!ctx.page_announced_frames_by_session.contains_key(&session_id));
+        assert!(ctx.announced_frames.contains_key(&page_id));
+    }
+
+    #[tokio::test]
+    async fn closing_target_removes_every_session_subscription() {
+        let mut ctx = CdpContext::new();
+        let page_id = ctx.create_page();
+        let session_id = "explicit-session".to_string();
+        ctx.sessions.insert(session_id.clone(), page_id.clone());
+        ctx.page_enabled_sessions.insert(session_id.clone());
+        ctx.lifecycle_enabled_sessions.insert(session_id.clone());
+        ctx.network_enabled_sessions.insert(session_id.clone());
+        ctx.runtime_enabled_sessions.insert(session_id.clone());
+        ctx.page_announced_frames_by_session
+            .insert(session_id.clone(), vec!["frame-1".into()]);
+        ctx.announced_frames
+            .insert(page_id.clone(), vec!["frame-1".into()]);
+
+        handle(
+            "closeTarget",
+            &json!({"targetId": page_id}),
+            &mut ctx,
+            &None,
+        )
+        .await
+        .expect("target close should succeed");
+
+        assert!(!ctx.sessions.contains_key(&session_id));
+        assert!(!ctx.page_enabled_sessions.contains(&session_id));
+        assert!(!ctx.lifecycle_enabled_sessions.contains(&session_id));
+        assert!(!ctx.network_enabled_sessions.contains(&session_id));
+        assert!(!ctx.runtime_enabled_sessions.contains(&session_id));
+        assert!(!ctx.page_announced_frames_by_session.contains_key(&session_id));
+        assert!(!ctx.announced_frames.contains_key(&page_id));
     }
 
     #[tokio::test]

--- a/crates/obscura-cdp/src/server.rs
+++ b/crates/obscura-cdp/src/server.rs
@@ -1607,8 +1607,8 @@ fn fast_path_response(text: &str) -> Option<String> {
     let req: CdpRequest = serde_json::from_str(text).ok()?;
 
     let result = match req.method.as_str() {
-        "Network.enable" | "Network.setCacheDisabled" | "Network.setRequestInterception" |
-        "Page.setLifecycleEventsEnabled" | "Page.setInterceptFileChooserDialog" |
+        "Network.setCacheDisabled" | "Network.setRequestInterception" |
+        "Page.setInterceptFileChooserDialog" |
         "Runtime.runIfWaitingForDebugger" | "Runtime.discardConsoleEntries" |
         "Performance.enable" | "Log.enable" | "Security.enable" |
         "Emulation.setTouchEmulationEnabled" |

--- a/crates/obscura-cdp/tests/child_frame_tree.rs
+++ b/crates/obscura-cdp/tests/child_frame_tree.rs
@@ -24,6 +24,8 @@ async fn serve() -> String {
                     "<html><body><iframe src=\"/grandchild.html\"></iframe></body></html>"
                 } else if request.starts_with("GET /grandchild.html ") {
                     "<html><body><p>deep</p></body></html>"
+                } else if request.starts_with("GET /plain.html ") {
+                    "<html><body><p>plain</p></body></html>"
                 } else {
                     "<html><body><iframe src=\"/child.html\"></iframe></body></html>"
                 };
@@ -94,8 +96,10 @@ async fn attached_session(ctx: &mut CdpContext) -> String {
 async fn get_frame_tree_reports_nested_child_frames() {
     std::env::set_var("OBSCURA_ALLOW_PRIVATE_NETWORK", "1");
     let url = serve().await;
+    let plain_url = format!("{url}plain.html");
     let mut ctx = CdpContext::new();
     let session = &attached_session(&mut ctx).await;
+    cdp(&mut ctx, 0, "Page.enable", json!({}), session).await;
 
     // Deliberately no `waitUntil`: that is what Puppeteer and Playwright send,
     // and it resolves to DomContentLoaded rather than to load. Passing
@@ -132,25 +136,20 @@ async fn get_frame_tree_reports_nested_child_frames() {
     assert_eq!(grandchild["frame"]["parentId"], child["frame"]["id"]);
 
     // A client builds its frame list from the events, so the tree alone is not
-    // enough. They have to carry the session the client attached with, because
-    // a client discards anything addressed to a session it does not hold, and
-    // Target.createTarget leaves a second session on the same page.
+    // enough. Events belong only to the session that enabled Page.
     let child_id = child["frame"]["id"].as_str().unwrap().to_string();
     let page_id = ctx.sessions.get(session.as_str()).cloned().unwrap();
-    // Announcing to one arbitrary session of the page is what the ordering of a
-    // HashMap decides, so require every session on the page to be told. That
-    // makes the client's own session covered whichever one it is.
     for (candidate, owner) in &ctx.sessions {
-        if owner != &page_id {
+        if owner != &page_id || candidate == session {
             continue;
         }
         assert!(
-            ctx.pending_events.iter().any(|e| {
+            !ctx.pending_events.iter().any(|e| {
                 e.method == "Page.frameAttached"
                     && e.params["frameId"] == child_id
                     && e.session_id.as_deref() == Some(candidate.as_str())
             }),
-            "session {candidate} on the page was never told the child frame attached"
+            "Page-disabled session {candidate} received a child-frame event"
         );
     }
 
@@ -182,6 +181,85 @@ async fn get_frame_tree_reports_nested_child_frames() {
         .filter(|e| e.method == "Page.frameAttached")
         .count();
     assert_eq!(repeats, 0, "the same frame was announced twice");
+
+    // A spawned navigation temporarily moves its page out of the context. A
+    // drain caused by another command must not forget that page's child-frame
+    // announcements and duplicate them when the page comes back.
+    let page_index = ctx
+        .pages
+        .iter()
+        .position(|page| page.id == page_id)
+        .expect("page in context");
+    let task_owned_page = ctx.pages.remove(page_index);
+    cdp(&mut ctx, 4, "Browser.getVersion", json!({}), session).await;
+    ctx.pages.push(task_owned_page);
+    let reinsert_start = ctx.pending_events.len();
+    cdp(&mut ctx, 5, "Runtime.evaluate", json!({"expression": "1"}), session).await;
+    assert!(!ctx.pending_events[reinsert_start..].iter().any(|event| {
+        matches!(event.method.as_str(), "Page.frameAttached" | "Page.frameNavigated")
+            && (event.params["frameId"] == child_id
+                || event.params["frame"]["id"] == child_id)
+            && event.session_id.as_deref() == Some(session.as_str())
+    }), "task-owned page lost its frame announcement state");
+
+    let late_session = ctx
+        .sessions
+        .iter()
+        .find(|(candidate, owner)| {
+            owner.as_str() == page_id.as_str() && candidate.as_str() != session.as_str()
+        })
+        .map(|(candidate, _)| candidate.clone())
+        .expect("second page session");
+    let late_start = ctx.pending_events.len();
+    cdp(&mut ctx, 6, "Page.enable", json!({}), &late_session).await;
+    assert!(ctx.pending_events[late_start..].iter().any(|event| {
+        event.method == "Page.frameAttached"
+            && event.params["frameId"] == child_id
+            && event.session_id.as_deref() == Some(late_session.as_str())
+    }));
+    assert!(!ctx.pending_events[late_start..].iter().any(|event| {
+        event.method == "Page.frameAttached"
+            && event.params["frameId"] == child_id
+            && event.session_id.as_deref() == Some(session.as_str())
+    }));
+
+    cdp(&mut ctx, 7, "Page.disable", json!({}), &late_session).await;
+    let reenable_start = ctx.pending_events.len();
+    cdp(&mut ctx, 8, "Page.enable", json!({}), &late_session).await;
+    assert!(ctx.pending_events[reenable_start..].iter().any(|event| {
+        event.method == "Page.frameAttached"
+            && event.params["frameId"] == child_id
+            && event.session_id.as_deref() == Some(late_session.as_str())
+    }));
+    assert!(!ctx.pending_events[reenable_start..].iter().any(|event| {
+        event.method == "Page.frameAttached"
+            && event.params["frameId"] == child_id
+            && event.session_id.as_deref() == Some(session.as_str())
+    }));
+
+    let removal_start = ctx.pending_events.len();
+    cdp(
+        &mut ctx,
+        9,
+        "Page.navigate",
+        json!({"url": plain_url, "waitUntil": "load"}),
+        session,
+    )
+    .await;
+    for expected_session in [session.as_str(), late_session.as_str()] {
+        assert_eq!(
+            ctx.pending_events[removal_start..]
+                .iter()
+                .filter(|event| {
+                    event.method == "Page.frameDetached"
+                        && event.params["frameId"] == child_id
+                        && event.session_id.as_deref() == Some(expected_session)
+                })
+                .count(),
+            1,
+            "child removal was not routed exactly once to {expected_session}",
+        );
+    }
 }
 
 #[tokio::test(flavor = "current_thread")]
@@ -206,8 +284,9 @@ async fn isolated_worlds_are_owned_by_their_exact_frame() {
     let second_session = attached["sessionId"].as_str().unwrap().to_string();
     for runtime_session in [&session, &second_session] {
         cdp(&mut ctx, 3, "Runtime.enable", json!({}), runtime_session).await;
+        cdp(&mut ctx, 4, "Page.enable", json!({}), runtime_session).await;
     }
-    let tree = cdp(&mut ctx, 4, "Page.getFrameTree", json!({}), &session).await;
+    let tree = cdp(&mut ctx, 5, "Page.getFrameTree", json!({}), &session).await;
     let main_id = tree["frameTree"]["frame"]["id"].as_str().unwrap().to_string();
     let child_id = tree["frameTree"]["childFrames"][0]["frame"]["id"]
         .as_str().unwrap().to_string();

--- a/crates/obscura-cdp/tests/domain_event_subscriptions.rs
+++ b/crates/obscura-cdp/tests/domain_event_subscriptions.rs
@@ -1,0 +1,706 @@
+use std::time::Duration;
+
+use futures_util::{SinkExt, StreamExt};
+use obscura_cdp::dispatch::{dispatch, CdpContext};
+use obscura_cdp::types::CdpRequest;
+use serde_json::{json, Value};
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::TcpListener;
+use tokio_tungstenite::{connect_async, tungstenite::Message};
+
+async fn cdp(
+    ctx: &mut CdpContext,
+    id: u64,
+    method: &str,
+    params: Value,
+    session_id: Option<&str>,
+) -> Value {
+    let response = dispatch(
+        &CdpRequest {
+            id,
+            method: method.to_string(),
+            params,
+            session_id: session_id.map(str::to_string),
+        },
+        ctx,
+    )
+    .await;
+    assert!(
+        response.error.is_none(),
+        "CDP {method} failed: {:?}",
+        response.error,
+    );
+    response.result.unwrap_or_else(|| json!({}))
+}
+
+async fn attach(ctx: &mut CdpContext, target_id: &str, id: u64) -> String {
+    let result = cdp(
+        ctx,
+        id,
+        "Target.attachToTarget",
+        json!({"targetId": target_id, "flatten": true}),
+        None,
+    )
+    .await;
+    result["sessionId"]
+        .as_str()
+        .expect("attached session id")
+        .to_string()
+}
+
+async fn enable_domains(ctx: &mut CdpContext, session_id: &str, first_id: u64) {
+    cdp(ctx, first_id, "Page.enable", json!({}), Some(session_id)).await;
+    cdp(
+        ctx,
+        first_id + 1,
+        "Page.setLifecycleEventsEnabled",
+        json!({"enabled": true}),
+        Some(session_id),
+    )
+    .await;
+    cdp(
+        ctx,
+        first_id + 2,
+        "Runtime.enable",
+        json!({}),
+        Some(session_id),
+    )
+    .await;
+    cdp(
+        ctx,
+        first_id + 3,
+        "Network.enable",
+        json!({}),
+        Some(session_id),
+    )
+    .await;
+}
+
+fn event_count(ctx: &CdpContext, session_id: &str, method: &str) -> usize {
+    ctx.pending_events
+        .iter()
+        .filter(|event| event.session_id.as_deref() == Some(session_id))
+        .filter(|event| event.method == method)
+        .count()
+}
+
+fn lifecycle_count(ctx: &CdpContext, session_id: &str, name: &str) -> usize {
+    ctx.pending_events
+        .iter()
+        .filter(|event| event.session_id.as_deref() == Some(session_id))
+        .filter(|event| event.method == "Page.lifecycleEvent")
+        .filter(|event| event.params["name"] == name)
+        .count()
+}
+
+fn document_request_id(ctx: &CdpContext, session_id: &str) -> String {
+    ctx.pending_events
+        .iter()
+        .find(|event| {
+            event.session_id.as_deref() == Some(session_id)
+                && event.method == "Network.responseReceived"
+                && event.params["type"] == "Document"
+        })
+        .and_then(|event| event.params["requestId"].as_str())
+        .expect("document response request id")
+        .to_string()
+}
+
+async fn serve_pages() -> String {
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    tokio::spawn(async move {
+        for request_number in 1..=3 {
+            let (mut socket, _) = listener.accept().await.unwrap();
+            let mut buffer = [0_u8; 2048];
+            let _ = socket.read(&mut buffer).await.unwrap();
+            let body = format!("<html><body>page-{request_number}</body></html>");
+            let response = format!(
+                "HTTP/1.1 200 OK\r\nContent-Type: text/html\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{body}",
+                body.len(),
+            );
+            socket.write_all(response.as_bytes()).await.unwrap();
+        }
+    });
+    format!("http://{addr}")
+}
+
+type Ws = tokio_tungstenite::WebSocketStream<
+    tokio_tungstenite::MaybeTlsStream<tokio::net::TcpStream>,
+>;
+
+async fn ws_send(ws: &mut Ws, value: Value) {
+    ws.send(Message::Text(value.to_string().into()))
+        .await
+        .unwrap();
+}
+
+async fn ws_next_json(ws: &mut Ws) -> Value {
+    loop {
+        let message = tokio::time::timeout(Duration::from_secs(5), ws.next())
+            .await
+            .expect("timed out waiting for CDP message")
+            .expect("CDP socket closed")
+            .expect("CDP WebSocket error");
+        if let Message::Text(text) = message {
+            return serde_json::from_str(&text).expect("CDP JSON message");
+        }
+    }
+}
+
+async fn ws_response(ws: &mut Ws, id: u64) -> Value {
+    loop {
+        let message = ws_next_json(ws).await;
+        if message["id"] == id {
+            return message;
+        }
+    }
+}
+
+async fn ws_attach(ws: &mut Ws, id: u64, target_id: &str) -> String {
+    ws_send(
+        ws,
+        json!({
+            "id": id,
+            "method": "Target.attachToTarget",
+            "params": {"targetId": target_id, "flatten": true},
+        }),
+    )
+    .await;
+    ws_response(ws, id).await["result"]["sessionId"]
+        .as_str()
+        .expect("attached session id")
+        .to_string()
+}
+
+async fn ws_enable_domains(ws: &mut Ws, session_id: &str, first_id: u64) {
+    for (offset, method, params) in [
+        (0, "Page.enable", json!({})),
+        (1, "Page.setLifecycleEventsEnabled", json!({"enabled": true})),
+        (2, "Runtime.enable", json!({})),
+        (3, "Network.enable", json!({})),
+    ] {
+        let id = first_id + offset;
+        ws_send(
+            ws,
+            json!({"id": id, "method": method, "sessionId": session_id, "params": params}),
+        )
+        .await;
+        let response = ws_response(ws, id).await;
+        assert!(response.get("error").is_none(), "{method} failed: {response}");
+    }
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn navigation_events_follow_each_sessions_domain_subscriptions() {
+    std::env::set_var("OBSCURA_ALLOW_PRIVATE_NETWORK", "1");
+    let base_url = serve_pages().await;
+    let mut ctx = CdpContext::new();
+    let created = cdp(
+        &mut ctx,
+        1,
+        "Target.createTarget",
+        json!({"url": "about:blank"}),
+        None,
+    )
+    .await;
+    let target_id = created["targetId"].as_str().unwrap().to_string();
+    let first = attach(&mut ctx, &target_id, 2).await;
+    let second = attach(&mut ctx, &target_id, 3).await;
+    let other_created = cdp(
+        &mut ctx,
+        4,
+        "Target.createTarget",
+        json!({"url": "about:blank"}),
+        None,
+    )
+    .await;
+    let other_target = other_created["targetId"].as_str().unwrap().to_string();
+    let other = attach(&mut ctx, &other_target, 5).await;
+    enable_domains(&mut ctx, &first, 10).await;
+    enable_domains(&mut ctx, &second, 20).await;
+    enable_domains(&mut ctx, &other, 40).await;
+    ctx.pending_events.clear();
+
+    cdp(
+        &mut ctx,
+        30,
+        "Page.navigate",
+        json!({"url": format!("{base_url}/first"), "waitUntil": "load"}),
+        Some(&first),
+    )
+    .await;
+
+    for session_id in [&first, &second] {
+        assert_eq!(event_count(&ctx, session_id, "Page.frameNavigated"), 1);
+        assert_eq!(event_count(&ctx, session_id, "Page.domContentEventFired"), 1);
+        assert_eq!(event_count(&ctx, session_id, "Page.loadEventFired"), 1);
+        assert_eq!(lifecycle_count(&ctx, session_id, "init"), 1);
+        assert_eq!(lifecycle_count(&ctx, session_id, "commit"), 1);
+        assert_eq!(lifecycle_count(&ctx, session_id, "DOMContentLoaded"), 1);
+        assert_eq!(lifecycle_count(&ctx, session_id, "load"), 1);
+        assert_eq!(event_count(&ctx, session_id, "Runtime.executionContextsCleared"), 1);
+        assert_eq!(event_count(&ctx, session_id, "Runtime.executionContextCreated"), 2);
+        assert_eq!(event_count(&ctx, session_id, "Network.requestWillBeSent"), 1);
+        assert_eq!(event_count(&ctx, session_id, "Network.responseReceived"), 1);
+        assert_eq!(event_count(&ctx, session_id, "Network.loadingFinished"), 1);
+    }
+    assert_eq!(event_count(&ctx, &other, "Page.frameNavigated"), 0);
+    assert_eq!(event_count(&ctx, &other, "Page.lifecycleEvent"), 0);
+    assert_eq!(event_count(&ctx, &other, "Runtime.executionContextCreated"), 0);
+    assert_eq!(event_count(&ctx, &other, "Network.responseReceived"), 0);
+
+    let request_id = document_request_id(&ctx, &first);
+    cdp(
+        &mut ctx,
+        31,
+        "Network.disable",
+        json!({}),
+        Some(&second),
+    )
+    .await;
+    let body = cdp(
+        &mut ctx,
+        32,
+        "Network.getResponseBody",
+        json!({"requestId": request_id}),
+        Some(&first),
+    )
+    .await;
+    assert!(body["body"].as_str().is_some_and(|body| body.contains("page-1")));
+
+    cdp(
+        &mut ctx,
+        33,
+        "Page.setLifecycleEventsEnabled",
+        json!({"enabled": false}),
+        Some(&second),
+    )
+    .await;
+    ctx.pending_events.clear();
+    cdp(
+        &mut ctx,
+        34,
+        "Page.navigate",
+        json!({"url": format!("{base_url}/second"), "waitUntil": "load"}),
+        Some(&first),
+    )
+    .await;
+
+    assert_eq!(event_count(&ctx, &second, "Page.frameNavigated"), 1);
+    assert_eq!(event_count(&ctx, &second, "Runtime.executionContextsCleared"), 1);
+    assert_eq!(event_count(&ctx, &second, "Page.lifecycleEvent"), 0);
+    assert_eq!(event_count(&ctx, &second, "Network.requestWillBeSent"), 0);
+    assert_eq!(event_count(&ctx, &first, "Page.frameNavigated"), 1);
+    assert_eq!(lifecycle_count(&ctx, &first, "load"), 1);
+    assert_eq!(event_count(&ctx, &first, "Network.responseReceived"), 1);
+
+    let last_network_request = document_request_id(&ctx, &first);
+    cdp(&mut ctx, 35, "Page.disable", json!({}), Some(&second)).await;
+    cdp(&mut ctx, 36, "Runtime.disable", json!({}), Some(&second)).await;
+
+    cdp(
+        &mut ctx,
+        37,
+        "Target.detachFromTarget",
+        json!({"sessionId": first}),
+        None,
+    )
+    .await;
+    ctx.pending_events.clear();
+    cdp(
+        &mut ctx,
+        38,
+        "Page.navigate",
+        json!({"url": format!("{base_url}/third"), "waitUntil": "load"}),
+        Some(&second),
+    )
+    .await;
+
+    assert!(ctx
+        .pending_events
+        .iter()
+        .all(|event| event.session_id.as_deref() != Some(first.as_str())));
+    assert_eq!(event_count(&ctx, &second, "Page.frameNavigated"), 0);
+    assert_eq!(event_count(&ctx, &second, "Runtime.executionContextsCleared"), 0);
+    assert_eq!(event_count(&ctx, &second, "Page.lifecycleEvent"), 0);
+    assert_eq!(event_count(&ctx, &second, "Network.responseReceived"), 0);
+
+    let cleared_body = dispatch(
+        &CdpRequest {
+            id: 39,
+            method: "Network.getResponseBody".to_string(),
+            params: json!({"requestId": last_network_request}),
+            session_id: Some(second.clone()),
+        },
+        &mut ctx,
+    )
+    .await;
+    assert!(cleared_body.error.is_some(), "last subscriber detach retained response bodies");
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn detached_binding_owner_does_not_leak_calls_to_another_session() {
+    let mut ctx = CdpContext::new();
+    let created = cdp(
+        &mut ctx,
+        1,
+        "Target.createTarget",
+        json!({"url": "about:blank"}),
+        None,
+    )
+    .await;
+    let target_id = created["targetId"].as_str().unwrap();
+    let owner = attach(&mut ctx, target_id, 2).await;
+    let survivor = attach(&mut ctx, target_id, 3).await;
+    cdp(&mut ctx, 4, "Runtime.enable", json!({}), Some(&owner)).await;
+    cdp(&mut ctx, 5, "Runtime.enable", json!({}), Some(&survivor)).await;
+    cdp(
+        &mut ctx,
+        6,
+        "Runtime.addBinding",
+        json!({"name": "detachedBinding"}),
+        Some(&owner),
+    )
+    .await;
+
+    cdp(
+        &mut ctx,
+        7,
+        "Target.detachFromTarget",
+        json!({"sessionId": owner}),
+        None,
+    )
+    .await;
+    ctx.pending_events.clear();
+    cdp(
+        &mut ctx,
+        8,
+        "Runtime.evaluate",
+        json!({"expression": "detachedBinding('payload')"}),
+        Some(&survivor),
+    )
+    .await;
+
+    assert_eq!(event_count(
+        &ctx,
+        &survivor,
+        "Runtime.bindingCalled",
+    ), 0);
+}
+
+#[test]
+fn websocket_enable_commands_drive_multi_session_routing() {
+    let runtime = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .unwrap();
+    let local = tokio::task::LocalSet::new();
+
+    local.block_on(&runtime, async move {
+        std::env::set_var("OBSCURA_ALLOW_PRIVATE_NETWORK", "1");
+        let base_url = serve_pages().await;
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let port = listener.local_addr().unwrap().port();
+        drop(listener);
+        tokio::task::spawn_local(async move {
+            let _ = obscura_cdp::server::start(port).await;
+        });
+
+        let url = format!("ws://127.0.0.1:{port}/devtools/browser");
+        let deadline = tokio::time::Instant::now() + Duration::from_secs(5);
+        let mut ws = loop {
+            match connect_async(&url).await {
+                Ok((ws, _)) => break ws,
+                Err(_error) if tokio::time::Instant::now() < deadline => {
+                    tokio::time::sleep(Duration::from_millis(20)).await;
+                }
+                Err(error) => panic!("CDP connection failed: {error}"),
+            }
+        };
+        ws_send(
+            &mut ws,
+            json!({"id": 1, "method": "Target.createTarget", "params": {"url": "about:blank"}}),
+        )
+        .await;
+        let target_id = ws_response(&mut ws, 1).await["result"]["targetId"]
+            .as_str()
+            .expect("created target id")
+            .to_string();
+        let first = ws_attach(&mut ws, 2, &target_id).await;
+        let second = ws_attach(&mut ws, 3, &target_id).await;
+        ws_enable_domains(&mut ws, &first, 10).await;
+        ws_enable_domains(&mut ws, &second, 20).await;
+
+        ws_send(
+            &mut ws,
+            json!({
+                "id": 30,
+                "method": "Page.navigate",
+                "sessionId": first,
+                "params": {"url": format!("{base_url}/initial"), "waitUntil": "load"},
+            }),
+        )
+        .await;
+
+        let mut frame = std::collections::HashMap::<String, usize>::new();
+        let mut lifecycle_load = std::collections::HashMap::<String, usize>::new();
+        let mut network_response = std::collections::HashMap::<String, usize>::new();
+        let mut navigated = false;
+        let deadline = tokio::time::Instant::now() + Duration::from_secs(5);
+        while !navigated
+            || frame.get(&first).copied().unwrap_or(0) < 1
+            || frame.get(&second).copied().unwrap_or(0) < 1
+            || lifecycle_load.get(&first).copied().unwrap_or(0) < 1
+            || lifecycle_load.get(&second).copied().unwrap_or(0) < 1
+            || network_response.get(&first).copied().unwrap_or(0) < 1
+            || network_response.get(&second).copied().unwrap_or(0) < 1
+        {
+            assert!(tokio::time::Instant::now() < deadline, "incomplete CDP event fan-out");
+            let message = ws_next_json(&mut ws).await;
+            if message["id"] == 30 {
+                navigated = true;
+                continue;
+            }
+            let Some(session_id) = message["sessionId"].as_str().map(str::to_string) else {
+                continue;
+            };
+            match message["method"].as_str() {
+                Some("Page.frameNavigated") => *frame.entry(session_id).or_default() += 1,
+                Some("Page.lifecycleEvent") if message["params"]["name"] == "load" => {
+                    *lifecycle_load.entry(session_id).or_default() += 1;
+                }
+                Some("Network.responseReceived") => {
+                    *network_response.entry(session_id).or_default() += 1;
+                }
+                _ => {}
+            }
+        }
+
+        ws_send(
+            &mut ws,
+            json!({"id": 31, "method": "Target.getTargets", "params": {}}),
+        )
+        .await;
+        loop {
+            let message = ws_next_json(&mut ws).await;
+            if message["id"] == 31 {
+                break;
+            }
+            let Some(session_id) = message["sessionId"].as_str().map(str::to_string) else {
+                continue;
+            };
+            match message["method"].as_str() {
+                Some("Page.frameNavigated") => *frame.entry(session_id).or_default() += 1,
+                Some("Page.lifecycleEvent") if message["params"]["name"] == "load" => {
+                    *lifecycle_load.entry(session_id).or_default() += 1;
+                }
+                Some("Network.responseReceived") => {
+                    *network_response.entry(session_id).or_default() += 1;
+                }
+                _ => {}
+            }
+        }
+
+        assert_eq!(frame.get(&first), Some(&1));
+        assert_eq!(frame.get(&second), Some(&1));
+        assert_eq!(lifecycle_load.get(&first), Some(&1));
+        assert_eq!(lifecycle_load.get(&second), Some(&1));
+        assert_eq!(network_response.get(&first), Some(&1));
+        assert_eq!(network_response.get(&second), Some(&1));
+
+        let first_fetch_url = format!("{base_url}/api-first");
+        ws_send(
+            &mut ws,
+            json!({
+                "id": 32,
+                "method": "Runtime.evaluate",
+                "sessionId": first,
+                "params": {
+                    "expression": format!("fetch('{}').then(function (r) {{ return r.text(); }})", first_fetch_url),
+                    "awaitPromise": true,
+                    "returnByValue": true,
+                },
+            }),
+        )
+        .await;
+        let mut first_fetch_response = false;
+        let mut first_fetch_request_id = None;
+        let mut first_fetch_counts = std::collections::HashMap::<(String, String), usize>::new();
+        let deadline = tokio::time::Instant::now() + Duration::from_secs(5);
+        while !first_fetch_response
+            || [first.as_str(), second.as_str()].iter().any(|session_id| {
+                [
+                    "Network.requestWillBeSent",
+                    "Network.responseReceived",
+                    "Network.loadingFinished",
+                ]
+                .iter()
+                .any(|method| {
+                    first_fetch_counts
+                        .get(&(session_id.to_string(), method.to_string()))
+                        .copied()
+                        .unwrap_or(0)
+                        < 1
+                })
+            })
+        {
+            assert!(tokio::time::Instant::now() < deadline, "incomplete script-fetch fan-out");
+            let message = ws_next_json(&mut ws).await;
+            if message["id"] == 32 {
+                assert!(message.get("error").is_none(), "fetch evaluation failed: {message}");
+                first_fetch_response = true;
+                continue;
+            }
+            let Some(session_id) = message["sessionId"].as_str() else {
+                continue;
+            };
+            let Some(method) = message["method"].as_str() else {
+                continue;
+            };
+            if method == "Network.requestWillBeSent"
+                && message["params"]["request"]["url"] == first_fetch_url
+            {
+                first_fetch_request_id = message["params"]["requestId"]
+                    .as_str()
+                    .map(str::to_string);
+            }
+            if first_fetch_request_id.as_deref() == message["params"]["requestId"].as_str() {
+                *first_fetch_counts
+                    .entry((session_id.to_string(), method.to_string()))
+                    .or_default() += 1;
+            }
+        }
+        let first_fetch_request_id = first_fetch_request_id.expect("script fetch request id");
+        for session_id in [&first, &second] {
+            for method in [
+                "Network.requestWillBeSent",
+                "Network.responseReceived",
+                "Network.loadingFinished",
+            ] {
+                assert_eq!(
+                    first_fetch_counts.get(&(session_id.clone(), method.to_string())),
+                    Some(&1),
+                );
+            }
+        }
+
+        ws_send(
+            &mut ws,
+            json!({
+                "id": 33,
+                "method": "Network.getResponseBody",
+                "sessionId": first,
+                "params": {"requestId": first_fetch_request_id},
+            }),
+        )
+        .await;
+        let body_response = ws_response(&mut ws, 33).await;
+        assert_eq!(body_response["result"]["body"].as_str(), Some("<html><body>page-2</body></html>"));
+
+        ws_send(
+            &mut ws,
+            json!({"id": 34, "method": "Network.disable", "sessionId": second, "params": {}}),
+        )
+        .await;
+        assert!(ws_response(&mut ws, 34).await.get("error").is_none());
+
+        let second_fetch_url = format!("{base_url}/api-second");
+        ws_send(
+            &mut ws,
+            json!({
+                "id": 35,
+                "method": "Runtime.evaluate",
+                "sessionId": first,
+                "params": {
+                    "expression": format!("fetch('{}').then(function (r) {{ return r.text(); }})", second_fetch_url),
+                    "awaitPromise": true,
+                    "returnByValue": true,
+                },
+            }),
+        )
+        .await;
+        let mut second_fetch_response = false;
+        let mut second_fetch_request_id = None;
+        let mut second_fetch_counts = std::collections::HashMap::<(String, String), usize>::new();
+        let deadline = tokio::time::Instant::now() + Duration::from_secs(5);
+        while !second_fetch_response
+            || [
+                "Network.requestWillBeSent",
+                "Network.responseReceived",
+                "Network.loadingFinished",
+            ]
+            .iter()
+            .any(|method| {
+                second_fetch_counts
+                    .get(&(first.clone(), method.to_string()))
+                    .copied()
+                    .unwrap_or(0)
+                    < 1
+            })
+        {
+            assert!(tokio::time::Instant::now() < deadline, "incomplete second script fetch");
+            let message = ws_next_json(&mut ws).await;
+            if message["id"] == 35 {
+                assert!(message.get("error").is_none(), "fetch evaluation failed: {message}");
+                second_fetch_response = true;
+                continue;
+            }
+            let Some(session_id) = message["sessionId"].as_str() else {
+                continue;
+            };
+            let Some(method) = message["method"].as_str() else {
+                continue;
+            };
+            if method == "Network.requestWillBeSent"
+                && message["params"]["request"]["url"] == second_fetch_url
+            {
+                second_fetch_request_id = message["params"]["requestId"]
+                    .as_str()
+                    .map(str::to_string);
+            }
+            if second_fetch_request_id.as_deref() == message["params"]["requestId"].as_str() {
+                *second_fetch_counts
+                    .entry((session_id.to_string(), method.to_string()))
+                    .or_default() += 1;
+            }
+        }
+        ws_send(&mut ws, json!({"id": 36, "method": "Target.getTargets", "params": {}})).await;
+        loop {
+            let message = ws_next_json(&mut ws).await;
+            if message["id"] == 36 {
+                break;
+            }
+            let Some(session_id) = message["sessionId"].as_str() else {
+                continue;
+            };
+            let Some(method) = message["method"].as_str() else {
+                continue;
+            };
+            if second_fetch_request_id.as_deref() == message["params"]["requestId"].as_str() {
+                *second_fetch_counts
+                    .entry((session_id.to_string(), method.to_string()))
+                    .or_default() += 1;
+            }
+        }
+        for method in [
+            "Network.requestWillBeSent",
+            "Network.responseReceived",
+            "Network.loadingFinished",
+        ] {
+            assert_eq!(
+                second_fetch_counts.get(&(first.clone(), method.to_string())),
+                Some(&1),
+            );
+            assert_eq!(
+                second_fetch_counts
+                    .get(&(second.clone(), method.to_string()))
+                    .copied()
+                    .unwrap_or(0),
+                0,
+            );
+        }
+        assert!(second_fetch_request_id.is_some());
+        let _ = ws.close(None).await;
+    });
+}

--- a/crates/obscura-cdp/tests/execution_context_ownership.rs
+++ b/crates/obscura-cdp/tests/execution_context_ownership.rs
@@ -188,6 +188,14 @@ async fn navigation_context_events_preserve_order_for_every_runtime_attachment()
     for (id, session) in [(10, &first), (11, &second)] {
         cdp(&mut ctx, id, "Runtime.enable", json!({}), Some(session)).await;
     }
+    cdp(&mut ctx, 20, "Page.enable", json!({}), Some(&first)).await;
+    cdp(
+        &mut ctx,
+        21,
+        "Page.setLifecycleEventsEnabled",
+        json!({"enabled": true}),
+        Some(&first),
+    ).await;
     cdp(
         &mut ctx, 12, "Page.createIsolatedWorld",
         json!({"worldName": "utility"}), Some(&first),

--- a/crates/obscura-cdp/tests/js_fetch_emits_network_events.rs
+++ b/crates/obscura-cdp/tests/js_fetch_emits_network_events.rs
@@ -109,6 +109,7 @@ async fn js_fetch_emits_network_request_and_response() {
     let page_id = ctx.create_page();
     let session_id = "session-1";
     ctx.sessions.insert(session_id.to_string(), page_id.clone());
+    cdp(&mut ctx, 0, "Network.enable", json!({}), session_id).await;
 
     // An ordinary fetch() is not load-delaying in Chromium: `load` may fire
     // while its response is still pending. Ask for networkidle0 explicitly so
@@ -177,6 +178,7 @@ async fn navigation_without_script_fetch_is_unaffected() {
     let page_id = ctx.create_page();
     let session_id = "session-1";
     ctx.sessions.insert(session_id.to_string(), page_id.clone());
+    cdp(&mut ctx, 0, "Network.enable", json!({}), session_id).await;
 
     cdp(&mut ctx, 1, "Page.navigate", json!({"url": base, "waitUntil": "load"}), session_id).await;
 

--- a/crates/obscura-cdp/tests/page_frame_contract.rs
+++ b/crates/obscura-cdp/tests/page_frame_contract.rs
@@ -122,6 +122,23 @@ async fn every_page_frame_path_uses_the_current_cdp_contract() {
     )
     .await;
     let session_id = attached["sessionId"].as_str().unwrap().to_string();
+    let managed_session = format!("{page_id}-session");
+    cdp(
+        &mut ctx,
+        30,
+        "Page.enable",
+        json!({}),
+        Some(&session_id),
+    )
+    .await;
+    cdp(
+        &mut ctx,
+        31,
+        "Page.enable",
+        json!({}),
+        Some(&managed_session),
+    )
+    .await;
 
     let initial_tree = cdp(
         &mut ctx,
@@ -223,6 +240,20 @@ async fn every_page_frame_path_uses_the_current_cdp_contract() {
         })
         .expect("same-document navigation event was not emitted")
         .params["frame"];
+    for expected_session in [&session_id, &managed_session] {
+        assert_eq!(
+            ctx.pending_events[route_event_start..]
+                .iter()
+                .filter(|event| {
+                    event.method == "Page.frameNavigated"
+                        && event.params["frame"]["id"] == page_id
+                        && event.session_id.as_deref() == Some(expected_session.as_str())
+                })
+                .count(),
+            1,
+            "same-document navigation was not routed exactly once to {expected_session}",
+        );
+    }
     assert_frame_contract(route_frame);
     assert_eq!(route_frame["loaderId"], loader_id);
     assert!(route_frame["url"].as_str().unwrap().ends_with("/next"));


### PR DESCRIPTION
## Summary

- track Page, lifecycle, Runtime, and Network subscriptions per attached session
- fan out navigation, same-document, child-frame, and script-fetch events only to enabled sessions on the owning target
- preserve response bodies until the last Network subscriber leaves and clean all subscription state on detach or target close
- retain child-frame announcement state while navigation temporarily owns a page

This is an independent prerequisite for the navigation lifecycle work. It does not close #394.

## Tests

- `cargo nextest run --release --features render -p obscura-cdp --no-fail-fast` (173 passed, 3 skipped)
- `cargo nextest run --release --features render --no-fail-fast` (1583 passed, 4 skipped)
- all four documented `obscura-cli` release builds
- obstacle course 33/33 when combined only with open prerequisite #786

Refs #394.