### PR TITLE
fix(js): cancel watchdog threads on drop

### DIFF
--- a/crates/obscura-js/src/runtime.rs
+++ b/crates/obscura-js/src/runtime.rs
@@ -283,10 +283,10 @@ pub fn spawn_watchdog(handle: IsolateHandle, budget: std::time::Duration) -> Wat
 }
 
 impl WatchdogToken {
-    /// Stop the watchdog. Returns true if it had already fired (terminated the
-    /// isolate). The caller must then clear the termination flag via
-    /// [`ObscuraJsRuntime::cancel_termination`] before the next eval.
-    pub fn stop(mut self) -> bool {
+    fn cancel_and_join(&mut self) {
+        if self.join.is_none() {
+            return;
+        }
         {
             let (lock, cvar) = &*self.pair;
             *lock.lock().unwrap() = true;
@@ -295,7 +295,23 @@ impl WatchdogToken {
         if let Some(j) = self.join.take() {
             let _ = j.join();
         }
+    }
+
+    /// Stop the watchdog. Returns true if it had already fired (terminated the
+    /// isolate). The caller must then clear the termination flag via
+    /// [`ObscuraJsRuntime::cancel_termination`] before the next eval.
+    pub fn stop(mut self) -> bool {
+        self.cancel_and_join();
         self.fired.load(std::sync::atomic::Ordering::SeqCst)
+    }
+}
+
+impl Drop for WatchdogToken {
+    fn drop(&mut self) {
+        // Futures which own a watchdog may be cancelled while parked on I/O.
+        // Dropping the token must not leave a detached thread which later
+        // terminates an isolate that has already moved on to another task.
+        self.cancel_and_join();
     }
 }
 
@@ -6186,6 +6202,18 @@ mod tests {
             serde_json::json!("usable"),
             "the per-turn watchdog must leave the isolate reusable",
         );
+    }
+
+    #[test]
+    fn dropping_a_watchdog_cannot_terminate_later_work() {
+        let mut rt = setup_runtime("<html><body></body></html>");
+        {
+            let _cancelled = rt.arm_watchdog(std::time::Duration::from_millis(500));
+            std::thread::sleep(std::time::Duration::from_millis(100));
+        }
+        std::thread::sleep(std::time::Duration::from_millis(600));
+
+        assert_eq!(rt.evaluate("1 + 1").unwrap(), serde_json::json!(2.0));
     }
 
     #[tokio::test(flavor = "current_thread")]


### PR DESCRIPTION
## What changed

Cancel and join a watchdog when its owning future is dropped so its detached thread cannot terminate the isolate during later work. The normal `stop()` path preserves the existing fired result and shares the same idempotent cleanup without a second mutex or notification pass.

This is an independent prerequisite for navigation cancellation. It does not close #394.

## Validation

- focused dropped-watchdog regression
- `cargo nextest run --release --features render -p obscura-js --no-fail-fast` (451 passed)
- `cargo nextest run --release --features render --no-fail-fast` (1580 passed, 4 skipped)
- all four documented `obscura-cli` release builds
- obstacle course 33/33 when combined only with open prerequisite #786

A later isolated `obscura-cli::mcp_client::test_evaluate` rerun returned an empty title on both this candidate and untouched `main`. It is pre-existing and is not attributed to this change.

Refs #394 and the Obscura 0.2.1 lifecycle diagnostics.

## Rendering

Not applicable.

## Performance

The evaluation hot path is unchanged. Drop now performs the same bounded cancellation and thread join already required by explicit `stop()`; normal `stop()` makes the subsequent implicit drop a constant-time no-op.

## Checklist

- [x] The change is focused and does not remove existing behavior without justification.
- [x] Tests cover the failure or feature.
- [x] Existing tests pass, including render and no-render configurations when affected.
- [x] I checked for CPU, latency, and memory regressions.
- [x] Public API or user-facing behavior changes are documented.