### PR TITLE
fix(net): thread --allow-private-network into the stealth client

### DIFF
--- a/crates/obscura-browser/src/page.rs
+++ b/crates/obscura-browser/src/page.rs
@@ -1094,6 +1094,7 @@ impl Page {
             Some(Arc::new(StealthHttpClient::with_proxy(
                 context.cookie_jar.clone(),
                 context.proxy_url.as_deref(),
+                context.allow_private_network,
             )))
         } else {
             None

--- a/crates/obscura-cli/src/main.rs
+++ b/crates/obscura-cli/src/main.rs
@@ -1110,9 +1110,14 @@ async fn fetch_original_response(
     if stealth && url.scheme() != "file" {
         #[cfg(feature = "stealth")]
         {
+            // `false` matches the reqwest path below (`with_options`); the
+            // CLI mirrors --allow-private-network into
+            // OBSCURA_ALLOW_PRIVATE_NETWORK at startup, which this client
+            // honours.
             let client = obscura_net::StealthHttpClient::with_proxy(
                 Arc::new(obscura_net::CookieJar::new()),
                 proxy.as_deref(),
+                false,
             );
             return match timeout(Duration::from_secs(timeout_secs), client.fetch(&url)).await {
                 Ok(Ok(resp)) => Ok(resp),

--- a/crates/obscura-net/src/wreq_client.rs
+++ b/crates/obscura-net/src/wreq_client.rs
@@ -173,6 +173,7 @@ async fn send_get_with_connection_reset_retry(
 #[cfg(feature = "stealth")]
 pub struct StealthHttpClient {
     client: wreq::Client,
+    allow_private_network: bool,
     pub cookie_jar: Arc<CookieJar>,
     pub extra_headers: RwLock<HashMap<String, String>>,
     pub in_flight: Arc<std::sync::atomic::AtomicU32>,
@@ -181,10 +182,14 @@ pub struct StealthHttpClient {
 #[cfg(feature = "stealth")]
 impl StealthHttpClient {
     pub fn new(cookie_jar: Arc<CookieJar>) -> Self {
-        Self::with_proxy(cookie_jar, None)
+        Self::with_proxy(cookie_jar, None, false)
     }
 
-    pub fn with_proxy(cookie_jar: Arc<CookieJar>, proxy_url: Option<&str>) -> Self {
+    pub fn with_proxy(
+        cookie_jar: Arc<CookieJar>,
+        proxy_url: Option<&str>,
+        allow_private_network: bool,
+    ) -> Self {
         let emulation_opts = wreq_util::Emulation::builder()
             .profile(wreq_util::Profile::Chrome145)
             .platform(wreq_util::Platform::Windows)
@@ -193,10 +198,11 @@ impl StealthHttpClient {
         let mut builder = wreq::Client::builder()
             .emulation(emulation_opts)
             .timeout(Duration::from_secs(30))
-            // SSRF guard: reject hostnames that resolve to a private/loopback IP.
-            // `false` mirrors the `validate_url(url, false)` calls below; the
+            // SSRF guard: reject hostnames that resolve to a private/loopback
+            // IP. Use the same opt-in as the `validate_url` calls below so
+            // `--allow-private-network` reaches this transport (#793); the
             // resolver still honours OBSCURA_ALLOW_PRIVATE_NETWORK on its own.
-            .dns_resolver(Arc::new(SsrfGuardResolver::new(false)))
+            .dns_resolver(Arc::new(SsrfGuardResolver::new(allow_private_network)))
             .redirect(wreq::redirect::Policy::none());
 
         // Honor SSL_CERT_FILE / SSL_CERT_DIR in the stealth client too.
@@ -243,6 +249,7 @@ impl StealthHttpClient {
 
         StealthHttpClient {
             client,
+            allow_private_network,
             cookie_jar,
             extra_headers: RwLock::new(HashMap::new()),
             in_flight: Arc::new(std::sync::atomic::AtomicU32::new(0)),
@@ -277,7 +284,7 @@ impl StealthHttpClient {
         request: ResourceRequest,
         callbacks: Option<&CallbackRegistry>,
     ) -> Result<Response, ObscuraNetError> {
-        validate_url(url, false)?;
+        validate_url(url, self.allow_private_network)?;
         validate_request_mode(&request, url)?;
         if url.scheme() == "file" {
             return fetch_file_url(url, request.max_response_bytes).await;
@@ -395,7 +402,7 @@ impl StealthHttpClient {
                     let next_url = current_url.join(location_str).map_err(|e| {
                         ObscuraNetError::Network(format!("Invalid redirect URL: {}", e))
                     })?;
-                    validate_url(&next_url, false)?;
+                    validate_url(&next_url, self.allow_private_network)?;
                     validate_request_mode(&request, &next_url)?;
                     redirect_tainted |=
                         redirect_taints_origin(&request, &current_url, &next_url);
@@ -621,6 +628,7 @@ mod tests {
         let (port, server) = reset_fixture(false);
         let client = StealthHttpClient {
             client: wreq::Client::builder().no_proxy().build().unwrap(),
+            allow_private_network: true,
             cookie_jar: Arc::new(CookieJar::new()),
             extra_headers: tokio::sync::RwLock::new(std::collections::HashMap::new()),
             in_flight: Arc::new(std::sync::atomic::AtomicU32::new(0)),
@@ -677,5 +685,24 @@ mod tests {
         let resp = client.fetch(&url).await.expect("fixture must be reachable");
         assert_eq!(resp.status, 200);
         assert_eq!(resp.text(), PLAIN_BODY, "gzip body must be decompressed");
+    }
+
+    // #793: the opt-in must reach the DNS resolver. `validate_url` already
+    // honours it for the localhost host, so a hostname target exercises the
+    // resolver itself; before the fix the resolver was pinned to block and
+    // refused loopback hostnames even with the flag set. Only the allowed
+    // leg is asserted: CI sets OBSCURA_ALLOW_PRIVATE_NETWORK, which also
+    // lifts the default block.
+    #[tokio::test]
+    async fn stealth_client_honors_allow_private_network_for_loopback_hostnames() {
+        let port = gzip_fixture().await;
+        let client = StealthHttpClient::with_proxy(Arc::new(CookieJar::new()), None, true);
+        let url = Url::parse(&format!("http://localhost:{port}/")).unwrap();
+
+        let resp = client
+            .fetch(&url)
+            .await
+            .expect("loopback hostname must be reachable with the opt-in");
+        assert_eq!(resp.status, 200);
     }
 }


### PR DESCRIPTION
`--allow-private-network` had no effect on the stealth (wreq) transport: the `SsrfGuardResolver` was pinned to `new(false)` and the `validate_url` calls used a hardcoded `false`, so a loopback **hostname** (e.g. `http://localhost:PORT/`) was refused even with the flag set, while the reqwest path honoured it. IP literals slipped past the resolver, which is why this stayed hidden.

## Changes

- `StealthHttpClient::with_proxy` takes `allow_private_network` and stores it.
- The resolver and both `validate_url` sites (request + redirect) use the flag, mirroring the reqwest client in `client.rs`.
- `Page` passes `context.allow_private_network` through.
- The CLI `--dump original` path keeps `false` and the startup `OBSCURA_ALLOW_PRIVATE_NETWORK` mirror, exactly like its reqwest path.
- Regression test: a `localhost` target must be reachable with the opt-in. It exercises the resolver directly (`validate_url` already honoured the flag). Only the allowed leg is asserted, since CI runs with the env var set, which lifts the default block.

Verified the test fails with the resolver pinned to `false` and passes with the fix.

## Verification

- `cargo nextest run --release -p obscura-net --features stealth` in CI's two phases (default policy, then env opt-in for the gzip fixture): 92/92 + 1/1.
- Full `cargo nextest run --release --features render --no-fail-fast`: 1548/1550; the two failures (`read_body_capped_reads_body_within_cap`, `mcp_client test_wait_for_selector`) reproduce identically on unmodified `origin/main` on this Windows host and pass on Linux CI.
- No-render suites, as CI runs them: `cargo nextest run --release -p obscura` 24/24 and `--workspace --exclude obscura --exclude obscura-render --no-default-features` green except the same host-specific `read_body_capped` failure.
- Builds: `render`, `render,stealth`, `no-default-features`, `no-default-features + stealth`.
- Obstacle course on the branch binary: 31/33; `observer-intersection` fails on upstream main identically (#671), and the `fingerprint` stage fails only because this host's timezone is Europe/Moscow while the fixture expects Europe/Berlin.
- End-to-end with `--stealth`: `--allow-private-network` now reaches a `localhost` fixture; without the flag the request is still blocked (fails safe).

Fixes #793.
