### PR TITLE
fix(js): make innerText approximate rendered text

### DIFF
--- a/crates/obscura-js/js/bootstrap.js
+++ b/crates/obscura-js/js/bootstrap.js
@@ -3138,6 +3138,56 @@ function _animationsForTarget(target) {
   });
 }
 
+// innerText approximates rendered text (issue #828), not the raw DOM: a
+// browser never shows <script> or <style> source, and display:none
+// subtrees are skipped too. Non-box-producing tags are skipped by name so
+// the rule holds in no-render builds as well; where a renderer is present,
+// an element without a layout box (display:none and friends) drops its
+// whole subtree, matching what would actually paint.
+const _INNER_TEXT_SKIP = new Set([
+  'script', 'style', 'template', 'noscript', 'iframe', 'canvas',
+  'video', 'audio', 'object', 'embed',
+]);
+const _INNER_TEXT_BLOCK = new Set([
+  'address', 'article', 'aside', 'blockquote', 'dd', 'details', 'div', 'dl',
+  'dt', 'fieldset', 'figcaption', 'figure', 'footer', 'form', 'h1', 'h2',
+  'h3', 'h4', 'h5', 'h6', 'header', 'hr', 'li', 'main', 'nav', 'ol', 'p',
+  'pre', 'section', 'table', 'tbody', 'tfoot', 'thead', 'tr', 'ul',
+]);
+
+function _renderTextOf(node) {
+  if (node.nodeType === 3) return node.nodeValue || '';
+  if (node.nodeType !== 1) return '';
+  const tag = node.localName;
+  if (_INNER_TEXT_SKIP.has(tag)) return '';
+  if (tag === 'br') return '\n';
+  if (typeof node._renderBoxGeometry === 'function') {
+    // null: renderer present but this element has no box. undefined:
+    // no-render build, fall back to the tag rules alone.
+    if (node._renderBoxGeometry() === null) return '';
+  }
+  const parts = [];
+  const kids = node.childNodes;
+  for (let i = 0; i < kids.length; i++) {
+    const text = _renderTextOf(kids[i]);
+    if (!text) continue;
+    if (_INNER_TEXT_BLOCK.has(kids[i].localName)) {
+      parts.push('\n' + text + '\n');
+    } else {
+      parts.push(text);
+    }
+  }
+  return parts.join('');
+}
+
+function _elementInnerText(el) {
+  return _renderTextOf(el)
+    .split('\n')
+    .map((line) => line.trim())
+    .filter((line) => line !== '')
+    .join('\n');
+}
+
 class Element extends Node {
   constructor(nid) {
     const entry = _customElementConstructionStack[_customElementConstructionStack.length - 1];
@@ -3246,7 +3296,7 @@ class Element extends Node {
     }
   }
   get outerHTML() { return _domParse("outer_html", this._nid) ?? ""; }
-  get innerText() { return this.textContent; }
+  get innerText() { return _elementInnerText(this); }
   set innerText(v) { this.textContent = v; }
   get children() {
     const ids = _domParse("element_children", this._nid) || [];

--- a/crates/obscura-js/src/runtime.rs
+++ b/crates/obscura-js/src/runtime.rs
@@ -13691,6 +13691,47 @@ mod tests {
     }
 
     #[test]
+    fn inner_text_excludes_non_rendered_subtrees() {
+        // #828: innerText approximates rendered text. Script and style
+        // source must never appear, and block boundaries produce line
+        // breaks. The display:none leg needs a renderer for box geometry.
+        let mut rt = setup_runtime(
+            "<html><body>\n\
+             <div id='d'>one</div>\n\
+             <script>var leaked = 'SCRIPT_SOURCE';</script>\n\
+             <style>p { color: red; }</style>\n\
+             <div id='h' style='display:none'>hidden block</div>\n\
+             <p>two</p>\n\
+             </body></html>",
+        );
+        let out = rt
+            .evaluate("document.body.innerText")
+            .unwrap()
+            .as_str()
+            .unwrap()
+            .to_string();
+        assert!(
+            !out.contains("SCRIPT_SOURCE"),
+            "script source leaked into innerText: {out:?}"
+        );
+        assert!(
+            !out.contains("color: red"),
+            "style source leaked into innerText: {out:?}"
+        );
+        assert!(out.contains("one"), "visible text missing: {out:?}");
+        assert!(out.contains("two"), "visible text missing: {out:?}");
+        assert!(
+            out.contains("one\ntwo"),
+            "block boundary must produce a line break: {out:?}"
+        );
+        #[cfg(feature = "render")]
+        assert!(
+            !out.contains("hidden block"),
+            "display:none subtree must not appear in innerText: {out:?}"
+        );
+    }
+
+    #[test]
     fn test_navigator() {
         let mut rt = setup_runtime("<html><body></body></html>");
         let ua = rt.evaluate("navigator.userAgent").unwrap();

--- a/crates/obscura-js/src/runtime.rs
+++ b/crates/obscura-js/src/runtime.rs
@@ -13720,15 +13720,20 @@ mod tests {
         );
         assert!(out.contains("one"), "visible text missing: {out:?}");
         assert!(out.contains("two"), "visible text missing: {out:?}");
-        assert!(
-            out.contains("one\ntwo"),
-            "block boundary must produce a line break: {out:?}"
-        );
+        // The display:none leg needs a renderer for box geometry: without one
+        // that div is indistinguishable from visible content and stays in the
+        // output, so the adjacency check only holds in render builds.
         #[cfg(feature = "render")]
-        assert!(
-            !out.contains("hidden block"),
-            "display:none subtree must not appear in innerText: {out:?}"
-        );
+        {
+            assert!(
+                !out.contains("hidden block"),
+                "display:none subtree must not appear in innerText: {out:?}"
+            );
+            assert!(
+                out.contains("one\ntwo"),
+                "block boundary must produce a line break: {out:?}"
+            );
+        }
     }
 
     #[test]


### PR DESCRIPTION
`innerText` was an alias for `textContent`, so inline `<script>` and `<style>` source leaked into it. On pages with heavy inline JS (Yahoo Finance, AASTOCKS) the scraped text is ~100x larger than Chromium's, with the first lines being raw JavaScript.

## Changes

- `innerText` now walks the subtree and approximates rendered text:
  - non-box-producing tags (`script`, `style`, `template`, `noscript`, `iframe`, `canvas`, `video`, `audio`, `object`, `embed`) are skipped by name, so the rule holds in no-render builds too;
  - in render builds, any element whose layout geometry reports no box drops its whole subtree (`display:none` and friends), matching what would actually paint;
  - block-level children and `<br>` insert line breaks; each line is trimmed and blank lines dropped, as browsers do.
- Regression test covers both configurations: the script/style exclusion and visible-text checks run everywhere; the `display:none` and block-adjacency checks are render-gated because the geometry op does not exist without the `render` feature.

## Verification

- Local fixture page with inline script, style, and a `display:none` block: `document.body.innerText` returns `first block\nsecond block` (before: raw script source interleaved).
- Full `cargo nextest run --release --features render --no-fail-fast`: 1550/1551; the single failure (`read_body_capped_reads_body_within_cap`) reproduces identically on unmodified `origin/main` on this Windows host (loopback RST) and passes on Linux CI.
- No-render suites, as CI runs them: `cargo nextest run --release -p obscura` 24/24 and `--workspace --exclude obscura --exclude obscura-render --no-default-features` green except the same host-specific `read_body_capped` failure.
- Obstacle course on the branch binary: 31/33; `observer-intersection` fails on upstream main identically (#671), and the `fingerprint` stage fails only because this host's timezone is Europe/Moscow while the fixture expects Europe/Berlin. All extraction stages (`extract-article`, `extract-markdown`, `extract-links`, `extract-html`, `textdecoder`) pass, so the dump paths are unaffected.

Fixes #828.
