### PR TITLE
fix(cdp): implement Input.insertText and label association getters

### DIFF
--- a/crates/obscura-cdp/src/domains/input.rs
+++ b/crates/obscura-cdp/src/domains/input.rs
@@ -316,6 +316,15 @@ pub async fn handle(
 
             Ok(json!({}))
         }
+        // Chrome's Input.insertText: Playwright's fill() focuses the field in
+        // page and then types the whole value through this one call (#577).
+        "insertText" => {
+            let text = params.get("text").and_then(|v| v.as_str()).unwrap_or("");
+            if let Some(page) = ctx.get_session_page_mut(session_id) {
+                page.evaluate(&insert_text_js(text));
+            }
+            Ok(json!({}))
+        }
         "dispatchKeyEvent" => {
             let event_type = params.get("type").and_then(|v| v.as_str()).unwrap_or("");
             let key = params.get("key").and_then(|v| v.as_str()).unwrap_or("");

--- a/crates/obscura-cdp/tests/input_key_event_escaping.rs
+++ b/crates/obscura-cdp/tests/input_key_event_escaping.rs
@@ -164,3 +164,52 @@ async fn dispatch_key_event_char_carries_a_newline_into_a_textarea() {
         "a newline sent as a char must reach the field, not be dropped by a malformed snippet"
     );
 }
+
+// #577: Playwright's fill() focuses the field in page and then types the whole
+// value with one Input.insertText call. The method must exist and drive the
+// same snippet the key-event text path uses, so quotes, backslashes, and
+// newlines survive intact.
+#[tokio::test(flavor = "current_thread")]
+async fn insert_text_types_into_the_focused_field() {
+    std::env::set_var("OBSCURA_ALLOW_PRIVATE_NETWORK", "1");
+    let url = serve_page().await;
+    let mut ctx = CdpContext::new();
+    let page_id = ctx.create_page();
+    let session_id = "session-1";
+    ctx.sessions.insert(session_id.to_string(), page_id.clone());
+
+    cdp(&mut ctx, 1, "Page.navigate", json!({"url": url, "waitUntil": "load"}), session_id).await;
+    cdp(
+        &mut ctx,
+        2,
+        "Runtime.evaluate",
+        json!({"expression": "document.getElementById('i').focus()", "returnByValue": true}),
+        session_id,
+    )
+    .await;
+    cdp(
+        &mut ctx,
+        3,
+        "Input.insertText",
+        json!({"text": "he'll\\o\nbye"}),
+        session_id,
+    )
+    .await;
+
+    let v = cdp(
+        &mut ctx,
+        4,
+        "Runtime.evaluate",
+        json!({
+            "expression": "JSON.stringify(document.getElementById('i').value)",
+            "returnByValue": true,
+        }),
+        session_id,
+    )
+    .await;
+    assert_eq!(
+        v["result"]["value"].as_str().unwrap_or_default(),
+        r#""he'll\\o\nbye""#,
+        "insertText must type the full text with quotes, backslashes, and newlines intact"
+    );
+}

--- a/crates/obscura-js/js/bootstrap.js
+++ b/crates/obscura-js/js/bootstrap.js
@@ -2799,6 +2799,25 @@ function _isSubmitButton(el) {
   return false;
 }
 
+// The HTML labelable-elements list (hidden inputs excluded), shared by the
+// Element.labels and HTMLLabelElement.control getters.
+function _isLabelable(el) {
+  if (!el || typeof el.localName !== "string") return false;
+  switch (el.localName) {
+    case "button":
+    case "meter":
+    case "output":
+    case "progress":
+    case "select":
+    case "textarea":
+      return true;
+    case "input":
+      return (((el.getAttribute && el.getAttribute("type")) || "").toLowerCase()) !== "hidden";
+    default:
+      return false;
+  }
+}
+
 // Carry the context element's full qualified name into html5ever. Fragment
 // parsing depends on both the local name and namespace (SVG/MathML included).
 function _fragmentContextPayload(context, html) {
@@ -4297,6 +4316,45 @@ class Element extends Node {
     let p = this.parentNode;
     while (p && p.localName !== 'form') p = p.parentNode;
     return p;
+  }
+  // Label association, per the HTML labelable-elements list. Playwright's
+  // getByLabel and its follow-label retargeting read these; without them a
+  // label-linked control is invisible to that engine.
+  get labels() {
+    if (!_isLabelable(this)) return _nodeList([]);
+    const doc = this.ownerDocument;
+    if (!doc || !doc.querySelectorAll) return _nodeList([]);
+    const out = [];
+    const id = this.getAttribute('id');
+    if (id) {
+      // Filter in JS rather than building a selector: an id containing a
+      // quote would break out of label[for="..."].
+      const all = doc.querySelectorAll('label');
+      for (let i = 0; i < all.length; i++) {
+        if (all[i].getAttribute('for') === id) out.push(all[i]);
+      }
+    }
+    let p = this.parentNode;
+    while (p) {
+      if (p.localName === 'label') out.push(p);
+      p = p.parentNode;
+    }
+    return _nodeList(out);
+  }
+  get control() {
+    if (this.localName !== 'label') return null;
+    const doc = this.ownerDocument;
+    const forId = this.getAttribute('for');
+    if (forId) {
+      if (!doc || !doc.getElementById) return null;
+      const target = doc.getElementById(forId);
+      return target && _isLabelable(target) ? target : null;
+    }
+    const candidates = this.querySelectorAll('button, input, meter, output, progress, select, textarea');
+    for (let i = 0; i < candidates.length; i++) {
+      if (_isLabelable(candidates[i])) return candidates[i];
+    }
+    return null;
   }
   get options() {
     if (this.localName !== 'select') return [];

--- a/crates/obscura-js/src/runtime.rs
+++ b/crates/obscura-js/src/runtime.rs
@@ -17874,4 +17874,47 @@ mod tests {
             "Intl must not leak the host OS locale while navigator.language says en-US"
         );
     }
+
+    // Momentic POC / Playwright getByLabel: the label association getters must
+    // link <label for> to its control and expose element.labels, both for
+    // for-linked and wrapping labels.
+    #[test]
+    fn label_control_and_labels_link_labelable_elements() {
+        let mut rt = setup_runtime(
+            r#"<html><body>
+            <label for="name" id="l1">Name</label><input id="name">
+            <label id="l2">Age <input id="age"></label>
+            <input type="hidden" id="hid">
+            <div id="plain"></div>
+            </body></html>"#,
+        );
+        let result = rt
+            .evaluate(
+                r#"(function() {
+                    var l1 = document.getElementById('l1');
+                    var l2 = document.getElementById('l2');
+                    var name = document.getElementById('name');
+                    var age = document.getElementById('age');
+                    var hid = document.getElementById('hid');
+                    var plain = document.getElementById('plain');
+                    return [
+                        l1.control === name,
+                        l2.control === age,
+                        name.labels.length,
+                        name.labels[0] === l1,
+                        age.labels.length,
+                        age.labels[0] === l2,
+                        hid.labels.length,
+                        plain.labels.length,
+                        plain.control === null,
+                    ].join(',');
+                })()"#,
+            )
+            .unwrap();
+        assert_eq!(
+            result,
+            serde_json::json!("true,true,1,true,1,true,0,0,true"),
+            "label association must follow the HTML labelable-element rules"
+        );
+    }
 }


### PR DESCRIPTION
Input.insertText had no handler, so Playwright's fill() failed with 'Unknown Input method: insertText'. The method now drives the existing insert_text_js snippet. Playwright's getByLabel also needs the DOM label association: Element.labels and HTMLLabelElement.control now follow the HTML labelable-elements rules, for both for-linked and wrapping labels.

Fixes #577.

## What changed

Two gaps blocked Playwright form filling over CDP, reported by a Momentic compatibility POC against v0.2.1:

• `Input.insertText` had no dispatch arm, so `locator.fill()` (and any raw insertText client) got a protocol error. It now drives the existing `insert_text_js` snippet on the session page, the same path `dispatchKeyEvent` uses for typed text, so quotes, backslashes, and newlines survive.
• `getByLabel` never resolved because the label association was missing from the DOM layer: `Element.labels` returned nothing useful and `HTMLLabelElement` was a bare `Element` alias with no `control`. Both getters now follow the HTML labelable-elements list (button, input except hidden, meter, output, progress, select, textarea), covering `for`-linked and wrapping labels.

## Validation

• Momentic-style probe: Playwright Core `connectOverCDP` against `obscura serve`, local fixture with a labeled input. `getByLabel("Name").fill("hello")` now passes and fires the page's `input` listener; `page.screenshot()` returns a valid PNG; navigator identity is populated. Same result in render and render+stealth builds.
• New regression tests:
• `obscura-cdp::input_key_event_escaping::insert_text_types_into_the_focused_field` (insertText with quotes, backslash, newline)
• `obscura-js runtime::tests::label_control_and_labels_link_labelable_elements` (for-linked, wrapping, hidden-input, and non-labelable cases)
• Full suite: `cargo nextest run --release --features render --no-fail-fast` -> 1581 passed, 0 failed, 4 skipped.
• Obstacle course: `OBSCURA_BIN=./target/release/obscura python3 obstacle-course/run.py --runs 1 --warmup 0` -> 33/33.

## Rendering

Not applicable.

## Performance

The new CDP arm runs once per insertText call. The `labels` getter scans `document.querySelectorAll('label')` only when the element is labelable and has an id; the scan is JS-side filtering, no selector parsing of the id. No hot path, memory, or rendering changes.

## Checklist

• [x] The change is focused and does not remove existing behavior without justification.
• [x] Tests cover the failure or feature.
• [x] Existing tests pass, including render and no-render configurations when affected.
• [x] I checked for CPU, latency, and memory regressions.
• [x] Public API or user-facing behavior changes are documented.