### PR TITLE
fix(cdp): emit the initial load events on Page.enable

### DIFF
--- a/crates/obscura-cdp/src/dispatch.rs
+++ b/crates/obscura-cdp/src/dispatch.rs
@@ -44,6 +44,11 @@ pub struct CdpContext {
     /// script-initiated Network events must share this id; inventing a loader
     /// for each fetch breaks DevTools request grouping.
     pub current_loader_ids: HashMap<String, String>,
+    /// Pages whose initial navigation event sequence has been emitted. A page
+    /// is created already loaded (about:blank), but Chrome emits that load's
+    /// events when the client attaches; Page.enable emits them once per page
+    /// so clients waiting on the initial load (chromiumoxide, #833) unblock.
+    pub nav_events_emitted: std::collections::HashSet<String>,
     /// Child frame ids already reported to the client, per page, so each frame
     /// is announced once and a frame that goes away can be retracted.
     pub announced_frames: HashMap<String, Vec<String>>,
@@ -167,6 +172,7 @@ impl CdpContext {
             pages: Vec::new(),
             sessions: HashMap::new(),
             current_loader_ids: HashMap::new(),
+            nav_events_emitted: std::collections::HashSet::new(),
             announced_frames: HashMap::new(),
             pending_events: Vec::new(),
             #[cfg(feature = "render")]

--- a/crates/obscura-cdp/src/domains/page.rs
+++ b/crates/obscura-cdp/src/domains/page.rs
@@ -850,6 +850,7 @@ pub fn emit_navigation_events(
 ) {
     ctx.current_loader_ids
         .insert(page_id.to_string(), loader_id.to_string());
+    ctx.nav_events_emitted.insert(page_id.to_string());
     let es = session_id.clone();
     let ts = timestamp();
 
@@ -1259,7 +1260,47 @@ pub async fn handle(
     session_id: &Option<String>,
 ) -> Result<Value, String> {
     match method {
-        "enable" => Ok(json!({})),
+        "enable" => {
+            // Chrome loads a new target's initial about:blank right after
+            // createTarget, so by the time a client attaches and calls
+            // Page.enable the page has already produced its load events.
+            // obscura creates pages silently, which starves clients that wait
+            // for the initial load: chromiumoxide's new_page blocks until the
+            // main frame's "load" lifecycle event arrives (#833). Emit those
+            // events once, the first time a session enables the page domain
+            // on a page that has not emitted a navigation. This is not a
+            // document change, so there is no execution-context churn: the
+            // existing context announced by Runtime.enable stays valid.
+            let initial = ctx.get_session_page(session_id).and_then(|page| {
+                if ctx.nav_events_emitted.contains(&page.id) {
+                    return None;
+                }
+                Some((page.id.clone(), page.frame_id.clone(), page.url_string()))
+            });
+            if let Some((page_id, frame_id, url)) = initial {
+                ctx.nav_events_emitted.insert(page_id.clone());
+                let ts = timestamp();
+                let loader_id = format!("loader-blank-{page_id}");
+                let es = session_id.clone();
+                // Build the frame through the schema-complete helper: generated
+                // CDP clients (chromiumoxide) reject a frameNavigated payload
+                // missing secureContextType/crossOriginIsolatedContextType and
+                // drop the whole connection (#833).
+                let frame = frame_value(&frame_id, None, &loader_id, &url, "text/html");
+                let events = vec![
+                    CdpEvent { method: "Page.frameNavigated".into(), params: json!({"frame": frame, "type": "Navigation"}), session_id: es.clone() },
+                    CdpEvent { method: "Page.lifecycleEvent".into(), params: json!({"frameId": frame_id, "loaderId": loader_id, "name": "commit", "timestamp": ts}), session_id: es.clone() },
+                    CdpEvent { method: "Page.lifecycleEvent".into(), params: json!({"frameId": frame_id, "loaderId": loader_id, "name": "DOMContentLoaded", "timestamp": ts}), session_id: es.clone() },
+                    CdpEvent { method: "Page.domContentEventFired".into(), params: json!({"timestamp": ts}), session_id: es.clone() },
+                    CdpEvent { method: "Page.lifecycleEvent".into(), params: json!({"frameId": frame_id, "loaderId": loader_id, "name": "load", "timestamp": ts}), session_id: es.clone() },
+                    CdpEvent { method: "Page.loadEventFired".into(), params: json!({"timestamp": ts}), session_id: es.clone() },
+                    CdpEvent { method: "Page.lifecycleEvent".into(), params: json!({"frameId": frame_id, "loaderId": loader_id, "name": "networkIdle", "timestamp": ts}), session_id: es.clone() },
+                    CdpEvent { method: "Page.frameStoppedLoading".into(), params: json!({"frameId": frame_id, "timestamp": ts}), session_id: es },
+                ];
+                ctx.pending_events.extend(events);
+            }
+            Ok(json!({}))
+        }
         "navigate" => {
             let url = params
                 .get("url")
@@ -1729,6 +1770,57 @@ fn timestamp() -> f64 {
 mod tests {
     use super::*;
     use crate::dispatch::CdpContext;
+
+    // #833: chromiumoxide's new_page waits for the initial target's "load"
+    // lifecycle event before returning. Page.enable on a freshly created
+    // (silently loaded) page must emit the initial load sequence once, with a
+    // schema-complete frame, and must not replay it on a second enable.
+    #[tokio::test(flavor = "current_thread")]
+    async fn page_enable_emits_the_initial_load_events_once() {
+        let mut ctx = CdpContext::new();
+        let page_id = ctx.create_page();
+        let session = Some(format!("{page_id}-session"));
+        ctx.sessions.insert(session.clone().unwrap(), page_id);
+
+        handle("enable", &json!({}), &mut ctx, &session)
+            .await
+            .expect("enable must succeed");
+        let names: Vec<&str> = ctx
+            .pending_events
+            .iter()
+            .map(|e| e.method.as_str())
+            .collect();
+        assert!(
+            names.contains(&"Page.frameNavigated"),
+            "frameNavigated must be emitted, got {names:?}"
+        );
+        assert!(
+            names.contains(&"Page.loadEventFired"),
+            "loadEventFired must be emitted, got {names:?}"
+        );
+        let frame_navigated = ctx
+            .pending_events
+            .iter()
+            .find(|e| e.method == "Page.frameNavigated")
+            .expect("frameNavigated present");
+        let frame = &frame_navigated.params["frame"];
+        for field in ["id", "loaderId", "url", "secureContextType", "crossOriginIsolatedContextType"] {
+            assert!(
+                !frame[field].is_null(),
+                "frameNavigated frame must carry {field}: {frame}"
+            );
+        }
+        assert!(ctx.pending_events.is_empty() == false);
+
+        ctx.pending_events.clear();
+        handle("enable", &json!({}), &mut ctx, &session)
+            .await
+            .expect("second enable must succeed");
+        assert!(
+            ctx.pending_events.is_empty(),
+            "the initial sequence must not replay on a second enable"
+        );
+    }
 
     #[test]
     fn runtime_network_events_reuse_the_document_loader_without_lifecycle_replay() {

--- a/crates/obscura-cdp/src/server.rs
+++ b/crates/obscura-cdp/src/server.rs
@@ -1608,7 +1608,7 @@ fn fast_path_response(text: &str) -> Option<String> {
 
     let result = match req.method.as_str() {
         "Network.enable" | "Network.setCacheDisabled" | "Network.setRequestInterception" |
-        "Page.enable" | "Page.setLifecycleEventsEnabled" | "Page.setInterceptFileChooserDialog" |
+        "Page.setLifecycleEventsEnabled" | "Page.setInterceptFileChooserDialog" |
         "Runtime.runIfWaitingForDebugger" | "Runtime.discardConsoleEntries" |
         "Performance.enable" | "Log.enable" | "Security.enable" |
         "Emulation.setTouchEmulationEnabled" |


### PR DESCRIPTION
Chrome loads a new target's initial about:blank right after createTarget, so by the time a client attaches and calls Page.enable the page has already produced its navigation events. obscura created pages silently and Page.enable was answered by a fast path that never reached the domain handler, so clients waiting for the initial load hung forever: chromiumoxide's new_page blocks until the main frame's load lifecycle event, and its strict Frame payload parser dropped the connection on the schema-incomplete frameNavigated.

Page.enable now goes to the domain handler, which emits the initial frameNavigated + lifecycle sequence once per page, with the frame built by the schema-complete frame_value helper. No execution-context churn: this is not a document change.

Fixes #833.

## What changed

• `Page.enable` removed from the server fast path so the domain handler runs (the handler only reads page state and queues events, so it stays on the lock-free `is_v8_free_method` path).
• On the first Page.enable for a page that has not emitted a navigation, the handler queues the initial load sequence: frameNavigated (frame built by `frame_value`, so generated clients accept it), lifecycle commit/DOMContentLoaded/load/networkIdle, domContentEventFired, loadEventFired, frameStoppedLoading. Tracked in a new `nav_events_emitted` set so it fires exactly once per page and never replays after real navigations.
• Unlike the full navigation emitter, this initial sequence does not clear or re-announce execution contexts: about:blank was never a document change for the client.

## Validation

• Reproduced the hang with a real chromiumoxide 0.7 client (spider's driver lineage): `new_page` timed out before, and chromiumoxide's serde dropped the connection on the incomplete frame payload. After the fix: connect, new_page, evaluate all pass.
• Playwright Core regression probe (connectOverCDP: navigate, locator fill, screenshot) unaffected.
• New regression test `page_enable_emits_the_initial_load_events_once`: asserts the sequence fires on first enable, carries all schema-required frame fields, and does not replay on a second enable. `cargo nextest run --release --features render -p obscura-cdp page_enable`
• Full suite: `cargo nextest run --release --features render --no-fail-fast` -> 1582 passed, 0 failed.
• Obstacle course 33/33.

## Rendering

Not applicable.

## Performance

Page.enable now queues eight small events once per page instead of returning from the fast path. No runtime path, memory, or rendering impact beyond that.

## Checklist

• [x] The change is focused and does not remove existing behavior without justification.
• [x] Tests cover the failure or feature.
• [x] Existing tests pass, including render and no-render configurations when affected.
• [x] I checked for CPU, latency, and memory regressions.
• [x] Public API or user-facing behavior changes are documented.