### PR TITLE
fix(js): repair merged runtime integrations

### DIFF
--- a/crates/obscura-js/src/runtime.rs
+++ b/crates/obscura-js/src/runtime.rs
@@ -1986,7 +1986,7 @@ impl ObscuraJsRuntime {
         );
         if !return_by_value {
             self.evaluation_recipes
-                .insert(oid.clone(), cleaned_expr.to_string());
+                .insert(oid.clone(), expression.to_string());
         }
 
         if return_by_value {
@@ -2415,7 +2415,7 @@ impl ObscuraJsRuntime {
                 let message = panic_payload_message(payload.as_ref());
                 let outcome = if message.contains("Module already evaluated") {
                     self
-                        .runtime
+                        .runtime()
                         .get_module_namespace(module_id)
                         .map(|_| ())
                         .map_err(|error| format!("{} eval error: {}", what, error))
@@ -2443,7 +2443,7 @@ impl ObscuraJsRuntime {
 
         let outcome = match outcome {
             Ok(Ok(())) => self
-                .runtime
+                .runtime()
                 .get_module_namespace(module_id)
                 .map(|_| ())
                 .map_err(|error| format!("{} eval error: {}", what, error)),


### PR DESCRIPTION
## Summary

- retain the original CDP evaluation expression after the evaluation refactor
- use the entered-runtime accessor for module namespace checks
- restore compilation after the recent runtime and execution-context merges

## Verification

- focused release render nextest: 9/9
- full release render nextest: 1632/1632 passed, 4 skipped
- exact obscura-cli release render build: passed
- obstacle course: 32/33, with only the existing observer-intersection failure covered by #786

No public API or browser behavior changes.