### PR TITLE
fix(cdp): repair the build after the 747/790/756 interaction, accept …

### DIFF
--- a/crates/obscura-cdp/src/domains/browser.rs
+++ b/crates/obscura-cdp/src/domains/browser.rs
@@ -31,6 +31,12 @@ pub async fn handle(method: &str, _params: &Value) -> Result<Value, String> {
         // lets the client's setup sequence complete instead of tearing down
         // the page on an unknown-method error.
         "setWindowBounds" => Ok(json!({})),
+        // Playwright grants permissions (geolocation, notifications, ...) per
+        // browser context during setup. obscura does not gate any API on a
+        // permission grant today, so the honest answer is to accept and
+        // remember nothing; an unknown-method error would abort the client's
+        // whole context initialization.
+        "grantPermissions" | "resetPermissions" => Ok(json!({})),
         _ => Err(format!("Unknown Browser method: {}", method)),
     }
 }

--- a/crates/obscura-js/js/bootstrap.js
+++ b/crates/obscura-js/js/bootstrap.js
@@ -9725,6 +9725,11 @@ globalThis.IntersectionObserver = class IntersectionObserver {
 })();
 globalThis.IntersectionObserverEntry = class IntersectionObserverEntry {};
 globalThis.PerformanceObserver = class { constructor(){} observe(){} disconnect(){} };
+// Feature detection reads this static before deciding to observe anything;
+// absent it, supportedEntryTypes.includes(...) throws and instrumentation
+// bails. Report only types the engine can actually emit records for.
+PerformanceObserver.supportedEntryTypes = ["mark", "measure", "navigation", "resource", "paint"];
+_markNative(PerformanceObserver);
 
 globalThis.DOMException = (function () {
   const NAME_TO_CODE = {

--- a/crates/obscura-js/src/runtime.rs
+++ b/crates/obscura-js/src/runtime.rs
@@ -1985,8 +1985,10 @@ impl ObscuraJsRuntime {
             format!("globalThis.__obscura_objects['{}']", oid),
         );
         if !return_by_value {
+            // The eval-based wrapper above parses the raw expression as
+            // statements, so no trailing-semicolon trim is needed here.
             self.evaluation_recipes
-                .insert(oid.clone(), cleaned_expr.to_string());
+                .insert(oid.clone(), expression.to_string());
         }
 
         if return_by_value {
@@ -2415,7 +2417,7 @@ impl ObscuraJsRuntime {
                 let message = panic_payload_message(payload.as_ref());
                 let outcome = if message.contains("Module already evaluated") {
                     self
-                        .runtime
+                        .runtime()
                         .get_module_namespace(module_id)
                         .map(|_| ())
                         .map_err(|error| format!("{} eval error: {}", what, error))
@@ -2443,7 +2445,7 @@ impl ObscuraJsRuntime {
 
         let outcome = match outcome {
             Ok(Ok(())) => self
-                .runtime
+                .runtime()
                 .get_module_namespace(module_id)
                 .map(|_| ())
                 .map_err(|error| format!("{} eval error: {}", what, error)),


### PR DESCRIPTION


Merging #747, #790 and the #756 isolate-entry refactor in any order left main not compiling: a removed cleaned_expr binding still fed evaluation_recipes, and two module-eval paths still read the runtime as a field. Reconcile both call sites.

Browser.grantPermissions/resetPermissions previously returned an unknown-method error, which aborts Playwright's browser-context setup. Accept them as no-ops; no engine API is gated on permission grants today.

PerformanceObserver.supportedEntryTypes was undefined, so clients that feature-detect with supportedEntryTypes.includes() threw. Report the entry types the engine actually emits records for.
