### PR TITLE
Fix/main build and cdp gaps

### DIFF
--- a/crates/obscura-cli/build.rs
+++ b/crates/obscura-cli/build.rs
@@ -21,6 +21,25 @@ fn github_tag_version() -> Option<String> {
         .map(normalize_version)
 }
 
+/// Local builds are not cut from a tag, so the bare workspace version cannot
+/// tell two checkouts apart. Append the commit when git is there to answer;
+/// tarball and minimal-image builds without git keep the bare version.
+fn local_version() -> String {
+    let package = env::var("CARGO_PKG_VERSION").expect("Cargo sets CARGO_PKG_VERSION");
+    let sha = std::process::Command::new("git")
+        .args(["rev-parse", "--short", "HEAD"])
+        .output()
+        .ok()
+        .filter(|out| out.status.success())
+        .and_then(|out| String::from_utf8(out.stdout).ok())
+        .map(|sha| sha.trim().to_string())
+        .filter(|sha| !sha.is_empty());
+    match sha {
+        Some(sha) => format!("{package}-dev+{sha}"),
+        None => package,
+    }
+}
+
 fn main() {
     println!("cargo:rerun-if-env-changed=OBSCURA_VERSION");
     println!("cargo:rerun-if-env-changed=GITHUB_REF_TYPE");
@@ -30,7 +49,7 @@ fn main() {
     let version = env_value("OBSCURA_VERSION")
         .map(normalize_version)
         .or_else(github_tag_version)
-        .unwrap_or_else(|| env::var("CARGO_PKG_VERSION").expect("Cargo sets CARGO_PKG_VERSION"));
+        .unwrap_or_else(local_version);
 
     println!("cargo:rustc-env=OBSCURA_BUILD_VERSION={version}");
 }

--- a/crates/obscura-mcp/build.rs
+++ b/crates/obscura-mcp/build.rs
@@ -1,0 +1,36 @@
+use std::env;
+
+fn env_value(name: &str) -> Option<String> {
+    env::var(name)
+        .ok()
+        .map(|value| value.trim().to_string())
+        .filter(|value| !value.is_empty())
+}
+
+fn normalize_version(version: String) -> String {
+    version.strip_prefix('v').unwrap_or(&version).to_string()
+}
+
+fn github_tag_version() -> Option<String> {
+    if env_value("GITHUB_REF_TYPE").as_deref() == Some("tag") {
+        return env_value("GITHUB_REF_NAME").map(normalize_version);
+    }
+
+    env_value("GITHUB_REF")
+        .and_then(|value| value.strip_prefix("refs/tags/").map(str::to_owned))
+        .map(normalize_version)
+}
+
+fn main() {
+    println!("cargo:rerun-if-env-changed=OBSCURA_VERSION");
+    println!("cargo:rerun-if-env-changed=GITHUB_REF_TYPE");
+    println!("cargo:rerun-if-env-changed=GITHUB_REF_NAME");
+    println!("cargo:rerun-if-env-changed=GITHUB_REF");
+
+    let version = env_value("OBSCURA_VERSION")
+        .map(normalize_version)
+        .or_else(github_tag_version)
+        .unwrap_or_else(|| env::var("CARGO_PKG_VERSION").expect("Cargo sets CARGO_PKG_VERSION"));
+
+    println!("cargo:rustc-env=OBSCURA_BUILD_VERSION={version}");
+}

--- a/crates/obscura-mcp/build.rs
+++ b/crates/obscura-mcp/build.rs
@@ -21,6 +21,25 @@ fn github_tag_version() -> Option<String> {
         .map(normalize_version)
 }
 
+/// Local builds are not cut from a tag, so the bare workspace version cannot
+/// tell two checkouts apart. Append the commit when git is there to answer;
+/// tarball and minimal-image builds without git keep the bare version.
+fn local_version() -> String {
+    let package = env::var("CARGO_PKG_VERSION").expect("Cargo sets CARGO_PKG_VERSION");
+    let sha = std::process::Command::new("git")
+        .args(["rev-parse", "--short", "HEAD"])
+        .output()
+        .ok()
+        .filter(|out| out.status.success())
+        .and_then(|out| String::from_utf8(out.stdout).ok())
+        .map(|sha| sha.trim().to_string())
+        .filter(|sha| !sha.is_empty());
+    match sha {
+        Some(sha) => format!("{package}-dev+{sha}"),
+        None => package,
+    }
+}
+
 fn main() {
     println!("cargo:rerun-if-env-changed=OBSCURA_VERSION");
     println!("cargo:rerun-if-env-changed=GITHUB_REF_TYPE");
@@ -30,7 +49,7 @@ fn main() {
     let version = env_value("OBSCURA_VERSION")
         .map(normalize_version)
         .or_else(github_tag_version)
-        .unwrap_or_else(|| env::var("CARGO_PKG_VERSION").expect("Cargo sets CARGO_PKG_VERSION"));
+        .unwrap_or_else(local_version);
 
     println!("cargo:rustc-env=OBSCURA_BUILD_VERSION={version}");
 }

--- a/crates/obscura-mcp/src/lib.rs
+++ b/crates/obscura-mcp/src/lib.rs
@@ -304,7 +304,9 @@ fn handle_initialize(id: Value, params: &Value) -> RpcResponse {
         },
         "serverInfo": {
             "name": "obscura-mcp",
-            "version": env!("CARGO_PKG_VERSION")
+            // Same build version the CLI reports (tag-derived at release time),
+            // so MCP clients see the version the binary was actually cut from.
+            "version": env!("OBSCURA_BUILD_VERSION")
         }
     }))
 }


### PR DESCRIPTION
 Local builds are not cut from a tag, so the bare workspace version cannot tell two checkouts apart. Append the commit when git is there to answer; tarball and minimal-image builds without git keep the bare version.