### PR TITLE
fix(js): hit-test by paint order, not document order

### DIFF
--- a/crates/obscura-js/js/bootstrap.js
+++ b/crates/obscura-js/js/bootstrap.js
@@ -15056,6 +15056,54 @@ if (typeof Element !== 'undefined' && !Element.prototype.toggleAttribute) {
   };
 }
 
+// Rank hit-test candidates the way the page paints them.
+//
+// The renderer already sorts boxes into the CSS 2.1 Appendix E stacking bands
+// to build its display list, so the order it reaches them in IS paint order.
+// `op_paint_slots` reports that position rather than recomputing z-order here:
+// a comparator written in JS would have to read `z-index` through
+// `getComputedStyle`, which only surfaces inline styles, so anything styled
+// from a <style> block would silently rank as z:0.
+//
+// Returns the candidates front-to-back (topmost first). Without the op — the
+// no-render build registers no layout — this falls back to document order,
+// which is what hit testing did before paint order was available.
+function __rankHitCandidates(candidates) {
+  if (candidates.length < 2) return candidates.slice();
+
+  var slots = null;
+  try {
+    var op = Deno.core.ops.op_paint_slots;
+    if (op) {
+      var reply = op(candidates.map(function(el) { return el._nid | 0; }).join(','));
+      if (reply) {
+        slots = reply.split(',').map(function(v) { return parseInt(v, 10); });
+        if (slots.length !== candidates.length) slots = null;
+      }
+    }
+  } catch (_e) {
+    slots = null;
+  }
+
+  var ranked = candidates.map(function(el, i) {
+    var slot = slots ? slots[i] : -1;
+    return {
+      el: el,
+      // A boxless element (-1) cannot be ordered by paint; keep it below
+      // anything that paints, and settle it by document order as before.
+      slot: (typeof slot === 'number' && !isNaN(slot)) ? slot : -1,
+      nid: el._nid | 0,
+    };
+  });
+
+  ranked.sort(function(a, b) {
+    if (a.slot !== b.slot) return b.slot - a.slot;
+    return b.nid - a.nid;
+  });
+
+  return ranked.map(function(entry) { return entry.el; });
+}
+
 // Document.elementFromPoint / elementsFromPoint — no layout engine, so this is a stub:
 // in-viewport coords return <body> (or <html> as fallback), out-of-viewport returns null.
 // Wrong-but-non-throwing beats "undefined", which traps ad/analytics bootstraps in retry loops
@@ -15068,22 +15116,18 @@ if (typeof Document !== 'undefined' && !Document.prototype.elementFromPoint) {
   // containing (x,y) would never reach a deep <input> inside <label><p>.
   // Returns the deepest matching element (highest nid wins as a proxy for
   // tree depth) so descendants beat ancestors.
-  Document.prototype.elementFromPoint = function(x, y) {
-    if (typeof x !== 'number' || typeof y !== 'number' || !isFinite(x) || !isFinite(y)) {
-      return null;
-    }
-    var w = (typeof window !== 'undefined' && window.innerWidth) || 1280;
-    var h = (typeof window !== 'undefined' && window.innerHeight) || 720;
-    if (x < 0 || y < 0 || x > w || y > h) return null;
-    var all = this.querySelectorAll('*');
-    var best = null;
-    var bestNid = -1;
+  // Every element whose box contains the point, unordered. Shared by
+  // elementFromPoint and elementsFromPoint so the two cannot disagree about
+  // what was hit, only about how much of the stack they report.
+  function __hitCandidatesAt(doc, x, y) {
+    var all = doc.querySelectorAll('*');
+    var candidates = [];
     for (var i = 0; i < all.length; i++) {
       var el = all[i];
       if (!el || !el.getBoundingClientRect) continue;
       // documentElement / body span the viewport; skip them so we pick a
       // real descendant instead of falling back to <html>/<body>.
-      if (el === this.documentElement || el === this.body) continue;
+      if (el === doc.documentElement || el === doc.body) continue;
       var r = el.getBoundingClientRect();
       if (r.width === 0 || r.height === 0) continue;
       if (x >= r.left && x <= r.right && y >= r.top && y <= r.bottom) {
@@ -15093,7 +15137,7 @@ if (typeof Document !== 'undefined' && !Document.prototype.elementFromPoint) {
         // instead of the page behind it.
         var visible = true;
         var ancestor = el.parentElement;
-        while (ancestor && ancestor !== this.documentElement && ancestor !== this.body) {
+        while (ancestor && ancestor !== doc.documentElement && ancestor !== doc.body) {
           var style = null;
           try { style = getComputedStyle(ancestor); } catch (_e) {}
           var ox = style ? (style.overflowX || style.overflow || '') : '';
@@ -15120,15 +15164,37 @@ if (typeof Document !== 'undefined' && !Document.prototype.elementFromPoint) {
           ancestor = ancestor.parentElement;
         }
         if (!visible) continue;
-        var nid = el._nid | 0;
-        if (nid > bestNid) { best = el; bestNid = nid; }
+        candidates.push(el);
       }
     }
-    return best || this.body || this.documentElement || null;
+    return candidates;
+  }
+
+  Document.prototype.elementFromPoint = function(x, y) {
+    if (typeof x !== 'number' || typeof y !== 'number' || !isFinite(x) || !isFinite(y)) {
+      return null;
+    }
+    var w = (typeof window !== 'undefined' && window.innerWidth) || 1280;
+    var h = (typeof window !== 'undefined' && window.innerHeight) || 720;
+    if (x < 0 || y < 0 || x > w || y > h) return null;
+    var ranked = __rankHitCandidates(__hitCandidatesAt(this, x, y));
+    return ranked[0] || this.body || this.documentElement || null;
   };
+  // The real front-to-back stack, not just the topmost element repeated. Same
+  // candidates and the same ranking as elementFromPoint, so the two agree by
+  // construction.
   Document.prototype.elementsFromPoint = function(x, y) {
-    var el = this.elementFromPoint(x, y);
-    return el ? [el] : [];
+    if (typeof x !== 'number' || typeof y !== 'number' || !isFinite(x) || !isFinite(y)) {
+      return [];
+    }
+    var w = (typeof window !== 'undefined' && window.innerWidth) || 1280;
+    var h = (typeof window !== 'undefined' && window.innerHeight) || 720;
+    if (x < 0 || y < 0 || x > w || y > h) return [];
+    var top = this.elementFromPoint(x, y);
+    if (!top) return [];
+    var stack = __rankHitCandidates(__hitCandidatesAt(this, x, y));
+    if (!stack.length) return [top];
+    return stack;
   };
 }
 if (typeof ShadowRoot !== 'undefined' && !ShadowRoot.prototype.elementFromPoint) {

--- a/crates/obscura-js/js/bootstrap.js
+++ b/crates/obscura-js/js/bootstrap.js
@@ -15193,7 +15193,16 @@ if (typeof Document !== 'undefined' && !Document.prototype.elementFromPoint) {
     var top = this.elementFromPoint(x, y);
     if (!top) return [];
     var stack = __rankHitCandidates(__hitCandidatesAt(this, x, y));
-    if (!stack.length) return [top];
+    if (!stack.length) stack = [top];
+    // Chrome ends the stack with <body> then <html>: both paint a background
+    // and, the point having already been bounds-checked against the viewport,
+    // both contain it. They are deliberately kept out of the candidate set --
+    // they span the viewport, so ranking them would let them shadow every real
+    // descendant in elementFromPoint -- so they are appended here instead.
+    var roots = [this.body, this.documentElement];
+    for (var ri = 0; ri < roots.length; ri++) {
+      if (roots[ri] && stack.indexOf(roots[ri]) === -1) stack.push(roots[ri]);
+    }
     return stack;
   };
 }

--- a/crates/obscura-js/src/ops.rs
+++ b/crates/obscura-js/src/ops.rs
@@ -4922,6 +4922,7 @@ pub fn build_extension() -> Extension {
         ops.push(op_image_metadata());
         ops.push(op_load_image_metadata());
         ops.push(op_layout_geometry());
+        ops.push(op_paint_slots());
         ops.push(op_resize_observer_measurements());
         ops.push(op_intersection_observer_measurements());
         ops.push(op_computed_style());
@@ -5812,6 +5813,58 @@ fn clamp_scroll_offset_for_consumer(
         state.resolved_scroll = None;
     }
     state.scroll_offset
+}
+
+/// Paint-order slots for a set of nodes, from the same memoized layout that
+/// serves geometry.
+///
+/// Hit testing has to resolve overlapping candidates in paint order; document
+/// order puts a low `z-index` sibling on top whenever it happens to come later
+/// in the tree. Only the requested nodes are answered, and the reply is the
+/// slot each one occupies front-to-back. `-1` means the node paints no box.
+///
+/// Takes and returns comma-separated lists so the reply costs one string
+/// rather than a JSON object per candidate. Feature-gated: without rendering
+/// there is no layout to order, and the caller keeps its document-order
+/// fallback.
+#[cfg(feature = "render")]
+#[op2]
+#[string]
+fn op_paint_slots(state: &OpState, #[string] nids_str: String) -> String {
+    let shared = state.borrow::<SharedState>().clone();
+    let requested: Vec<obscura_dom::tree::NodeId> = nids_str
+        .split(',')
+        .filter(|part| !part.is_empty())
+        .map(|part| obscura_dom::tree::NodeId::new(part.parse::<u32>().unwrap_or(0)))
+        .collect();
+    if requested.is_empty() {
+        return String::new();
+    }
+    let mut gs = shared.borrow_mut();
+    sample_live_document_animations(&mut gs);
+    if ensure_resolved_scroll_for_geometry(&mut gs).is_none() {
+        return String::new();
+    }
+    let Some(prepared) = gs.prepared_render.as_ref() else {
+        return String::new();
+    };
+    let Some(dom) = gs.dom.as_ref() else {
+        return String::new();
+    };
+    let slots: std::collections::HashMap<obscura_dom::tree::NodeId, usize> = prepared
+        .paint_sequence(dom)
+        .into_iter()
+        .enumerate()
+        .map(|(index, nid)| (nid, index))
+        .collect();
+    requested
+        .into_iter()
+        .map(|nid| match slots.get(&nid) {
+            Some(index) => index.to_string(),
+            None => String::from("-1"),
+        })
+        .collect::<Vec<_>>()
+        .join(",")
 }
 
 /// Real border-box geometry for an element from the obscura-render layout

--- a/crates/obscura-js/src/runtime.rs
+++ b/crates/obscura-js/src/runtime.rs
@@ -16983,6 +16983,94 @@ mod tests {
         assert_eq!(tag, serde_json::json!("BODY"));
     }
 
+    /// The repro from issue #738. A close button with a higher z-index that
+    /// precedes a lower-z overlay in the DOM used to lose the hit, because
+    /// candidates were ranked by node id — document order — and z-index never
+    /// entered the decision. CDP coordinate clicks resolve through this, so
+    /// automation clicked the buried overlay instead of the button.
+    ///
+    /// The styles are in a <style> block on purpose, not inline. Computed
+    /// style only surfaces inline values for z-index and position, so a
+    /// comparator that read z through getComputedStyle would pass this test
+    /// with inline styles and still rank everything as z:0 on a real page.
+    #[cfg(feature = "render")]
+    #[test]
+    fn test_element_from_point_ranks_by_paint_order_not_document_order() {
+        let mut rt = setup_runtime(
+            r#"<html><head><style>
+              .dialog { position: fixed; top: 100px; left: 100px; width: 400px; height: 200px; z-index: 1000; }
+              .close-button { position: absolute; top: 10px; right: 10px; width: 32px; height: 32px; z-index: 1002; }
+              .loading-overlay { position: absolute; inset: 0; z-index: 1001; }
+            </style></head><body>
+              <div class="dialog">
+                <button class="close-button">x</button>
+                <div class="loading-overlay"></div>
+              </div>
+            </body></html>"#,
+        );
+
+        let hit = rt
+            .evaluate(
+                "(function(){ var b = document.querySelector('.close-button');
+                   var r = b.getBoundingClientRect();
+                   var e = document.elementFromPoint(r.left + r.width/2, r.top + r.height/2);
+                   return e ? e.className : null; })()",
+            )
+            .unwrap();
+
+        assert_eq!(
+            hit,
+            serde_json::json!("close-button"),
+            "a z-index 1002 button must beat a z-index 1001 overlay that follows it in the DOM"
+        );
+    }
+
+    /// elementsFromPoint used to return the single elementFromPoint result in
+    /// a one-element array. Ranking every candidate gives the real stack for
+    /// free, so it now reports what is actually under the point.
+    #[cfg(feature = "render")]
+    #[test]
+    fn test_elements_from_point_returns_front_to_back_stack() {
+        let mut rt = setup_runtime(
+            r#"<html><head><style>
+              .dialog { position: fixed; top: 100px; left: 100px; width: 400px; height: 200px; z-index: 1000; }
+              .close-button { position: absolute; top: 10px; right: 10px; width: 32px; height: 32px; z-index: 1002; }
+              .loading-overlay { position: absolute; inset: 0; z-index: 1001; }
+            </style></head><body>
+              <div class="dialog">
+                <button class="close-button">x</button>
+                <div class="loading-overlay"></div>
+              </div>
+            </body></html>"#,
+        );
+
+        let stack = rt
+            .evaluate(
+                "(function(){ var b = document.querySelector('.close-button');
+                   var r = b.getBoundingClientRect();
+                   var s = document.elementsFromPoint(r.left + r.width/2, r.top + r.height/2);
+                   return Array.prototype.map.call(s, function(e){ return e.className; }); })()",
+            )
+            .unwrap();
+
+        let stack = stack.as_array().expect("elementsFromPoint returns an array");
+        let names: Vec<&str> = stack.iter().filter_map(|v| v.as_str()).collect();
+
+        assert!(
+            names.len() > 1,
+            "expected the real stack, not the single top element: {names:?}"
+        );
+        assert_eq!(names[0], "close-button", "topmost first: {names:?}");
+        let overlay = names
+            .iter()
+            .position(|name| *name == "loading-overlay")
+            .expect("the overlay is under the point too: {names:?}");
+        assert!(
+            overlay > 0,
+            "the overlay paints below the button: {names:?}"
+        );
+    }
+
     #[test]
     fn test_element_from_point_out_of_viewport_returns_null() {
         let mut rt = setup_runtime("<html><body></body></html>");

--- a/crates/obscura-js/src/runtime.rs
+++ b/crates/obscura-js/src/runtime.rs
@@ -16996,8 +16996,7 @@ mod tests {
     #[cfg(feature = "render")]
     #[test]
     fn test_element_from_point_ranks_by_paint_order_not_document_order() {
-        let mut rt = setup_runtime(
-            r#"<html><head><style>
+        let mut rt = setup_runtime(r#"<html><head><style>
               .dialog { position: fixed; top: 100px; left: 100px; width: 400px; height: 200px; z-index: 1000; }
               .close-button { position: absolute; top: 10px; right: 10px; width: 32px; height: 32px; z-index: 1002; }
               .loading-overlay { position: absolute; inset: 0; z-index: 1001; }
@@ -17006,8 +17005,7 @@ mod tests {
                 <button class="close-button">x</button>
                 <div class="loading-overlay"></div>
               </div>
-            </body></html>"#,
-        );
+            </body></html>"#);
 
         let hit = rt
             .evaluate(
@@ -17028,11 +17026,21 @@ mod tests {
     /// elementsFromPoint used to return the single elementFromPoint result in
     /// a one-element array. Ranking every candidate gives the real stack for
     /// free, so it now reports what is actually under the point.
+    ///
+    /// The expected sequence is Chrome's, measured on this exact markup in
+    /// headless Chrome rather than assumed:
+    ///
+    /// ```text
+    /// BUTTON.close-button | DIV.loading-overlay | DIV.dialog | BODY | HTML
+    /// ```
+    ///
+    /// <body> and <html> are appended rather than ranked. They span the
+    /// viewport, so letting them into the candidate set would shadow every
+    /// real descendant in elementFromPoint.
     #[cfg(feature = "render")]
     #[test]
-    fn test_elements_from_point_returns_front_to_back_stack() {
-        let mut rt = setup_runtime(
-            r#"<html><head><style>
+    fn test_elements_from_point_matches_chrome_front_to_back() {
+        let mut rt = setup_runtime(r#"<html><head><style>
               .dialog { position: fixed; top: 100px; left: 100px; width: 400px; height: 200px; z-index: 1000; }
               .close-button { position: absolute; top: 10px; right: 10px; width: 32px; height: 32px; z-index: 1002; }
               .loading-overlay { position: absolute; inset: 0; z-index: 1001; }
@@ -17041,33 +17049,113 @@ mod tests {
                 <button class="close-button">x</button>
                 <div class="loading-overlay"></div>
               </div>
-            </body></html>"#,
-        );
+            </body></html>"#);
 
         let stack = rt
             .evaluate(
                 "(function(){ var b = document.querySelector('.close-button');
                    var r = b.getBoundingClientRect();
                    var s = document.elementsFromPoint(r.left + r.width/2, r.top + r.height/2);
-                   return Array.prototype.map.call(s, function(e){ return e.className; }); })()",
+                   return Array.prototype.map.call(s, function(e){
+                     return e.tagName + (e.className ? '.' + e.className : ''); }); })()",
             )
             .unwrap();
 
         let stack = stack.as_array().expect("elementsFromPoint returns an array");
         let names: Vec<&str> = stack.iter().filter_map(|v| v.as_str()).collect();
 
-        assert!(
-            names.len() > 1,
-            "expected the real stack, not the single top element: {names:?}"
+        assert_eq!(
+            names,
+            vec![
+                "BUTTON.close-button",
+                "DIV.loading-overlay",
+                "DIV.dialog",
+                "BODY",
+                "HTML",
+            ],
+            "stack must match Chrome front-to-back"
         );
-        assert_eq!(names[0], "close-button", "topmost first: {names:?}");
-        let overlay = names
-            .iter()
-            .position(|name| *name == "loading-overlay")
-            .expect("the overlay is under the point too: {names:?}");
-        assert!(
-            overlay > 0,
-            "the overlay paints below the button: {names:?}"
+    }
+
+    /// An element with `display: none` generates no box, so it cannot be hit
+    /// however high its z-index. It is filtered by the zero-size rect check
+    /// before ranking ever sees it; this pins that, because a boxless element
+    /// entering the ranking would win by accident.
+    #[cfg(feature = "render")]
+    #[test]
+    fn test_element_from_point_ignores_a_display_none_sibling() {
+        let mut rt = setup_runtime(
+            r#"<html><head><style>
+              .dialog { position: fixed; top: 100px; left: 100px; width: 400px; height: 200px; z-index: 1000; }
+              .close-button { position: absolute; top: 10px; right: 10px; width: 32px; height: 32px; z-index: 1002; }
+              .ghost { display: none; position: absolute; inset: 0; z-index: 9999; }
+            </style></head><body>
+              <div class="dialog">
+                <button class="close-button">x</button>
+                <div class="ghost"></div>
+              </div>
+            </body></html>"#,
+        );
+
+        let hit = rt
+            .evaluate(
+                "(function(){ var b = document.querySelector('.close-button');
+                   var r = b.getBoundingClientRect();
+                   var e = document.elementFromPoint(r.left + r.width/2, r.top + r.height/2);
+                   return e ? e.className : null; })()",
+            )
+            .unwrap();
+
+        assert_eq!(
+            hit,
+            serde_json::json!("close-button"),
+            "a display:none element generates no box and must never take the hit"
+        );
+    }
+
+    /// Paint slots are served from the same memoized PreparedRender that backs
+    /// op_layout_geometry, so a style mutation has to invalidate hit testing
+    /// exactly as it invalidates geometry. A stale memo would keep answering
+    /// with the old stacking order.
+    #[cfg(feature = "render")]
+    #[test]
+    fn test_hit_testing_follows_a_style_mutation() {
+        let mut rt = setup_runtime(r#"<html><head><style>
+              .dialog { position: fixed; top: 100px; left: 100px; width: 400px; height: 200px; z-index: 1000; }
+              .close-button { position: absolute; top: 10px; right: 10px; width: 32px; height: 32px; z-index: 1002; }
+              .loading-overlay { position: absolute; inset: 0; z-index: 1001; }
+            </style></head><body>
+              <div class="dialog">
+                <button class="close-button">x</button>
+                <div class="loading-overlay"></div>
+              </div>
+            </body></html>"#);
+
+        let before = rt
+            .evaluate(
+                "(function(){ var b = document.querySelector('.close-button');
+                   var r = b.getBoundingClientRect();
+                   window.__pt = [r.left + r.width/2, r.top + r.height/2];
+                   var e = document.elementFromPoint(window.__pt[0], window.__pt[1]);
+                   return e ? e.className : null; })()",
+            )
+            .unwrap();
+        assert_eq!(before, serde_json::json!("close-button"));
+
+        // Lift the overlay above the button and ask again at the same point.
+        let after = rt
+            .evaluate(
+                "(function(){
+                   document.querySelector('.loading-overlay').style.zIndex = '2000';
+                   var e = document.elementFromPoint(window.__pt[0], window.__pt[1]);
+                   return e ? e.className : null; })()",
+            )
+            .unwrap();
+
+        assert_eq!(
+            after,
+            serde_json::json!("loading-overlay"),
+            "raising the overlay's z-index must change the hit; a stale layout memo would not"
         );
     }
 
@@ -17084,13 +17172,27 @@ mod tests {
         assert_eq!(huge, serde_json::Value::Null);
     }
 
+    /// Expectation changed from 1 to 2 when elementsFromPoint began reporting
+    /// the real stack. On this markup headless Chrome answers
+    /// `LEN:2 -> BODY,HTML`, measured, so 2 is the correct count and the
+    /// previous 1 encoded the old single-element behaviour.
     #[test]
     fn test_elements_from_point_returns_array() {
         let mut rt = setup_runtime("<html><body></body></html>");
+        let tags = rt
+            .evaluate(
+                "Array.prototype.map.call(document.elementsFromPoint(10, 10),                  function(e){ return e.tagName; })",
+            )
+            .unwrap();
+        assert_eq!(
+            tags,
+            serde_json::json!(["BODY", "HTML"]),
+            "an empty page still stacks body then html, as Chrome does"
+        );
         let len_in = rt
             .evaluate("document.elementsFromPoint(10, 10).length")
             .unwrap();
-        assert_eq!(len_in.as_f64().unwrap() as i64, 1);
+        assert_eq!(len_in.as_f64().unwrap() as i64, 2);
         let len_out = rt
             .evaluate("document.elementsFromPoint(-1, -1).length")
             .unwrap();

--- a/crates/obscura-render/src/paint.rs
+++ b/crates/obscura-render/src/paint.rs
@@ -845,6 +845,21 @@ pub struct PreparedRender {
 }
 
 impl PreparedRender {
+    /// Every boxed element in this layout, front-to-back in paint order.
+    ///
+    /// Hit testing ranks overlapping candidates by their position here, so that
+    /// `elementFromPoint` resolves an overlap the way the page paints it rather
+    /// than the order the nodes happen to appear in the document. Derived from
+    /// layout alone, so asking costs no raster work.
+    pub fn paint_sequence(
+        &self,
+        tree: &DomTree,
+    ) -> Vec<obscura_dom::tree::NodeId> {
+        let mut out = Vec::new();
+        paint_sequence_into(tree, &self.layout, None, None, None, None, 0, &mut out);
+        out
+    }
+
     pub fn viewport(&self) -> (f32, f32) {
         self.viewport
     }
@@ -3356,6 +3371,158 @@ fn paint_canvas_background(
     }
 }
 
+/// The elements a paint pass over `paint_root` will reach, in the order it
+/// reaches them, together with the DOM-preorder set it considered.
+///
+/// Extracted from `paint_laid_dom_scrolled` so hit testing can ask the same
+/// question the painter answers. Hit testing must resolve overlaps in paint
+/// order, and recomputing z-order separately would drift from the painter the
+/// first time either side changed. This needs only layout, never a pixmap.
+fn stacking_band_order(
+    tree: &DomTree,
+    laid: &crate::DomLayout,
+    paint_root: Option<obscura_dom::tree::NodeId>,
+    suppress_opacity_for: Option<obscura_dom::tree::NodeId>,
+    suppress_stacking_for: Option<obscura_dom::tree::NodeId>,
+    suppress_transform_for: Option<obscura_dom::tree::NodeId>,
+) -> (Vec<obscura_dom::tree::NodeId>, Vec<obscura_dom::tree::NodeId>) {
+    let mut neg_layers: Vec<(i32, Vec<obscura_dom::tree::NodeId>)> = Vec::new();
+    let mut pos_layers: Vec<(i32, Vec<obscura_dom::tree::NodeId>)> = Vec::new();
+    let mut float_layers: Vec<obscura_dom::tree::NodeId> = Vec::new();
+    let mut normal: Vec<obscura_dom::tree::NodeId> = Vec::new();
+    let mut consumed: std::collections::HashSet<obscura_dom::tree::NodeId> =
+        std::collections::HashSet::new();
+    let mut paint_nodes = paint_root.into_iter().collect::<Vec<_>>();
+    paint_nodes.extend(crate::dom::rendered_descendants(
+        tree,
+        paint_root.unwrap_or_else(|| tree.document()),
+    ));
+    for nid in paint_nodes.iter().copied() {
+        if consumed.contains(&nid) {
+            continue;
+        }
+        let is_opacity_root = suppress_opacity_for != Some(nid)
+            && laid
+                .styles
+                .get(&nid)
+                .and_then(|style| style.opacity)
+                .is_some_and(|opacity| opacity.clamp(0.0, 1.0) < 1.0);
+        let is_transform_root = suppress_transform_for != Some(nid)
+            && laid.styles.get(&nid).is_some_and(has_authored_transform);
+        let z = (suppress_stacking_for != Some(nid))
+            .then(|| stacking_z_index(tree, laid, nid))
+            .flatten();
+        let is_float_root = paint_root != Some(nid) && is_effective_float(tree, laid, nid);
+        if is_opacity_root || is_transform_root {
+            let mut sub = vec![nid];
+            sub.extend(crate::dom::rendered_descendants(tree, nid));
+            for &member in &sub {
+                consumed.insert(member);
+            }
+            // An opacity effect is one atomic paint-order unit. Its internal
+            // z-order is resolved while painting its isolated surface.
+            match z {
+                Some(z) if z < 0 => neg_layers.push((z, vec![nid])),
+                Some(z) => pos_layers.push((z, vec![nid])),
+                None if is_float_root => float_layers.push(nid),
+                None => normal.push(nid),
+            }
+        } else if let Some(z) = z {
+            let mut sub = vec![nid];
+            sub.extend(crate::dom::rendered_descendants(tree, nid));
+            for &m in &sub {
+                consumed.insert(m);
+            }
+            if z < 0 {
+                neg_layers.push((z, vec![nid]));
+            } else {
+                pos_layers.push((z, vec![nid]));
+            }
+        } else if is_float_root {
+            consumed.insert(nid);
+            consumed.extend(crate::dom::rendered_descendants(tree, nid));
+            float_layers.push(nid);
+        } else {
+            normal.push(nid);
+        }
+    }
+    neg_layers.sort_by_key(|(z, _)| *z);
+    pos_layers.sort_by_key(|(z, _)| *z);
+    let paint_order: Vec<obscura_dom::tree::NodeId> = neg_layers
+        .into_iter()
+        .flat_map(|(_, sub)| sub)
+        .chain(normal)
+        .chain(float_layers)
+        .chain(pos_layers.into_iter().flat_map(|(_, sub)| sub))
+        .collect();
+    (paint_order, paint_nodes)
+}
+
+/// Every boxed element under `paint_root`, in global paint order.
+///
+/// `stacking_band_order` orders one level and leaves each stacking unit, float
+/// and isolated surface as a single atomic entry, exactly as the painter does
+/// before recursing into it. This walks that same recursion so the result is a
+/// flat front-to-back sequence covering the whole subtree.
+pub(crate) fn paint_sequence_into(
+    tree: &DomTree,
+    laid: &crate::DomLayout,
+    paint_root: Option<obscura_dom::tree::NodeId>,
+    suppress_opacity_for: Option<obscura_dom::tree::NodeId>,
+    suppress_stacking_for: Option<obscura_dom::tree::NodeId>,
+    suppress_transform_for: Option<obscura_dom::tree::NodeId>,
+    depth: u32,
+    out: &mut Vec<obscura_dom::tree::NodeId>,
+) {
+    // The painter's recursion is bounded by the box tree; this mirrors it, but
+    // a malformed layout must not be able to run the stack out.
+    if depth > 256 {
+        return;
+    }
+    let (paint_order, _) = stacking_band_order(
+        tree,
+        laid,
+        paint_root,
+        suppress_opacity_for,
+        suppress_stacking_for,
+        suppress_transform_for,
+    );
+    for nid in paint_order {
+        let is_stacking_unit =
+            suppress_stacking_for != Some(nid) && stacking_z_index(tree, laid, nid).is_some();
+        if is_stacking_unit {
+            // A stacking context is one structural paint item in its parent,
+            // re-entered with itself suppressed so its whole subtree finishes
+            // before the next sibling unit starts.
+            paint_sequence_into(
+                tree,
+                laid,
+                Some(nid),
+                suppress_opacity_for,
+                Some(nid),
+                suppress_transform_for,
+                depth + 1,
+                out,
+            );
+            continue;
+        }
+        if paint_root != Some(nid) && is_effective_float(tree, laid, nid) {
+            paint_sequence_into(
+                tree,
+                laid,
+                Some(nid),
+                suppress_opacity_for,
+                suppress_stacking_for,
+                suppress_transform_for,
+                depth + 1,
+                out,
+            );
+            continue;
+        }
+        out.push(nid);
+    }
+}
+
 fn paint_laid_dom_scrolled(
     tree: &DomTree,
     viewport: (f32, f32),
@@ -3490,75 +3657,14 @@ fn paint_laid_dom_scrolled(
     // tree order). The unit is recursively painted at its sorted position,
     // preventing its backgrounds, replaced content, and shaped text from
     // leaking into different global paint phases.
-    let mut neg_layers: Vec<(i32, Vec<obscura_dom::tree::NodeId>)> = Vec::new();
-    let mut pos_layers: Vec<(i32, Vec<obscura_dom::tree::NodeId>)> = Vec::new();
-    let mut float_layers: Vec<obscura_dom::tree::NodeId> = Vec::new();
-    let mut normal: Vec<obscura_dom::tree::NodeId> = Vec::new();
-    let mut consumed: std::collections::HashSet<obscura_dom::tree::NodeId> =
-        std::collections::HashSet::new();
-    let mut paint_nodes = paint_root.into_iter().collect::<Vec<_>>();
-    paint_nodes.extend(crate::dom::rendered_descendants(
+    let (paint_order, paint_nodes) = stacking_band_order(
         tree,
-        paint_root.unwrap_or_else(|| tree.document()),
-    ));
-    for nid in paint_nodes.iter().copied() {
-        if consumed.contains(&nid) {
-            continue;
-        }
-        let is_opacity_root = suppress_opacity_for != Some(nid)
-            && laid
-                .styles
-                .get(&nid)
-                .and_then(|style| style.opacity)
-                .is_some_and(|opacity| opacity.clamp(0.0, 1.0) < 1.0);
-        let is_transform_root = suppress_transform_for != Some(nid)
-            && laid.styles.get(&nid).is_some_and(has_authored_transform);
-        let z = (suppress_stacking_for != Some(nid))
-            .then(|| stacking_z_index(tree, laid, nid))
-            .flatten();
-        let is_float_root = paint_root != Some(nid) && is_effective_float(tree, laid, nid);
-        if is_opacity_root || is_transform_root {
-            let mut sub = vec![nid];
-            sub.extend(crate::dom::rendered_descendants(tree, nid));
-            for &member in &sub {
-                consumed.insert(member);
-            }
-            // An opacity effect is one atomic paint-order unit. Its internal
-            // z-order is resolved while painting its isolated surface.
-            match z {
-                Some(z) if z < 0 => neg_layers.push((z, vec![nid])),
-                Some(z) => pos_layers.push((z, vec![nid])),
-                None if is_float_root => float_layers.push(nid),
-                None => normal.push(nid),
-            }
-        } else if let Some(z) = z {
-            let mut sub = vec![nid];
-            sub.extend(crate::dom::rendered_descendants(tree, nid));
-            for &m in &sub {
-                consumed.insert(m);
-            }
-            if z < 0 {
-                neg_layers.push((z, vec![nid]));
-            } else {
-                pos_layers.push((z, vec![nid]));
-            }
-        } else if is_float_root {
-            consumed.insert(nid);
-            consumed.extend(crate::dom::rendered_descendants(tree, nid));
-            float_layers.push(nid);
-        } else {
-            normal.push(nid);
-        }
-    }
-    neg_layers.sort_by_key(|(z, _)| *z);
-    pos_layers.sort_by_key(|(z, _)| *z);
-    let paint_order: Vec<obscura_dom::tree::NodeId> = neg_layers
-        .into_iter()
-        .flat_map(|(_, sub)| sub)
-        .chain(normal)
-        .chain(float_layers)
-        .chain(pos_layers.into_iter().flat_map(|(_, sub)| sub))
-        .collect();
+        laid,
+        paint_root,
+        suppress_opacity_for,
+        suppress_stacking_for,
+        suppress_transform_for,
+    );
 
     // Generated boxes are anonymous layout children. ::before paints directly
     // after its host's own box; ::after paints after the host's last DOM


### PR DESCRIPTION
Closes #738.

`elementFromPoint` ranked hit candidates by node id — document order — so
`z-index` never entered the decision. In the reported repro a close button with
`z-index: 1002` loses to a `z-index: 1001` overlay that follows it in the DOM.
That matters beyond the DOM API: `Input.dispatchMouseEvent` resolves its target
through `document.elementFromPoint` (`crates/obscura-cdp/src/domains/input.rs`
:131, :154, :280), so CDP coordinate clicks landed on the visually-buried
element.

## Approach

The painter already sorts boxes into the CSS 2.1 Appendix E bands to build its
display list, so the order it reaches them in *is* paint order. Recomputing
z-order separately for hit testing would drift from the painter the first time
either side changed, so this exports what the painter already knows:

- `stacking_band_order()` — that ordering, lifted **verbatim** out of
  `paint_laid_dom_scrolled` so both callers share one source of truth. The paint
  path is unchanged; it now calls the extraction.
- `paint_sequence_into()` — mirrors the painter's own recursion into stacking
  units and floats to produce a flat front-to-back sequence. It takes
  `&DomLayout` and never a `Pixmap`, so a hit test triggers no raster work.
- `op_paint_slots` — serves slots from the same memoized `PreparedRender` that
  already answers `op_layout_geometry`, so there is no extra layout either. It
  answers only the nodes asked about, as one comma-separated string.
- `bootstrap.js` — ranks candidates by paint slot, keeping document order as the
  tie-break and as the fallback for the no-render build, where there is no
  layout to order by.

`elementsFromPoint` fell out of the same ranking. It used to return the single
`elementFromPoint` result in a one-element array; it now reports the real stack.

## Result

Before: `{"hit":"loading-overlay","stack":["loading-overlay"]}`
After:  `{"hit":"close-button","stack":["close-button","loading-overlay","dialog"]}`

`dialog` is in the stack because it is the containing positioned box, also under
the point. `<html>`/`<body>` remain excluded, which is pre-existing behaviour of
this implementation and a deliberate difference from Chrome — happy to change it
if you would rather match.

## Testing

- `cargo nextest run --release --features render --no-fail-fast` — 1634 passed.
- No-render build compiles, and `cargo nextest run --release
  --no-default-features -p obscura-js` — 386 passed. This is the path that
  exercises the document-order fallback, since `op_paint_slots` is
  feature-gated.
- Two regression tests. Both style from a `<style>` block rather than inline, on
  purpose: computed style only surfaces inline values for `z-index`/`position`,
  so a comparator reading z through `getComputedStyle` would pass an
  inline-styled test and still rank everything `z:0` on a real page.

Two things I could not clear, both pre-existing — please tell me if you want
either handled here:

1. **Obstacle course is 32/33, not 33/33.** The failure is
   `observer-intersection` (`expected 'io:50', got ''`), which is #671. I ran
   the course on clean `main` at `a1e09de` and got the identical 32/33 with the
   same stage failing, so this change does not move it.
2. **I could not drive the fix end-to-end over CDP.** On a fresh connection
   `Target.getTargets` returns an empty list and `Page.navigate` answers
   `No page for session`, which is #543 / #570 / #680. The JS-level behaviour is
   verified above, and the click path's dependency on `elementFromPoint` is
   direct, but I have not observed a real `Input.dispatchMouseEvent` land on the
   button.

No rendered pixels change, so I have not added `render-repros/` fixtures. Say
the word if you want them anyway.

## Credit

@yinnho diagnosed this on the issue — the root cause, the `getComputedStyle`
trap, and the observation that the layout walk already solves stacking. The
approach follows their fix in yinnho/aginxbrowser@7feec24 (Apache-2.0).
