### PR TITLE
fix(js): do not abort the process when set_v8_flags runs after V8 started

### DIFF
--- a/crates/obscura-js/src/runtime.rs
+++ b/crates/obscura-js/src/runtime.rs
@@ -526,6 +526,12 @@ impl ObscuraJsRuntime {
             // lands before the first isolate exists.
             deno_core::v8::icu::set_default_locale("en-US");
 
+            // From here on V8's platform is up, and `set_flags_from_string`
+            // becomes fatal rather than merely ineffective. Record it under the
+            // same lock that serialises isolate creation, so a later
+            // `set_v8_flags` refuses instead of aborting the process.
+            crate::v8_flags::mark_v8_started();
+
             let mut runtime = JsRuntime::new(RuntimeOptions {
                 extensions: vec![build_extension()],
                 module_loader: Some(module_loader),
@@ -17289,8 +17295,29 @@ mod tests {
         );
     }
 
+    /// `--max-old-space-size` is a process-global V8 flag and can only be
+    /// applied before the first isolate exists. Under `cargo nextest` every
+    /// test has its own process, so that always holds. Under plain `cargo test`
+    /// the whole binary shares one process and earlier tests have already built
+    /// runtimes; `set_v8_flags` used to abort the process in that situation (V8
+    /// answers a late `set_flags_from_string` with `V8_Fatal`), taking every
+    /// later test down with it. The abort is fixed, and this test skips instead
+    /// of asserting something the process can no longer show.
+    ///
+    /// The proper fix is a per-isolate heap cap via `RuntimeOptions`'
+    /// `create_params` (`v8::CreateParams::heap_limits`), which would make this
+    /// order-independent. Deliberately not attempted here: it means threading a
+    /// parameter through three public constructors in this file for a test's
+    /// benefit.
     #[test]
     fn heap_limit_terminates_script_and_runtime_recovers() {
+        if crate::v8_flags::v8_started() {
+            eprintln!(
+                "skipping: an isolate already exists in this process, so \
+                 --max-old-space-size cannot apply; run under cargo nextest"
+            );
+            return;
+        }
         crate::v8_flags::set_v8_flags("--max-old-space-size=32 --max-semi-space-size=1");
         let mut rt = ObscuraJsRuntime::new();
 

--- a/crates/obscura-js/src/v8_flags.rs
+++ b/crates/obscura-js/src/v8_flags.rs
@@ -1,6 +1,25 @@
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Once;
 
 static INIT: Once = Once::new();
+
+/// Set once the first isolate has been constructed, i.e. once V8's platform is
+/// up. From that point `set_flags_from_string` is not merely ineffective but
+/// fatal, so [`set_v8_flags`] must refuse rather than call it.
+static V8_STARTED: AtomicBool = AtomicBool::new(false);
+
+/// Records that V8 has been initialized. Called from `ObscuraJsRuntime`'s
+/// constructor under the isolate-creation lock, before the first
+/// `JsRuntime::new`.
+pub(crate) fn mark_v8_started() {
+    V8_STARTED.store(true, Ordering::SeqCst);
+}
+
+/// Whether the first isolate has already been constructed in this process.
+#[cfg(test)]
+pub(crate) fn v8_started() -> bool {
+    V8_STARTED.load(Ordering::SeqCst)
+}
 
 /// Apply user-supplied V8 flags exactly once, before the first isolate is
 /// created.
@@ -10,12 +29,30 @@ static INIT: Once = Once::new();
 /// whitespace-only string is a no-op and does not consume the one-shot guard,
 /// so a later non-empty call still takes effect.
 ///
-/// V8 ignores `set_flags_from_string` once the platform is initialized, so the
-/// first non-empty call must run before any `JsRuntime` is constructed.
-/// Subsequent calls are silently dropped.
+/// A call made after the first isolate exists is **ignored with a warning**.
+/// The previous comment here claimed "V8 ignores `set_flags_from_string` once
+/// the platform is initialized", which is not what V8 does: it calls
+/// `V8_Fatal` from `FlagList::SetFlagsFromCommandLine` and aborts the process
+/// with SIGTRAP. Under `cargo test`, where a whole test binary shares one
+/// process, that is how `obscura-js --lib` died mid-suite:
+/// `heap_limit_terminates_script_and_runtime_recovers` calls this after earlier
+/// tests have already built runtimes, and the abort took the binary down,
+/// hiding every test that would have run after it.
+///
+/// The same crash was reachable in production: any embedder calling
+/// `set_v8_flags` after creating a runtime aborted the process.
 pub fn set_v8_flags(flags: &str) {
     let trimmed = flags.trim();
     if trimmed.is_empty() {
+        return;
+    }
+    if V8_STARTED.load(Ordering::SeqCst) {
+        tracing::warn!(
+            "ignoring V8 flags {:?}: an isolate already exists, and V8 aborts the \
+             process if flags are set after initialization. Pass --v8-flags before \
+             the first page or CDP connection.",
+            trimmed
+        );
         return;
     }
     INIT.call_once(|| {
@@ -33,5 +70,16 @@ mod tests {
         set_v8_flags("");
         set_v8_flags("   ");
         set_v8_flags("\t\n");
+    }
+
+    /// The regression that matters: once V8 is up, this must return quietly
+    /// instead of aborting the process. Before the guard existed this call was
+    /// a SIGTRAP.
+    #[test]
+    fn setting_flags_after_v8_started_is_ignored_not_fatal() {
+        mark_v8_started();
+        // If this aborts, the test binary dies and no later test reports.
+        set_v8_flags("--max-old-space-size=32");
+        set_v8_flags("--this-is-not-a-real-v8-flag");
     }
 }

--- a/crates/obscura-net/src/client.rs
+++ b/crates/obscura-net/src/client.rs
@@ -1739,8 +1739,42 @@ pub enum ObscuraNetError {
     ResponseTooLarge { url: String, limit: usize },
 }
 
+/// Test-only environment guard, shared by this crate's test modules.
+///
+/// `.cargo/config.toml` pins `RUST_TEST_THREADS = "1"`, so every test in a
+/// binary shares one process and libtest runs them alphabetically. A bare
+/// `std::env::set_var` leaks into every test that sorts after it, which is how
+/// several tests in this workspace ended up depending on, or being broken by,
+/// a neighbour's setting. Bind one of these instead.
+#[cfg(test)]
+pub(crate) struct EnvGuard {
+    key: &'static str,
+    previous: Option<String>,
+}
+
+#[cfg(test)]
+impl EnvGuard {
+    #[must_use = "the variable is restored when the guard drops, so it must be bound"]
+    pub(crate) fn set(key: &'static str, value: &str) -> Self {
+        let previous = std::env::var(key).ok();
+        std::env::set_var(key, value);
+        Self { key, previous }
+    }
+}
+
+#[cfg(test)]
+impl Drop for EnvGuard {
+    fn drop(&mut self) {
+        match self.previous.take() {
+            Some(value) => std::env::set_var(self.key, value),
+            None => std::env::remove_var(self.key),
+        }
+    }
+}
+
 #[cfg(test)]
 mod ssrf_tests {
+    use super::EnvGuard;
     use super::{
         is_forbidden_ip, request_fetch_site, request_referrer, validate_url,
         CallbackRegistry, ObscuraHttpClient, ObscuraNetError, RequestCredentials, RequestMode,
@@ -2729,17 +2763,23 @@ mod ssrf_tests {
         (port, ca_cert.pem())
     }
 
-    // The two configured-roots tests set/rely on SSL_CERT_FILE, which is
-    // cached once per process at client build. They are only correct under
-    // `cargo nextest` (one process per test), the same constraint the whole
-    // workspace already has.
+    // Both configured-roots tests need a process where no client has been
+    // built yet: the rustls root store is resolved from SSL_CERT_FILE /
+    // SSL_CERT_DIR once per process, at first client build. Under `cargo
+    // nextest` (one process per test, the supported runner) that always holds.
+    // Under plain `cargo test` the first test to build a client fixes the root
+    // store for every later one, so at most one of these can pass per run.
+    //
+    // Either way the variables must not leak: an unrestored SSL_CERT_DIR
+    // pointing at a deleted tempdir is collateral damage for any later HTTPS
+    // test, so both bind their variable to a guard.
 
     #[tokio::test]
     async fn configured_roots_trust_a_private_ca_via_ssl_cert_file() {
         let (port, ca_pem) = https_fixture_with_private_ca().await;
         let ca_file = tempfile::NamedTempFile::new().unwrap();
         std::fs::write(ca_file.path(), ca_pem).unwrap();
-        std::env::set_var("SSL_CERT_FILE", ca_file.path());
+        let _cert_file = EnvGuard::set("SSL_CERT_FILE", &ca_file.path().to_string_lossy());
 
         let client =
             ObscuraHttpClient::with_full_options(Arc::new(CookieJar::new()), None, true);
@@ -2754,7 +2794,7 @@ mod ssrf_tests {
         let (port, ca_pem) = https_fixture_with_private_ca().await;
         let ca_dir = tempfile::tempdir().unwrap();
         std::fs::write(ca_dir.path().join("private-ca.pem"), ca_pem).unwrap();
-        std::env::set_var("SSL_CERT_DIR", ca_dir.path());
+        let _cert_dir = EnvGuard::set("SSL_CERT_DIR", &ca_dir.path().to_string_lossy());
 
         let client =
             ObscuraHttpClient::with_full_options(Arc::new(CookieJar::new()), None, true);

--- a/crates/obscura-net/src/wreq_client.rs
+++ b/crates/obscura-net/src/wreq_client.rs
@@ -680,6 +680,15 @@ mod tests {
     // decoder the raw gzip bytes reach the HTML parser as document text.
     #[tokio::test]
     async fn stealth_client_decodes_gzip_response() {
+        // The fixture is on loopback, and `StealthHttpClient::fetch_with_profile`
+        // calls `validate_url(url, false)` -- it carries no allow-private-network
+        // field of its own, so the gate can only be opened through the
+        // environment. This test previously passed only when some *other* test
+        // happened to have set the variable and not restored it; run in an order
+        // where that had not happened, it failed with "Access to
+        // private/internal IP address 127.0.0.1 is not allowed". Set it here,
+        // bound to a guard so it does not leak onward.
+        let _loopback = crate::client::EnvGuard::set("OBSCURA_ALLOW_PRIVATE_NETWORK", "1");
         let port = gzip_fixture().await;
         let client = StealthHttpClient::new(Arc::new(CookieJar::new()));
         let url = Url::parse(&format!("http://127.0.0.1:{port}/")).unwrap();

--- a/crates/obscura/tests/child_frame_scripts.rs
+++ b/crates/obscura/tests/child_frame_scripts.rs
@@ -7,6 +7,48 @@ use std::io::{Read, Write};
 
 use obscura::Browser;
 
+/// Sets an environment variable for the duration of the guard and restores the
+/// previous value on drop.
+///
+/// `.cargo/config.toml` pins `RUST_TEST_THREADS = "1"`, so every test in this
+/// binary shares one process and libtest runs them in alphabetical order. A
+/// bare `std::env::set_var` therefore leaks into every test that sorts after
+/// it. That was not hypothetical here:
+/// `a_rejected_child_frame_does_not_leave_js_references` set
+/// `OBSCURA_MAX_LIVE_FRAMES=0` and never restored it, capping live frames at
+/// zero for the rest of the run and failing the three later tests that need a
+/// frame to survive. They passed in isolation and failed in the full file,
+/// which is the signature of exactly this bug.
+#[must_use = "the variable is restored when the guard drops, so it must be bound"]
+struct EnvGuard {
+    key: &'static str,
+    previous: Option<String>,
+}
+
+impl EnvGuard {
+    fn set(key: &'static str, value: &str) -> Self {
+        let previous = std::env::var(key).ok();
+        std::env::set_var(key, value);
+        Self { key, previous }
+    }
+}
+
+impl Drop for EnvGuard {
+    fn drop(&mut self) {
+        match self.previous.take() {
+            Some(value) => std::env::set_var(self.key, value),
+            None => std::env::remove_var(self.key),
+        }
+    }
+}
+
+/// Every test here drives a loopback fixture, so it needs the private-network
+/// gate open. Returned as a guard so it cannot outlive the test.
+#[must_use]
+fn allow_loopback() -> EnvGuard {
+    EnvGuard::set("OBSCURA_ALLOW_PRIVATE_NETWORK", "1")
+}
+
 const PARENT_HTML: &str = r#"<!doctype html><html><head><title>parent</title></head><body>
 <script>
   var f = document.createElement('iframe');
@@ -115,7 +157,7 @@ fn spawn_server(parent_html: &'static str) -> String {
 
 #[tokio::test]
 async fn a_child_frame_runs_its_own_script() {
-    std::env::set_var("OBSCURA_ALLOW_PRIVATE_NETWORK", "1");
+    let _loopback = allow_loopback();
     let base = spawn_server(PARENT_HTML);
 
     let browser = Browser::new().unwrap();
@@ -149,7 +191,7 @@ async fn a_child_frame_runs_its_own_script() {
 
 #[tokio::test]
 async fn a_child_frame_set_by_attribute_runs_its_own_script() {
-    std::env::set_var("OBSCURA_ALLOW_PRIVATE_NETWORK", "1");
+    let _loopback = allow_loopback();
     let base = spawn_server(ATTRIBUTE_PARENT_HTML);
 
     let browser = Browser::new().unwrap();
@@ -170,7 +212,7 @@ async fn a_child_frame_set_by_attribute_runs_its_own_script() {
 
 #[tokio::test]
 async fn a_shadow_dom_child_frame_stays_alive_and_runs_its_script() {
-    std::env::set_var("OBSCURA_ALLOW_PRIVATE_NETWORK", "1");
+    let _loopback = allow_loopback();
     let base = spawn_server(SHADOW_PARENT_HTML);
 
     let browser = Browser::new().unwrap();
@@ -193,7 +235,7 @@ async fn a_shadow_dom_child_frame_stays_alive_and_runs_its_script() {
 /// its result back out. This is the reporter's `parentGot` assertion.
 #[tokio::test]
 async fn a_child_frame_reaches_its_parent_with_post_message() {
-    std::env::set_var("OBSCURA_ALLOW_PRIVATE_NETWORK", "1");
+    let _loopback = allow_loopback();
     let base = spawn_server(MESSAGING_PARENT_HTML);
 
     let browser = Browser::new().unwrap();
@@ -221,7 +263,7 @@ async fn a_child_frame_reaches_its_parent_with_post_message() {
 /// The other direction: a page talking into its frame.
 #[tokio::test]
 async fn a_parent_reaches_its_child_with_post_message() {
-    std::env::set_var("OBSCURA_ALLOW_PRIVATE_NETWORK", "1");
+    let _loopback = allow_loopback();
     let base = spawn_server(MESSAGING_PARENT_HTML);
 
     let browser = Browser::new().unwrap();
@@ -244,7 +286,7 @@ async fn a_parent_reaches_its_child_with_post_message() {
 /// forever.
 #[tokio::test]
 async fn window_post_message_delivers_to_the_same_window() {
-    std::env::set_var("OBSCURA_ALLOW_PRIVATE_NETWORK", "1");
+    let _loopback = allow_loopback();
     let base = spawn_server(
         r#"<!doctype html><html><body><script>
   window.__got = [];
@@ -272,7 +314,7 @@ async fn window_post_message_delivers_to_the_same_window() {
 /// delivered.
 #[tokio::test]
 async fn window_post_message_honours_target_origin() {
-    std::env::set_var("OBSCURA_ALLOW_PRIVATE_NETWORK", "1");
+    let _loopback = allow_loopback();
     let base = spawn_server(
         r#"<!doctype html><html><body><script>
   window.__got = [];
@@ -299,7 +341,7 @@ async fn window_post_message_honours_target_origin() {
 /// nothing used to start its load at all.
 #[tokio::test]
 async fn a_static_child_frame_runs_its_own_script() {
-    std::env::set_var("OBSCURA_ALLOW_PRIVATE_NETWORK", "1");
+    let _loopback = allow_loopback();
     let base = spawn_server(STATIC_PARENT_HTML);
 
     let browser = Browser::new().unwrap();
@@ -320,8 +362,11 @@ async fn a_static_child_frame_runs_its_own_script() {
 
 #[tokio::test]
 async fn a_rejected_child_frame_does_not_leave_js_references() {
-    std::env::set_var("OBSCURA_ALLOW_PRIVATE_NETWORK", "1");
-    std::env::set_var("OBSCURA_MAX_LIVE_FRAMES", "0");
+    let _loopback = allow_loopback();
+    // Bound, not bare: leaving this set capped live frames at zero for every
+    // alphabetically-later test in this binary, which is what failed three of
+    // them.
+    let _max_frames = EnvGuard::set("OBSCURA_MAX_LIVE_FRAMES", "0");
     let base = spawn_server(STATIC_PARENT_HTML);
 
     let browser = Browser::new().unwrap();
@@ -346,7 +391,7 @@ async fn a_rejected_child_frame_does_not_leave_js_references() {
 
 #[tokio::test]
 async fn navigating_blank_releases_child_realms() {
-    std::env::set_var("OBSCURA_ALLOW_PRIVATE_NETWORK", "1");
+    let _loopback = allow_loopback();
     let base = spawn_server(STATIC_PARENT_HTML);
 
     let browser = Browser::new().unwrap();
@@ -361,7 +406,7 @@ async fn navigating_blank_releases_child_realms() {
 
 #[tokio::test]
 async fn changing_iframe_src_releases_the_previous_realm() {
-    std::env::set_var("OBSCURA_ALLOW_PRIVATE_NETWORK", "1");
+    let _loopback = allow_loopback();
     let base = spawn_server(RESET_PARENT_HTML);
 
     let browser = Browser::new().unwrap();


### PR DESCRIPTION

## What changed

`set_v8_flags` called `V8::set_flags_from_string` unconditionally. Its doc comment said V8 ignores the call once the platform is initialized; V8 does not ignore it. `FlagList::SetFlagsFromCommandLine` calls `V8_Fatal` and the process dies with SIGTRAP. Any embedder that calls `set_v8_flags` after constructing a runtime aborted, and so did any test binary in which an earlier test had already built one.

This records that V8 has started, under the same lock that serialises isolate creation, and makes a later `set_v8_flags` log a warning and return. A test pins that the late call is no longer fatal.

`heap_limit_terminates_script_and_runtime_recovers` is the caller that used to trigger the abort. Under `cargo nextest` (one process per test) it runs exactly as before. Under plain `cargo test`, where the binary shares one process, it now skips with a message instead of taking the binary down mid-suite; that abort is why `cargo test -p obscura-js --lib` printed no `test result:` line and silently dropped every later test.

The rest is test hygiene of the same shape: tests that set process-global state and left it for the next test in the same process. `child_frame_scripts.rs` set `OBSCURA_MAX_LIVE_FRAMES=0` and never restored it (three later tests fail only in the full file). `stealth_client_decodes_gzip_response` relied on a neighbour having left `OBSCURA_ALLOW_PRIVATE_NETWORK` set. The two `configured_roots` TLS tests set `SSL_CERT_FILE` / `SSL_CERT_DIR` without restoring them. All now bind their variables to a restore-on-drop `EnvGuard`. No test is `#[ignore]`d, and CI's explicit opt-in for the gzip test keeps working unchanged.

No new `unsafe`: these crates are edition 2021, where `set_var` and `remove_var` are safe.

Fixes #853.

## Validation

- `cargo nextest run --release --features render -p obscura-js -p obscura-net -p obscura`: 599 tests run, 599 passed, 0 skipped (obscura-js 474 passed, 0 failed; obscura-net 93 passed, 0 failed; obscura 32 passed, 0 failed); stealth `-p obscura-net --features stealth` 98 tests run, 98 passed, 1 skipped; the gzip test now passes without the CI env opt-in (passed)
- `cargo test --release -p obscura-js --lib -- --test-threads=1` (one process for the whole binary): on `main` the binary aborts with SIGTRAP after "running 383 tests" and prints no `test result:` line; on this branch it completes, 384 passed, 0 failed, 0 ignored (the heap-limit test skips itself with a message because an isolate already exists in the shared process).
- `cargo test --release -p obscura-net --lib configured_roots -- --test-threads=1`: 1 passed, 1 failed. That is the pre-existing single-process race the old comment described (the second test to build a client finds the rustls root store already fixed); it is unchanged from `main` and does not occur under nextest, which runs each test in its own process. This PR deliberately does not `#[ignore]` those tests, so CI keeps them.
- Full render-feature nextest run on the integration of this batch: on the integration of all 16 branches (tree `f58095e`): render `cargo nextest run --release --features render --no-fail-fast` 1791 tests run, 1791 passed, 4 skipped; stealth `-p obscura-net --features stealth` 157 tests run, 157 passed, 1 skipped plus the opt-in gzip test passed; no-render `-p obscura` 30 tests run, 30 passed, 0 skipped; `--workspace --no-default-features` (excluding obscura and obscura-render) 1031 tests run, 1031 passed, 3 skipped (nextest flagged one allowlist test as leaky once, meaning a child handle outlived the passing test by more than its 100 ms grace; it did not recur in the earlier run); all four release configurations build and `cargo check -p obscura-render --no-default-features` passes. The skipped tests are upstream's own pre-existing `#[ignore]`s.

## Rendering

Not applicable.

## Performance

No expected impact. The change on the runtime path is one atomic store at first isolate creation and one atomic load in `set_v8_flags`, which runs once at startup.

## Checklist

- [x] The change is focused and does not remove existing behavior without justification.
- [x] Tests cover the failure or feature.
- [x] Existing tests pass, including render and no-render configurations when affected.
- [x] I checked for CPU, latency, and memory regressions.
- [x] Public API or user-facing behavior changes are documented.

https://claude.ai/code/session_018uyG49E7pxjZGyrR62pwmi
