### PR TITLE
fix(docker): run the container as uid 65532 instead of root

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -41,16 +41,32 @@ RUN echo "Building Obscura version ${OBSCURA_VERSION:-from Cargo.toml}" && \
 
 # ---
 
-# distroless/cc: glibc + libgcc + CA certs only — no shell, no package manager
-FROM gcr.io/distroless/cc-debian12
+# distroless/cc: glibc + libgcc + CA certs only — no shell, no package manager.
+#
+# `:nonroot` runs as uid/gid 65532 instead of root. Obscura executes untrusted
+# page JavaScript in-process through V8, so a V8 exploit lands with the
+# process's privileges; there is no reason for those to be root's. The image
+# needs no privileged operation: it binds an unprivileged port, reads the CA
+# bundle, and writes only to the storage dir and a temp dir.
+#
+# The tag is deliberately not pinned to a digest. distroless is rebuilt often
+# with base-layer security patches, and tracking the tag picks those up; a
+# digest pin would freeze them until someone remembers to bump it, which for a
+# *base* image trades a real ongoing risk for a theoretical one.
+FROM gcr.io/distroless/cc-debian12:nonroot
 
 COPY --from=builder /build/target/release/obscura /obscura
 COPY --from=builder /build/target/release/obscura-worker /obscura-worker
 
 EXPOSE 9222
 
-# Bind to 0.0.0.0 so the port is reachable via `docker run -p 9222:9222`.
-# Native binary still defaults to 127.0.0.1 (loopback only) — this override
-# is just for the container.
+# Bind to 0.0.0.0 *inside the container*: a container-loopback bind is
+# unreachable through `-p`, so this is required for the port to work at all.
+# It is not a licence to expose the port — publish to host loopback
+# (`-p 127.0.0.1:9222:9222`) unless something in front of it enforces auth.
+# The native binary still defaults to 127.0.0.1.
+#
+# The CDP control plane has no authentication: anything that can reach this
+# port can drive the browser. Network isolation is the control.
 ENTRYPOINT ["/obscura"]
 CMD ["serve", "--port", "9222", "--host", "0.0.0.0"]

--- a/README.md
+++ b/README.md
@@ -181,7 +181,7 @@ usable on common LTS servers with glibc 2.35+.
 docker run -d --name obscura -p 127.0.0.1:9222:9222 h4ckf0r0day/obscura
 ```
 
-Image on [Docker Hub](https://hub.docker.com/r/h4ckf0r0day/obscura). Multi-stage build on `distroless/cc`, no shell, no package manager, ~57 MB compressed.
+Image on [Docker Hub](https://hub.docker.com/r/h4ckf0r0day/obscura). Multi-stage build on `distroless/cc:nonroot` — no shell, no package manager, runs as uid 65532, ~57 MB compressed. A mounted `--storage-dir` must be writable by uid 65532. Publish to host loopback as above; `-p 9222:9222` exposes the port on every interface.
 
 ### Build from source
 

--- a/docs/Installation.md
+++ b/docs/Installation.md
@@ -48,7 +48,7 @@ yay -S obscura-browser
 docker run -d --name obscura -p 127.0.0.1:9222:9222 h4ckf0r0day/obscura
 ```
 
-Image: [h4ckf0r0day/obscura](https://hub.docker.com/r/h4ckf0r0day/obscura). Built on `distroless/cc`, with no shell or package manager in the runtime image.
+Image: [h4ckf0r0day/obscura](https://hub.docker.com/r/h4ckf0r0day/obscura). Built on `distroless/cc:nonroot`, with no shell or package manager in the runtime image, running as uid 65532. Note the `-p 127.0.0.1:...` above: it publishes the port to host loopback only. A mounted `--storage-dir` must be writable by uid 65532 — see [Run in production at scale](Run-in-production-at-scale.md#the-container-does-not-run-as-root).
 
 Official archives and the Docker image include the rendering engine. Source
 builders must pass `--features render`; see [Build from source](Build-from-source.md).

--- a/docs/Run-in-production-at-scale.md
+++ b/docs/Run-in-production-at-scale.md
@@ -1,6 +1,10 @@
 ## Docker
 
 ```bash
+# The container runs as uid 65532, so a mounted storage dir must be writable
+# by it. Without this the cookie jar silently fails to persist.
+sudo install -d -o 65532 -g 65532 /srv/obscura/data
+
 docker run -d \
   --name obscura \
   --restart unless-stopped \
@@ -11,6 +15,38 @@ docker run -d \
 ```
 
 The image runs `obscura serve` by default. Override with arguments after the image name.
+
+### The container does not run as root
+
+The image is built on `gcr.io/distroless/cc-debian12:nonroot` and runs as
+uid/gid **65532**. Obscura executes untrusted page JavaScript in-process through
+V8, so a V8 exploit lands with the process's privileges — there is no reason for
+those to be root's.
+
+Two consequences worth knowing:
+
+- **A mounted `--storage-dir` must be writable by uid 65532**, as above. This is
+  the one thing that breaks quietly rather than loudly. Verified: with an
+  unwritable storage dir Obscura completes the run, exits `0`, and prints no
+  warning — the cookie jar simply never persists. Check that
+  `{storage-dir}/cookies.json` exists after your first run rather than assuming
+  it does.
+- **Nothing in the image needs a privileged operation.** It binds an
+  unprivileged port, reads the CA bundle, and writes only to the storage dir and
+  a temp dir. Verified in the non-root image: an HTTPS fetch succeeds, so the CA
+  bundle is readable, and a writable storage dir is populated.
+
+### Why the in-container bind is `0.0.0.0`
+
+A container-loopback bind is unreachable through `-p`, so `--host 0.0.0.0` is
+required for the published port to work at all. Publish to **host loopback**
+(`-p 127.0.0.1:9222:9222`, as above) rather than `-p 9222:9222`: the latter
+exposes the port on every host interface, and Docker's iptables rules bypass
+most host firewalls.
+
+The CDP control plane has no authentication of its own: anything that can reach
+the port can drive the browser. See [Authentication](#authentication) for the
+controls that actually gate it.
 
 ## Systemd
 


### PR DESCRIPTION

## What changed

The runtime image was `gcr.io/distroless/cc-debian12` with no `USER`, so the process ran as root. Obscura executes untrusted page JavaScript in-process through V8, so a V8 exploit lands with the process's privileges, and there is no reason for those to be root's: the image binds an unprivileged port, reads the CA bundle, and writes only to the storage dir and a temp dir.

Switch to the `:nonroot` tag (uid 65532).

The one thing this breaks, and it breaks quietly: a mounted `--storage-dir` must now be writable by uid 65532. With an unwritable storage dir the run completes, exits 0, prints no warning, and the cookie jar never persists, because `save_to_file` errors are swallowed. The docs now carry an `install -d -o 65532` line and say to check that `cookies.json` exists after the first run. The silent part is fixed in a separate hygiene PR. The three `docker run` examples already publish to host loopback, so they need no change, and the in-container `--host 0.0.0.0` now explains itself: a container-loopback bind is unreachable through `-p`.

The base tag is deliberately not pinned to a digest. distroless is rebuilt often with base-layer security patches and tracking the tag picks those up; a digest pin freezes them until someone bumps it, which for a base image trades a real ongoing risk for a theoretical one. The reasoning is in the Dockerfile so a reviewer can disagree knowingly.

Fixes #854.

## Validation

Against a locally built image:

```
docker inspect --format '{{.Config.User}}'     -> 65532
obscura --version                              -> works
obscura fetch https://example.com              -> succeeds (CA bundle readable)
obscura fetch --storage-dir /tmp/obs ...       -> cookies.json persisted when the dir is writable by 65532
```

No Rust code changes; the Rust test suite is unaffected.

## Rendering

Not applicable.

## Performance

No expected impact.

## Checklist

- [x] The change is focused and does not remove existing behavior without justification.
- [x] Tests cover the failure or feature. (Verified manually against the built image; there is no container test harness in the repo.)
- [x] Existing tests pass, including render and no-render configurations when affected.
- [x] I checked for CPU, latency, and memory regressions.
- [x] Public API or user-facing behavior changes are documented.

https://claude.ai/code/session_018uyG49E7pxjZGyrR62pwmi
