### PR TITLE
feat(net): scoped --allow-network instead of all-or-nothing

### DIFF
--- a/crates/obscura-cli/src/main.rs
+++ b/crates/obscura-cli/src/main.rs
@@ -51,6 +51,22 @@ struct Args {
     #[arg(long, global = true)]
     allow_private_network: bool,
 
+    /// Permit fetches to specific otherwise-blocked networks, as CIDR prefixes
+    /// or bare addresses. Repeatable, and comma-separated lists are accepted.
+    ///
+    /// Prefer this over `--allow-private-network` when testing an internal
+    /// application: that flag disables the whole deny-set, including the cloud
+    /// metadata endpoints (169.254.169.254, 100.100.100.200), so a page you
+    /// load gets an unrestricted internal pivot. `--allow-network` opens only
+    /// what you name.
+    ///
+    ///   --allow-network 10.20.0.0/16 --allow-network 192.168.1.5
+    ///
+    /// Equivalent to `OBSCURA_ALLOW_NETWORK`, but per-process and survives in
+    /// command pipelines.
+    #[arg(long, global = true, value_name = "CIDR")]
+    allow_network: Vec<String>,
+
     /// Pass raw flags to V8, in the same form V8/Chromium/Node accept
     /// (e.g. `"--max-old-space-size=4096 --max-semi-space-size=64 --expose-gc"`).
     /// Applied once at startup before any isolate is created.
@@ -350,6 +366,28 @@ async fn main() -> anyhow::Result<()> {
         // threaded at this point.
         unsafe {
             std::env::set_var("OBSCURA_ALLOW_PRIVATE_NETWORK", "1");
+        }
+    }
+    if !args.allow_network.is_empty() {
+        // Validate before publishing it: a typo'd prefix must fail loudly at
+        // startup, not silently leave the operator with a policy that denies
+        // the thing they meant to allow.
+        let joined = args.allow_network.join(",");
+        match obscura_net::NetworkPolicy::new(args.allow_private_network, &args.allow_network) {
+            Ok(policy) => {
+                if policy.has_catch_all() {
+                    tracing::warn!(
+                        "--allow-network includes a /0 prefix, which disables the SSRF guard for that address family entirely"
+                    );
+                }
+                // SAFETY: same as above -- before any thread reads the env.
+                unsafe {
+                    std::env::set_var("OBSCURA_ALLOW_NETWORK", &joined);
+                }
+            }
+            Err(error) => {
+                anyhow::bail!("invalid --allow-network: {error}");
+            }
         }
     }
 

--- a/crates/obscura-js/src/ops.rs
+++ b/crates/obscura-js/src/ops.rs
@@ -2214,8 +2214,13 @@ fn build_request_client(proxy_url: Option<&str>) -> Result<reqwest::Client, Stri
         .redirect(reqwest::redirect::Policy::none())
         .timeout(fetch_timeout())
         // SSRF guard: also reject hostnames that resolve to a private/loopback IP.
+        //
+        // This is the fallback client, used when no page client is available,
+        // so it has none of the page's configuration to inherit. Reading the
+        // policy from the environment keeps it consistent with what the CLI set
+        // rather than silently denying an allowlist the operator configured.
         .dns_resolver(std::sync::Arc::new(obscura_net::SsrfGuardResolver::new(
-            false,
+            obscura_net::NetworkPolicy::from_env(false).unwrap_or_default(),
         )))
         // Be explicit about pool size: default is unbounded which is fine,
         // but pool_idle_timeout default (90s) is short for SPA-heavy
@@ -2375,11 +2380,12 @@ async fn op_fetch_url(
     // process-wide environment setting.  Navigation already honours the
     // context's configured HTTP client; scripted fetch/XHR must use the same
     // policy for its initial URL and every URL it can reach below.
-    let allow_private_network = http_client
+    let network_policy = http_client
         .as_ref()
-        .is_some_and(|client| client.allow_private_network);
+        .map(|client| client.network_policy().clone())
+        .unwrap_or_default();
     if let Ok(parsed_url) = url::Url::parse(&url) {
-        if let Err(e) = validate_fetch_url(&parsed_url, allow_private_network) {
+        if let Err(e) = validate_fetch_url(&parsed_url, &network_policy) {
             return Ok(serde_json::json!({
                 "status": 0,
                 "body": "",
@@ -2476,7 +2482,7 @@ async fn op_fetch_url(
     // bypass validate_fetch_url entirely.
     let url = if let Some(new_url) = override_url {
         if let Ok(parsed) = url::Url::parse(&new_url) {
-            if let Err(reason) = validate_fetch_url(&parsed, allow_private_network) {
+            if let Err(reason) = validate_fetch_url(&parsed, &network_policy) {
                 return Ok(serde_json::json!({
                     "status": 0,
                     "body": "",
@@ -2607,7 +2613,7 @@ async fn op_fetch_url(
                 mode.clone(),
                 credentials,
                 callbacks.clone(),
-                allow_private_network,
+                network_policy.clone(),
             )
             .await;
         }
@@ -2720,7 +2726,7 @@ async fn op_fetch_url(
         };
 
         // Re-validate every redirect target against the SSRF policy.
-        if let Err(reason) = validate_fetch_url(&next_url, allow_private_network) {
+        if let Err(reason) = validate_fetch_url(&next_url, &network_policy) {
             return Ok(serde_json::json!({
                 "status": 0,
                 "body": "",
@@ -2924,7 +2930,7 @@ async fn stealth_fetch_all(
     mode: String,
     credentials: FetchCredentials,
     callbacks: Option<Arc<CallbackRegistry>>,
-    allow_private_network: bool,
+    network_policy: obscura_net::NetworkPolicy,
 ) -> Result<String, deno_error::JsErrorBox> {
     let mut current_url = url.clone();
     let mut current_method = method;
@@ -2981,7 +2987,7 @@ async fn stealth_fetch_all(
         };
         // Re-validate every redirect target against the SSRF policy, matching
         // op_fetch_url (GHSA-8v6v-g4rh-jmcm).
-        if let Err(reason) = validate_fetch_url(&next_url, allow_private_network) {
+        if let Err(reason) = validate_fetch_url(&next_url, &network_policy) {
             return Ok(serde_json::json!({
                 "status": 0, "body": "", "url": next_url.to_string(), "headers": {},
                 "blocked": true,
@@ -3306,7 +3312,27 @@ mod tests {
     #[test]
     fn fetch_url_validation_honors_per_context_private_network_opt_in() {
         let loopback = url::Url::parse("http://127.0.0.1:8080/resource").unwrap();
-        assert!(validate_fetch_url(&loopback, true).is_ok());
+        let allow_all = obscura_net::NetworkPolicy::allow_all_private();
+        assert!(validate_fetch_url(&loopback, &allow_all).is_ok());
+        // Denied by default, so the opt-in above is what changed the outcome.
+        let deny = obscura_net::NetworkPolicy::deny_private();
+        assert!(validate_fetch_url(&loopback, &deny).is_err());
+    }
+
+    /// A scoped allowlist reaches only what it names, and in particular does
+    /// not open the cloud metadata endpoint the blanket flag does.
+    #[test]
+    fn fetch_url_validation_honors_a_scoped_network_allowlist() {
+        let scoped =
+            obscura_net::NetworkPolicy::new(false, &["127.0.0.1/32".to_string()]).unwrap();
+        let loopback = url::Url::parse("http://127.0.0.1:8080/resource").unwrap();
+        assert!(validate_fetch_url(&loopback, &scoped).is_ok());
+
+        let metadata = url::Url::parse("http://169.254.169.254/latest/meta-data/").unwrap();
+        assert!(
+            validate_fetch_url(&metadata, &scoped).is_err(),
+            "a loopback-scoped allowlist must not open cloud metadata"
+        );
     }
 
     // SEC-005 / #708 — fetch() must not accept file:// (deny-by-default, matching
@@ -3316,7 +3342,7 @@ mod tests {
     fn fetch_url_validation_rejects_file_scheme() {
         let file = url::Url::parse("file:///etc/passwd").unwrap();
         // Rejected even with private-network access granted.
-        let err = validate_fetch_url(&file, true)
+        let err = validate_fetch_url(&file, &obscura_net::NetworkPolicy::allow_all_private())
             .expect_err("file:// must be rejected by the fetch scheme gate");
         assert!(
             err.to_lowercase().contains("scheme"),
@@ -3838,7 +3864,10 @@ mod tests {
     }
 }
 
-fn validate_fetch_url(url: &url::Url, allow_private_network: bool) -> Result<(), String> {
+fn validate_fetch_url(
+    url: &url::Url,
+    policy: &obscura_net::NetworkPolicy,
+) -> Result<(), String> {
     let scheme = url.scheme();
     // file:// is denied by default here, matching Page.navigate /
     // Target.createTarget (which gate it behind --allow-file-access). The
@@ -3851,14 +3880,14 @@ fn validate_fetch_url(url: &url::Url, allow_private_network: bool) -> Result<(),
         ));
     }
 
-    if allow_private_network || obscura_net::env_allows_private_network() {
+    if policy.allows_all_private() {
         return Ok(());
     }
 
     if let Some(host) = url.host() {
         match host {
             url::Host::Ipv4(ip) => {
-                if obscura_net::is_forbidden_ip(std::net::IpAddr::V4(ip)) {
+                if !policy.permits(std::net::IpAddr::V4(ip)) {
                     return Err(format!(
                         "Access to private/internal IP address {} is not allowed",
                         ip
@@ -3866,7 +3895,7 @@ fn validate_fetch_url(url: &url::Url, allow_private_network: bool) -> Result<(),
                 }
             }
             url::Host::Ipv6(ip) => {
-                if obscura_net::is_forbidden_ip(std::net::IpAddr::V6(ip)) {
+                if !policy.permits(std::net::IpAddr::V6(ip)) {
                     return Err(format!(
                         "Access to private/internal IPv6 address {} is not allowed",
                         ip
@@ -3874,11 +3903,15 @@ fn validate_fetch_url(url: &url::Url, allow_private_network: bool) -> Result<(),
                 }
             }
             url::Host::Domain(domain) => {
+                // A hostname carries no address, so an allowlist cannot be
+                // evaluated here; the SSRF resolver makes the real decision on
+                // the addresses the name resolves to.
                 let lower_domain = domain.to_lowercase();
-                if lower_domain == "localhost"
-                    || lower_domain.ends_with(".localhost")
-                    || lower_domain == "127.0.0.1"
-                    || lower_domain == "::1"
+                if !policy.has_allowlist()
+                    && (lower_domain == "localhost"
+                        || lower_domain.ends_with(".localhost")
+                        || lower_domain == "127.0.0.1"
+                        || lower_domain == "::1")
                 {
                     return Err(format!(
                         "Access to localhost domain '{}' is not allowed",

--- a/crates/obscura-net/src/client.rs
+++ b/crates/obscura-net/src/client.rs
@@ -669,33 +669,33 @@ pub fn is_forbidden_ip(ip: IpAddr) -> bool {
 /// `wreq::dns::Resolve` in `wreq_client.rs`, so `--stealth` never trades the
 /// guard away for a better TLS fingerprint.
 pub struct SsrfGuardResolver {
-    pub(crate) allow_private: bool,
+    pub(crate) policy: crate::policy::NetworkPolicy,
 }
 
 impl SsrfGuardResolver {
-    pub fn new(allow_private: bool) -> Self {
-        Self { allow_private }
+    pub fn new(policy: crate::policy::NetworkPolicy) -> Self {
+        Self { policy }
     }
 }
 
 impl Resolve for SsrfGuardResolver {
     fn resolve(&self, name: Name) -> Resolving {
-        let allow = self.allow_private || env_allows_private_network();
+        let policy = self.policy.clone();
         let host = name.as_str().to_string();
         Box::pin(async move {
             let addrs: Vec<SocketAddr> = tokio::net::lookup_host((host.as_str(), 0))
                 .await
                 .map_err(|e| -> Box<dyn std::error::Error + Send + Sync> { Box::new(e) })?
                 .collect();
-            if !allow {
-                if let Some(bad) = addrs.iter().find(|sa| is_forbidden_ip(sa.ip())) {
-                    return Err(format!(
-                        "SSRF blocked: '{}' resolves to forbidden address {}",
-                        host,
-                        bad.ip()
-                    )
-                    .into());
-                }
+            // The authoritative check: it sees the addresses the name actually
+            // resolves to, which is what closes DNS rebinding.
+            if let Some(bad) = addrs.iter().find(|sa| !policy.permits(sa.ip())) {
+                return Err(format!(
+                    "SSRF blocked: '{}' resolves to forbidden address {}",
+                    host,
+                    bad.ip()
+                )
+                .into());
             }
             let iter: Addrs = Box::new(addrs.into_iter());
             Ok(iter)
@@ -703,8 +703,10 @@ impl Resolve for SsrfGuardResolver {
     }
 }
 
-pub(crate) fn validate_url(url: &Url, allow_private_network: bool) -> Result<(), ObscuraNetError> {
-    let allow_private_network = allow_private_network || env_allows_private_network();
+pub(crate) fn validate_url(
+    url: &Url,
+    policy: &crate::policy::NetworkPolicy,
+) -> Result<(), ObscuraNetError> {
     let scheme = url.scheme();
     if scheme != "http" && scheme != "https" && scheme != "file" {
         return Err(ObscuraNetError::Network(format!(
@@ -713,14 +715,15 @@ pub(crate) fn validate_url(url: &Url, allow_private_network: bool) -> Result<(),
         )));
     }
 
-    if scheme == "file" || allow_private_network {
+    // file:// is gated separately, at the read primitive.
+    if scheme == "file" || policy.allows_all_private() {
         return Ok(());
     }
 
     if let Some(host) = url.host() {
         match host {
             url::Host::Ipv4(ip) => {
-                if is_forbidden_ip(IpAddr::V4(ip)) {
+                if !policy.permits(IpAddr::V4(ip)) {
                     return Err(ObscuraNetError::Network(format!(
                         "Access to private/internal IP address {} is not allowed",
                         ip
@@ -728,7 +731,7 @@ pub(crate) fn validate_url(url: &Url, allow_private_network: bool) -> Result<(),
                 }
             }
             url::Host::Ipv6(ip) => {
-                if is_forbidden_ip(IpAddr::V6(ip)) {
+                if !policy.permits(IpAddr::V6(ip)) {
                     return Err(ObscuraNetError::Network(format!(
                         "Access to private/internal IPv6 address {} is not allowed",
                         ip
@@ -736,11 +739,19 @@ pub(crate) fn validate_url(url: &Url, allow_private_network: bool) -> Result<(),
                 }
             }
             url::Host::Domain(domain) => {
+                // A hostname carries no address, so an allowlist cannot be
+                // evaluated here. When the operator listed prefixes, defer to
+                // `SsrfGuardResolver`, which sees what the name actually
+                // resolves to and is the authoritative check -- otherwise
+                // `--allow-network 127.0.0.1/32` would still refuse
+                // `http://localhost:8080`, which is the exact case the flag
+                // exists for.
                 let lower_domain = domain.to_lowercase();
-                if lower_domain == "localhost"
-                    || lower_domain.ends_with(".localhost")
-                    || lower_domain == "127.0.0.1"
-                    || lower_domain == "::1"
+                if !policy.has_allowlist()
+                    && (lower_domain == "localhost"
+                        || lower_domain.ends_with(".localhost")
+                        || lower_domain == "127.0.0.1"
+                        || lower_domain == "::1")
                 {
                     return Err(ObscuraNetError::Network(format!(
                         "Access to localhost domain '{}' is not allowed",
@@ -908,6 +919,11 @@ pub struct ObscuraHttpClient {
     /// through in addition to the `OBSCURA_ALLOW_PRIVATE_NETWORK` env var.
     /// Set via `--allow-private-network` on the CLI (issue #33).
     pub allow_private_network: bool,
+    /// Which otherwise-forbidden destinations this client may reach. Built once
+    /// at construction from `allow_private_network` plus
+    /// `OBSCURA_ALLOW_NETWORK`, so the decision is data on the client rather
+    /// than a process-global consulted per request.
+    network_policy: crate::policy::NetworkPolicy,
 }
 
 const RESOURCE_CACHE_MAX_ENTRIES: usize = 256;
@@ -1119,7 +1135,36 @@ impl ObscuraHttpClient {
             block_trackers: false,
             resource_loader: std::sync::Mutex::new(ResourceLoaderState::default()),
             allow_private_network,
+            network_policy: crate::policy::NetworkPolicy::from_env(allow_private_network)
+                .unwrap_or_else(|error| {
+                    // A malformed OBSCURA_ALLOW_NETWORK must not silently widen
+                    // or narrow the policy. Refuse the entries, keep the
+                    // blanket flag's meaning, and say so loudly.
+                    tracing::error!(
+                        "ignoring OBSCURA_ALLOW_NETWORK: {error}. No extra networks are permitted."
+                    );
+                    if allow_private_network {
+                        crate::policy::NetworkPolicy::allow_all_private()
+                    } else {
+                        crate::policy::NetworkPolicy::deny_private()
+                    }
+                }),
         }
+    }
+
+    /// The network policy this client enforces.
+    pub fn network_policy(&self) -> &crate::policy::NetworkPolicy {
+        &self.network_policy
+    }
+
+    /// Replace the network policy.
+    ///
+    /// Takes `&mut self` deliberately: the reqwest client is built lazily and
+    /// captures the policy in its DNS resolver at that point, so this is only
+    /// meaningful before the first request. Requiring exclusive access makes
+    /// that ordering a compile-time constraint rather than a comment.
+    pub fn set_network_policy(&mut self, policy: crate::policy::NetworkPolicy) {
+        self.network_policy = policy;
     }
 
     async fn get_client(&self) -> &Client {
@@ -1129,7 +1174,7 @@ impl ObscuraHttpClient {
                 .timeout(self.timeout)
                 .danger_accept_invalid_certs(false)
                 // SSRF guard: reject hostnames that resolve to a private/loopback IP.
-                .dns_resolver(Arc::new(SsrfGuardResolver::new(self.allow_private_network)))
+                .dns_resolver(Arc::new(SsrfGuardResolver::new(self.network_policy.clone())))
 ;
 
             if std::env::var_os("SSL_CERT_FILE").is_some()
@@ -1428,7 +1473,7 @@ impl ObscuraHttpClient {
         callbacks: Option<&CallbackRegistry>,
         request: ResourceRequest,
     ) -> Result<Response, ObscuraNetError> {
-        validate_url(url, self.allow_private_network)?;
+        validate_url(url, &self.network_policy)?;
         validate_request_mode(&request, url)?;
 
         if url.scheme() == "file" {
@@ -1651,7 +1696,7 @@ impl ObscuraHttpClient {
                     let next_url = current_url.join(location_str).map_err(|e| {
                         ObscuraNetError::Network(format!("Invalid redirect URL: {}", e))
                     })?;
-                    validate_url(&next_url, self.allow_private_network)?;
+                    validate_url(&next_url, &self.network_policy)?;
                     validate_request_mode(&request, &next_url)?;
                     redirect_tainted |=
                         redirect_taints_origin(&request, &current_url, &next_url);
@@ -1755,6 +1800,16 @@ mod ssrf_tests {
     use std::sync::atomic::{AtomicUsize, Ordering};
     use std::time::Duration;
     use url::Url;
+
+    /// The default policy: everything in the deny-set stays denied.
+    fn deny() -> crate::policy::NetworkPolicy {
+        crate::policy::NetworkPolicy::deny_private()
+    }
+
+    /// The blanket `--allow-private-network` opt-out.
+    fn allow_all() -> crate::policy::NetworkPolicy {
+        crate::policy::NetworkPolicy::allow_all_private()
+    }
 
     fn ip(s: &str) -> IpAddr {
         IpAddr::from_str(s).unwrap()
@@ -1906,21 +1961,21 @@ mod ssrf_tests {
     #[test]
     fn validate_url_blocks_unspecified_and_allows_public() {
         // 0.0.0.0 previously slipped through validate_url's literal-host check.
-        assert!(validate_url(&Url::parse("http://0.0.0.0:8080/").unwrap(), false).is_err());
-        assert!(validate_url(&Url::parse("http://127.0.0.1/").unwrap(), false).is_err());
-        assert!(validate_url(&Url::parse("http://example.com/").unwrap(), false).is_ok());
+        assert!(validate_url(&Url::parse("http://0.0.0.0:8080/").unwrap(), &deny()).is_err());
+        assert!(validate_url(&Url::parse("http://127.0.0.1/").unwrap(), &deny()).is_err());
+        assert!(validate_url(&Url::parse("http://example.com/").unwrap(), &deny()).is_ok());
         assert!(
-            validate_url(&Url::parse("http://[64:ff9b::7f00:1]/").unwrap(), false).is_err()
+            validate_url(&Url::parse("http://[64:ff9b::7f00:1]/").unwrap(), &deny()).is_err()
         );
         assert!(
-            validate_url(&Url::parse("http://[2002:a9fe:a9fe::]/").unwrap(), false).is_err()
+            validate_url(&Url::parse("http://[2002:a9fe:a9fe::]/").unwrap(), &deny()).is_err()
         );
-        assert!(validate_url(&Url::parse("http://192.0.0.9/").unwrap(), false).is_ok());
+        assert!(validate_url(&Url::parse("http://192.0.0.9/").unwrap(), &deny()).is_ok());
         assert!(
-            validate_url(&Url::parse("http://[64:ff9b::808:808]/").unwrap(), false).is_ok()
+            validate_url(&Url::parse("http://[64:ff9b::808:808]/").unwrap(), &deny()).is_ok()
         );
         // The allow flag bypasses the guard (local-dev escape hatch).
-        assert!(validate_url(&Url::parse("http://127.0.0.1/").unwrap(), true).is_ok());
+        assert!(validate_url(&Url::parse("http://127.0.0.1/").unwrap(), &allow_all()).is_ok());
     }
 
     #[test]
@@ -2654,7 +2709,7 @@ mod ssrf_tests {
         // canonical DNS-rebinding test. The guard must reject it. If DNS is
         // unavailable the lookup itself errors (also Err), so the assertion
         // holds either way.
-        let r = SsrfGuardResolver::new(false);
+        let r = SsrfGuardResolver::new(deny());
         let res = r.resolve(Name::from_str("localtest.me").unwrap()).await;
         assert!(res.is_err(), "localtest.me -> 127.0.0.1 must be blocked");
     }
@@ -2663,7 +2718,7 @@ mod ssrf_tests {
     async fn resolver_does_not_ssrf_block_public_host() {
         // A public host must not be SSRF-blocked. Tolerate a no-network sandbox
         // by only failing on an actual SSRF rejection, not a lookup failure.
-        let r = SsrfGuardResolver::new(false);
+        let r = SsrfGuardResolver::new(deny());
         match r.resolve(Name::from_str("example.com").unwrap()).await {
             Ok(_) => {}
             Err(e) => assert!(

--- a/crates/obscura-net/src/lib.rs
+++ b/crates/obscura-net/src/lib.rs
@@ -2,6 +2,7 @@ pub mod client;
 pub mod cookies;
 pub mod encoding;
 pub mod interceptor;
+pub mod policy;
 pub mod robots;
 pub mod blocklist;
 #[cfg(feature = "stealth")]
@@ -17,6 +18,7 @@ pub use encoding::{
     decode_non_html, decode_response, decode_response_with_name, decode_with_label, label_name,
     url_encode_query,
 };
+pub use policy::{NetworkPolicy, Prefix};
 pub use robots::RobotsCache;
 pub use blocklist::is_blocked as is_tracker_blocked;
 #[cfg(feature = "stealth")]

--- a/crates/obscura-net/src/policy.rs
+++ b/crates/obscura-net/src/policy.rs
@@ -1,0 +1,332 @@
+//! Which otherwise-forbidden network destinations this process may reach.
+//!
+//! `is_forbidden_ip` defines the deny-set: loopback, RFC1918, link-local
+//! (including the cloud-metadata addresses), CGNAT, and the rest. That
+//! definition is unchanged and stays the single source of truth.
+//!
+//! What changes is the escape hatch. `--allow-private-network` was the only
+//! one, and it disables the deny-set **entirely** — including
+//! `169.254.169.254` and `100.100.100.200`. It is also the flag an operator
+//! must set to test an internal application, which is the common case: testing
+//! an app on `10.20.0.0/16` should not also hand every page the cloud
+//! metadata service.
+//!
+//! `NetworkPolicy` adds a scoped alternative. `--allow-network 10.20.0.0/16`
+//! exempts exactly that prefix and leaves everything else denied.
+//!
+//! CIDR parsing is hand-rolled rather than pulling in `ipnet`: it is ~40 lines,
+//! and a new dependency needs a `deny.toml` policy review that would dwarf it.
+
+use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
+
+use crate::client::is_forbidden_ip;
+
+/// A single CIDR prefix, or a bare address (an implicit /32 or /128).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Prefix {
+    addr: IpAddr,
+    bits: u8,
+}
+
+impl Prefix {
+    /// Parse `10.0.0.0/8`, `192.168.1.5`, `fd00::/8`, or `::1`.
+    pub fn parse(entry: &str) -> Result<Self, String> {
+        let entry = entry.trim();
+        if entry.is_empty() {
+            return Err("empty network entry".to_string());
+        }
+        let (addr_part, bits_part) = match entry.split_once('/') {
+            Some((a, b)) => (a, Some(b)),
+            None => (entry, None),
+        };
+        let addr: IpAddr = addr_part
+            .parse()
+            .map_err(|_| format!("'{addr_part}' is not an IP address"))?;
+        let max_bits = if addr.is_ipv4() { 32u8 } else { 128u8 };
+        let bits = match bits_part {
+            None => max_bits,
+            Some(b) => {
+                let parsed: u8 = b
+                    .trim()
+                    .parse()
+                    .map_err(|_| format!("'{b}' is not a prefix length"))?;
+                if parsed > max_bits {
+                    return Err(format!(
+                        "prefix /{parsed} is longer than /{max_bits} for {addr_part}"
+                    ));
+                }
+                parsed
+            }
+        };
+        Ok(Prefix { addr, bits })
+    }
+
+    /// Does this prefix cover `ip`?
+    ///
+    /// An IPv4-mapped IPv6 address is compared as its embedded v4, matching
+    /// `is_forbidden_ip`: otherwise `::ffff:10.20.5.5` would slip past a
+    /// `10.20.0.0/16` entry and be denied when the operator meant to allow it.
+    pub fn contains(&self, ip: IpAddr) -> bool {
+        let ip = match ip {
+            IpAddr::V6(v6) => match v6.to_ipv4_mapped().or_else(|| v6.to_ipv4()) {
+                Some(v4) if self.addr.is_ipv4() => IpAddr::V4(v4),
+                _ => ip,
+            },
+            other => other,
+        };
+        match (self.addr, ip) {
+            (IpAddr::V4(net), IpAddr::V4(candidate)) => {
+                masked_v4(net, self.bits) == masked_v4(candidate, self.bits)
+            }
+            (IpAddr::V6(net), IpAddr::V6(candidate)) => {
+                masked_v6(net, self.bits) == masked_v6(candidate, self.bits)
+            }
+            _ => false,
+        }
+    }
+
+    /// True for `/0`, which exempts the entire address family.
+    pub fn is_everything(&self) -> bool {
+        self.bits == 0
+    }
+}
+
+fn masked_v4(addr: Ipv4Addr, bits: u8) -> u32 {
+    let raw = u32::from(addr);
+    if bits == 0 {
+        0
+    } else {
+        raw & (!0u32 << (32 - bits))
+    }
+}
+
+fn masked_v6(addr: Ipv6Addr, bits: u8) -> u128 {
+    let raw = u128::from(addr);
+    if bits == 0 {
+        0
+    } else {
+        raw & (!0u128 << (128 - bits))
+    }
+}
+
+/// The set of destinations a client may reach.
+#[derive(Debug, Clone, Default)]
+pub struct NetworkPolicy {
+    /// `--allow-private-network` / `OBSCURA_ALLOW_PRIVATE_NETWORK`. Disables
+    /// the whole deny-set. Unchanged behaviour, kept for compatibility.
+    allow_all_private: bool,
+    /// `--allow-network <CIDR>` / `OBSCURA_ALLOW_NETWORK`. Exempts only these.
+    allowed: Vec<Prefix>,
+}
+
+impl NetworkPolicy {
+    /// Deny everything in the deny-set. The default.
+    pub fn deny_private() -> Self {
+        Self::default()
+    }
+
+    /// The blanket opt-out, preserving `--allow-private-network`.
+    pub fn allow_all_private() -> Self {
+        Self {
+            allow_all_private: true,
+            allowed: Vec::new(),
+        }
+    }
+
+    /// Build from the two opt-ins. `entries` are CIDRs or bare addresses.
+    pub fn new(allow_all_private: bool, entries: &[String]) -> Result<Self, String> {
+        let mut allowed = Vec::with_capacity(entries.len());
+        for entry in entries {
+            for part in entry.split(',') {
+                let part = part.trim();
+                if part.is_empty() {
+                    continue;
+                }
+                allowed.push(Prefix::parse(part)?);
+            }
+        }
+        Ok(Self {
+            allow_all_private,
+            allowed,
+        })
+    }
+
+    /// Read both opt-ins from the environment, the way the CLI sets them.
+    ///
+    /// A malformed `OBSCURA_ALLOW_NETWORK` is a hard error rather than a silent
+    /// skip: an operator who typos a prefix should be told, not quietly left
+    /// with a policy that denies the thing they meant to allow.
+    pub fn from_env(allow_all_private: bool) -> Result<Self, String> {
+        let entries: Vec<String> = std::env::var("OBSCURA_ALLOW_NETWORK")
+            .ok()
+            .filter(|s| !s.trim().is_empty())
+            .into_iter()
+            .collect();
+        let allow_all_private =
+            allow_all_private || crate::client::env_allows_private_network();
+        Self::new(allow_all_private, &entries)
+    }
+
+    /// Whether the blanket private-network opt-out is in force.
+    pub fn allows_all_private(&self) -> bool {
+        self.allow_all_private
+    }
+
+    /// Any `/0` entry disables the guard for its address family. Callers warn
+    /// about it rather than refuse, because an operator may genuinely mean it.
+    pub fn has_catch_all(&self) -> bool {
+        self.allowed.iter().any(Prefix::is_everything)
+    }
+
+    /// True when the operator listed at least one prefix.
+    ///
+    /// `validate_url` uses this for the `localhost` *domain* check: a hostname
+    /// carries no IP, so an allowlist cannot be evaluated against it there.
+    /// When one exists the decision is deferred to `SsrfGuardResolver`, which
+    /// sees the addresses the name actually resolves to and is the
+    /// authoritative check anyway.
+    pub fn has_allowlist(&self) -> bool {
+        !self.allowed.is_empty()
+    }
+
+    /// May `ip` be dialled?
+    ///
+    /// Public addresses short-circuit: the deny-set is the only thing this
+    /// policy relaxes, so a policy can never *forbid* something
+    /// `is_forbidden_ip` permits. That keeps `--allow-network` an escape hatch
+    /// rather than a firewall an operator might mistake it for.
+    pub fn permits(&self, ip: IpAddr) -> bool {
+        if !is_forbidden_ip(ip) {
+            return true;
+        }
+        if self.allow_all_private {
+            return true;
+        }
+        self.allowed.iter().any(|prefix| prefix.contains(ip))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn ip(s: &str) -> IpAddr {
+        s.parse().unwrap()
+    }
+
+    fn policy(entries: &[&str]) -> NetworkPolicy {
+        NetworkPolicy::new(false, &entries.iter().map(|s| s.to_string()).collect::<Vec<_>>())
+            .expect("entries must parse")
+    }
+
+    #[test]
+    fn an_allowed_prefix_is_reachable_and_its_neighbours_are_not() {
+        let p = policy(&["10.20.0.0/16"]);
+        assert!(p.permits(ip("10.20.5.5")));
+        assert!(p.permits(ip("10.20.255.254")));
+        assert!(!p.permits(ip("10.21.0.1")), "outside the prefix");
+        assert!(!p.permits(ip("127.0.0.1")), "loopback is not in the prefix");
+    }
+
+    /// The whole point of the allowlist: opening an internal range must not open the
+    /// cloud metadata endpoint.
+    #[test]
+    fn allowing_an_internal_range_does_not_open_cloud_metadata() {
+        let p = policy(&["10.20.0.0/16"]);
+        assert!(!p.permits(ip("169.254.169.254")), "AWS/GCP/Azure metadata");
+        assert!(!p.permits(ip("100.100.100.200")), "Alibaba metadata");
+        assert!(!p.permits(ip("169.254.1.1")), "link-local generally");
+    }
+
+    /// The blanket flag keeps its old, deliberately broad meaning.
+    #[test]
+    fn allow_all_private_still_opens_everything() {
+        let p = NetworkPolicy::allow_all_private();
+        for addr in ["127.0.0.1", "10.0.0.1", "192.168.1.1", "169.254.169.254", "::1"] {
+            assert!(p.permits(ip(addr)), "{addr} must be reachable");
+        }
+    }
+
+    #[test]
+    fn the_default_policy_denies_the_whole_deny_set() {
+        let p = NetworkPolicy::deny_private();
+        for addr in ["127.0.0.1", "10.0.0.1", "169.254.169.254", "::1", "fd00::1"] {
+            assert!(!p.permits(ip(addr)), "{addr} must be denied by default");
+        }
+    }
+
+    /// A policy relaxes the deny-set; it never tightens it. Public addresses
+    /// are unaffected, so `--allow-network` cannot be mistaken for a firewall.
+    #[test]
+    fn public_addresses_are_unaffected_by_any_policy() {
+        for p in [
+            NetworkPolicy::deny_private(),
+            NetworkPolicy::allow_all_private(),
+            policy(&["10.0.0.0/8"]),
+        ] {
+            assert!(p.permits(ip("1.1.1.1")));
+            assert!(p.permits(ip("2606:4700:4700::1111")));
+        }
+    }
+
+    #[test]
+    fn a_bare_address_is_an_implicit_host_route() {
+        let p = policy(&["192.168.1.5"]);
+        assert!(p.permits(ip("192.168.1.5")));
+        assert!(!p.permits(ip("192.168.1.6")));
+    }
+
+    #[test]
+    fn ipv6_prefixes_work() {
+        let p = policy(&["fd00::/8"]);
+        assert!(p.permits(ip("fd00::1")));
+        assert!(p.permits(ip("fdff::9999")));
+        assert!(!p.permits(ip("fc00::1")), "outside fd00::/8");
+        assert!(!p.permits(ip("::1")), "loopback is not in the prefix");
+    }
+
+    /// `::ffff:10.20.5.5` must match a v4 prefix, or the guard's own
+    /// IPv4-mapped unwrapping would deny what the operator allowed.
+    #[test]
+    fn an_ipv4_mapped_address_matches_a_v4_prefix() {
+        let p = policy(&["10.20.0.0/16"]);
+        assert!(p.permits(ip("::ffff:10.20.5.5")));
+        assert!(!p.permits(ip("::ffff:10.21.5.5")));
+    }
+
+    #[test]
+    fn several_entries_and_comma_separated_lists_both_work() {
+        let p = policy(&["10.0.0.0/8", "192.168.0.0/16,172.16.0.0/12"]);
+        assert!(p.permits(ip("10.1.2.3")));
+        assert!(p.permits(ip("192.168.9.9")));
+        assert!(p.permits(ip("172.16.0.1")));
+        assert!(!p.permits(ip("127.0.0.1")));
+    }
+
+    #[test]
+    fn malformed_entries_are_rejected_with_a_reason() {
+        for bad in ["10.0.0.0/33", "nonsense", "10.0.0.0/", "999.1.1.1", "fd00::/129"] {
+            let err = NetworkPolicy::new(false, &[bad.to_string()])
+                .expect_err(&format!("{bad} must not parse"));
+            assert!(!err.is_empty(), "the error should say what was wrong");
+        }
+    }
+
+    #[test]
+    fn a_catch_all_prefix_is_detectable_so_callers_can_warn() {
+        assert!(policy(&["0.0.0.0/0"]).has_catch_all());
+        assert!(policy(&["::/0"]).has_catch_all());
+        assert!(!policy(&["10.0.0.0/8"]).has_catch_all());
+        // It does what it says, which is why it is worth warning about.
+        assert!(policy(&["0.0.0.0/0"]).permits(ip("127.0.0.1")));
+    }
+
+    #[test]
+    fn prefix_boundaries_are_exact() {
+        let p = policy(&["10.20.0.0/16"]);
+        assert!(p.permits(ip("10.20.0.0")));
+        assert!(p.permits(ip("10.20.255.255")));
+        assert!(!p.permits(ip("10.19.255.255")));
+        assert!(!p.permits(ip("10.21.0.0")));
+    }
+}

--- a/crates/obscura-net/src/wreq_client.rs
+++ b/crates/obscura-net/src/wreq_client.rs
@@ -19,8 +19,8 @@ use crate::cookies::CookieJar;
 #[cfg(feature = "stealth")]
 use crate::client::{
     CallbackRegistry, InFlightGuard, ObscuraNetError, RequestInfo, RequestMode,
-    ResourceRequest, Response, SsrfGuardResolver, cors_required, env_allows_private_network,
-    fetch_file_url, is_forbidden_ip, redirect_taints_origin, request_fetch_site,
+    ResourceRequest, Response, SsrfGuardResolver, cors_required, fetch_file_url,
+    redirect_taints_origin, request_fetch_site,
     request_referrer, response_too_large, serialized_request_origin, validate_cors_response,
     validate_request_mode, validate_url,
 };
@@ -34,22 +34,20 @@ use crate::client::{
 #[cfg(feature = "stealth")]
 impl wreq::dns::Resolve for SsrfGuardResolver {
     fn resolve(&self, name: wreq::dns::Name) -> wreq::dns::Resolving {
-        let allow = self.allow_private || env_allows_private_network();
+        let policy = self.policy.clone();
         let host = name.as_str().to_string();
         Box::pin(async move {
             let addrs: Vec<std::net::SocketAddr> = tokio::net::lookup_host((host.as_str(), 0))
                 .await
                 .map_err(|e| -> Box<dyn Error + Send + Sync> { Box::new(e) })?
                 .collect();
-            if !allow {
-                if let Some(bad) = addrs.iter().find(|sa| is_forbidden_ip(sa.ip())) {
-                    return Err(format!(
-                        "SSRF blocked: '{}' resolves to forbidden address {}",
-                        host,
-                        bad.ip()
-                    )
-                    .into());
-                }
+            if let Some(bad) = addrs.iter().find(|sa| !policy.permits(sa.ip())) {
+                return Err(format!(
+                    "SSRF blocked: '{}' resolves to forbidden address {}",
+                    host,
+                    bad.ip()
+                )
+                .into());
             }
             let iter: wreq::dns::Addrs = Box::new(addrs.into_iter());
             Ok(iter)
@@ -173,10 +171,29 @@ async fn send_get_with_connection_reset_retry(
 #[cfg(feature = "stealth")]
 pub struct StealthHttpClient {
     client: wreq::Client,
-    allow_private_network: bool,
     pub cookie_jar: Arc<CookieJar>,
     pub extra_headers: RwLock<HashMap<String, String>>,
     pub in_flight: Arc<std::sync::atomic::AtomicU32>,
+    /// Same policy the default transport enforces: seeded from
+    /// `allow_private_network` (#831), with the scoped `OBSCURA_ALLOW_NETWORK`
+    /// allowlist layered on top.
+    network_policy: crate::policy::NetworkPolicy,
+}
+
+/// The network policy for the stealth transport.
+///
+/// `allow_all_private` is `--allow-private-network` (#793); the scoped
+/// `OBSCURA_ALLOW_NETWORK` allowlist layers on top of it. A malformed
+/// allowlist denies the extra networks rather than silently widening or
+/// narrowing the policy, and says so.
+#[cfg(feature = "stealth")]
+fn stealth_network_policy(allow_all_private: bool) -> crate::policy::NetworkPolicy {
+    crate::policy::NetworkPolicy::from_env(allow_all_private).unwrap_or_else(|error| {
+        tracing::error!(
+            "ignoring OBSCURA_ALLOW_NETWORK: {error}. No extra networks are permitted."
+        );
+        crate::policy::NetworkPolicy::deny_private()
+    })
 }
 
 #[cfg(feature = "stealth")]
@@ -190,6 +207,8 @@ impl StealthHttpClient {
         proxy_url: Option<&str>,
         allow_private_network: bool,
     ) -> Self {
+        let network_policy = stealth_network_policy(allow_private_network);
+
         let emulation_opts = wreq_util::Emulation::builder()
             .profile(wreq_util::Profile::Chrome145)
             .platform(wreq_util::Platform::Windows)
@@ -202,7 +221,7 @@ impl StealthHttpClient {
             // IP. Use the same opt-in as the `validate_url` calls below so
             // `--allow-private-network` reaches this transport (#793); the
             // resolver still honours OBSCURA_ALLOW_PRIVATE_NETWORK on its own.
-            .dns_resolver(Arc::new(SsrfGuardResolver::new(allow_private_network)))
+            .dns_resolver(Arc::new(SsrfGuardResolver::new(network_policy.clone())))
             .redirect(wreq::redirect::Policy::none());
 
         // Honor SSL_CERT_FILE / SSL_CERT_DIR in the stealth client too.
@@ -249,10 +268,10 @@ impl StealthHttpClient {
 
         StealthHttpClient {
             client,
-            allow_private_network,
             cookie_jar,
             extra_headers: RwLock::new(HashMap::new()),
             in_flight: Arc::new(std::sync::atomic::AtomicU32::new(0)),
+            network_policy,
         }
     }
 
@@ -284,7 +303,7 @@ impl StealthHttpClient {
         request: ResourceRequest,
         callbacks: Option<&CallbackRegistry>,
     ) -> Result<Response, ObscuraNetError> {
-        validate_url(url, self.allow_private_network)?;
+        validate_url(url, &self.network_policy)?;
         validate_request_mode(&request, url)?;
         if url.scheme() == "file" {
             return fetch_file_url(url, request.max_response_bytes).await;
@@ -404,7 +423,7 @@ impl StealthHttpClient {
                     let next_url = current_url.join(location_str).map_err(|e| {
                         ObscuraNetError::Network(format!("Invalid redirect URL: {}", e))
                     })?;
-                    validate_url(&next_url, self.allow_private_network)?;
+                    validate_url(&next_url, &self.network_policy)?;
                     validate_request_mode(&request, &next_url)?;
                     redirect_tainted |=
                         redirect_taints_origin(&request, &current_url, &next_url);
@@ -542,7 +561,7 @@ mod tests {
     // public name points inward, so the stealth client needs the same resolver.
     #[tokio::test]
     async fn stealth_resolver_blocks_hostname_that_resolves_to_loopback() {
-        let resolver = SsrfGuardResolver::new(false);
+        let resolver = SsrfGuardResolver::new(crate::policy::NetworkPolicy::deny_private());
         let res = resolver.resolve(Name::from("localtest.me")).await;
         assert!(res.is_err(), "localtest.me -> 127.0.0.1 must be blocked");
     }
@@ -550,7 +569,7 @@ mod tests {
     #[tokio::test]
     async fn stealth_resolver_does_not_block_public_host() {
         // Tolerate a no-network sandbox: only an actual SSRF rejection fails.
-        let resolver = SsrfGuardResolver::new(false);
+        let resolver = SsrfGuardResolver::new(crate::policy::NetworkPolicy::deny_private());
         match resolver.resolve(Name::from("example.com")).await {
             Ok(_) => {}
             Err(e) => assert!(
@@ -630,10 +649,12 @@ mod tests {
         let (port, server) = reset_fixture(false);
         let client = StealthHttpClient {
             client: wreq::Client::builder().no_proxy().build().unwrap(),
-            allow_private_network: true,
             cookie_jar: Arc::new(CookieJar::new()),
             extra_headers: tokio::sync::RwLock::new(std::collections::HashMap::new()),
             in_flight: Arc::new(std::sync::atomic::AtomicU32::new(0)),
+            // This test drives send_single against a loopback fixture and does
+            // its own reachability assertions; the policy is not under test.
+            network_policy: crate::policy::NetworkPolicy::allow_all_private(),
         };
         let url = Url::parse(&format!("http://127.0.0.1:{port}/")).unwrap();
         let error = client

--- a/crates/obscura-net/tests/network_allowlist.rs
+++ b/crates/obscura-net/tests/network_allowlist.rs
@@ -1,0 +1,173 @@
+//! The private-network opt-in was all-or-nothing.
+//!
+//! `--allow-private-network` disables the entire SSRF deny-set — loopback,
+//! RFC1918, link-local, CGNAT, and with them `169.254.169.254` and
+//! `100.100.100.200`. It is also the flag an operator *must* set to test an
+//! internal application, so the common case handed every page a page loads an
+//! unrestricted internal pivot.
+//!
+//! `--allow-network <CIDR>` exempts only what is named.
+//!
+//! These drive the real client rather than the policy type directly (the pure
+//! logic has its own unit tests in `policy.rs`), so they exercise the wiring:
+//! the literal-host check in `validate_url` and the client's stored policy.
+//!
+//! Run with `cargo test -p obscura-net --test network_allowlist`.
+
+use std::sync::Arc;
+
+use obscura_net::{CookieJar, NetworkPolicy, ObscuraHttpClient};
+use url::Url;
+
+/// A client built with an explicit policy, bypassing the environment so these
+/// tests are order-independent (`RUST_TEST_THREADS = "1"` shares one process).
+fn client_with(policy: NetworkPolicy) -> ObscuraHttpClient {
+    let mut client = ObscuraHttpClient::with_options(Arc::new(CookieJar::new()), None);
+    client.set_network_policy(policy);
+    client
+}
+
+fn policy(entries: &[&str]) -> NetworkPolicy {
+    NetworkPolicy::new(
+        false,
+        &entries.iter().map(|s| s.to_string()).collect::<Vec<_>>(),
+    )
+    .expect("entries must parse")
+}
+
+/// The finding. Opening an internal range must not open cloud metadata.
+#[tokio::test]
+async fn allowing_an_internal_range_leaves_cloud_metadata_blocked() {
+    let client = client_with(policy(&["10.20.0.0/16"]));
+
+    let metadata = Url::parse("http://169.254.169.254/latest/meta-data/").unwrap();
+    let error = client
+        .fetch(&metadata)
+        .await
+        .expect_err("cloud metadata must stay blocked");
+    assert!(
+        error.to_string().contains("169.254.169.254"),
+        "expected an SSRF refusal naming the address, got: {error}"
+    );
+
+    let alibaba = Url::parse("http://100.100.100.200/").unwrap();
+    assert!(
+        client.fetch(&alibaba).await.is_err(),
+        "Alibaba metadata must stay blocked"
+    );
+}
+
+/// The blanket flag keeps its old meaning, including the part that makes it
+/// worth avoiding.
+#[tokio::test]
+async fn the_blanket_flag_still_opens_metadata() {
+    let client = client_with(NetworkPolicy::allow_all_private());
+    // Not asserting a successful fetch -- nothing is listening -- only that the
+    // request is not refused by policy before it is attempted.
+    let error = client
+        .fetch(&Url::parse("http://169.254.169.254/").unwrap())
+        .await
+        .expect_err("nothing is listening, so this fails at the transport");
+    assert!(
+        !error.to_string().contains("not allowed"),
+        "--allow-private-network must not refuse metadata by policy: {error}"
+    );
+}
+
+/// A default client refuses the allowlisted range too, so the flag is what
+/// changed the outcome rather than something incidental.
+#[tokio::test]
+async fn the_default_policy_refuses_the_same_range() {
+    let client = client_with(NetworkPolicy::deny_private());
+    let error = client
+        .fetch(&Url::parse("http://10.20.5.5/").unwrap())
+        .await
+        .expect_err("10.20.5.5 is RFC1918 and denied by default");
+    assert!(
+        error.to_string().contains("10.20.5.5"),
+        "expected a policy refusal, got: {error}"
+    );
+}
+
+/// An allowlisted literal address is reachable: it gets past the policy and
+/// fails at the transport instead, which is the observable difference.
+#[tokio::test]
+async fn an_allowlisted_address_is_not_refused_by_policy() {
+    let client = client_with(policy(&["10.20.0.0/16"]));
+    let error = client
+        .fetch(&Url::parse("http://10.20.5.5/").unwrap())
+        .await
+        .expect_err("nothing is listening there");
+    assert!(
+        !error.to_string().contains("not allowed"),
+        "an allowlisted address must not be refused by policy: {error}"
+    );
+}
+
+/// A loopback fixture is the realistic shape of "test my internal app", and it
+/// must work through `--allow-network` without opening anything else.
+#[tokio::test]
+async fn a_loopback_allowlist_reaches_a_real_fixture() {
+    let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+    let port = listener.local_addr().unwrap().port();
+    std::thread::spawn(move || {
+        use std::io::{Read, Write};
+        for incoming in listener.incoming() {
+            let Ok(mut stream) = incoming else { continue };
+            let mut buf = [0u8; 1024];
+            let _ = stream.read(&mut buf);
+            let body = "INTERNAL-APP-OK";
+            let _ = stream.write_all(
+                format!(
+                    "HTTP/1.1 200 OK\r\nContent-Type: text/plain\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+                    body.len(),
+                    body
+                )
+                .as_bytes(),
+            );
+            let _ = stream.shutdown(std::net::Shutdown::Both);
+        }
+    });
+
+    let client = client_with(policy(&["127.0.0.1/32"]));
+    let response = client
+        .fetch(&Url::parse(&format!("http://127.0.0.1:{port}/")).unwrap())
+        .await
+        .expect("an allowlisted loopback fixture must be reachable");
+    assert!(response.text().contains("INTERNAL-APP-OK"));
+
+    // The same client must still refuse everything it was not given.
+    assert!(
+        client
+            .fetch(&Url::parse("http://169.254.169.254/").unwrap())
+            .await
+            .is_err(),
+        "metadata must stay blocked for a loopback-scoped policy"
+    );
+}
+
+/// An allowlist opens only what it names, and the deny-set is wider than
+/// "private" in the colloquial sense.
+///
+/// This test exists because the first version of it was wrong: it used
+/// `192.0.2.1` as a stand-in for "a public address", on the assumption that
+/// TEST-NET-1 is outside the deny-set. It is not — `is_forbidden_ip` includes
+/// `Ipv4Addr::is_documentation()`, which covers 192.0.2.0/24, and the client
+/// correctly refused it. Pin the real behaviour rather than the assumption.
+///
+/// (That a policy never blocks a genuinely public address is asserted in
+/// `policy.rs`'s unit tests, which need no network.)
+#[tokio::test]
+async fn documentation_space_stays_denied_under_an_unrelated_allowlist() {
+    let client = client_with(policy(&["10.20.0.0/16"]));
+    for denied in ["192.0.2.1", "198.51.100.1", "203.0.113.1"] {
+        let error = client
+            .fetch(&Url::parse(&format!("http://{denied}/")).unwrap())
+            .await
+            .expect_err("documentation space is in the deny-set");
+        assert!(
+            error.to_string().contains(denied),
+            "{denied} should be refused by policy, got: {error}"
+        );
+    }
+}

--- a/docs/Environment-variables.md
+++ b/docs/Environment-variables.md
@@ -14,6 +14,30 @@ OBSCURA_ALLOW_PRIVATE_NETWORK=1 obscura fetch http://localhost:8080
 
 Per-process equivalent: `--allow-private-network` on any subcommand.
 
+### `OBSCURA_ALLOW_NETWORK`
+
+Comma-separated CIDR prefixes or bare addresses that may be reached even though
+they are in the SSRF deny-set. Everything else stays denied.
+
+Prefer this over `OBSCURA_ALLOW_PRIVATE_NETWORK` when testing an internal
+application. That variable disables the deny-set **entirely**, including the
+cloud metadata endpoints (`169.254.169.254`, `100.100.100.200`), so any page you
+load gets an unrestricted internal pivot. This one opens only what you name.
+
+```bash
+OBSCURA_ALLOW_NETWORK="10.20.0.0/16" obscura fetch http://10.20.5.5/
+OBSCURA_ALLOW_NETWORK="127.0.0.1/32,192.168.1.0/24" obscura serve
+```
+
+Equivalent to the repeatable `--allow-network` flag. A malformed prefix is a
+startup error rather than a silent skip: a typo must not leave you with a policy
+that denies what you meant to allow. A `/0` prefix is accepted but logs a
+warning, since it disables the guard for that address family.
+
+A hostname such as `localhost` carries no address, so the decision is made by the
+DNS guard against whatever the name resolves to — `--allow-network 127.0.0.1/32`
+does reach `http://localhost:8080`.
+
 ### `OBSCURA_NAV_TIMEOUT_MS`
 
 Hard ceiling on a single navigation. Default 30000 (30 seconds). Applies to `Page.navigate` and the CLI `fetch` command.


### PR DESCRIPTION

## What changed

To test an internal app you must set `--allow-private-network`. That disables the entire SSRF deny-set, including `169.254.169.254` and `100.100.100.200`. So the common case ("point Obscura at my app on 10.20.x.y") also hands every page that app loads an unrestricted internal pivot, cloud metadata credentials included.

`--allow-network 10.20.0.0/16` (repeatable, comma-separated lists accepted, `OBSCURA_ALLOW_NETWORK` equivalent) exempts exactly what is named and leaves the rest denied.

`is_forbidden_ip` is unchanged and remains the single definition of the deny-set. The policy only ever relaxes it: `permits` short-circuits on a public address, so a policy can never forbid something the deny-set allows. That keeps `--allow-network` an escape hatch rather than a firewall an operator might mistake it for, and there is a test for it.

Threaded onto both HTTP clients rather than replacing `allow_private_network: bool` across five crates. The policy is built once at client construction and consulted by `validate_url`, both `SsrfGuardResolver` impls, and `validate_fetch_url`: data on the client, not a process-global read per request, so tests can inject one without touching the environment.

Builds directly on #831, which threaded `--allow-private-network` into the stealth client. That work is kept as-is: `StealthHttpClient::with_proxy`'s signature is unchanged, `stealth_client_honors_allow_private_network_for_loopback_hostnames` passes untouched, and the flag is fed in as the seed of `NetworkPolicy::from_env`. The NAT64/6to4 assertions #842's `validate_url` test added are all preserved.

Two details: a hostname carries no address, so `localhost` cannot be judged against an allowlist in `validate_url`; when one is configured the decision defers to `SsrfGuardResolver`, which sees what the name resolves to, otherwise `--allow-network 127.0.0.1/32` would still refuse `http://localhost:8080`. And `::ffff:10.20.5.5` matches a v4 prefix, mirroring the deny-set's own IPv4-mapped unwrapping.

A malformed prefix is a startup error, not a silent skip. A `/0` entry is accepted but warns. CIDR parsing is hand-rolled (about 40 lines) rather than adding `ipnet`, which would need a `deny.toml` review larger than the code. Documented in `docs/Environment-variables.md`.

Fixes #856.

## Validation

- `cargo nextest run --release --features render -p obscura-net -p obscura-js -p obscura-cli`: 658 tests run, 658 passed, 0 skipped (obscura-net 111 passed, 0 failed; obscura-js 474 passed, 0 failed; obscura-cli 73 passed, 0 failed)
- `cargo nextest run --release -p obscura-net --features stealth`: branch run where the branch was tested alone: allowlist 116 tests run, 116 passed, 1 skipped, file gate 103 tests run, 103 passed, 1 skipped; on the integration 157 tests run, 157 passed, 1 skipped (includes #831's own test)
- New tests: 6 integration and 13 unit.
- Full render-feature nextest run on the integration of this batch: on the integration of all 16 branches (tree `f58095e`): render `cargo nextest run --release --features render --no-fail-fast` 1791 tests run, 1791 passed, 4 skipped; stealth `-p obscura-net --features stealth` 157 tests run, 157 passed, 1 skipped plus the opt-in gzip test passed; no-render `-p obscura` 30 tests run, 30 passed, 0 skipped; `--workspace --no-default-features` (excluding obscura and obscura-render) 1031 tests run, 1031 passed, 3 skipped (nextest flagged one allowlist test as leaky once, meaning a child handle outlived the passing test by more than its 100 ms grace; it did not recur in the earlier run); all four release configurations build and `cargo check -p obscura-render --no-default-features` passes. The skipped tests are upstream's own pre-existing `#[ignore]`s.

## Rendering

Not applicable.

## Performance

No expected impact. The policy check replaces a boolean-plus-env read with a prefix match over a short list, on the DNS-resolution path only.

## Checklist

- [x] The change is focused and does not remove existing behavior without justification.
- [x] Tests cover the failure or feature.
- [x] Existing tests pass, including render and no-render configurations when affected.
- [x] I checked for CPU, latency, and memory regressions.
- [x] Public API or user-facing behavior changes are documented.

https://claude.ai/code/session_018uyG49E7pxjZGyrR62pwmi
