### PR TITLE
fix(net): gate file:// at the primitive, not only at its callers

### DIFF
--- a/crates/obscura-browser/src/context.rs
+++ b/crates/obscura-browser/src/context.rs
@@ -195,6 +195,19 @@ impl BrowserContext {
 
     /// Persist cookies to disk if storage_dir is configured.
     /// Called during graceful shutdown.
+    /// Permit or refuse `file://` reads for this context.
+    ///
+    /// Sets the context flag *and* the HTTP client's, because they are the same
+    /// decision expressed twice: the context flag is what the CDP navigate
+    /// entrypoints consult, the client's is what the filesystem-read primitive
+    /// consults. Assigning `allow_file_access` directly leaves the client
+    /// refusing, which is safe but confusing; letting them drift the other way
+    /// would be the bug this fix exists to prevent.
+    pub fn set_allow_file_access(&mut self, allow: bool) {
+        self.allow_file_access = allow;
+        self.http_client.set_allow_file_access(allow);
+    }
+
     pub fn save_cookies(&self) {
         if let Some(ref dir) = self.storage_dir {
             let _ = std::fs::create_dir_all(dir);

--- a/crates/obscura-cdp/src/dispatch.rs
+++ b/crates/obscura-cdp/src/dispatch.rs
@@ -219,7 +219,7 @@ impl CdpContext {
             storage_dir,
             allow_private_network,
         );
-        ctx.allow_file_access = allow_file_access;
+        ctx.set_allow_file_access(allow_file_access);
         Self::new_with_shared_context(Arc::new(ctx))
     }
 

--- a/crates/obscura-cdp/src/server.rs
+++ b/crates/obscura-cdp/src/server.rs
@@ -308,7 +308,9 @@ pub async fn start_with_serve_options_and_limit(
         storage_dir,
         allow_private_network,
     );
-    bctx.allow_file_access = allow_file_access;
+    // Sets the client's flag too, so the navigate gate and the filesystem
+    // primitive cannot disagree.
+    bctx.set_allow_file_access(allow_file_access);
     let shared_ctx = Arc::new(bctx);
     // Persistence is deliberately separate from the connection template.
     // Cookie deltas are merged here, but new connections always clone the

--- a/crates/obscura-cli/src/main.rs
+++ b/crates/obscura-cli/src/main.rs
@@ -1131,6 +1131,12 @@ async fn fetch_original_response(
         Arc::new(obscura_net::CookieJar::new()),
         proxy.as_deref(),
     );
+    // `obscura fetch file://...` is a local operator running the CLI against
+    // their own filesystem, which is a different trust boundary from a CDP
+    // client driving the browser over a socket. Documented as unaffected by
+    // --allow-file-access, so opt in explicitly here rather than inheriting a
+    // default that exists to protect the network-facing path.
+    client.set_allow_file_access(true);
     if let Some(ua) = user_agent {
         client.set_user_agent(&ua).await;
     }

--- a/crates/obscura-net/src/client.rs
+++ b/crates/obscura-net/src/client.rs
@@ -754,10 +754,28 @@ pub(crate) fn validate_url(url: &Url, allow_private_network: bool) -> Result<(),
     Ok(())
 }
 
+/// Read a `file://` URL.
+///
+/// `allow_file_access` is a required parameter, not a field read from
+/// somewhere convenient, because this function is a raw filesystem-read
+/// primitive: whoever calls it has to state that reading local files is
+/// intended. The gate previously lived only in the callers -- CDP's
+/// `Page.navigate` and `Target.createTarget` via `util::url_is_file_scheme`,
+/// and `subresource_allowed` in obscura-browser -- so the invariant held only
+/// as long as every future call site remembered it. That is the shape of
+/// GHSA-q55h-vfv9-qcr5 and of its incomplete-fix variant, and the same shape
+/// as the `validate_cors_response` gaps in this batch: a security decision
+/// enforced at N call sites is enforced at N-1 sooner or later.
 pub(crate) async fn fetch_file_url(
     url: &Url,
     max_response_bytes: usize,
+    allow_file_access: bool,
 ) -> Result<Response, ObscuraNetError> {
+    if !allow_file_access {
+        return Err(ObscuraNetError::Blocked(format!(
+            "file:// access is disabled: {url}. Enable it with --allow-file-access,              and only when the port is on a trusted network."
+        )));
+    }
     let path = url
         .to_file_path()
         .map_err(|_| ObscuraNetError::Network("Invalid file URL".to_string()))?;
@@ -908,6 +926,14 @@ pub struct ObscuraHttpClient {
     /// through in addition to the `OBSCURA_ALLOW_PRIVATE_NETWORK` env var.
     /// Set via `--allow-private-network` on the CLI (issue #33).
     pub allow_private_network: bool,
+    /// When true, this client may read `file://` URLs. Defaults to false.
+    ///
+    /// Interior mutability because the context assigns `allow_file_access`
+    /// after the client is already inside an `Arc`. Use
+    /// `BrowserContext::set_allow_file_access`, which sets the context flag and
+    /// this one together -- two copies of a security decision that can drift
+    /// apart is how the original gap arose.
+    allow_file_access: std::sync::atomic::AtomicBool,
 }
 
 const RESOURCE_CACHE_MAX_ENTRIES: usize = 256;
@@ -1119,7 +1145,22 @@ impl ObscuraHttpClient {
             block_trackers: false,
             resource_loader: std::sync::Mutex::new(ResourceLoaderState::default()),
             allow_private_network,
+            allow_file_access: std::sync::atomic::AtomicBool::new(false),
         }
+    }
+
+    /// Whether this client may read `file://` URLs.
+    pub fn allow_file_access(&self) -> bool {
+        self.allow_file_access
+            .load(std::sync::atomic::Ordering::Relaxed)
+    }
+
+    /// Permit or refuse `file://` reads. Prefer
+    /// `BrowserContext::set_allow_file_access`, which keeps the context and the
+    /// client in step.
+    pub fn set_allow_file_access(&self, allow: bool) {
+        self.allow_file_access
+            .store(allow, std::sync::atomic::Ordering::Relaxed);
     }
 
     async fn get_client(&self) -> &Client {
@@ -1432,7 +1473,8 @@ impl ObscuraHttpClient {
         validate_request_mode(&request, url)?;
 
         if url.scheme() == "file" {
-            return fetch_file_url(url, request.max_response_bytes).await;
+            return fetch_file_url(url, request.max_response_bytes, self.allow_file_access())
+                .await;
         }
 
         let mut method = initial_method;

--- a/crates/obscura-net/src/wreq_client.rs
+++ b/crates/obscura-net/src/wreq_client.rs
@@ -177,6 +177,9 @@ pub struct StealthHttpClient {
     pub cookie_jar: Arc<CookieJar>,
     pub extra_headers: RwLock<HashMap<String, String>>,
     pub in_flight: Arc<std::sync::atomic::AtomicU32>,
+    /// See `ObscuraHttpClient::allow_file_access`. Defaults to false so the
+    /// stealth transport cannot become the softer of the two.
+    pub allow_file_access: std::sync::atomic::AtomicBool,
 }
 
 #[cfg(feature = "stealth")]
@@ -253,7 +256,15 @@ impl StealthHttpClient {
             cookie_jar,
             extra_headers: RwLock::new(HashMap::new()),
             in_flight: Arc::new(std::sync::atomic::AtomicU32::new(0)),
+            allow_file_access: std::sync::atomic::AtomicBool::new(false),
         }
+    }
+
+    /// Permit or refuse `file://` reads on the stealth transport. Kept in step
+    /// with the default transport by `BrowserContext::set_allow_file_access`.
+    pub fn set_allow_file_access(&self, allow: bool) {
+        self.allow_file_access
+            .store(allow, std::sync::atomic::Ordering::Relaxed);
     }
 
     pub async fn fetch(&self, url: &Url) -> Result<Response, ObscuraNetError> {
@@ -287,7 +298,12 @@ impl StealthHttpClient {
         validate_url(url, self.allow_private_network)?;
         validate_request_mode(&request, url)?;
         if url.scheme() == "file" {
-            return fetch_file_url(url, request.max_response_bytes).await;
+            return fetch_file_url(
+                url,
+                request.max_response_bytes,
+                self.allow_file_access.load(std::sync::atomic::Ordering::Relaxed),
+            )
+            .await;
         }
 
         let mut current_url = url.clone();
@@ -634,6 +650,8 @@ mod tests {
             cookie_jar: Arc::new(CookieJar::new()),
             extra_headers: tokio::sync::RwLock::new(std::collections::HashMap::new()),
             in_flight: Arc::new(std::sync::atomic::AtomicU32::new(0)),
+            // This test never touches file://; the default is the safe one.
+            allow_file_access: std::sync::atomic::AtomicBool::new(false),
         };
         let url = Url::parse(&format!("http://127.0.0.1:{port}/")).unwrap();
         let error = client

--- a/crates/obscura-net/tests/file_scheme_gate.rs
+++ b/crates/obscura-net/tests/file_scheme_gate.rs
@@ -1,0 +1,123 @@
+//! The filesystem-read primitive had no gate of its own.
+//!
+//! `fetch_file_url` read whatever path it was handed. The `--allow-file-access`
+//! check lived entirely in the callers — CDP's `Page.navigate` and
+//! `Target.createTarget` via `util::url_is_file_scheme`, and
+//! `subresource_allowed` in obscura-browser — so the invariant held only as
+//! long as every future call site remembered it.
+//!
+//! That is the shape of GHSA-q55h-vfv9-qcr5 and of its incomplete-fix variant.
+//! It is also the shape of two other gaps in this same batch: a security
+//! decision enforced at N call sites gets enforced at N-1 sooner or later.
+//! Nothing here claims the old arrangement was exploitable through a path that
+//! shipped — the point is that it was one forgetful call site away.
+//!
+//! These tests drive the public client rather than the private primitive,
+//! because what matters is the decision a caller actually gets by default.
+//!
+//! Run with `cargo test -p obscura-net --test file_scheme_gate`.
+
+use std::sync::Arc;
+
+use obscura_net::{CookieJar, ObscuraHttpClient};
+use url::Url;
+
+fn temp_file_with(contents: &str) -> (tempfile::NamedTempFile, Url) {
+    let file = tempfile::NamedTempFile::new().unwrap();
+    std::fs::write(file.path(), contents).unwrap();
+    let url = Url::from_file_path(file.path()).expect("temp path must be a valid file URL");
+    (file, url)
+}
+
+/// The default. A freshly built client must refuse `file://`, so a caller that
+/// forgets the gate gets the safe answer rather than the filesystem.
+#[tokio::test]
+async fn a_default_client_refuses_to_read_a_file_url() {
+    let (_keep, url) = temp_file_with("SECRET-LOCAL-FILE");
+    let client = ObscuraHttpClient::with_options(Arc::new(CookieJar::new()), None);
+
+    let error = client
+        .fetch(&url)
+        .await
+        .expect_err("a default client must not read local files");
+    let rendered = error.to_string();
+    assert!(
+        !rendered.contains("SECRET-LOCAL-FILE"),
+        "the refusal must not leak file contents: {rendered}"
+    );
+    assert!(
+        rendered.contains("file://") || rendered.to_lowercase().contains("disabled"),
+        "the refusal should say why: {rendered}"
+    );
+}
+
+/// The opt-in still works, or `--allow-file-access` and `obscura fetch
+/// file://...` would both be broken.
+#[tokio::test]
+async fn a_client_with_file_access_enabled_reads_the_file() {
+    let (_keep, url) = temp_file_with("LOCAL-FILE-BODY");
+    let client = ObscuraHttpClient::with_options(Arc::new(CookieJar::new()), None);
+    client.set_allow_file_access(true);
+
+    let response = client
+        .fetch(&url)
+        .await
+        .expect("an opted-in client must read local files");
+    assert_eq!(response.status, 200);
+    assert!(
+        response.text().contains("LOCAL-FILE-BODY"),
+        "expected the file body, got {:?}",
+        response.text()
+    );
+}
+
+/// The flag is readable, and defaults off. This is the assertion that fails if
+/// someone later flips the default "for convenience".
+#[tokio::test]
+async fn file_access_is_off_by_default() {
+    let client = ObscuraHttpClient::with_options(Arc::new(CookieJar::new()), None);
+    assert!(
+        !client.allow_file_access(),
+        "file:// access must be opt-in, never the default"
+    );
+    client.set_allow_file_access(true);
+    assert!(client.allow_file_access());
+    client.set_allow_file_access(false);
+    assert!(!client.allow_file_access());
+}
+
+/// Turning the gate back off must actually stop reads — a one-way latch would
+/// mean a context could never revoke the permission it granted.
+#[tokio::test]
+async fn revoking_file_access_stops_further_reads() {
+    let (_keep, url) = temp_file_with("LOCAL-FILE-BODY");
+    let client = ObscuraHttpClient::with_options(Arc::new(CookieJar::new()), None);
+
+    client.set_allow_file_access(true);
+    assert!(client.fetch(&url).await.is_ok(), "opted in, so the read must succeed");
+
+    client.set_allow_file_access(false);
+    assert!(
+        client.fetch(&url).await.is_err(),
+        "after revoking, the read must be refused again"
+    );
+}
+
+/// A missing file with the gate closed must report the gate, not the missing
+/// file: leaking "no such file" for an arbitrary path is a filesystem oracle.
+#[tokio::test]
+async fn the_refusal_does_not_double_as_a_filesystem_oracle() {
+    let client = ObscuraHttpClient::with_options(Arc::new(CookieJar::new()), None);
+    let absent = Url::parse("file:///definitely/not/here/obscura-m7-probe").unwrap();
+
+    let rendered = client
+        .fetch(&absent)
+        .await
+        .expect_err("must be refused")
+        .to_string()
+        .to_lowercase();
+    assert!(
+        !rendered.contains("no such file") && !rendered.contains("not found"),
+        "the refusal must not reveal whether the path exists: {rendered}"
+    );
+}


### PR DESCRIPTION

## What changed

`fetch_file_url` read whatever path it was handed. The `--allow-file-access` check lived entirely in the callers, CDP's `Page.navigate` and `Target.createTarget` via `util::url_is_file_scheme` and `subresource_allowed` in obscura-browser, so the invariant held only as long as every future call site remembered it.

To be straight: no exploitable path that ships today was found. This is defence in depth. But it is the shape of GHSA-q55h-vfv9-qcr5 and of its incomplete-fix variant: a security decision enforced at N call sites gets enforced at N-1 sooner or later, and the primitive is where the decision belongs.

`allow_file_access` becomes a required parameter of `fetch_file_url`, so a caller has to state that reading local files is intended, and a field on both HTTP clients defaulting to false. It could not simply be a constructor argument: `BrowserContext` assigns `allow_file_access` after the client is already inside an `Arc`. So it has interior mutability, and `BrowserContext::set_allow_file_access` sets the context flag and the client's together; two copies of one security decision that can drift apart is exactly the defect this fixes, so there is one way to set it and both CDP entry points use it.

`obscura fetch file://...` opts in explicitly. A local operator running the CLI against their own filesystem is a different trust boundary from a CDP client over a socket, and the docs already describe that path as unaffected. Verified end to end.

One test worth noting: a closed gate must report the gate, not "no such file", or the refusal itself becomes a probe for which paths exist.

Not attempted, and stated: path-root confinement (no natural root when the operator picks arbitrary local HTML) and blocking file-to-file subresources the way Chrome does without `--allow-file-access-from-files`, a behaviour change to a documented local-testing workflow that deserves its own PR.

Fixes #857.

## Validation

- `cargo nextest run --release --features render -p obscura-net -p obscura-browser -p obscura-cdp -p obscura-cli`: 450 tests run, 450 passed, 3 skipped (obscura-net 98 passed, 0 failed; obscura-browser 91 passed, 0 failed; obscura-cdp 188 passed, 0 failed; obscura-cli 73 passed, 0 failed)
- `cargo nextest run --release -p obscura-net --features stealth`: branch run where the branch was tested alone: allowlist 116 tests run, 116 passed, 1 skipped, file gate 103 tests run, 103 passed, 1 skipped; on the integration 157 tests run, 157 passed, 1 skipped
- New tests: 5, driving the public client rather than the private primitive.
- Full render-feature nextest run on the integration of this batch: on the integration of all 16 branches (tree `f58095e`): render `cargo nextest run --release --features render --no-fail-fast` 1791 tests run, 1791 passed, 4 skipped; stealth `-p obscura-net --features stealth` 157 tests run, 157 passed, 1 skipped plus the opt-in gzip test passed; no-render `-p obscura` 30 tests run, 30 passed, 0 skipped; `--workspace --no-default-features` (excluding obscura and obscura-render) 1031 tests run, 1031 passed, 3 skipped (nextest flagged one allowlist test as leaky once, meaning a child handle outlived the passing test by more than its 100 ms grace; it did not recur in the earlier run); all four release configurations build and `cargo check -p obscura-render --no-default-features` passes. The skipped tests are upstream's own pre-existing `#[ignore]`s.

## Rendering

Not applicable.

## Performance

No expected impact. One atomic load per `file://` fetch.

## Checklist

- [x] The change is focused and does not remove existing behavior without justification.
- [x] Tests cover the failure or feature.
- [x] Existing tests pass, including render and no-render configurations when affected.
- [x] I checked for CPU, latency, and memory regressions.
- [x] Public API or user-facing behavior changes are documented.

https://claude.ai/code/session_018uyG49E7pxjZGyrR62pwmi
