### PR TITLE
fix(js): stop frame realms segfaulting on promise rejection / dynamic import (#850, #841)

### DIFF
--- a/crates/obscura-js/src/frame.rs
+++ b/crates/obscura-js/src/frame.rs
@@ -65,6 +65,10 @@ impl FrameRealm {
             return None;
         }
         parent.copy_identity_to_realm(&context);
+        // A snapshot-created realm has null deno_core per-context state slots, so
+        // a promise rejection or dynamic import() in the frame would segfault in
+        // deno_core's global callbacks (#850, #841). Alias the main realm's state.
+        parent.share_deno_context_state_with_realm(&context);
 
         // Only a same-origin frame is reachable from the page. Cross-origin
         // keeps its own security token, so V8 answers `undefined` for any
@@ -912,6 +916,46 @@ mod tests {
                 .unwrap(),
             serde_json::json!("https://child.example/"),
         );
+    }
+
+    // #850 / #841 — a promise rejection or dynamic import() inside a frame realm
+    // used to null-deref deno_core's global callbacks (which read per-context
+    // state from V8 embedder slots) and segfault the whole process. The realm
+    // must now alias the main realm's state so these run without crashing.
+    #[test]
+    fn a_frame_rejection_does_not_crash_the_process() {
+        let mut parent = page("https://parent.example/", "<html><body></body></html>");
+        let frame = FrameRealm::new(
+            &mut parent,
+            1,
+            0,
+            "https://parent.example/f",
+            "<html><body></body></html>",
+        )
+        .expect("frame realm");
+        // Reaching this line at all (no SIGSEGV) is the regression check.
+        frame
+            .execute_script(&mut parent, "Promise.reject(new Error('boom')); 'ok'")
+            .unwrap();
+    }
+
+    #[test]
+    fn a_frame_dynamic_import_does_not_crash_the_process() {
+        let mut parent = page("https://parent.example/", "<html><body></body></html>");
+        let frame = FrameRealm::new(
+            &mut parent,
+            1,
+            0,
+            "https://parent.example/f",
+            "<html><body></body></html>",
+        )
+        .expect("frame realm");
+        frame
+            .execute_script(
+                &mut parent,
+                "import('data:text/javascript,export default 1').catch(() => {}); 'ok'",
+            )
+            .unwrap();
     }
 
     /// A frame posting to `parent` must reach the page, arrive trusted, and

--- a/crates/obscura-js/src/runtime.rs
+++ b/crates/obscura-js/src/runtime.rs
@@ -665,8 +665,8 @@ impl ObscuraJsRuntime {
     /// `ops` table on it is enough to give every shim in that realm a working
     /// op surface. The functions are shared, not copied: same isolate.
     /// deno_core's isolate-global promise-reject and dynamic-`import()`
-    /// callbacks read per-context state from V8 embedder-data slots 1
-    /// (`ContextState`) and 2 (`ModuleMap`) of the *current* context. A
+    /// callbacks read per-context state from V8's `ContextState` and
+    /// `ModuleMap` embedder-data slots in the *current* context. A
     /// snapshot-created frame realm leaves those slots null, so a promise
     /// rejection or dynamic import inside a frame null-dereferenced in
     /// deno_core's `clone_rc_raw` and segfaulted the whole process (#850, #841).
@@ -682,10 +682,7 @@ impl ObscuraJsRuntime {
         &mut self,
         realm: &deno_core::v8::Global<deno_core::v8::Context>,
     ) {
-        use deno_core::v8;
-        // deno_core::runtime::jsrealm CONTEXT_STATE_SLOT_INDEX / MODULE_MAP_SLOT_INDEX.
-        const CONTEXT_STATE_SLOT_INDEX: i32 = 1;
-        const MODULE_MAP_SLOT_INDEX: i32 = 2;
+        use deno_core::{v8, CONTEXT_STATE_SLOT_INDEX, MODULE_MAP_SLOT_INDEX};
 
         let main = self.runtime().main_context();
         let mut entered = self.runtime();
@@ -693,9 +690,10 @@ impl ObscuraJsRuntime {
         let scope = &mut v8::HandleScope::new(isolate);
         let main_ctx = v8::Local::new(scope, main);
         let realm_ctx = v8::Local::new(scope, realm);
-        // SAFETY: slots 1/2 on the main context are `Rc::into_raw` pointers set
-        // by deno_core at runtime construction; they outlive every frame realm.
-        // We only copy (alias) them and never reconstruct the Rc from the frame.
+        // SAFETY: these slots on the main context are `Rc::into_raw` pointers
+        // set by deno_core at runtime construction; they outlive every frame
+        // realm. We only copy (alias) them and never reconstruct the Rc from
+        // the frame.
         unsafe {
             let cs = main_ctx.get_aligned_pointer_from_embedder_data(CONTEXT_STATE_SLOT_INDEX);
             let mm = main_ctx.get_aligned_pointer_from_embedder_data(MODULE_MAP_SLOT_INDEX);

--- a/crates/obscura-js/src/runtime.rs
+++ b/crates/obscura-js/src/runtime.rs
@@ -664,6 +664,46 @@ impl ObscuraJsRuntime {
     /// ops table, and its bootstrap captured that exact object, so filling the
     /// `ops` table on it is enough to give every shim in that realm a working
     /// op surface. The functions are shared, not copied: same isolate.
+    /// deno_core's isolate-global promise-reject and dynamic-`import()`
+    /// callbacks read per-context state from V8 embedder-data slots 1
+    /// (`ContextState`) and 2 (`ModuleMap`) of the *current* context. A
+    /// snapshot-created frame realm leaves those slots null, so a promise
+    /// rejection or dynamic import inside a frame null-dereferenced in
+    /// deno_core's `clone_rc_raw` and segfaulted the whole process (#850, #841).
+    /// Alias the main context's slot pointers into the frame context so those
+    /// callbacks resolve to the main realm's state instead of crashing.
+    ///
+    /// Safe: the frame context only *borrows* these pointers. The callbacks
+    /// `clone_rc_raw` (increment then drop) them — net-zero on the strong count
+    /// — and obscura never tears a frame context down through deno_core's
+    /// `Rc::from_raw` destroy path (only the main realm owns and frees the Rc),
+    /// so no double-free is possible.
+    pub(crate) fn share_deno_context_state_with_realm(
+        &mut self,
+        realm: &deno_core::v8::Global<deno_core::v8::Context>,
+    ) {
+        use deno_core::v8;
+        // deno_core::runtime::jsrealm CONTEXT_STATE_SLOT_INDEX / MODULE_MAP_SLOT_INDEX.
+        const CONTEXT_STATE_SLOT_INDEX: i32 = 1;
+        const MODULE_MAP_SLOT_INDEX: i32 = 2;
+
+        let main = self.runtime().main_context();
+        let mut entered = self.runtime();
+        let isolate = entered.v8_isolate();
+        let scope = &mut v8::HandleScope::new(isolate);
+        let main_ctx = v8::Local::new(scope, main);
+        let realm_ctx = v8::Local::new(scope, realm);
+        // SAFETY: slots 1/2 on the main context are `Rc::into_raw` pointers set
+        // by deno_core at runtime construction; they outlive every frame realm.
+        // We only copy (alias) them and never reconstruct the Rc from the frame.
+        unsafe {
+            let cs = main_ctx.get_aligned_pointer_from_embedder_data(CONTEXT_STATE_SLOT_INDEX);
+            let mm = main_ctx.get_aligned_pointer_from_embedder_data(MODULE_MAP_SLOT_INDEX);
+            realm_ctx.set_aligned_pointer_in_embedder_data(CONTEXT_STATE_SLOT_INDEX, cs);
+            realm_ctx.set_aligned_pointer_in_embedder_data(MODULE_MAP_SLOT_INDEX, mm);
+        }
+    }
+
     pub(crate) fn share_ops_with_realm(
         &mut self,
         realm: &deno_core::v8::Global<deno_core::v8::Context>,


### PR DESCRIPTION
**Fixes a page-triggerable native crash that takes down the whole server.** A promise rejection or dynamic `import()` inside a child frame realm crashed the process with SIGSEGV — over `serve` it killed every session, not just one tab. Reproduced locally under default features (fingerprint.com per #850, devpost.com per #841).

## Root cause

deno_core installs isolate-global promise-reject and host-import callbacks that read per-context state from V8 embedder-data slots 1 (`ContextState`) and 2 (`ModuleMap`) of the *current* context, via `clone_rc_raw` (`Rc::increment_strong_count` + `from_raw`). obscura builds frame realms with `v8::Context::from_snapshot` rather than deno_core's realm path, so those slots are **null** in a frame; the callback null-dereferenced at `-16` off a null base — exactly the reports' `0xfffffffffffffff0`.

## Fix

Alias the main context's slot-1/slot-2 pointers into each frame context at realm creation (`share_deno_context_state_with_realm`), so the callbacks resolve to the main realm's state instead of crashing.

**Safe:** the frame only *borrows* the pointers — the callbacks `clone_rc_raw` them (net-zero on the strong count) — and obscura never tears a frame context down through deno_core's `Rc::from_raw` destroy path (only the main realm owns and frees the Rc), so no double-free is possible.

## Tests

RED: both repros SIGSEGV'd. GREEN: a promise rejection and a dynamic `import()` in a frame realm now run without crashing. All 24 frame-module tests and 11 child-frame integration tests (incl. realm create/teardown cycles) pass.

Closes #850
Closes #841