### PR TITLE
fix(net): let OBSCURA_FETCH_MAX_BODY_BYTES reach the module-script cap (#849)

### DIFF
--- a/crates/obscura-net/src/client.rs
+++ b/crates/obscura-net/src/client.rs
@@ -242,7 +242,13 @@ impl ResourceRequest {
             referrer: Some(referrer.clone()),
             mode: RequestMode::Cors,
             credentials: RequestCredentials::SameOrigin,
-            max_response_bytes: 32 * 1024 * 1024,
+            // OBSCURA_FETCH_MAX_BODY_BYTES (the fetch()/XHR override from #581)
+            // also raises this cap: a large SPA bundle otherwise dies silently
+            // at 32 MiB while fetch() of the same URL succeeds (#849).
+            max_response_bytes: std::env::var("OBSCURA_FETCH_MAX_BODY_BYTES")
+                .ok()
+                .and_then(|v| v.parse().ok())
+                .unwrap_or(32 * 1024 * 1024),
         }
     }
 
@@ -2089,6 +2095,37 @@ mod ssrf_tests {
         assert!(request.contains("sec-fetch-dest: font\r\n"));
         assert!(!request.contains("cookie:"));
         assert_eq!(jar.get_cookie_header(&target), "seed=1");
+    }
+
+    // #849 — the OBSCURA_FETCH_MAX_BODY_BYTES override #581 gave fetch()/XHR
+    // must also reach the module-script cap; a large SPA bundle otherwise dies
+    // silently at a hardcoded 32 MiB while fetch() of the same URL succeeds.
+    // (nextest runs each test in its own process, so set_var cannot race.)
+    #[test]
+    fn module_script_cap_honours_the_fetch_body_env_override() {
+        let u = Url::parse("https://example.com/app.mjs").unwrap();
+
+        std::env::remove_var("OBSCURA_FETCH_MAX_BODY_BYTES");
+        assert_eq!(
+            ResourceRequest::module_script(&u, &u).max_response_bytes,
+            32 * 1024 * 1024,
+            "default module cap stays 32 MiB"
+        );
+
+        std::env::set_var("OBSCURA_FETCH_MAX_BODY_BYTES", "134217728");
+        assert_eq!(
+            ResourceRequest::module_script(&u, &u).max_response_bytes,
+            128 * 1024 * 1024,
+            "the env override must reach the module-script cap"
+        );
+
+        // Garbage stays on the default rather than panicking.
+        std::env::set_var("OBSCURA_FETCH_MAX_BODY_BYTES", "not-a-number");
+        assert_eq!(
+            ResourceRequest::module_script(&u, &u).max_response_bytes,
+            32 * 1024 * 1024,
+        );
+        std::env::remove_var("OBSCURA_FETCH_MAX_BODY_BYTES");
     }
 
     #[tokio::test]


### PR DESCRIPTION
The ES module loader rejected any module over a hardcoded 32 MiB (`ResourceRequest::module_script`'s `max_response_bytes`), while `OBSCURA_FETCH_MAX_BODY_BYTES` — the override #581 introduced — only affected `op_fetch_url`. A large SPA bundle therefore never bootstrapped, **silently**: `fetch()` of the same URL succeeded, but the module import died with a body-limit rejection that surfaced nothing to the page.

Read the env override in `module_script()`: when set (and parseable) it becomes the module cap; otherwise the 32 MiB default stays; garbage values fall back to the default rather than panicking.

**TDD:** RED — the override was ignored on the module path; GREEN — it raises the cap. Covers default, override, and unparseable-value cases; existing module tests pass.

Closes #849