### PR TITLE
fix(js): drop set_v8_flags called after a runtime exists instead of aborting (#853)

### DIFF
--- a/crates/obscura-js/src/runtime.rs
+++ b/crates/obscura-js/src/runtime.rs
@@ -496,6 +496,9 @@ impl ObscuraJsRuntime {
     /// through `proxy_url` (#139). `None` is equivalent to `with_base_url`
     /// (direct connection).
     pub fn with_base_url_and_proxy(base_url: &str, proxy_url: Option<String>) -> Self {
+        // A runtime is about to initialize the V8 platform; from here on a
+        // set_v8_flags call must be refused rather than aborting the process.
+        crate::v8_flags::mark_platform_started();
         let state = Rc::new(RefCell::new(ObscuraState::new()));
         let state_clone = state.clone();
         let import_map = state.borrow().import_map.clone();

--- a/crates/obscura-js/src/v8_flags.rs
+++ b/crates/obscura-js/src/v8_flags.rs
@@ -1,6 +1,18 @@
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Once;
 
 static INIT: Once = Once::new();
+/// Set once the first `ObscuraJsRuntime` (and thus the V8 platform) has been
+/// constructed. A `set_v8_flags` call after this point is dropped rather than
+/// aborting the process.
+static PLATFORM_STARTED: AtomicBool = AtomicBool::new(false);
+
+/// Record that a JS runtime is being constructed, so any later `set_v8_flags`
+/// call is refused instead of reaching V8's fatal late-flag path. Called at the
+/// top of runtime construction, before the platform is initialized.
+pub(crate) fn mark_platform_started() {
+    PLATFORM_STARTED.store(true, Ordering::SeqCst);
+}
 
 /// Apply user-supplied V8 flags exactly once, before the first isolate is
 /// created.
@@ -18,6 +30,18 @@ pub fn set_v8_flags(flags: &str) {
     if trimmed.is_empty() {
         return;
     }
+    if PLATFORM_STARTED.load(Ordering::SeqCst) {
+        // Once an isolate exists, V8's SetFlagsFromCommandLine calls V8_Fatal
+        // and aborts the whole process (SIGTRAP) — it does NOT silently ignore
+        // the call as the platform docs imply. Drop the late call with a
+        // warning instead of crashing the embedder; flags only take effect
+        // before the first ObscuraJsRuntime is constructed.
+        tracing::warn!(
+            "set_v8_flags({trimmed:?}) ignored: a JS runtime already exists — \
+             V8 flags must be set before the first ObscuraJsRuntime is constructed"
+        );
+        return;
+    }
     INIT.call_once(|| {
         deno_core::v8::V8::set_flags_from_string(trimmed);
     });
@@ -33,5 +57,17 @@ mod tests {
         set_v8_flags("");
         set_v8_flags("   ");
         set_v8_flags("\t\n");
+    }
+
+    // #853 — a set_v8_flags call after a runtime exists used to abort the whole
+    // process (V8_Fatal / SIGTRAP). Constructing a real runtime initializes the
+    // V8 platform (and marks it started); the subsequent set_v8_flags must be
+    // dropped with a warning rather than crashing. Reaching the assertion at all
+    // (no SIGTRAP) is the regression check.
+    #[test]
+    fn late_call_after_a_runtime_exists_does_not_abort() {
+        let _rt = crate::runtime::ObscuraJsRuntime::new();
+        set_v8_flags("--max-old-space-size=32");
+        assert!(PLATFORM_STARTED.load(Ordering::SeqCst));
     }
 }


### PR DESCRIPTION
`set_v8_flags` used a `Once` guard so flags applied only once — but if that first call landed **after** an `ObscuraJsRuntime` (and thus the V8 platform) already existed, it still reached `V8::set_flags_from_string`, whose `SetFlagsFromCommandLine` calls `V8_Fatal` once the platform is initialized, **aborting the whole process with SIGTRAP**. The doc claimed V8 'ignores' a late call; it does not. Any embedder that constructs a runtime and then sets flags crashes.

Track platform startup with an atomic set at the top of runtime construction, and refuse a late `set_v8_flags` with a `tracing::warn!` instead of crashing. Flags still take effect when set before the first runtime.

**TDD:** a regression test constructs a runtime then calls `set_v8_flags`. Verified RED — with the guard removed the test **SIGTRAPs (signal 5)**, exactly the report; GREEN with the guard.

Note: the issue also flags test-hygiene (tests leaking `OBSCURA_*`/`SSL_CERT_*` env vars, breaking single-process `cargo test`) — that's test-only and left as a separate follow-up.

Closes #853