### PR TITLE
fix(js): preserve worker message handlers and state

### DIFF
--- a/crates/obscura-js/js/bootstrap.js
+++ b/crates/obscura-js/js/bootstrap.js
@@ -13511,6 +13511,8 @@ globalThis.Worker = class Worker {
     this.onerror = null;
     this._terminated = false;
     this._listeners = {};
+    this._scope = null;
+    this._pendingMessages = [];
     const worker = this;
 
     let resolvedUrl = url;
@@ -13537,8 +13539,8 @@ globalThis.Worker = class Worker {
   }
   _makeScope() {
     const worker = this;
-    // WorkerGlobalScope defined + no document property → IS_WORKER_SCOPE = true in creepjs
     const scope = {
+      onmessage: null,
       WorkerGlobalScope: function WorkerGlobalScope() {},
       DedicatedWorkerGlobalScope: function DedicatedWorkerGlobalScope() {},
       postMessage: (msg) => {
@@ -13553,7 +13555,7 @@ globalThis.Worker = class Worker {
         if (!scope._ev[type]) scope._ev[type] = [];
         scope._ev[type].push(fn);
       },
-      close: () => { worker._terminated = true; },
+      close: () => { worker.terminate(); },
       crypto: globalThis.crypto,
       Crypto: globalThis.Crypto,
       TextEncoder: globalThis.TextEncoder,
@@ -13575,36 +13577,49 @@ globalThis.Worker = class Worker {
     return scope;
   }
   _autoRun() {
-    if (this._terminated || !this._code) return;
-    const worker = this;
-    const scope = worker._makeScope();
+    if (this._terminated || this._scope || this._code === undefined) return;
+    const scope = this._makeScope();
     try {
-      const fn = new Function('self', 'postMessage', 'addEventListener', 'close', worker._code);
-      fn(scope, scope.postMessage, scope.addEventListener, scope.close);
+      // Direct eval preserves script directives and resolves bare handler names
+      // against the worker scope. Run once so message closures retain their state.
+      const fn = new Function('scope', 'source', 'with (scope) { eval(source); }');
+      fn.call(scope, scope, this._code);
     } catch(e) {
       console.error('Worker error:', e.message);
-      if (worker.onerror) worker.onerror(e);
+      if (this.onerror) this.onerror(e);
+    } finally {
+      if (!this._terminated) {
+        this._scope = scope;
+        for (const data of this._pendingMessages.splice(0)) this.postMessage(data);
+      }
     }
   }
   postMessage(data) {
     if (this._terminated) return;
+    if (!this._scope) {
+      this._pendingMessages.push(data);
+      return;
+    }
     const worker = this;
     setTimeout(() => {
-      if (worker._terminated || !worker._code) return;
-      const scope = worker._makeScope();
+      if (worker._terminated || !worker._scope) return;
+      const scope = worker._scope;
       try {
-        const fn = new Function('self', 'postMessage', 'addEventListener', 'close', worker._code);
-        fn(scope, scope.postMessage, scope.addEventListener, scope.close);
+        const event = { data };
+        if (typeof scope.onmessage === 'function') scope.onmessage.call(scope, event);
         const evs = (scope._ev && scope._ev['message']) || [];
-        if (evs.length) { for (const h of evs) h({ data }); }
-        else if (scope.onmessage) scope.onmessage({ data });
+        for (const handler of evs.slice()) handler.call(scope, event);
       } catch(e) {
         console.error('Worker error:', e.message);
         if (worker.onerror) worker.onerror(e);
       }
     }, 0);
   }
-  terminate() { this._terminated = true; }
+  terminate() {
+    this._terminated = true;
+    this._pendingMessages.length = 0;
+    this._scope = null;
+  }
   addEventListener(type, fn) {
     if (!this._listeners[type]) this._listeners[type] = [];
     this._listeners[type].push(fn);

--- a/crates/obscura-js/src/runtime.rs
+++ b/crates/obscura-js/src/runtime.rs
@@ -4130,6 +4130,294 @@ mod tests {
     }
 
     #[tokio::test(flavor = "current_thread")]
+    async fn worker_onmessage_bindings_do_not_mutate_window() {
+        let mut rt = setup_runtime("<html><body></body></html>");
+        rt.execute_script("worker-onmessage-bindings", r#"
+            globalThis.__workerReplies = {};
+            const originalHandler = window.onmessage;
+            const sources = {
+                bare: 'onmessage = function(event) { postMessage([event.data, this === self]); };',
+                declared: 'var onmessage = function(event) { postMessage([event.data, this === self]); };',
+                strict: '"use strict"; onmessage = function(event) { postMessage([event.data, this === self]); };',
+            };
+            for (const [name, source] of Object.entries(sources)) {
+                const url = URL.createObjectURL(new Blob([source], { type: 'application/javascript' }));
+                const worker = new Worker(url);
+                worker.onmessage = event => {
+                    __workerReplies[name] = event.data;
+                    worker.terminate();
+                    URL.revokeObjectURL(url);
+                };
+                worker.postMessage(name);
+            }
+            globalThis.__workerWindowUnchanged = () => window.onmessage === originalHandler;
+        "#).unwrap();
+        rt.run_event_loop_bounded(100).await.unwrap();
+        assert_eq!(
+            rt.evaluate("__workerReplies").unwrap(),
+            serde_json::json!({
+                "bare": ["bare", true], "declared": ["declared", true], "strict": ["strict", true],
+            })
+        );
+        assert_eq!(
+            rt.evaluate("__workerWindowUnchanged()").unwrap(),
+            serde_json::json!(true)
+        );
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn worker_initializes_once_and_retains_message_state() {
+        let mut rt = setup_runtime("<html><body></body></html>");
+        rt.execute_script("worker-persistent-state", r#"
+            globalThis.__workerReplies = [];
+            const source = 'let count = 0; postMessage("ready"); self.onmessage = () => postMessage(++count);';
+            const url = URL.createObjectURL(new Blob([source], { type: 'application/javascript' }));
+            const worker = new Worker(url);
+            worker.onmessage = event => {
+                __workerReplies.push(event.data);
+                if (event.data === 2) {
+                    worker.terminate();
+                    URL.revokeObjectURL(url);
+                }
+            };
+            worker.postMessage(null);
+            worker.postMessage(null);
+        "#).unwrap();
+        rt.run_event_loop_bounded(100).await.unwrap();
+        assert_eq!(
+            rt.evaluate("__workerReplies").unwrap(),
+            serde_json::json!(["ready", 1, 2])
+        );
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn worker_scopes_keep_counters_and_handlers_independent() {
+        let mut rt = setup_runtime("<html><body></body></html>");
+        rt.execute_script(
+            "worker-independent-scopes",
+            r#"
+            globalThis.__workerReplies = [[], []];
+            const source = 'let count = 0; onmessage = () => postMessage(++count);';
+            const url = URL.createObjectURL(new Blob([source], { type: 'application/javascript' }));
+            const workers = [new Worker(url), new Worker(url)];
+            workers.forEach((worker, index) => {
+                worker.onmessage = event => __workerReplies[index].push(event.data);
+            });
+            workers[0].postMessage(null);
+            workers[1].postMessage(null);
+            workers[0].postMessage(null);
+        "#,
+        )
+        .unwrap();
+        rt.run_event_loop_bounded(100).await.unwrap();
+        assert_eq!(
+            rt.evaluate("__workerReplies").unwrap(),
+            serde_json::json!([[1, 2], [1]])
+        );
+        rt.execute_script(
+            "worker-cleanup",
+            "workers.forEach(worker => worker.terminate()); URL.revokeObjectURL(url);",
+        )
+        .unwrap();
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn worker_delivers_to_handler_and_listener_without_reinitializing() {
+        let mut rt = setup_runtime("<html><body></body></html>");
+        rt.execute_script(
+            "worker-handler-and-listener",
+            r#"
+            globalThis.__workerReplies = [];
+            const source = `
+                let count = 0;
+                self.onmessage = event => postMessage(['handler', ++count]);
+                addEventListener('message', function(event) {
+                    postMessage(['listener', count, this === self]);
+                });
+            `;
+            const url = URL.createObjectURL(new Blob([source], { type: 'application/javascript' }));
+            const worker = new Worker(url);
+            worker.onmessage = event => __workerReplies.push(event.data);
+            worker.postMessage(null);
+            worker.postMessage(null);
+        "#,
+        )
+        .unwrap();
+        rt.run_event_loop_bounded(100).await.unwrap();
+        assert_eq!(
+            rt.evaluate("__workerReplies").unwrap(),
+            serde_json::json!([
+                ["handler", 1],
+                ["listener", 1, true],
+                ["handler", 2],
+                ["listener", 2, true],
+            ])
+        );
+        rt.execute_script(
+            "worker-cleanup",
+            "worker.terminate(); URL.revokeObjectURL(url);",
+        )
+        .unwrap();
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn worker_queues_messages_while_source_is_loading() {
+        let mut rt = setup_runtime("<html><body></body></html>");
+        rt.execute_script("worker-queued-messages", r#"
+            globalThis.__workerReplies = [];
+            const originalFetch = globalThis.fetch;
+            let finishSource;
+            globalThis.fetch = async () => ({ text: () => new Promise(resolve => { finishSource = resolve; }) });
+            const worker = new Worker('https://example.com/worker.js');
+            worker.onmessage = event => __workerReplies.push(event.data);
+            worker.postMessage('first');
+            worker.postMessage('second');
+            setTimeout(() => {
+                globalThis.fetch = originalFetch;
+                finishSource('let count = 0; onmessage = event => postMessage([++count, event.data]);');
+            }, 0);
+        "#).unwrap();
+        rt.run_event_loop_bounded(100).await.unwrap();
+        assert_eq!(
+            rt.evaluate("__workerReplies").unwrap(),
+            serde_json::json!([[1, "first"], [2, "second"]])
+        );
+        rt.execute_script("worker-cleanup", "worker.terminate();")
+            .unwrap();
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn worker_termination_discards_queued_messages() {
+        let mut rt = setup_runtime("<html><body></body></html>");
+        rt.execute_script(
+            "worker-terminated-messages",
+            r#"
+            globalThis.__workerReplies = [];
+            const source = 'postMessage("started"); onmessage = () => postMessage("reply");';
+            const url = URL.createObjectURL(new Blob([source], { type: 'application/javascript' }));
+            const worker = new Worker(url);
+            worker.onmessage = event => __workerReplies.push(event.data);
+            worker.postMessage('queued');
+            worker.terminate();
+            worker.postMessage('after termination');
+            URL.revokeObjectURL(url);
+        "#,
+        )
+        .unwrap();
+        rt.run_event_loop_bounded(100).await.unwrap();
+        assert_eq!(
+            rt.evaluate("__workerReplies").unwrap(),
+            serde_json::json!([])
+        );
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn worker_source_preserves_strict_mode_in_message_closures() {
+        let mut rt = setup_runtime("<html><body></body></html>");
+        rt.execute_script(
+            "worker-strict-closure",
+            r#"
+            globalThis.__workerReplies = [];
+            const source = `
+                'use strict';
+                onmessage = () => {
+                    try { workerUndeclaredVariable = 1; postMessage('unexpected assignment'); }
+                    catch (error) { postMessage(error.name); }
+                };
+            `;
+            const url = URL.createObjectURL(new Blob([source], { type: 'application/javascript' }));
+            const worker = new Worker(url);
+            worker.onmessage = event => __workerReplies.push(event.data);
+            worker.postMessage(null);
+        "#,
+        )
+        .unwrap();
+        rt.run_event_loop_bounded(100).await.unwrap();
+        assert_eq!(
+            rt.evaluate("__workerReplies").unwrap(),
+            serde_json::json!(["ReferenceError"])
+        );
+        assert_eq!(
+            rt.evaluate("typeof workerUndeclaredVariable").unwrap(),
+            serde_json::json!("undefined")
+        );
+        rt.execute_script(
+            "worker-cleanup",
+            "worker.terminate(); URL.revokeObjectURL(url);",
+        )
+        .unwrap();
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn worker_initialization_error_does_not_rerun_source() {
+        let mut rt = setup_runtime("<html><body></body></html>");
+        rt.execute_script(
+            "worker-initialization-error",
+            r#"
+            globalThis.__workerReplies = [];
+            globalThis.__workerErrors = [];
+            const source = 'postMessage("started"); throw new Error("initialization failed");';
+            const url = URL.createObjectURL(new Blob([source], { type: 'application/javascript' }));
+            const worker = new Worker(url);
+            worker.onmessage = event => __workerReplies.push(event.data);
+            worker.onerror = error => __workerErrors.push(error.message);
+            worker.postMessage(null);
+            worker.postMessage(null);
+        "#,
+        )
+        .unwrap();
+        rt.run_event_loop_bounded(100).await.unwrap();
+        assert_eq!(
+            rt.evaluate("__workerReplies").unwrap(),
+            serde_json::json!(["started"])
+        );
+        assert_eq!(
+            rt.evaluate("__workerErrors").unwrap(),
+            serde_json::json!(["initialization failed"])
+        );
+        rt.execute_script(
+            "worker-cleanup",
+            "worker.terminate(); URL.revokeObjectURL(url);",
+        )
+        .unwrap();
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn worker_startup_reply_does_not_overtake_queued_messages() {
+        let mut rt = setup_runtime("<html><body></body></html>");
+        rt.execute_script(
+            "worker-startup-order",
+            r#"
+            globalThis.__workerReplies = [];
+            const source = 'postMessage("ready"); onmessage = event => postMessage(event.data);';
+            const url = URL.createObjectURL(new Blob([source], { type: 'application/javascript' }));
+            const worker = new Worker(url);
+            let replied = false;
+            worker.onmessage = event => {
+                __workerReplies.push(event.data);
+                if (event.data === 'ready' && !replied) {
+                    replied = true;
+                    worker.postMessage(3);
+                }
+            };
+            worker.postMessage(1);
+            worker.postMessage(2);
+        "#,
+        )
+        .unwrap();
+        rt.run_event_loop_bounded(100).await.unwrap();
+        assert_eq!(
+            rt.evaluate("__workerReplies").unwrap(),
+            serde_json::json!(["ready", 1, 2, 3])
+        );
+        rt.execute_script(
+            "worker-cleanup",
+            "worker.terminate(); URL.revokeObjectURL(url);",
+        )
+        .unwrap();
+    }
+
+    #[tokio::test(flavor = "current_thread")]
     async fn self_requeueing_message_channel_yields_to_timers() {
         let mut rt = setup_runtime("<html><body></body></html>");
         rt.execute_script(

--- a/docs/Architecture-overview.md
+++ b/docs/Architecture-overview.md
@@ -93,6 +93,16 @@ Adding a Web API usually means:
 
 Worked example: [Adding a CDP method or Web API](Adding-a-CDP-method-or-Web-API.md).
 
+## Classic Web Workers
+
+The JavaScript shim executes each classic Worker source once and retains its
+message handlers and lexical state. Bare `onmessage` assignments target the
+worker scope, and messages posted before the source loads are queued until
+initialization finishes. Terminating a worker discards pending messages.
+
+Workers remain emulated within the page runtime, not separate V8 isolates or
+OS threads. This is not a complete WorkerGlobalScope implementation.
+
 ## CDP session model
 
 Each CDP client connection gets attached to one or more targets.


### PR DESCRIPTION
## What changed

Fixes #867.

Assigning bare `onmessage` inside a classic Worker overwrites the page's handler,
and the Worker never receives the message. The shim also reruns the source in a
new scope for every message, so closures lose their state between calls.

The Worker now keeps its scope and runs the source once. Direct eval inside that
scope makes bare handler assignments work without changing script directives.
Messages wait in a queue while the source loads and initializes, then go to the
handler and listeners. Termination discards pending messages.

The architecture document describes this behavior and its limits: Workers still
share the page runtime, and the shim does not implement a complete
WorkerGlobalScope.

## Validation

Tested on macOS arm64 with Rust 1.96.0-nightly, comparing base `a1e09de` with
candidate `88d5cb0`. Builds used `CARGO_INCREMENTAL=0 CARGO_BUILD_JOBS=2`, and
nextest ran with one test thread.

The 9 new runtime tests cover bare, declared, and strict handler assignments;
initialization count and closure state; independent Workers; handler and listener
delivery; messages queued during source loading; termination; strict closures;
initialization errors; and replies sent during startup. Of the initial 8 tests,
7 failed on the original implementation. The final 9 tests pass.

- `cargo nextest run --release --features render --no-fail-fast --test-threads 1`:
  1,641 passed; 4 existing ignored tests skipped.
- `cargo nextest run --release -p obscura --no-fail-fast --test-threads 1`:
  30 passed without rendering.
- `cargo nextest run --release --workspace --exclude obscura --exclude obscura-render --no-default-features --no-fail-fast --test-threads 1`:
  881 passed; 3 existing ignored tests skipped.
- `cargo check --release -p obscura-render --no-default-features`: passed.
- All four `cargo build --release -p obscura-cli --bins` configurations built:
  `--features render`, `--features render,stealth`, `--no-default-features`,
  and `--no-default-features --features stealth`.
- The stealth network tests passed: 98 tests, plus the gzip test run separately
  with `OBSCURA_ALLOW_PRIVATE_NETWORK=1` for its loopback fixture.
- The no-render CLI rejects `--screenshot`, reports that the render feature is
  required, and exits with status 1.
- The native stealth binary and Chrome each pass 4 offline Blob Worker probes
  without changing the page handler: bare assignment with and without a debugger
  statement, `self.onmessage`, and `addEventListener`.

The obstacle course returns 32/33 on the base and 32/33 on the candidate. This falls short of the
documented 33/33 requirement. The only failure is `observer-intersection`, which
expects `io:50` but gets an empty string. The released v0.2.2 binary fails the
same check; existing issue #671 tracks it.

Those runs used
`obscura-benchmark@6ebac8293d7477f59e837768bfd4e74173f04f1c` with
`--runs 1 --warmup 0`. There are no new failures, and
`scripts/ci/compare_obstacle.py` passes the comparison against the base version.
It flags the timings for `static` and `ssr-hydrate`. The candidate run overlapped
compilation, so performance was measured separately with alternating base and
candidate runs, as described below.

`git diff --check` and `scripts/ci/pr_policy.py` pass. The policy script warns
about the lack of an integration-test file because the new tests live in
`crates/obscura-js/src/runtime.rs`.

## Rendering

Not applicable.

## Performance

Base and candidate runs alternated, using the same release flags and local
fixtures. Each version ran two batches, each with 1 warmup and 5 measured runs.
The results below include all 10 measurements per version and fixture. The
second batch also recorded CPU time, giving 5 CPU samples per version.

macOS `/usr/bin/time -l` measured CPU time and peak RSS. Wall time includes
process startup, and every run checked the result for correctness. The DOM and
storage fixtures match the CI performance smoke cases. The Worker fixture
exchanges 100 messages and records its own elapsed time. Both binaries use a
fixed 2-second CLI settle period for that fixture.

Values are median [minimum, maximum].

| Fixture | Base wall ms | Candidate wall ms | Base peak RSS MiB | Candidate peak RSS MiB |
| --- | ---: | ---: | ---: | ---: |
| Build 5,000 DOM rows | 98.12 [80.41, 116.48] | 99.71 [82.21, 135.72] | 47.45 [47.22, 48.09] | 47.39 [47.05, 48.23] |
| Storage roundtrip | 28.24 [23.10, 35.16] | 29.87 [25.32, 33.13] | 31.12 [30.23, 33.84] | 31.36 [30.16, 33.75] |
| Worker 100 messages | 2029.23 [2025.78, 2037.67] | 2029.22 [2024.97, 2051.61] | 28.58 [28.47, 28.64] | 28.47 [28.30, 28.59] |

The Worker's own elapsed time was 545.5 [543, 552] ms before the change and
547.5 [541, 555] ms after it. Combined user and system CPU times in the second
batch were 100 [90, 100] versus 90 [90, 100] ms for DOM, 10 [10, 10] versus
10 [10, 10] ms for storage, and 30 [20, 30] versus 20 [20, 30] ms for Worker.
CPU time is reported in 10 ms increments, which is too coarse to claim a speedup.

None of these samples crosses the CI smoke failure thresholds: latency must
increase by both >20% and >10 ms, or RSS by both >15% and >8 MiB. These results
do not establish performance equivalence for other workloads.

## Checklist

- [x] The change is focused and does not remove existing behavior without justification.
- [x] Tests cover the failure or feature.
- [ ] Existing tests pass, including render and no-render configurations when affected.
- [x] I checked for CPU, latency, and memory regressions.
- [x] Public API or user-facing behavior changes are documented.

The test checkbox remains open because the obstacle course fails the existing
`observer-intersection` check on both versions. The nextest suites listed above
pass.
