### PR TITLE
Fix per-document font re-parsing and add --font-dir loading (#879)

### DIFF
--- a/README.md
+++ b/README.md
@@ -463,6 +463,7 @@ Start a CDP WebSocket server.
 | `--stealth` | off | Enable anti-detection + tracker blocking |
 | `--workers` | `1` | Number of parallel worker processes |
 | `--obey-robots` | off | Respect robots.txt |
+| `--font-dir` | — | Load fonts from a directory into the process-wide font database at startup, so pages don't need a `document.fonts.add()` script just to get glyphs (e.g. CJK). Repeatable for multiple directories; forwarded to worker processes when `--workers` > 1 |
 
 ### `obscura fetch <URL>`
 

--- a/crates/obscura-browser/src/lib.rs
+++ b/crates/obscura-browser/src/lib.rs
@@ -11,6 +11,7 @@ pub use lifecycle::{LifecycleState, WaitUntil};
 pub use obscura_js::HTML_TO_MARKDOWN_JS;
 #[cfg(feature = "render")]
 pub use obscura_js::{
+    configure_extra_font_directories,
     validate_capture_region, AnimationSample, AnimationSampleMode, AnimationSampleTime,
     CaptureError, CaptureRegion,
 };

--- a/crates/obscura-cli/src/main.rs
+++ b/crates/obscura-cli/src/main.rs
@@ -97,6 +97,13 @@ enum Command {
         #[arg(long)]
         storage_dir: Option<std::path::PathBuf>,
 
+        /// Load fonts from a directory into the process-wide font database
+        /// once at startup, so pages that need those faces don't have to
+        /// inject a `document.fonts.add()` script just to get glyphs
+        /// (issue #879). Repeatable to load from multiple directories.
+        #[arg(long)]
+        font_dir: Vec<std::path::PathBuf>,
+
         /// Suppress all logs (same as on `fetch`). Useful when scraping pages
         /// that flood the console with per-page script warnings (issue #264).
         #[arg(long)]
@@ -367,6 +374,7 @@ async fn main() -> anyhow::Result<()> {
             max_connections,
             allow_file_access,
             storage_dir,
+            font_dir,
             quiet: _,
         }) => {
             // Fall back to OBSCURA_PROXY so a proxy can be supplied without
@@ -396,9 +404,32 @@ async fn main() -> anyhow::Result<()> {
                 tracing::info!("Stealth mode enabled (tracker blocking)");
             }
 
+            if !font_dir.is_empty() {
+                #[cfg(feature = "render")]
+                {
+                    for dir in &font_dir {
+                        tracing::info!("Font dir: {}", dir.display());
+                    }
+                    obscura_browser::configure_extra_font_directories(font_dir.clone());
+                }
+                #[cfg(not(feature = "render"))]
+                tracing::info!(
+                    "--font-dir has no effect in this build (compiled without the `render` feature)"
+                );
+            }
+
             if workers > 1 {
                 tracing::info!("{} worker processes", workers);
-                run_multi_worker_serve(port, host, workers, proxy, stealth, user_agent).await?;
+                run_multi_worker_serve(
+                    port,
+                    host,
+                    workers,
+                    proxy,
+                    stealth,
+                    user_agent,
+                    font_dir,
+                )
+                .await?;
             } else {
                 obscura_cdp::start_with_serve_options_and_limit(
                     port,
@@ -540,6 +571,7 @@ async fn run_multi_worker_serve(
     proxy: Option<String>,
     stealth: bool,
     user_agent: Option<String>,
+    font_dir: Vec<std::path::PathBuf>,
 ) -> anyhow::Result<()> {
     use tokio::io::AsyncWriteExt as _;
     use tokio::net::TcpListener;
@@ -560,6 +592,9 @@ async fn run_multi_worker_serve(
         }
         if let Some(ref ua) = user_agent {
             cmd.arg("--user-agent").arg(ua);
+        }
+        for dir in &font_dir {
+            cmd.arg("--font-dir").arg(dir);
         }
         if stealth {
             cmd.arg("--stealth");
@@ -2202,6 +2237,53 @@ mod tests {
     #[test]
     fn no_subcommand_is_not_quiet() {
         assert!(!is_quiet_command(&None));
+    }
+
+    #[test]
+    fn parsed_serve_font_dir_single() {
+        let args = Args::try_parse_from(["obscura", "serve", "--font-dir", "/fonts/one"])
+            .expect("clap should accept --font-dir on serve");
+        match args.command {
+            Some(Command::Serve { font_dir, .. }) => {
+                assert_eq!(font_dir, vec![std::path::PathBuf::from("/fonts/one")]);
+            }
+            _ => panic!("expected Serve command"),
+        }
+    }
+
+    #[test]
+    fn parsed_serve_font_dir_repeated_collects_into_vec() {
+        let args = Args::try_parse_from([
+            "obscura",
+            "serve",
+            "--font-dir",
+            "/fonts/one",
+            "--font-dir",
+            "/fonts/two",
+        ])
+        .expect("clap should accept repeated --font-dir on serve");
+        match args.command {
+            Some(Command::Serve { font_dir, .. }) => {
+                assert_eq!(
+                    font_dir,
+                    vec![
+                        std::path::PathBuf::from("/fonts/one"),
+                        std::path::PathBuf::from("/fonts/two"),
+                    ]
+                );
+            }
+            _ => panic!("expected Serve command"),
+        }
+    }
+
+    #[test]
+    fn parsed_serve_without_font_dir_is_empty() {
+        let args = Args::try_parse_from(["obscura", "serve"])
+            .expect("clap should accept serve without --font-dir");
+        match args.command {
+            Some(Command::Serve { font_dir, .. }) => assert!(font_dir.is_empty()),
+            _ => panic!("expected Serve command"),
+        }
     }
 
     #[test]

--- a/crates/obscura-js/src/lib.rs
+++ b/crates/obscura-js/src/lib.rs
@@ -15,6 +15,7 @@ pub use v8_flags::set_v8_flags;
 // render feature (which enables obscura-render/paint) is compiled in.
 #[cfg(feature = "render")]
 pub use obscura_render::{
+    configure_extra_font_directories,
     screenshot_png, screenshot_png_scrolled, screenshot_png_scrolled_at_animation_time,
     screenshot_png_scrolled_at_animation_time_with_surface_color,
     validate_capture_region, AnimationSample, AnimationSampleMode, AnimationSampleTime,

--- a/crates/obscura-render/Cargo.toml
+++ b/crates/obscura-render/Cargo.toml
@@ -11,7 +11,7 @@ default = []
 # Rasterize the laid-out tree to a pixmap (tiny-skia) with text (cosmic-text
 # shaping + line breaking, ab_glyph fallback) and images.
 # Off by default; the layout core (getBoundingClientRect etc.) works without it.
-paint = ["dep:tiny-skia", "dep:ab_glyph", "dep:cosmic-text", "dep:swash", "dep:image", "dep:ureq", "dep:base64", "dep:resvg", "dep:usvg", "dep:url", "dep:wuff"]
+paint = ["dep:tiny-skia", "dep:ab_glyph", "dep:cosmic-text", "dep:swash", "dep:image", "dep:ureq", "dep:base64", "dep:resvg", "dep:usvg", "dep:url", "dep:wuff", "dep:log"]
 
 [dependencies]
 taffy = { workspace = true }
@@ -37,8 +37,11 @@ usvg = { version = "0.47", default-features = false, optional = true }
 url = { workspace = true, optional = true }
 cssparser = "0.34"
 wuff = { version = "0.2.7", optional = true }
-# Same `log` instance usvg emits glyph-fallback warnings through, so tests can
-# install a collector and assert on them.
+# Font-directory/cache misconfiguration warnings (e.g. a missing `--font-dir`
+# path) go through this. Same `log` instance usvg emits glyph-fallback
+# warnings through, so tests can install a collector and assert on them.
+log = { version = "0.4", optional = true }
+
 [dev-dependencies]
 log = "0.4"
 

--- a/crates/obscura-render/src/font_cache.rs
+++ b/crates/obscura-render/src/font_cache.rs
@@ -1,0 +1,285 @@
+//! Process-wide font caching for the HTML text engine ([`crate::inline`]).
+//!
+//! `TextEngine::new_with_web_fonts_and_emoji` used to build a brand-new
+//! `fontdb::Database` from scratch on every call: parsing the 14 embedded
+//! bundled faces plus every authored `@font-face`/dynamic `FontFace` on every
+//! single document, even pages that reuse the exact same page fonts as the
+//! previous request. `fontdb::Database::load_font_source` parses the sfnt
+//! tables synchronously, which is the multi-second cost reported in #879 for
+//! multi-MB CJK faces.
+//!
+//! This module adds two independent caches, mirroring `RenderResourceCache`'s
+//! FIFO-bounded shape (`paint.rs`) and `svg_font_database`'s once-per-process
+//! base database (`paint.rs`):
+//!
+//! - [`load_cached_web_font`]: a process-wide, mutex-guarded, FIFO-bounded
+//!   cache from a font's raw bytes to the `fontdb::FaceInfo`s it produces.
+//!   A cache hit uses `Database::push_face_info`, which stores an
+//!   already-parsed `FaceInfo` without re-parsing.
+//! - Extra `--font-dir` directories: [`configure_extra_font_directories`]
+//!   registers directories to fold into the base bundled-face database
+//!   (built once per process, see `inline::base_font_database`) the first
+//!   time it is built.
+use std::collections::hash_map::RandomState;
+use std::collections::{HashMap, HashSet, VecDeque};
+use std::hash::BuildHasher;
+use std::path::{Path, PathBuf};
+use std::sync::{Mutex, OnceLock};
+
+use cosmic_text::fontdb;
+
+const DEFAULT_FONT_BYTE_CACHE_ENTRIES: usize = 128;
+const DEFAULT_FONT_BYTE_CACHE_BYTES: usize = 128 * 1024 * 1024;
+
+/// One cached font source: the parsed faces plus the raw byte count charged
+/// against the cache's byte bound (once per source, not once per face, since
+/// every face in a collection shares the same underlying bytes).
+struct CachedFontSource {
+    faces: Vec<fontdb::FaceInfo>,
+    bytes: usize,
+}
+
+/// Page-provided font bytes shared across every document/browser context in
+/// this process. Bounded by both entry count and total retained byte size,
+/// evicting the oldest entry first, matching `RenderResourceCache` (`paint.rs`).
+struct FontByteCache {
+    entries: HashMap<u64, CachedFontSource>,
+    order: VecDeque<u64>,
+    retained_bytes: usize,
+    max_entries: usize,
+    max_bytes: usize,
+}
+
+impl FontByteCache {
+    fn new(max_entries: usize, max_bytes: usize) -> Self {
+        Self {
+            entries: HashMap::new(),
+            order: VecDeque::new(),
+            retained_bytes: 0,
+            max_entries,
+            max_bytes,
+        }
+    }
+
+    fn get(&self, hash: u64) -> Option<Vec<fontdb::FaceInfo>> {
+        self.entries.get(&hash).map(|entry| entry.faces.clone())
+    }
+
+    fn insert(&mut self, hash: u64, faces: Vec<fontdb::FaceInfo>, bytes: usize) {
+        if self.entries.contains_key(&hash) || self.max_entries == 0 || bytes > self.max_bytes {
+            return;
+        }
+        while self.entries.len() >= self.max_entries
+            || self.retained_bytes.saturating_add(bytes) > self.max_bytes
+        {
+            let Some(oldest) = self.order.pop_front() else {
+                break;
+            };
+            if let Some(evicted) = self.entries.remove(&oldest) {
+                self.retained_bytes = self.retained_bytes.saturating_sub(evicted.bytes);
+            }
+        }
+        self.retained_bytes = self.retained_bytes.saturating_add(bytes);
+        self.order.push_back(hash);
+        self.entries.insert(hash, CachedFontSource { faces, bytes });
+    }
+}
+
+fn font_byte_cache() -> &'static Mutex<FontByteCache> {
+    static CACHE: OnceLock<Mutex<FontByteCache>> = OnceLock::new();
+    CACHE.get_or_init(|| {
+        Mutex::new(FontByteCache::new(
+            DEFAULT_FONT_BYTE_CACHE_ENTRIES,
+            DEFAULT_FONT_BYTE_CACHE_BYTES,
+        ))
+    })
+}
+
+/// Content-address a font source's raw bytes.
+///
+/// This cache is content-addressed and the content is attacker-influenced (a
+/// screenshot service renders untrusted pages, and `document.fonts.add()`
+/// bytes come straight from page script). Do **not** switch this to
+/// `std::collections::hash_map::DefaultHasher::new()`: its seed is fixed
+/// (`(0, 0)`), not randomized, which would make a deliberate hash collision
+/// (poisoning one document's cache entry with another's face data) at least
+/// theoretically searchable offline. `RandomState` is seeded from the OS RNG
+/// once per process start, the same guarantee `HashMap::new()` relies on by
+/// default, at zero extra dependency cost. The `RandomState` instance itself
+/// is built once and reused so identical bytes keep hashing identically for
+/// the life of the process (otherwise every lookup would miss).
+pub(crate) fn hash_font_bytes(data: &[u8]) -> u64 {
+    static STATE: OnceLock<RandomState> = OnceLock::new();
+    STATE.get_or_init(RandomState::new).hash_one(data)
+}
+
+/// Insert an already-parsed `FaceInfo` into `db` without re-parsing, and
+/// recover the `fontdb::ID` it was assigned.
+///
+/// `Database::push_face_info` (fontdb 0.16) does not return the new id, so
+/// recover it by diffing the face id set before/after the call; `db` only
+/// ever grows by exactly one face per call.
+fn push_face_info_and_get_id(db: &mut fontdb::Database, mut info: fontdb::FaceInfo) -> fontdb::ID {
+    info.id = fontdb::ID::dummy();
+    let before: HashSet<fontdb::ID> = db.faces().map(|face| face.id).collect();
+    db.push_face_info(info);
+    db.faces()
+        .map(|face| face.id)
+        .find(|id| !before.contains(id))
+        .expect("push_face_info always inserts exactly one new face")
+}
+
+/// Load one page-provided font's bytes into `db`, using the process-wide
+/// cache when this exact content has been seen before.
+///
+/// On a hit, every cached `FaceInfo` (a source can be a font collection, so
+/// there can be more than one) is pushed into `db` without re-parsing. On a
+/// miss, `db.load_font_source` parses as before and the resulting faces are
+/// cloned into the cache (subject to the FIFO bound) for the next caller.
+///
+/// The whole miss path runs under the cache's lock: a second caller
+/// requesting the exact same bytes while the first is still parsing blocks
+/// on the mutex instead of racing to parse (and cache) the same content
+/// twice. This serializes concurrent *first-time* parses of distinct
+/// content too, trading a little concurrency for a simple, provably correct
+/// cache; every parse other than the first, for any given content, is a
+/// cheap hit.
+pub(crate) fn load_cached_web_font(db: &mut fontdb::Database, data: &[u8]) -> Vec<fontdb::ID> {
+    let hash = hash_font_bytes(data);
+    let mut cache = font_byte_cache()
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
+    if let Some(faces) = cache.get(hash) {
+        return faces
+            .into_iter()
+            .map(|info| push_face_info_and_get_id(db, info))
+            .collect();
+    }
+    #[cfg(test)]
+    test_support::record_miss(hash);
+    let ids: Vec<fontdb::ID> = db
+        .load_font_source(fontdb::Source::Binary(std::sync::Arc::new(data.to_vec())))
+        .into_iter()
+        .collect();
+    let faces: Vec<fontdb::FaceInfo> = ids.iter().filter_map(|id| db.face(*id).cloned()).collect();
+    cache.insert(hash, faces, data.len());
+    ids
+}
+
+static EXTRA_FONT_DIRECTORIES: OnceLock<Vec<PathBuf>> = OnceLock::new();
+
+/// Register extra font directories to fold into the base bundled-face
+/// database (see `inline::base_font_database`) the first time it is built.
+///
+/// Must be called before the first render in this process: the base
+/// database is itself cached in a process-wide `OnceLock` and is only ever
+/// built once, so directories registered after that point have already
+/// missed their only chance to be scanned. Calling this too late is a no-op;
+/// a warning is logged so the misuse is visible rather than silently
+/// ignored.
+pub fn configure_extra_font_directories(dirs: Vec<PathBuf>) {
+    if !set_extra_font_directories(&EXTRA_FONT_DIRECTORIES, dirs) {
+        log::warn!(
+            "configure_extra_font_directories called after the base font database was already \
+             built; the requested directories will not be loaded in this process (call this \
+             before the first render)"
+        );
+    }
+}
+
+/// Testable core of [`configure_extra_font_directories`]: attempt to set
+/// `store` and report whether it took effect. Takes the `OnceLock` by
+/// reference, rather than always the process-global one, so the "too late"
+/// no-op path can be unit tested without depending on this test binary's
+/// (unpredictable) test execution order.
+pub(crate) fn set_extra_font_directories(
+    store: &OnceLock<Vec<PathBuf>>,
+    dirs: Vec<PathBuf>,
+) -> bool {
+    store.set(dirs).is_ok()
+}
+
+/// Directories configured via [`configure_extra_font_directories`], or empty
+/// if none were (or if it was called too late to take effect).
+pub(crate) fn configured_extra_font_directories() -> &'static [PathBuf] {
+    EXTRA_FONT_DIRECTORIES.get_or_init(Vec::new)
+}
+
+/// Load every `.ttf`/`.otf`/`.ttc`/`.otc` face found (recursively) in `dir`
+/// into `db`, returning the newly added ids. `fontdb::Database::load_fonts_dir`
+/// already recursively scans and never errors (it logs and skips malformed
+/// files), but silently no-ops for a directory that doesn't exist at all;
+/// this wrapper adds a warning for that case too, so a misconfigured
+/// `--font-dir` is never silent.
+///
+/// Deliberately takes `db`/`dirs` directly rather than reading the global
+/// `OnceLock` config, so this can be unit tested without process-global
+/// state or the "only built once" hazard `base_font_database` has.
+pub(crate) fn load_extra_font_directory(db: &mut fontdb::Database, dir: &Path) -> Vec<fontdb::ID> {
+    if !dir.is_dir() {
+        log::warn!(
+            "configured font directory {} does not exist or is not a directory; skipping",
+            dir.display()
+        );
+        return Vec::new();
+    }
+    let before: HashSet<fontdb::ID> = db.faces().map(|face| face.id).collect();
+    db.load_fonts_dir(dir);
+    let added: Vec<fontdb::ID> = db
+        .faces()
+        .map(|face| face.id)
+        .filter(|id| !before.contains(id))
+        .collect();
+    if added.is_empty() {
+        log::warn!(
+            "configured font directory {} contained no loadable fonts",
+            dir.display()
+        );
+    }
+    added
+}
+
+/// [`load_extra_font_directory`] over every configured directory.
+pub(crate) fn load_extra_font_directories(
+    db: &mut fontdb::Database,
+    dirs: &[PathBuf],
+) -> Vec<fontdb::ID> {
+    dirs.iter()
+        .flat_map(|dir| load_extra_font_directory(db, dir))
+        .collect()
+}
+
+#[cfg(test)]
+pub(crate) mod test_support {
+    use std::collections::HashMap;
+    use std::sync::{Mutex, OnceLock};
+
+    /// Number of real (non-cached) parses ever performed for a given content
+    /// hash, for the life of this test binary's process.
+    ///
+    /// This is deliberately keyed by content hash rather than a single
+    /// `AtomicUsize` total. `cargo test`'s default harness runs every
+    /// `#[test]` in this binary concurrently on a shared thread pool, and
+    /// any other test that builds a `TextEngine` with its own (different)
+    /// `WebFont` bytes also causes a cache miss; a single shared counter
+    /// would let that unrelated activity land in between one test's own
+    /// calls, making an exact "+1" delta assertion flaky under parallel
+    /// execution. Scoping by hash sidesteps this: unrelated tests use
+    /// different bytes and so touch different buckets, while the *same*
+    /// hash's count is still guaranteed to reach exactly 1 and never more,
+    /// because the whole miss path in `load_cached_web_font` runs under the
+    /// byte cache's mutex.
+    static MISS_COUNTS: OnceLock<Mutex<HashMap<u64, usize>>> = OnceLock::new();
+
+    fn counts() -> &'static Mutex<HashMap<u64, usize>> {
+        MISS_COUNTS.get_or_init(|| Mutex::new(HashMap::new()))
+    }
+
+    pub(crate) fn record_miss(hash: u64) {
+        *counts().lock().unwrap().entry(hash).or_insert(0) += 1;
+    }
+
+    pub(crate) fn miss_count(hash: u64) -> usize {
+        counts().lock().unwrap().get(&hash).copied().unwrap_or(0)
+    }
+}

--- a/crates/obscura-render/src/inline.rs
+++ b/crates/obscura-render/src/inline.rs
@@ -960,6 +960,115 @@ pub(crate) fn constrained_auto_replaced_size(
     })
 }
 
+/// One face pending family/weight/italic resolution: the id it was loaded
+/// under plus its declared `@font-face`/`FontFace` descriptor overrides
+/// (`None` for the embedded/emoji/directory faces, which use whatever the
+/// font's own name table declares).
+type FontDeclaration = (
+    cosmic_text::fontdb::ID,
+    Option<String>,
+    Option<(u16, u16)>,
+    Option<bool>,
+);
+
+/// Resolve each declaration's family/weight/italic/metrics against `db` and
+/// fold the result into `loaded_families`. Shared by the once-per-process
+/// base database build and every per-document page-font merge so both paths
+/// stay byte-for-byte identical.
+fn record_face_declarations(
+    db: &cosmic_text::fontdb::Database,
+    declarations: Vec<FontDeclaration>,
+    loaded_families: &mut HashMap<String, LoadedFamily>,
+) {
+    for (id, declared_family, declared_weight, declared_italic) in declarations {
+        let Some(face) = db.face(id) else { continue };
+        let names = face.families.clone();
+        let internal_name = names
+            .first()
+            .map(|(name, _)| Arc::<str>::from(name.as_str()))
+            .unwrap_or_else(|| Arc::from(FAMILY));
+        let shape_weight = face.weight.0;
+        let metrics = font_metrics(db, id)
+            .unwrap_or_else(|| bundled_face_metrics(internal_name.as_ref()));
+        let italic = declared_italic
+            .unwrap_or(!matches!(face.style, cosmic_text::fontdb::Style::Normal));
+        let weight = declared_weight.unwrap_or((shape_weight, shape_weight));
+        let declared_names: Vec<String> = declared_family
+            .map(|name| vec![name])
+            .unwrap_or_else(|| names.into_iter().map(|(name, _)| name).collect());
+        for name in declared_names {
+            let family = loaded_families
+                .entry(name.to_ascii_lowercase())
+                .or_insert_with(|| LoadedFamily { faces: Vec::new() });
+            family.faces.push(LoadedFace {
+                name: Arc::clone(&internal_name),
+                font_id: Some(id),
+                metrics,
+                min_weight: weight.0,
+                max_weight: weight.1,
+                italic,
+            });
+        }
+    }
+}
+
+/// Build the embedded/emoji/extra-directory base once. Called only from
+/// [`base_font_database`]'s `OnceLock::get_or_init`, never directly.
+fn build_base_font_database(
+    load_emoji: bool,
+) -> (cosmic_text::fontdb::Database, HashMap<String, LoadedFamily>) {
+    let mut db = cosmic_text::fontdb::Database::new();
+    let mut declarations = Vec::new();
+    for bytes in [
+        SANS_R, SANS_B, SANS_O, SANS_BO, SERIF_R, SERIF_B, SERIF_O, SERIF_BO, MONO_R, MONO_B,
+        MONO_O, MONO_BO, SYSTEM_R, SYSTEM_B,
+    ] {
+        for id in db.load_font_source(cosmic_text::fontdb::Source::Binary(Arc::new(bytes))) {
+            declarations.push((id, None, None, None));
+        }
+    }
+    if load_emoji {
+        for id in db.load_font_source(cosmic_text::fontdb::Source::Binary(Arc::new(EMOJI_R))) {
+            declarations.push((id, None, None, None));
+        }
+    }
+    // Directories registered via `configure_extra_font_directories` before
+    // this database's first build (see that function's doc comment for the
+    // "must be called before the first render" ordering requirement).
+    let extra_dirs = crate::font_cache::configured_extra_font_directories();
+    for id in crate::font_cache::load_extra_font_directories(&mut db, extra_dirs) {
+        declarations.push((id, None, None, None));
+    }
+    let mut loaded_families = HashMap::new();
+    record_face_declarations(&db, declarations, &mut loaded_families);
+    db.set_sans_serif_family(FAMILY);
+    (db, loaded_families)
+}
+
+/// The 14 embedded bundled faces, plus the emoji face when `load_emoji`, plus
+/// any `--font-dir` directories, parsed exactly once per process and shared
+/// (cheaply cloned) by every [`TextEngine`]. Mirrors `svg_font_database`
+/// (`paint.rs`), which solves the identical problem for the SVG-text
+/// database; two locks (rather than one keyed by `bool`) because there are
+/// only ever two possible bases.
+fn base_font_database(
+    load_emoji: bool,
+) -> &'static (cosmic_text::fontdb::Database, HashMap<String, LoadedFamily>) {
+    static BASE_NO_EMOJI: std::sync::OnceLock<(
+        cosmic_text::fontdb::Database,
+        HashMap<String, LoadedFamily>,
+    )> = std::sync::OnceLock::new();
+    static BASE_WITH_EMOJI: std::sync::OnceLock<(
+        cosmic_text::fontdb::Database,
+        HashMap<String, LoadedFamily>,
+    )> = std::sync::OnceLock::new();
+    if load_emoji {
+        BASE_WITH_EMOJI.get_or_init(|| build_base_font_database(true))
+    } else {
+        BASE_NO_EMOJI.get_or_init(|| build_base_font_database(false))
+    }
+}
+
 impl Default for TextEngine {
     fn default() -> Self {
         Self::new()
@@ -989,63 +1098,26 @@ impl TextEngine {
     }
 
     pub(crate) fn new_with_web_fonts_and_emoji(fonts: &[WebFont], load_emoji: bool) -> Self {
-        // Build a database from embedded and page-provided faces. Never call
-        // load_system_fonts: a host's font set would make layout differ
-        // machine to machine and add a multi-millisecond startup scan.
-        let mut db = cosmic_text::fontdb::Database::new();
+        // The embedded/emoji/extra-directory base is parsed exactly once per
+        // process (see `base_font_database`) and cloned here: `Database::clone`
+        // shares each Arc-backed binary source instead of re-parsing, the
+        // same trick `svg_font_database` (`paint.rs`) uses for the SVG-text
+        // database. Never call load_system_fonts: a host's font set would
+        // make layout differ machine to machine and add a startup scan.
+        let (base_db, base_families) = base_font_database(load_emoji);
+        let mut db = base_db.clone();
+        let mut loaded_families = base_families.clone();
         let mut declarations = Vec::new();
-        for bytes in [
-            SANS_R, SANS_B, SANS_O, SANS_BO, SERIF_R, SERIF_B, SERIF_O, SERIF_BO, MONO_R, MONO_B,
-            MONO_O, MONO_BO, SYSTEM_R, SYSTEM_B,
-        ] {
-            for id in db.load_font_source(cosmic_text::fontdb::Source::Binary(Arc::new(bytes))) {
-                declarations.push((id, None, None, None));
-            }
-        }
-        if load_emoji {
-            for id in db.load_font_source(cosmic_text::fontdb::Source::Binary(Arc::new(EMOJI_R))) {
-                declarations.push((id, None, None, None));
-            }
-        }
         for font in fonts {
-            for id in db.load_font_source(cosmic_text::fontdb::Source::Binary(Arc::new(
-                font.data.clone(),
-            ))) {
+            // Page-provided bytes (authored `@font-face` + dynamic
+            // `FontFace`) go through the cross-document cache: identical
+            // bytes across documents/contexts are pushed without
+            // re-parsing (`font_cache::load_cached_web_font`).
+            for id in crate::font_cache::load_cached_web_font(&mut db, &font.data) {
                 declarations.push((id, font.family.clone(), font.weight, font.italic));
             }
         }
-        let mut loaded_families = HashMap::new();
-        for (id, declared_family, declared_weight, declared_italic) in declarations {
-            let Some(face) = db.face(id) else { continue };
-            let names = face.families.clone();
-            let internal_name = names
-                .first()
-                .map(|(name, _)| Arc::<str>::from(name.as_str()))
-                .unwrap_or_else(|| Arc::from(FAMILY));
-            let shape_weight = face.weight.0;
-            let metrics = font_metrics(&db, id)
-                .unwrap_or_else(|| bundled_face_metrics(internal_name.as_ref()));
-            let italic = declared_italic
-                .unwrap_or(!matches!(face.style, cosmic_text::fontdb::Style::Normal));
-            let weight = declared_weight.unwrap_or((shape_weight, shape_weight));
-            let declared_names: Vec<String> = declared_family
-                .map(|name| vec![name])
-                .unwrap_or_else(|| names.into_iter().map(|(name, _)| name).collect());
-            for name in declared_names {
-                let family = loaded_families
-                    .entry(name.to_ascii_lowercase())
-                    .or_insert_with(|| LoadedFamily { faces: Vec::new() });
-                family.faces.push(LoadedFace {
-                    name: Arc::clone(&internal_name),
-                    font_id: Some(id),
-                    metrics,
-                    min_weight: weight.0,
-                    max_weight: weight.1,
-                    italic,
-                });
-            }
-        }
-        db.set_sans_serif_family(FAMILY);
+        record_face_declarations(&db, declarations, &mut loaded_families);
         let font_system = FontSystem::new_with_locale_and_db("en-US".to_string(), db);
         TextEngine {
             font_system,
@@ -4299,6 +4371,160 @@ mod tests {
         assert!(
             space_advance > 5.0,
             "setting wght and opsz must not repeatedly remap avar coordinates and collapse the space advance: {space_advance}"
+        );
+    }
+
+    /// Cross-document cache for `fonts: &[WebFont]` (#879): identical bytes
+    /// across two `TextEngine` constructions must be parsed at most once.
+    ///
+    /// This asserts an absolute per-hash miss count, not a before/after
+    /// delta on a single shared counter: `cargo test`'s default harness runs
+    /// every `#[test]` in this binary concurrently, and other tests here
+    /// build `TextEngine`s from their own (different) `WebFont` bytes, which
+    /// would land in between this test's own two calls and make a shared,
+    /// non-hash-scoped counter's delta flaky. Scoping by content hash makes
+    /// this deterministic regardless of test order/concurrency: unrelated
+    /// tests touch different hash buckets, and this exact content's bucket
+    /// is guaranteed to reach exactly 1 (never more) because the whole
+    /// cache-miss path in `font_cache::load_cached_web_font` runs under one
+    /// mutex. See `font_cache::test_support` for the full rationale.
+    #[test]
+    fn identical_dynamic_font_bytes_are_parsed_at_most_once() {
+        let noto = include_bytes!("../../../vendor/cosmic-text/fonts/NotoSansArabic.ttf").to_vec();
+        let variable = variable_font_fixture();
+        let noto_hash = crate::font_cache::hash_font_bytes(&noto);
+        let variable_hash = crate::font_cache::hash_font_bytes(&variable);
+        assert_ne!(noto_hash, variable_hash);
+
+        let noto_font = || WebFont {
+            data: noto.clone(),
+            family: Some("Parse Count Noto".to_string()),
+            weight: None,
+            italic: None,
+        };
+        let _first = TextEngine::new_with_web_fonts(&[noto_font()]);
+        let _second = TextEngine::new_with_web_fonts(&[noto_font()]);
+        assert_eq!(
+            crate::font_cache::test_support::miss_count(noto_hash),
+            1,
+            "identical font bytes must be parsed at most once per process"
+        );
+
+        let _third = TextEngine::new_with_web_fonts(&[WebFont {
+            data: variable.clone(),
+            family: Some("Parse Count Variable".to_string()),
+            weight: None,
+            italic: None,
+        }]);
+        assert_eq!(
+            crate::font_cache::test_support::miss_count(variable_hash),
+            1,
+            "different font bytes must still be parsed (once each)"
+        );
+    }
+
+    /// Two distinct `WebFont` byte buffers must be independently cached: a
+    /// cache bug that conflated `FaceInfo`s by, say, insertion order rather
+    /// than content hash would leak one document's page font into another's.
+    #[test]
+    fn distinct_dynamic_fonts_are_not_conflated_by_the_shared_cache() {
+        let noto_engine = TextEngine::new_with_web_fonts(&[WebFont {
+            data: include_bytes!("../../../vendor/cosmic-text/fonts/NotoSansArabic.ttf").to_vec(),
+            family: Some("Conflation Test Noto".to_string()),
+            weight: None,
+            italic: None,
+        }]);
+        let variable_engine = TextEngine::new_with_web_fonts(&[WebFont {
+            data: variable_font_fixture(),
+            family: Some("Conflation Test Variable".to_string()),
+            weight: None,
+            italic: None,
+        }]);
+
+        assert!(noto_engine
+            .loaded_families
+            .contains_key("conflation test noto"));
+        assert!(!noto_engine
+            .loaded_families
+            .contains_key("conflation test variable"));
+        assert!(variable_engine
+            .loaded_families
+            .contains_key("conflation test variable"));
+        assert!(!variable_engine
+            .loaded_families
+            .contains_key("conflation test noto"));
+
+        let noto_face = &noto_engine.loaded_families["conflation test noto"].faces[0];
+        let variable_face =
+            &variable_engine.loaded_families["conflation test variable"].faces[0];
+        assert_ne!(
+            noto_face.name, variable_face.name,
+            "two distinct byte buffers must resolve to distinct cached face metadata"
+        );
+    }
+
+    /// The pure directory-scanning core behind `configure_extra_font_directories`
+    /// (#879's `--font-dir`), exercised directly against a fresh `Database`
+    /// rather than through the process-wide base-database `OnceLock`.
+    ///
+    /// The full `configure_extra_font_directories` -> `TextEngine` path is
+    /// deliberately not covered end-to-end here: the base database is a
+    /// process-wide `OnceLock` built at most once per test binary, so
+    /// whichever test (of the many in this file) triggers it first wins, and
+    /// `cargo test`'s default harness gives no ordering guarantee between
+    /// `#[test]` functions. Testing the directory-loading logic as a
+    /// standalone function that takes its `Database` and directory list as
+    /// plain arguments (no global state) sidesteps that hazard entirely.
+    #[test]
+    fn load_extra_font_directories_loads_valid_fonts_from_disk() {
+        let dir = std::env::temp_dir().join(format!(
+            "obscura-render-font-dir-test-{}",
+            std::process::id()
+        ));
+        std::fs::create_dir_all(&dir).expect("create temp font directory");
+        std::fs::write(dir.join("liberation-sans.ttf"), SANS_R)
+            .expect("write fixture font into temp directory");
+
+        let mut db = cosmic_text::fontdb::Database::new();
+        let ids = crate::font_cache::load_extra_font_directories(&mut db, &[dir.clone()]);
+
+        assert_eq!(ids.len(), 1, "one font file must load to exactly one face");
+        let face = db.face(ids[0]).expect("pushed face id resolves");
+        assert!(
+            face.families.iter().any(|(name, _)| name == "Liberation Sans"),
+            "the copied fixture's family must be discoverable after a directory load"
+        );
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn load_extra_font_directories_skips_a_missing_directory_without_panicking() {
+        let mut db = cosmic_text::fontdb::Database::new();
+        let missing =
+            std::env::temp_dir().join("obscura-render-font-dir-test-does-not-exist-at-all");
+        let ids = crate::font_cache::load_extra_font_directories(&mut db, &[missing]);
+        assert!(ids.is_empty());
+    }
+
+    /// The "configured too late" no-op path in `configure_extra_font_directories`,
+    /// tested against a locally-owned `OnceLock` instead of the process-global
+    /// one so it does not depend on this test binary's (unpredictable) test
+    /// execution order.
+    #[test]
+    fn set_extra_font_directories_is_a_no_op_once_already_initialized() {
+        let store: std::sync::OnceLock<Vec<std::path::PathBuf>> = std::sync::OnceLock::new();
+        assert!(crate::font_cache::set_extra_font_directories(
+            &store,
+            vec![std::path::PathBuf::from("/tmp/obscura-font-dir-a")]
+        ));
+        assert!(!crate::font_cache::set_extra_font_directories(
+            &store,
+            vec![std::path::PathBuf::from("/tmp/obscura-font-dir-b")]
+        ));
+        assert_eq!(
+            store.get(),
+            Some(&vec![std::path::PathBuf::from("/tmp/obscura-font-dir-a")])
         );
     }
 

--- a/crates/obscura-render/src/lib.rs
+++ b/crates/obscura-render/src/lib.rs
@@ -137,6 +137,13 @@ pub use paint::{
 // `dom.rs` name `inline::TextEngine` and call `try_build` unconditionally.
 #[cfg(feature = "paint")]
 pub mod inline;
+// Process-wide font caching (dynamic/authored web-font byte cache, extra
+// `--font-dir` directories) backing `inline::TextEngine`. See
+// `font_cache.rs` for the full rationale (fix for #879).
+#[cfg(feature = "paint")]
+mod font_cache;
+#[cfg(feature = "paint")]
+pub use font_cache::configure_extra_font_directories;
 
 #[cfg(not(feature = "paint"))]
 pub mod inline {
@@ -157,6 +164,12 @@ pub mod inline {
     pub(crate) fn text_may_need_emoji_font(_text: &str) -> bool {
         false
     }
+
+    /// Layout-only builds have no shaper and never load any fonts, bundled
+    /// or otherwise, so there is no base database for these directories to
+    /// join. Kept as a no-op purely so callers never need a `cfg(feature =
+    /// "paint")` guard around the call site.
+    pub fn configure_extra_font_directories(_dirs: Vec<std::path::PathBuf>) {}
 
     impl TextEngine {
         pub fn new() -> Self {
@@ -378,6 +391,9 @@ pub mod inline {
         taffy::Size { width, height }
     }
 }
+
+#[cfg(not(feature = "paint"))]
+pub use inline::configure_extra_font_directories;
 
 /// An axis-aligned rectangle in CSS pixels, relative to the containing block.
 #[derive(Debug, Clone, Copy, Default, PartialEq)]


### PR DESCRIPTION
## What changed

Fixes #879. Two related problems reported there:

1. **No font-discovery mechanism.** The only way to give the engine a font was `document.fonts.add(new FontFace(...))` from page script — no directory scanning, no fontconfig, no CLI flag, and `@font-face` in page CSS had no effect (it's parsed and used for family/weight matching, but there was no way to make the actual bytes available process-wide ahead of time). Added a repeatable `--font-dir <path>` flag on `obscura serve` that loads fonts from a directory into the process-wide font database once at startup (`fontdb::Database::load_fonts_dir`, no new dependency), so pages needing those faces (e.g. CJK) don't need a script-injection workaround. Forwarded to spawned processes in `--workers N` mode. This is intentionally *not* `load_system_fonts()` — it stays an explicit, opt-in directory, so a host's installed fonts still never affect layout determinism.

2. **Every registered face was re-parsed on every document**, which is what actually caused the ~7s/request regression: `TextEngine::new_with_web_fonts_and_emoji` built a brand-new `fontdb::Database` from scratch per document/layout, calling `load_font_source` (which parses the sfnt tables synchronously) on the embedded bundled faces *and* every authored `@font-face`/dynamic `FontFace` face, every single call — including documents with no CJK content at all. Fixed with two caches:
   - The embedded/emoji/`--font-dir` base database is now built once per process behind a `OnceLock` and cloned per document (`fontdb::Database::clone` shares `Arc`-backed sources rather than re-parsing) — the same pattern this codebase already uses for the SVG-text font database (`svg_font_database` in `paint.rs`).
   - Page-provided fonts (authored + dynamic) go through a new process-wide, mutex-guarded, FIFO-bounded cache keyed by a randomized-seed hash of the font bytes. A hit uses `fontdb::Database::push_face_info` to insert the
     already-parsed `FaceInfo` without re-parsing; a miss parses once and
     populates the cache for every later document/context, in this process,
     that registers the same bytes.

No change to the `document.fonts.add()` / CSS Font Loading API surface — existing pages behave identically, just without paying to re-parse fonts they (or a previous document) already registered.

## Validation

- `cargo test -p obscura-render --features paint` — full suite green (479 + 113 tests across the lib and layout integration tests, 1 pre-existing ignored release-only benchmark, 0 failures), including every pre-existing font/text test in `inline.rs` unmodified — proof this is behavior-preserving, not just "doesn't crash." Added tests cover: identical font bytes are parsed at most once across two `TextEngine` constructions; two distinct font byte buffers are cached independently (no cross-document conflation); the `--font-dir` directory-scanning logic in isolation (valid fonts load, a missing directory is skipped without panicking); and the "configured after first use" no-op path.
- `cargo test -p obscura-render --features paint --lib` re-run 5x with `--test-threads=16` to check the new global-cache-backed tests for concurrency flakiness — consistently 0 failures.
- `cargo clippy -p obscura-render --features paint --no-deps` — clean.
- `cargo build -p obscura-render` (with and without `--features paint`) — both succeed; confirmed via `git stash` that the warning set is byte-identical before/after, i.e. no new warnings introduced.
- `cargo build -p obscura-cli --features render` and `cargo test -p obscura-cli --features render --bin obscura` (48 tests) — cover the new `--font-dir` flag parsing (single, repeated, absent) and the full `obscura-cli` → `obscura-browser` → `obscura-js` → `obscura-render` dependency chain building with the new re-exports wired through.
- `cargo build -p obscura-cli` (no `render` feature) — still succeeds; the flag still parses, it's just a no-op (logged) without `render`.
- `cargo build --workspace --features render` and `cargo test --workspace --features render` — the only failures are three pre-existing, unrelated tests in `obscura`'s `child_frame_scripts.rs` (iframe/shadow-DOM realm lifecycle); confirmed via `git stash` that they fail identically on unmodified `main`, so not a regression from this change.

## Rendering

This touches the font-loading path feeding paint/layout, but is designed to be behavior-preserving for existing content — the point above about the full pre-existing `obscura-render` test suite passing unmodified is the evidence for that. The new `--font-dir` flag *does* intentionally change rendering output when used (that's the feature): a font placed in a configured directory becomes available where it previously wasn't (e.g. CJK tofu → correct glyphs). I didn't capture a live before/after screenshot for this PR — that needs a running `obscura serve`, a CJK-covering font file, and a page with CJK text, which I didn't have on hand in this environment. Happy to add one if useful for review; the quick way to check locally is rendering the same CJK page with and without `--font-dir <dir-containing-the-font>`.

## Performance

The mechanism: after the first document/context in a process registers a given face's bytes, every later render of that same content is a cache hit (`push_face_info`, metadata-only, no table parsing) instead of a miss (`load_font_source`, which parses sfnt tables). For a large multi-face CJK collection — the case in the original report — the avoided `load_font_source` call is the multi-second cost; a cache hit there should bring repeated requests back down close to the no-extra-fonts baseline.

One caveat found while benchmarking locally with a large (10 MB) embedded font as a stand-in (I don't have the reporter's actual CJK files or their AL2023/Lambda environment, so I can't reproduce their exact 150 ms / 7,000 ms figures): the cache key is a hash of the *entire* font byte buffer, recomputed on every lookup including hits, to keep the cache content-addressed against a fixed/predictable-seed collision (the content is attacker-influenced in a screenshot-service deployment, so I used `RandomStat `, not `DefaultHasher`). Hashing alone measured ~3 ms per 10 MB in this environment. For a large CJK collection where the *avoided* parse is multi-second, that's still a large net win. But for a font cheap enough that `load_font_source` itself is fast (e.g. a single non-collection face — my synthetic 10 MB test font parsed in under 1 ms, since a lot of a font's byte size is glyph outline data that `load_font_source` doesn't need to fully touch), the hashing cost on a *hit* can exceed the parse cost it's replacing. This doesn't reintroduce the reported bug (nothing is re-parsed on a hit) and doesn't affect correctness, but it means the win scales with how expensive parsing that specific font actually is, not uniformly. Flagging this now rather than silently shipping a claim I couldn't fully verify — happy to follow up with a cheaper content-signature (e.g. hash a bounded prefix/suffix + length instead of the whole buffer) if that's worth doing, or if you can share representative CJK font files/sizes I can benchmark against directly.

## Checklist

- [x] The change is focused and does not remove existing behavior without justification.
- [x] Tests cover the failure or feature.
- [x] Existing tests pass, including render and no-render configurations when affected.
- [x] I checked for CPU, latency, and memory regressions.
- [x] Public API or user-facing behavior changes are documented.
