### PR TITLE
fix(dom): stop a generic parsererror from erasing the reason

### DIFF
--- a/crates/obscura-js/js/bootstrap.js
+++ b/crates/obscura-js/js/bootstrap.js
@@ -10399,35 +10399,46 @@ function _xmlWellFormed(src) {
   return stack.length === 0 && rootsClosed === 1;
 }
 
+// The parsererror detail quotes tag names taken from the input, and it is
+// written through innerHTML, so `<` and `&` have to stop being markup.
+const _escapeXmlErrorText = (text) =>
+  String(text).replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+
 globalThis.DOMParser = class DOMParser {
   parseFromString(source, mimeType) {
     const html = String(source ?? "");
     const isXml = typeof mimeType === "string" && /xml/i.test(mimeType);
     const root = document.createElement("html");
 
-    // For XML mime types, check well-formedness first (conservative: only
-    // clear errors like tag mismatch / extra root are flagged).  If the
-    // check fires, build a <parsererror> root so callers doing
-    // doc.querySelector('parsererror') get the same signal as in Chrome.
+    // For XML mime types, surface a <parsererror> on clearly-malformed input so
+    // error-detection code (doc.querySelector('parsererror')) works, matching
+    // Chrome. obscura has no XML parser, so the tree stays HTML-parsed.
+    //
+    // Two checks, one decision. `_xmlWellFormed` is the stricter of the pair --
+    // it also rejects input with no root element at all, and an unterminated
+    // comment/CDATA/PI -- so it decides whether this is an error. What it cannot
+    // do is say why: it returns a bool. `_checkXmlWellFormed` names the fault,
+    // so its message fills the <div> when it has one.
+    //
+    // These used to run as two independent blocks, the second overwriting the
+    // first. Since the stricter check flags everything the descriptive one
+    // flags, the description never reached a caller.
     const xmlError = isXml ? _checkXmlWellFormed(html) : null;
-    const isParserError = xmlError && !xmlError.wellFormed;
+    const isParserError = isXml && (!_xmlWellFormed(html) || !xmlError.wellFormed);
     if (isParserError) {
-      root.innerHTML = '<parsererror>' + xmlError.error + '</parsererror>';
+      const detail = (xmlError && xmlError.error) || 'error while parsing XML';
+      try {
+        root.innerHTML =
+          '<parsererror xmlns="http://www.w3.org/1999/xhtml">This page contains the following errors:<div>' +
+          _escapeXmlErrorText(detail) +
+          '</div></parsererror>';
+      } catch (e) { /* ignore */ }
     } else {
       // innerHTML parses children via html5ever fragment-parsing rules. Most
       // HTML inputs start with `<!DOCTYPE>` / `<html>` / `<head>` etc.; the
       // fragment parser strips the outer `<html>` and emits its head+body
       // children, which is what callers want.
       try { root.innerHTML = html; } catch (e) { /* leave empty on parse error */ }
-    }
-
-    // For XML mime types, surface a <parsererror> on clearly-malformed input so
-    // error-detection code (doc.querySelector('parsererror')) works, matching
-    // Chrome. obscura has no XML parser, so the tree stays HTML-parsed.
-    if (isXml && !_xmlWellFormed(html)) {
-      try {
-        root.innerHTML = '<parsererror xmlns="http://www.w3.org/1999/xhtml">This page contains the following errors:<div>error while parsing XML</div></parsererror>';
-      } catch (e) { /* ignore */ }
     }
 
     // Helper: depth-first walk to find an element by predicate.

--- a/crates/obscura-js/src/runtime.rs
+++ b/crates/obscura-js/src/runtime.rs
@@ -5255,6 +5255,42 @@ mod tests {
     }
 
     #[test]
+    fn a_parsererror_says_what_was_wrong() {
+        // The <div> is where Chrome puts the reason, and callers show it. A
+        // parsererror that only says "error while parsing XML" tells a user
+        // nothing the presence of the element did not already say.
+        let mut rt = setup_runtime("<html><body></body></html>");
+        let detail = rt
+            .evaluate("(function(){var d=new DOMParser().parseFromString('<a><b></a>','application/xml'); return d.querySelector('parsererror').textContent;})()")
+            .unwrap();
+        let detail = detail.as_str().unwrap_or_default().to_string();
+        assert!(
+            detail.contains("mismatch") && detail.contains('b') && detail.contains('a'),
+            "the reason must name the fault and the tags involved, got: {detail}"
+        );
+    }
+
+    #[test]
+    fn a_parsererror_detail_is_text_not_markup() {
+        // The reason quotes a tag name lifted from the input and is written
+        // through innerHTML, so an input tag name must not become an element.
+        //
+        // The input has to be one whose message carries the angle brackets:
+        // "unclosed tag <img>" does, "mismatch: img and a" does not, and a test
+        // built on the latter passes with the escaping removed.
+        let mut rt = setup_runtime("<html><body></body></html>");
+        let n = rt
+            .evaluate("(function(){var d=new DOMParser().parseFromString('<img src=x>','application/xml'); var e=d.querySelector('parsererror'); return e ? e.querySelectorAll('img').length : -1;})()")
+            .unwrap();
+        // JS numbers arrive as f64, so compare as one.
+        assert_eq!(
+            n.as_f64(),
+            Some(0.0),
+            "a tag name from the input became an element in the error detail"
+        );
+    }
+
+    #[test]
     fn dom_parser_html_never_gets_parsererror() {
         // HTML parsing is tolerant and must never synthesize a parsererror.
         let mut rt = setup_runtime("<html><body></body></html>");


### PR DESCRIPTION
`DOMParser.parseFromString` runs **two independent well-formedness checks in sequence**, and the second erases the first's answer.

```js
const xmlError = isXml ? _checkXmlWellFormed(html) : null;   // names the fault
if (isParserError) {
  root.innerHTML = '<parsererror>' + xmlError.error + '</parsererror>';
} else { … }

if (isXml && !_xmlWellFormed(html)) {                        // returns a bool
  root.innerHTML = '<parsererror xmlns="…">…<div>error while parsing XML</div></parsererror>';
}
```

`_checkXmlWellFormed` produces `opening and ending tag mismatch: b and a`, `unclosed tag <a>`, `extra closing tag </a>`. `_xmlWellFormed` produces `true`/`false`. The second block runs unconditionally afterwards, so whenever both agree, the specific message is replaced by the fixed one.

**And they always agree, because the second is strictly stronger.** It additionally rejects input with no root element at all, and an unterminated comment / CDATA / PI:

| input | `_checkXmlWellFormed` | `_xmlWellFormed` |
|---|---|---|
| `<a><b></a>` | ✗ mismatch: b and a | ✗ |
| `<a>` | ✗ unclosed tag `<a>` | ✗ |
| `<a/><b/>` | ✗ extra content after root | ✗ |
| `""` | ✓ | ✗ |
| `<a></a><!-- x` | ✓ | ✗ |

Lifting both functions out and running **200,000 generated inputs** produced **zero** cases where the descriptive one flags and the strict one does not. The description has never reached a caller.

## The change

Both checks stay; there is now one decision between them. The strict one decides *that* it is an error — no detection is lost — and the descriptive one says *what* it was. The Chrome-shaped `<parsererror xmlns="http://www.w3.org/1999/xhtml">` wrapper the second block introduced is what gets built either way, so `doc.querySelector('parsererror')` is unchanged.

The detail quotes a tag name taken from the input and is written through `innerHTML`, so it is escaped. That is not theoretical: `unclosed tag <img>` carries the angle brackets, and unescaped it becomes a real `<img>` element inside the parsererror.

## Verification

Run in the CI image (`obscura-ci:local`), since `rusty_v8` has no prebuilt for the `windows-gnu` toolchain:

- `cargo test -p obscura-js` — **397 passed, 0 failed**.
- the four `parsererror` tests — 4 passed.

Each claim checked by reverting it:

| reverted | fails |
|---|---|
| detail back to the fixed string | only `a_parsererror_says_what_was_wrong` |
| escaping removed | only `a_parsererror_detail_is_text_not_markup` |

The escape test needed a sharper input to say anything. Built on `<a><img src=x></a>`, whose message is `mismatch: img and a` and carries no angle brackets, it **passed with the escaping removed** — so it was rewritten around `<img src=x>`, whose message is `unclosed tag <img>`.

This does not touch #883 — obscura still has no XML parser, and the tree stays HTML-parsed.
