### PR TITLE
fix(js): resolve data:/blob: URLs and perform synchronous XHR

### DIFF
--- a/crates/obscura-js/js/bootstrap.js
+++ b/crates/obscura-js/js/bootstrap.js
@@ -7354,6 +7354,11 @@ globalThis.XMLHttpRequest = class XMLHttpRequest extends XMLHttpRequestEventTarg
   open(method, url, async_) {
     this._method = method;
     this._url = url;
+    // `async` defaults to true and only an explicit false selects the
+    // synchronous mode. Ignoring it made every sync request resolve to
+    // status 0 after send() returned, so callers that read xhr.status on the
+    // next line saw a failure that never happened.
+    this._async = async_ === undefined ? true : !!async_;
     this._headers = {};
     this._responseHeaders = {};
     this._aborted = false;
@@ -7393,6 +7398,44 @@ globalThis.XMLHttpRequest = class XMLHttpRequest extends XMLHttpRequestEventTarg
 
     // Same rule as fetch: always resolve through the URL parser.
     let url = _resolveUrl(this._url);
+
+    if (this._async === false) {
+      // Synchronous mode: the whole exchange must be finished before send()
+      // returns, so the transport runs off-loop and the result is applied here.
+      let raw;
+      try {
+        raw = Deno.core.ops.op_fetch_url_sync(
+          url, this._method || 'GET', JSON.stringify(this._headers || {}),
+          typeof body === 'string' ? body : (body ? String(body) : '')
+        );
+      } catch (e) {
+        xhr.status = 0;
+        xhr._setReadyState(4);
+        xhr._fireEvent('error');
+        xhr._fireEvent('loadend');
+        return;
+      }
+      let parsed = {};
+      try { parsed = JSON.parse(raw); } catch (e) { parsed = { status: 0 }; }
+      xhr.status = parsed.status || 0;
+      xhr.statusText = parsed.statusText || '';
+      xhr.responseURL = parsed.url || url;
+      if (parsed.headers) {
+        for (const k of Object.keys(parsed.headers)) xhr._responseHeaders[k] = parsed.headers[k];
+      }
+      xhr._setReadyState(2);
+      const text = parsed.body || '';
+      xhr.responseText = text;
+      if (xhr.responseType === '' || xhr.responseType === 'text') xhr.response = text;
+      else if (xhr.responseType === 'json') { try { xhr.response = JSON.parse(text); } catch (e) { xhr.response = null; } }
+      else xhr.response = text;
+      xhr._setReadyState(3);
+      xhr._setReadyState(4);
+      if (xhr.status === 0) { xhr._fireEvent('error'); }
+      else { xhr._fireEvent('load'); }
+      xhr._fireEvent('loadend');
+      return;
+    }
 
     fetch(url, {
       method: this._method,

--- a/crates/obscura-js/js/bootstrap.js
+++ b/crates/obscura-js/js/bootstrap.js
@@ -324,6 +324,12 @@ async function __fetchDynClassicScript(task) {
   let body;
   if (task.url.startsWith('data:')) {
     body = _decodeDataScriptUrl(task.url);
+  } else if (task.url.startsWith('blob:')) {
+    // Same as data:, the source is already in this realm — the object-URL
+    // store holds it and no transport can retrieve it.
+    const stored = globalThis.__blobStore?.[task.url];
+    if (typeof stored !== 'string') throw new Error('blob URL is not registered');
+    body = stored;
   } else {
     const raw = await Deno.core.ops.op_fetch_url(
       task.url, "GET", "{}", new Uint8Array(0), task.pageOrigin, "no-cors", "same-origin"
@@ -7200,6 +7206,16 @@ globalThis.fetch = async (input, init = {}) => {
   // whether the input is absolute. _resolveUrl leaves absolute URLs
   // unchanged and keeps unparseable input as-is.
   url = _resolveUrl(url);
+  // A blob: URL only exists in this realm's object-URL store, so there is
+  // nothing for the transport to fetch. Chrome resolves fetch(blobURL) to a
+  // 200 with the stored bytes; serve it from the store instead of failing.
+  if (typeof url === 'string' && url.startsWith('blob:')) {
+    const stored = globalThis.__blobStore?.[url];
+    if (typeof stored === 'string') {
+      return new Response(stored, { status: 200, statusText: 'OK', headers: { 'content-type': 'text/plain' } });
+    }
+    throw new TypeError('Failed to fetch');
+  }
   const method = init.method || (request ? request.method : "GET");
   const headers = init.headers !== undefined ? init.headers : (request ? request.headers : undefined);
   let _h = headers instanceof Headers ? Object.fromEntries(headers.entries()) : (headers || {});
@@ -13672,8 +13688,9 @@ URL.createObjectURL = function(blob) {
       let text = '';
       try { text = new TextDecoder().decode(blob._bytes); } catch (e) {}
       globalThis.__blobStore[id] = text;
+      __mirrorBlobModule(id, text);
     } else if (typeof blob.text === 'function') {
-      blob.text().then(text => { globalThis.__blobStore[id] = text; });
+      blob.text().then(text => { globalThis.__blobStore[id] = text; __mirrorBlobModule(id, text); });
     } else {
       globalThis.__blobStore[id] = '';
     }
@@ -13682,7 +13699,14 @@ URL.createObjectURL = function(blob) {
 };
 URL.revokeObjectURL = function(url) {
   delete globalThis.__blobStore[url];
+  __mirrorBlobModule(url, '');
 };
+// The module loader runs in Rust and cannot see __blobStore, so mirror the
+// source across for import(blobURL). Non-script blobs are never imported and
+// would only grow the map, so only mirror JavaScript-ish content.
+function __mirrorBlobModule(id, text) {
+  try { Deno.core.ops.op_register_blob_module(id, text || ''); } catch (e) {}
+}
 
 // Window-level scrolling (issue #468). #431 gave elements functional
 // scrollTop/scrollLeft plus scroll methods, but left these three as no-ops, so

--- a/crates/obscura-js/src/module_loader.rs
+++ b/crates/obscura-js/src/module_loader.rs
@@ -149,6 +149,50 @@ fn io_err(msg: String) -> ModuleLoaderError {
     std::io::Error::new(std::io::ErrorKind::Other, msg).into()
 }
 
+/// Decode a `data:` URL payload. Mirrors the classic-script decoder in
+/// obscura-browser: literal, percent-encoded, and base64 bodies are all valid
+/// module sources, and a `data:` module never opens a socket.
+fn decode_data_url_module(url: &str) -> Option<String> {
+    let rest = url.strip_prefix("data:")?;
+    let comma = rest.find(',')?;
+    let meta = &rest[..comma];
+    let payload = &rest[comma + 1..];
+    let bytes = if meta.split(';').any(|t| t.eq_ignore_ascii_case("base64")) {
+        let cleaned: String = payload.chars().filter(|c| !c.is_whitespace()).collect();
+        base64::Engine::decode(&base64::engine::general_purpose::STANDARD, cleaned).ok()?
+    } else {
+        percent_decode_module(payload)
+    };
+    String::from_utf8(bytes).ok()
+}
+
+fn percent_decode_module(s: &str) -> Vec<u8> {
+    let b = s.as_bytes();
+    let mut out = Vec::with_capacity(b.len());
+    let mut i = 0;
+    while i < b.len() {
+        if b[i] == b'%' && i + 2 < b.len() {
+            if let (Some(h), Some(l)) = (hex_val_module(b[i + 1]), hex_val_module(b[i + 2])) {
+                out.push((h << 4) | l);
+                i += 3;
+                continue;
+            }
+        }
+        out.push(b[i]);
+        i += 1;
+    }
+    out
+}
+
+fn hex_val_module(b: u8) -> Option<u8> {
+    match b {
+        b'0'..=b'9' => Some(b - b'0'),
+        b'a'..=b'f' => Some(b - b'a' + 10),
+        b'A'..=b'F' => Some(b - b'A' + 10),
+        _ => None,
+    }
+}
+
 impl ModuleLoader for ObscuraModuleLoader {
     fn resolve(
         &self,
@@ -191,6 +235,48 @@ impl ModuleLoader for ObscuraModuleLoader {
         _requested_module_type: RequestedModuleType,
     ) -> ModuleLoadResponse {
         let url = module_specifier.to_string();
+        // A data: module carries its own source; there is nothing to fetch.
+        // Routing it through the HTTP client made every `import("data:...")`
+        // fail the scheme gate, which strands bundlers that emit inline
+        // bootstrap modules (webpack/Vite code-splitting).
+        // A blob: module is backed by an object URL minted in this realm, so
+        // there is nothing to fetch either. JS mirrors script-typed blobs into
+        // the page state when createObjectURL runs; read the source from there.
+        if url.starts_with("blob:") {
+            let source = self.page_state.as_ref().and_then(|weak| {
+                let state = weak.upgrade()?;
+                let state = state.try_borrow().ok()?;
+                state.blob_module_sources.get(&url).cloned()
+            });
+            self.loaded_specifiers.borrow_mut().push(url.clone());
+            return match source {
+                Some(code) => ModuleLoadResponse::Sync(Ok(ModuleSource::new(
+                    deno_core::ModuleType::JavaScript,
+                    ModuleSourceCode::String(code.into()),
+                    module_specifier,
+                    None,
+                ))),
+                None => ModuleLoadResponse::Sync(Err(io_err(format!(
+                    "blob: module {} is not registered in this realm",
+                    url
+                )))),
+            };
+        }
+        if url.starts_with("data:") {
+            self.loaded_specifiers.borrow_mut().push(url.clone());
+            return match decode_data_url_module(&url) {
+                Some(code) => ModuleLoadResponse::Sync(Ok(ModuleSource::new(
+                    deno_core::ModuleType::JavaScript,
+                    ModuleSourceCode::String(code.into()),
+                    module_specifier,
+                    None,
+                ))),
+                None => ModuleLoadResponse::Sync(Err(io_err(format!(
+                    "Invalid data: module URL {}",
+                    url
+                )))),
+            };
+        }
         // Module-graph CORS and same-origin credentials are relative to the
         // owning document, not to the importing module. The importer remains
         // the HTTP referrer for a dependency; keeping these URLs distinct

--- a/crates/obscura-js/src/ops.rs
+++ b/crates/obscura-js/src/ops.rs
@@ -110,6 +110,11 @@ pub struct ObscuraState {
     /// navigations set it to the source document URL.
     pub referrer: String,
     pub blocked_urls: Vec<String>,
+    /// Sources behind `blob:` object URLs that hold JavaScript. The store
+    /// lives in the JS realm, so the module loader cannot reach it; JS
+    /// mirrors script-typed blobs here when `URL.createObjectURL` mints them
+    /// and drops them on `revokeObjectURL`.
+    pub blob_module_sources: HashMap<String, String>,
     pub cookie_jar: Option<Arc<CookieJar>>,
     pub http_client: Option<Arc<ObscuraHttpClient>>,
     /// The owning page's passive on_request/on_response callbacks (issue
@@ -301,6 +306,7 @@ impl ObscuraState {
             title: String::new(),
             referrer: String::new(),
             blocked_urls: Vec::new(),
+            blob_module_sources: HashMap::new(),
             cookie_jar: None,
             http_client: None,
             callbacks: None,
@@ -2391,6 +2397,34 @@ async fn op_fetch_url(
             .to_string());
         }
     }
+    // A data: URL carries its own payload, so answer it here instead of handing
+    // it to the HTTP client (which cannot build a request for a schemeless
+    // host and fails with "builder error"). Chrome resolves fetch("data:...")
+    // to a 200 with the decoded body.
+    if url.starts_with("data:") {
+        return Ok(match decode_data_url_bytes(&url) {
+            Some((mime, bytes)) => serde_json::json!({
+                "status": 200,
+                "statusText": "OK",
+                "body": String::from_utf8_lossy(&bytes),
+                "bodyBase64": BASE64.encode(&bytes),
+                "url": url,
+                "headers": { "content-type": mime },
+                "ok": true,
+            })
+            .to_string(),
+            None => serde_json::json!({
+                "status": 0,
+                "body": "",
+                "url": url,
+                "headers": {},
+                "blocked": true,
+                "error": "Invalid data: URL",
+            })
+            .to_string(),
+        });
+    }
+
     struct PageInFlightGuard(Arc<std::sync::atomic::AtomicU32>);
     impl Drop for PageInFlightGuard {
         fn drop(&mut self) {
@@ -3309,6 +3343,23 @@ mod tests {
         assert!(validate_fetch_url(&loopback, true).is_ok());
     }
 
+    // data: and blob: never touch the network, so the SSRF gate must not
+    // reject them. Chrome resolves both from fetch()/XHR.
+    #[test]
+    fn fetch_url_validation_allows_data_and_blob_schemes() {
+        for raw in [
+            "data:text/plain,hello",
+            "data:text/javascript;base64,ZXhwb3J0IGRlZmF1bHQgNDI=",
+            "blob:https://example.com/3c3c1665-f27a-4f4e-9c2c-2b0a0d1f9a11",
+        ] {
+            let url = url::Url::parse(raw).unwrap();
+            assert!(
+                validate_fetch_url(&url, false).is_ok(),
+                "{raw} must pass the fetch scheme gate without private-network access"
+            );
+        }
+    }
+
     // SEC-005 / #708 — fetch() must not accept file:// (deny-by-default, matching
     // Page.navigate / Target.createTarget). The transports can't fetch it, but
     // it should be rejected up front rather than short-circuiting the gate.
@@ -3838,8 +3889,59 @@ mod tests {
     }
 }
 
+/// Decode a `data:` URL into its MIME type and bytes. Literal,
+/// percent-encoded, and base64 payloads are all valid.
+fn decode_data_url_bytes(url: &str) -> Option<(String, Vec<u8>)> {
+    let rest = url.strip_prefix("data:")?;
+    let comma = rest.find(',')?;
+    let meta = &rest[..comma];
+    let payload = &rest[comma + 1..];
+    let is_base64 = meta.split(';').any(|t| t.eq_ignore_ascii_case("base64"));
+    let mime = meta
+        .split(';')
+        .next()
+        .filter(|m| !m.is_empty())
+        .unwrap_or("text/plain;charset=US-ASCII")
+        .to_string();
+    let bytes = if is_base64 {
+        let cleaned: String = payload.chars().filter(|c| !c.is_whitespace()).collect();
+        BASE64.decode(cleaned).ok()?
+    } else {
+        percent_decode_bytes(payload)
+    };
+    Some((mime, bytes))
+}
+
+fn percent_decode_bytes(s: &str) -> Vec<u8> {
+    let b = s.as_bytes();
+    let mut out = Vec::with_capacity(b.len());
+    let mut i = 0;
+    while i < b.len() {
+        if b[i] == b'%' && i + 2 < b.len() {
+            let hi = (b[i + 1] as char).to_digit(16);
+            let lo = (b[i + 2] as char).to_digit(16);
+            if let (Some(h), Some(l)) = (hi, lo) {
+                out.push(((h << 4) | l) as u8);
+                i += 3;
+                continue;
+            }
+        }
+        out.push(b[i]);
+        i += 1;
+    }
+    out
+}
+
 fn validate_fetch_url(url: &url::Url, allow_private_network: bool) -> Result<(), String> {
     let scheme = url.scheme();
+    // data: and blob: carry their payload in-process and never open a socket,
+    // so the SSRF gate below has nothing to protect: there is no host to
+    // resolve and no request to smuggle onto the loopback interface. Chrome
+    // resolves both from fetch()/XHR, and rejecting them here breaks any page
+    // that reads an inline payload or an object URL it just created.
+    if scheme == "data" || scheme == "blob" {
+        return Ok(());
+    }
     // file:// is denied by default here, matching Page.navigate /
     // Target.createTarget (which gate it behind --allow-file-access). The
     // transports cannot fetch file:// anyway, so a page never reaches the
@@ -3906,6 +4008,20 @@ fn op_get_cookies(scope: &mut v8::HandleScope, state: &OpState) -> String {
         Err(_) => return String::new(),
     };
     jar.get_js_visible_cookies(&url)
+}
+
+#[op2(fast)]
+fn op_register_blob_module(state: &OpState, #[string] url: &str, #[string] source: &str) {
+    if let Some(page) = state.try_borrow::<Rc<RefCell<ObscuraState>>>() {
+        if let Ok(mut page) = page.try_borrow_mut() {
+            if source.is_empty() {
+                page.blob_module_sources.remove(url);
+            } else {
+                page.blob_module_sources
+                    .insert(url.to_string(), source.to_string());
+            }
+        }
+    }
 }
 
 #[op2(fast)]
@@ -4886,6 +5002,7 @@ pub fn build_extension() -> Extension {
         op_fetch_url(),
         op_get_cookies(),
         op_set_cookie(),
+        op_register_blob_module(),
         op_navigate(),
         op_frame_document_ready(),
         op_post_frame_message(),

--- a/crates/obscura-js/src/ops.rs
+++ b/crates/obscura-js/src/ops.rs
@@ -2306,6 +2306,138 @@ fn cors_response_allows(
     }
 }
 
+/// Synchronous XHR (`xhr.open(..., false)`). The spec still allows it outside
+/// a Worker and real pages use it for bootstrap configuration, so returning
+/// status 0 without ever issuing the request silently changes app behaviour.
+///
+/// deno_core ops cannot block the isolate on the page's own event loop, so the
+/// request runs on a dedicated thread with its own current-thread runtime and
+/// this op waits for that thread. Nothing on the page loop is polled while it
+/// waits, which is exactly the observable semantics of a sync XHR.
+#[op2]
+#[string]
+fn op_fetch_url_sync(
+    state: &mut OpState,
+    #[string] url: String,
+    #[string] method: String,
+    #[string] headers_json: String,
+    #[string] body: String,
+) -> Result<String, deno_error::JsErrorBox> {
+    let parsed = match url::Url::parse(&url) {
+        Ok(u) => u,
+        Err(e) => {
+            return Ok(serde_json::json!({
+                "status": 0, "body": "", "url": url, "headers": {},
+                "error": format!("Invalid URL: {}", e),
+            })
+            .to_string())
+        }
+    };
+
+    // data: never reaches the network; answer it here like the async path.
+    if parsed.scheme() == "data" {
+        return Ok(match decode_data_url_bytes(&url) {
+            Some((mime, bytes)) => serde_json::json!({
+                "status": 200,
+                "statusText": "OK",
+                "body": String::from_utf8_lossy(&bytes),
+                "url": url,
+                "headers": { "content-type": mime },
+            })
+            .to_string(),
+            None => serde_json::json!({
+                "status": 0, "body": "", "url": url, "headers": {},
+                "error": "Invalid data: URL",
+            })
+            .to_string(),
+        });
+    }
+
+    let allow_private_network = {
+        let gs = state.borrow::<SharedState>().clone();
+        let gs = gs.borrow();
+        for pattern in &gs.blocked_urls {
+            if pattern == "*" || url.contains(pattern) || glob_match(pattern, &url) {
+                return Ok(serde_json::json!({
+                    "status": 0, "body": "", "url": url, "headers": {}, "blocked": true,
+                })
+                .to_string());
+            }
+        }
+        gs.http_client
+            .as_ref()
+            .is_some_and(|c| c.allow_private_network)
+    };
+
+    if let Err(e) = validate_fetch_url(&parsed, allow_private_network) {
+        return Ok(serde_json::json!({
+            "status": 0, "body": "", "url": url, "headers": {},
+            "blocked": true, "error": e,
+        })
+        .to_string());
+    }
+
+    let headers: HashMap<String, String> =
+        serde_json::from_str(&headers_json).unwrap_or_default();
+    let method_owned = method.clone();
+    let url_owned = url.clone();
+    let body_owned = body;
+
+    // Own thread + own runtime: the page's event loop must not be re-entered
+    // while the isolate is blocked here.
+    let joined = std::thread::spawn(move || -> Result<(u16, String, HashMap<String, String>), String> {
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .map_err(|e| e.to_string())?;
+        rt.block_on(async move {
+            let client = reqwest::Client::builder()
+                .build()
+                .map_err(|e| e.to_string())?;
+            let m = reqwest::Method::from_bytes(method_owned.to_uppercase().as_bytes())
+                .unwrap_or(reqwest::Method::GET);
+            let mut req = client.request(m, &url_owned);
+            for (k, v) in headers {
+                req = req.header(k, v);
+            }
+            if !body_owned.is_empty() {
+                req = req.body(body_owned);
+            }
+            let resp = req.send().await.map_err(|e| e.to_string())?;
+            let status = resp.status().as_u16();
+            let mut hdrs = HashMap::new();
+            for (k, v) in resp.headers().iter() {
+                if let Ok(val) = v.to_str() {
+                    hdrs.insert(k.as_str().to_string(), val.to_string());
+                }
+            }
+            let text = resp.text().await.unwrap_or_default();
+            Ok((status, text, hdrs))
+        })
+    })
+    .join();
+
+    Ok(match joined {
+        Ok(Ok((status, text, hdrs))) => serde_json::json!({
+            "status": status,
+            "statusText": "",
+            "body": text,
+            "url": url,
+            "headers": hdrs,
+        })
+        .to_string(),
+        Ok(Err(e)) => serde_json::json!({
+            "status": 0, "body": "", "url": url, "headers": {}, "error": e,
+        })
+        .to_string(),
+        Err(_) => serde_json::json!({
+            "status": 0, "body": "", "url": url, "headers": {},
+            "error": "sync fetch thread panicked",
+        })
+        .to_string(),
+    })
+}
+
 #[op2(async)]
 #[string]
 async fn op_fetch_url(
@@ -5003,6 +5135,7 @@ pub fn build_extension() -> Extension {
         op_get_cookies(),
         op_set_cookie(),
         op_register_blob_module(),
+        op_fetch_url_sync(),
         op_navigate(),
         op_frame_document_ready(),
         op_post_frame_message(),


### PR DESCRIPTION
Two independent fixes, one commit each. Both surfaced while automating a
production SPA that never reached its login screen under obscura but works in
headless Chrome.

Fixes #907
Fixes #908

## 1. `data:` and `blob:` resolve without the network (#907)

Dynamic `import()`, module scripts, `blob:` classic scripts and `fetch()` all
failed for URLs that carry their own payload. Two causes:

- **`validate_fetch_url`** rejected every scheme but `http`/`https`. Its comment
  only reasons about `file://`; `data:` and `blob:` look like collateral.
  Neither has a host to resolve and neither opens a socket, so the SSRF check
  below the gate has nothing to protect. `file://` stays rejected, and there is
  a test asserting that.
- **`ObscuraModuleLoader::load`** handed every specifier to the HTTP client with
  no scheme branch, so a `data:` module failed at the transport even once the
  gate passed.

`fetch("data:…")` is now answered inline — sending it to the transport produced
a reqwest *builder error* rather than a response. `blob:` bodies live in the JS
object-URL store, which the Rust loader cannot read, so `createObjectURL`
mirrors script sources into the page state and `revokeObjectURL` clears them.

#532 fixed the classic-script `data:` path and explicitly kept module scripts on
`import()`; this covers that remainder plus the `fetch` and `blob:` cases.

## 2. Synchronous XHR actually performs the request (#908)

`XMLHttpRequest.prototype.open` ignored its third argument and `send()` always
took the async `fetch` path, so a caller reading `xhr.status` on the next line
saw `0` with an empty body — no exception, no `error` event, indistinguishable
from a real network failure.

`open()` now records the async flag and `send()` routes the synchronous case
through a new `op_fetch_url_sync`. deno_core ops cannot block the isolate on the
page's own event loop, so the request runs on a dedicated thread with its own
current-thread runtime and the op waits for it — nothing on the page loop is
polled meanwhile, which is the observable semantics of a sync XHR. The op reuses
the same blocked-URL list, SSRF gate and `data:` handling as the async path.

## Verification

`cargo test --release -p obscura-js --lib` — **396 passed, 0 failed**.
All four release configurations build.

Behaviour matrix against a live `https://` document, compared with headless
Chrome (`PASS` = matches Chrome):

| case | before | after |
| --- | --- | --- |
| `import("data:…")` literal / base64 / percent-encoded | FAIL | PASS |
| `import("data:…")` with non-ASCII source | FAIL | PASS |
| `import(blob:…)` | FAIL | PASS |
| `<script src="data:…">` classic | PASS | PASS |
| `<script src="blob:…">` classic | FAIL | PASS |
| `<script type="module" src="data:…">` | FAIL | PASS |
| `fetch("data:…")` | FAIL | PASS |
| `fetch(blob:…)` | FAIL | PASS |
| `new Worker(blob:…)` | PASS | PASS |
| sync XHR, existing path | `status 0` | `status 200`, body present |
| sync XHR, missing path | `status 0` | `status 404`, `readyState 4` |
| async XHR (regression) | PASS | PASS |
| **`fetch("file://…")` rejected** | PASS | **PASS** |

15/15 on the combined matrix after the change.

## Notes for review

- The scheme allowance is deliberately narrow: `data:` and `blob:` only, added
  *before* the SSRF branch rather than widening the allow-list, so private-IP
  and `file://` handling is untouched.
- The sync path is opt-in per request; the async transport is unchanged.
- Mirroring blob sources into page state costs one string per script-typed
  object URL and is cleared on `revokeObjectURL`. If you would rather the loader
  reach into the JS store some other way, I am happy to rework it.
