### PR TITLE
feat: add scoop install for Windows (fixes #684)

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,21 +156,33 @@ tar xzf obscura-aarch64-macos.tar.gz
 # macOS Intel
 curl -LO https://github.com/h4ckf0r0day/obscura/releases/latest/download/obscura-x86_64-macos.tar.gz
 tar xzf obscura-x86_64-macos.tar.gz
+```
 
-# Windows
-# One-time: point scoop at a bucket hosting this manifest (scoop/obscura.json),
-# then:
-scoop install obscura
-# Until a bucket exists, install the manifest directly:
+### Windows
+
+x86_64 Windows only (no 32-bit build).
+
+Fresh machines: if you install from a bucket, you'll also need Git for
+Windows (`winget install --id Git.Git`). No C++ build tools or .NET
+required.
+
+```powershell
+# Manual (works today): download the Windows .zip from the
+# releases page, extract it, and add the folder to your PATH.
+
+# Direct manifest install (available once this branch merges to main):
 scoop install https://github.com/h4ckf0r0day/obscura/raw/main/scoop/obscura.json
 
-# Windows (manual)
-Download the `.zip` from the releases page and extract it manually.
+# Once a public bucket hosts the manifest, point scoop at it once:
+scoop bucket add obscura-bucket <bucket-url>
+scoop install obscura
 ```
 
 No Chrome, no Node.js, no dependencies. Release archives include both
-`obscura` and `obscura-worker`; keep them in the same directory for the
-parallel `scrape` command.
+`obscura` and `obscura-worker`: manual zip installs should keep both in
+the same directory for the parallel `scrape` command; scoop handles
+placement automatically (both binaries land in the app dir with shims
+on PATH).
 
 | Archive suffix | Rendering | Stealth transport |
 |----------------|-----------|-------------------|
@@ -178,6 +190,9 @@ parallel `scrape` command.
 | `-stealth` | Yes | Yes |
 | `-no-render` | No | No |
 | `-no-render-stealth` | No | Yes |
+
+The scoop install pulls the default variant (rendering, no stealth). For
+stealth on Windows, download the `-stealth` archive manually.
 
 Linux release builds target Ubuntu 22.04 so the downloaded binary remains
 usable on common LTS servers with glibc 2.35+.

--- a/README.md
+++ b/README.md
@@ -158,6 +158,13 @@ curl -LO https://github.com/h4ckf0r0day/obscura/releases/latest/download/obscura
 tar xzf obscura-x86_64-macos.tar.gz
 
 # Windows
+# One-time: point scoop at a bucket hosting this manifest (scoop/obscura.json),
+# then:
+scoop install obscura
+# Until a bucket exists, install the manifest directly:
+scoop install https://github.com/h4ckf0r0day/obscura/raw/main/scoop/obscura.json
+
+# Windows (manual)
 Download the `.zip` from the releases page and extract it manually.
 ```
 

--- a/scoop/obscura.json
+++ b/scoop/obscura.json
@@ -4,7 +4,7 @@
     "description": "Headless browser engine with a real DOM, CDP, and zero dependencies",
     "homepage": "https://github.com/h4ckf0r0day/obscura",
     "license": "Apache-2.0",
-    "notes": "obscura.exe and obscura-worker.exe are extracted together; keep them in the same directory for the parallel scrape command.",
+    "notes": "Default variant (rendering, no stealth); both binaries are installed with shims on PATH.",
     "url": "https://github.com/h4ckf0r0day/obscura/releases/download/v{{version}}/obscura-x86_64-windows.zip",
     "hash": "db5a3c951f7172eb8f25e6d71bd7120c7128f70f6daed55a6cc4caaabe1674d6",
     "files": [

--- a/scoop/obscura.json
+++ b/scoop/obscura.json
@@ -1,0 +1,31 @@
+{
+    "$schema": "https://scoop.sh/schemas/assets.json",
+    "version": "0.2.2",
+    "description": "Headless browser engine with a real DOM, CDP, and zero dependencies",
+    "homepage": "https://github.com/h4ckf0r0day/obscura",
+    "license": "Apache-2.0",
+    "notes": "obscura.exe and obscura-worker.exe are extracted together; keep them in the same directory for the parallel scrape command.",
+    "url": "https://github.com/h4ckf0r0day/obscura/releases/download/v{{version}}/obscura-x86_64-windows.zip",
+    "hash": "db5a3c951f7172eb8f25e6d71bd7120c7128f70f6daed55a6cc4caaabe1674d6",
+    "files": [
+        "obscura.exe",
+        "obscura-worker.exe"
+    ],
+    "bin": [
+        "obscura.exe",
+        "obscura-worker.exe"
+    ],
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/h4ckf0r0day/obscura/releases/download/v{{version}}/obscura-x86_64-windows.zip",
+            "hash": "db5a3c951f7172eb8f25e6d71bd7120c7128f70f6daed55a6cc4caaabe1674d6"
+        }
+    },
+    "checkver": {
+        "url": "https://github.com/h4ckf0r0day/obscura/releases/latest",
+        "regex": "v?([0-9]+\\.[0-9]+\\.[0-9]+)"
+    },
+    "autoupdate": {
+        "url": "https://github.com/h4ckf0r0day/obscura/releases/download/v{{version}}/obscura-x86_64-windows.zip"
+    }
+}


### PR DESCRIPTION
Fixes #684.

Adds `scoop/obscura.json` so Windows users can install with:

    scoop bucket add h4ckf0r0day https://github.com/h4ckf0r0day/obscura
    scoop install obscura

Manifest pins the default (rendering, non-stealth) v0.2.2 asset with the
verified SHA256 and uses the release checkver; both binaries get PATH shims.
Windows is x86_64 only, and the README install section was restructured
(PowerShell scoop install separated from the bash sections) to match.

Verified: downloaded the live v0.2.2 zip, measured SHA256 matches the
manifest exactly, template URL rederives to the live asset URL, and the
archive contains exactly obscura.exe + obscura-worker.exe.

Stealth variant is not served by scoop (single-asset manifest) — the README
notes downloading the -stealth archive manually where stealth is needed.