### PR TITLE
fix(obscura-cdp): bring Fetch domain path to parity with server.rs (#919)

### DIFF
--- a/crates/obscura-cdp/src/domains/fetch.rs
+++ b/crates/obscura-cdp/src/domains/fetch.rs
@@ -123,7 +123,9 @@ pub async fn handle(
                         .get("method")
                         .and_then(|v| v.as_str())
                         .map(|s| s.to_string()),
-                    headers: None,
+                    // Honor client header overrides (route.continue({ headers }))
+                    // — parity with server.rs handle_fetch_resolution (#919).
+                    headers: crate::server::parse_cdp_headers(params),
                     post_data: params
                         .get("postData")
                         .and_then(|v| v.as_str())
@@ -155,11 +157,11 @@ pub async fn handle(
                         .collect()
                 })
                 .unwrap_or_default();
-            let body = params
-                .get("body")
-                .and_then(|v| v.as_str())
-                .unwrap_or("")
-                .to_string();
+            // The CDP fulfillRequest body is base64-encoded; decode it — parity
+            // with server.rs handle_fetch_resolution (#919). (Binary-safe body
+            // transport across the JS boundary remains tracked in #912.)
+            let body =
+                crate::server::decode_base64(params.get("body").and_then(|v| v.as_str()).unwrap_or(""));
 
             if let Some(paused) = ctx.fetch_intercept.paused.remove(request_id) {
                 let _ = paused.resolver.send(FetchResolution::Fulfill {
@@ -220,5 +222,78 @@ pub async fn handle(
             Ok(json!({ "stream": handle }))
         }
         _ => Err(format!("Unknown Fetch method: {}", method)),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::dispatch::CdpContext;
+    use serde_json::json;
+    use std::collections::HashMap;
+
+    fn pause(ctx: &mut CdpContext, id: &str) -> tokio::sync::oneshot::Receiver<FetchResolution> {
+        let (tx, rx) = tokio::sync::oneshot::channel();
+        ctx.fetch_intercept.paused.insert(
+            id.to_string(),
+            PausedRequest {
+                request_id: id.to_string(),
+                url: "https://example.test/".to_string(),
+                method: "GET".to_string(),
+                headers: HashMap::new(),
+                resource_type: "Fetch".to_string(),
+                resolver: tx,
+            },
+        );
+        rx
+    }
+
+    // Parity with server.rs handle_fetch_resolution: continueRequest must
+    // forward the client's header overrides (route.continue({ headers })), not
+    // drop them. See #919.
+    #[tokio::test]
+    async fn continue_request_forwards_header_overrides() {
+        let mut ctx = CdpContext::new();
+        let rx = pause(&mut ctx, "req-1");
+        handle(
+            "continueRequest",
+            &json!({ "requestId": "req-1", "headers": [{ "name": "X-Test", "value": "42" }] }),
+            &mut ctx,
+            &None,
+        )
+        .await
+        .expect("continueRequest should succeed");
+
+        match rx.await.expect("resolver should fire") {
+            FetchResolution::Continue { headers, .. } => {
+                let mut expected = HashMap::new();
+                expected.insert("X-Test".to_string(), "42".to_string());
+                assert_eq!(headers, Some(expected), "continue must forward header overrides");
+            }
+            _ => panic!("expected FetchResolution::Continue"),
+        }
+    }
+
+    // Parity with server.rs: the fulfillRequest body is base64-encoded per CDP
+    // and must be decoded, not passed through as raw base64 text. See #919/#912.
+    #[tokio::test]
+    async fn fulfill_request_base64_decodes_body() {
+        let mut ctx = CdpContext::new();
+        let rx = pause(&mut ctx, "req-2");
+        handle(
+            "fulfillRequest",
+            &json!({ "requestId": "req-2", "responseCode": 200, "body": "SGVsbG8=" }),
+            &mut ctx,
+            &None,
+        )
+        .await
+        .expect("fulfillRequest should succeed");
+
+        match rx.await.expect("resolver should fire") {
+            FetchResolution::Fulfill { body, .. } => {
+                assert_eq!(body, "Hello", "fulfill body must be base64-decoded");
+            }
+            _ => panic!("expected FetchResolution::Fulfill"),
+        }
     }
 }

--- a/crates/obscura-cdp/src/server.rs
+++ b/crates/obscura-cdp/src/server.rs
@@ -1198,7 +1198,7 @@ fn is_navigate_method(text: &str) -> bool {
 // Fetch.continueRequest / fulfillRequest) into a map. Returns None when the
 // `headers` field is absent, so the caller can leave the request's headers
 // untouched rather than clearing them.
-fn parse_cdp_headers(params: &serde_json::Value) -> Option<HashMap<String, String>> {
+pub(crate) fn parse_cdp_headers(params: &serde_json::Value) -> Option<HashMap<String, String>> {
     let arr = params.get("headers")?.as_array()?;
     Some(
         arr.iter()
@@ -1576,7 +1576,7 @@ async fn process_cdp_message(
     }
 }
 
-fn decode_base64(input: &str) -> String {
+pub(crate) fn decode_base64(input: &str) -> String {
     fn val(c: u8) -> Option<u8> {
         match c {
             b'A'..=b'Z' => Some(c - b'A'),


### PR DESCRIPTION
## What & why

The `FetchInterceptState` dispatch path in `crates/obscura-cdp/src/domains/fetch.rs` is a less-complete duplicate of `handle_fetch_resolution` in `crates/obscura-cdp/src/server.rs`. Two symptoms of that drift:

- **`continueRequest`** built `FetchResolution::Continue { headers: None, .. }`, silently dropping client header overrides — Playwright `route.continue({ headers })`, Puppeteer `request.continue({ headers })`.
- **`fulfillRequest`** passed the `body` param through as raw text, but the CDP `fulfillRequest` body is **base64-encoded**, so this path served undecoded base64 as the response body.

`server.rs` already parses continue headers (`parse_cdp_headers`) and decodes the fulfill body (`decode_base64`); `fetch.rs` did neither.

Closes #919. Also fixes the **consistency half of #912** (fetch.rs now decodes the fulfill body like server.rs).

## Fix

Expose `parse_cdp_headers` and `decode_base64` as `pub(crate)` and route both fetch.rs sites through them, so the two paths share one implementation and can't drift again.

> The deeper binary-safety defect — fulfill bodies carried as a lossy `String` (`from_utf8_lossy`) across the Rust↔JS boundary, which corrupts non-UTF-8 payloads — is out of scope here and remains tracked in **#912**. This PR brings fetch.rs to parity with server.rs's *existing* behavior.

## Tests

TDD RED→GREEN. New unit tests drive `handle` and inspect the `FetchResolution` sent over the paused resolver:
- `continue_request_forwards_header_overrides`
- `fulfill_request_base64_decodes_body`

Verified RED first (headers `None`; body was raw base64), then GREEN. Full `obscura-cdp` lib suite: **100 passed, 0 failed**.

https://claude.ai/code/session_01W4C7V9e3rXKRY8jn1rYCoY
