### PR TITLE
Load persistent storage in MCP sessions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1983,6 +1983,7 @@ dependencies = [
  "obscura-net",
  "serde",
  "serde_json",
+ "tempfile",
  "tokio",
  "tracing",
  "url",

--- a/crates/obscura-cli/src/main.rs
+++ b/crates/obscura-cli/src/main.rs
@@ -516,9 +516,23 @@ async fn main() -> anyhow::Result<()> {
         }) => {
             let mcp_proxy = merge_proxy(global_proxy.clone(), proxy);
             if http {
-                obscura_mcp::http::run(host, port, mcp_proxy, user_agent, stealth).await?;
+                obscura_mcp::http::run_with_storage(
+                    host,
+                    port,
+                    mcp_proxy,
+                    user_agent,
+                    stealth,
+                    args.storage_dir,
+                )
+                .await?;
             } else {
-                obscura_mcp::run(mcp_proxy, user_agent, stealth).await?;
+                obscura_mcp::run_with_storage(
+                    mcp_proxy,
+                    user_agent,
+                    stealth,
+                    args.storage_dir,
+                )
+                .await?;
             }
         }
         None => {

--- a/crates/obscura-mcp/Cargo.toml
+++ b/crates/obscura-mcp/Cargo.toml
@@ -21,3 +21,6 @@ serde_json = { workspace = true }
 anyhow = { workspace = true }
 tracing = { workspace = true }
 base64 = { workspace = true, optional = true }
+
+[dev-dependencies]
+tempfile = "3"

--- a/crates/obscura-mcp/src/http.rs
+++ b/crates/obscura-mcp/src/http.rs
@@ -1,3 +1,5 @@
+use std::path::PathBuf;
+
 use anyhow::Result;
 use serde_json::{json, Value};
 use tokio::io::{AsyncBufRead, AsyncBufReadExt, AsyncReadExt, AsyncWriteExt, BufReader};
@@ -178,12 +180,29 @@ fn cors_header(origin: Option<&str>, allowlist: Option<&str>) -> String {
 /// Connections are handled sequentially on the current thread — the browser
 /// session (including the V8 runtime) is single-threaded and `!Send`, so we
 /// never need to move state across threads.
-pub async fn run(host: String, port: u16, proxy: Option<String>, user_agent: Option<String>, stealth: bool) -> Result<()> {
+pub async fn run(
+    host: String,
+    port: u16,
+    proxy: Option<String>,
+    user_agent: Option<String>,
+    stealth: bool,
+) -> Result<()> {
+    run_with_storage(host, port, proxy, user_agent, stealth, None).await
+}
+
+pub async fn run_with_storage(
+    host: String,
+    port: u16,
+    proxy: Option<String>,
+    user_agent: Option<String>,
+    stealth: bool,
+    storage_dir: Option<PathBuf>,
+) -> Result<()> {
     let addr: std::net::SocketAddr = format!("{}:{}", host, port).parse()?;
     let listener = TcpListener::bind(&addr).await?;
     tracing::info!("MCP HTTP server on http://{}:{}/mcp", host, port);
 
-    let mut state = BrowserState::new(proxy, user_agent, stealth);
+    let mut state = BrowserState::with_storage(proxy, user_agent, stealth, storage_dir);
     let allowed_origins = allowed_origins_env();
 
     loop {

--- a/crates/obscura-mcp/src/lib.rs
+++ b/crates/obscura-mcp/src/lib.rs
@@ -6,6 +6,7 @@
 pub mod http;
 
 use std::collections::HashMap;
+use std::path::PathBuf;
 use std::sync::Arc;
 
 use anyhow::Result;
@@ -80,12 +81,31 @@ pub struct BrowserState {
 }
 
 impl BrowserState {
-    pub fn new(proxy: Option<String>, user_agent: Option<String>, stealth: bool) -> Self {
+    pub fn new(
+        proxy: Option<String>,
+        user_agent: Option<String>,
+        stealth: bool,
+    ) -> Self {
+        Self::with_storage(proxy, user_agent, stealth, None)
+    }
+
+    pub fn with_storage(
+        proxy: Option<String>,
+        user_agent: Option<String>,
+        stealth: bool,
+        storage_dir: Option<PathBuf>,
+    ) -> Self {
         BrowserState {
             tabs: std::collections::BTreeMap::new(),
             active_tab: None,
             tab_counter: 0,
-            context: Arc::new(BrowserContext::with_options("mcp".to_string(), proxy, stealth)),
+            context: Arc::new(BrowserContext::with_storage_full(
+                "mcp".to_string(),
+                proxy,
+                stealth,
+                user_agent.clone(),
+                storage_dir,
+            )),
             user_agent,
             console_messages: Vec::new(),
             interactive_refs: HashMap::new(),
@@ -225,7 +245,11 @@ pub(crate) async fn dispatch(method: &str, id: Value, params: &Value, state: &mu
         "initialize" => handle_initialize(id, params),
         "ping" => RpcResponse::ok(id, json!({})),
         "tools/list" => handle_tools_list(id),
-        "tools/call" => handle_tool_call(id, params, state).await,
+        "tools/call" => {
+            let response = handle_tool_call(id, params, state).await;
+            state.context.save_cookies();
+            response
+        }
         "resources/list" => RpcResponse::ok(id, json!({"resources": []})),
         "prompts/list" => RpcResponse::ok(id, json!({"prompts": []})),
         _ => RpcResponse::err(id, -32601, format!("Unknown method: {method}")),
@@ -233,12 +257,21 @@ pub(crate) async fn dispatch(method: &str, id: Value, params: &Value, state: &mu
 }
 
 pub async fn run(proxy: Option<String>, user_agent: Option<String>, stealth: bool) -> Result<()> {
+    run_with_storage(proxy, user_agent, stealth, None).await
+}
+
+pub async fn run_with_storage(
+    proxy: Option<String>,
+    user_agent: Option<String>,
+    stealth: bool,
+    storage_dir: Option<PathBuf>,
+) -> Result<()> {
     let stdin = tokio::io::stdin();
     let stdout = tokio::io::stdout();
     let mut reader = BufReader::new(stdin);
     let mut writer = stdout;
 
-    let mut state = BrowserState::new(proxy, user_agent, stealth);
+    let mut state = BrowserState::with_storage(proxy, user_agent, stealth, storage_dir);
     let mut runtime_pump_armed = false;
 
     loop {
@@ -266,6 +299,7 @@ pub async fn run(proxy: Option<String>, user_agent: Option<String>, stealth: boo
             continue;
         };
         if n == 0 {
+            state.context.save_cookies();
             return Ok(());
         }
 
@@ -2078,6 +2112,31 @@ fn tool_set_storage_state(args: &Value, state: &mut BrowserState) -> Result<Stri
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn browser_state_loads_cookies_from_persistent_storage() {
+        let temp = tempfile::tempdir().expect("temporary storage directory");
+        let source = BrowserContext::with_storage(
+            "cookie-source".to_string(),
+            Some(temp.path().to_path_buf()),
+        );
+        source.cookie_jar.set_cookie(
+            "session=authenticated; Domain=example.com; Path=/; Secure; HttpOnly",
+            &url::Url::parse("https://example.com/").unwrap(),
+        );
+        source.save_cookies();
+
+        let state = BrowserState::with_storage(
+            None,
+            None,
+            false,
+            Some(temp.path().to_path_buf()),
+        );
+        let header = state.context.cookie_jar.get_cookie_header(
+            &url::Url::parse("https://example.com/").unwrap(),
+        );
+        assert!(header.contains("session=authenticated"));
+    }
 
     fn listed_tools() -> Vec<Value> {
         handle_tools_list(json!(1)).result.expect("tools/list result")


### PR DESCRIPTION
`--storage-dir` is accepted as a global CLI option for `obscura mcp`, but the MCP command currently discards it. As a result, provider clients see an empty cookie jar even when the same Obscura storage authenticates successfully through `fetch`.

Pass persistent storage into both stdio and HTTP MCP browser contexts, preserve the existing public run functions, and save refreshed cookies after tool calls and graceful stdio shutdown.

Validation:

- `cargo check -p obscura-cli -p obscura-mcp`
- `cargo test -p obscura-mcp browser_state_loads_cookies_from_persistent_storage`
- `git diff --check`
