### PR TITLE
fix(obscura-cdp): fix navigateToHistoryEntry index corruption and dropped network events (#920)

### DIFF
--- a/crates/obscura-cdp/src/domains/page.rs
+++ b/crates/obscura-cdp/src/domains/page.rs
@@ -1473,34 +1473,48 @@ pub async fn handle(
         }
         "navigateToHistoryEntry" => {
             let entry_id = params.get("entryId").and_then(|v| v.as_u64()).unwrap_or(0) as usize;
-            let target_url = {
+            // Snapshot history and the current cursor BEFORE moving it, so a
+            // navigation that fails can roll back to where the page actually is
+            // instead of leaving currentIndex on an entry it never reached (#920).
+            let (target_url, saved_history, prev_index) = {
                 let page = ctx
                     .get_session_page_mut(session_id)
                     .ok_or("No page for session")?;
                 let url = page.history.get(entry_id).cloned();
+                let snapshot = (page.history.clone(), page.history_index);
                 if url.is_some() {
                     page.set_history_index(entry_id);
                 }
-                url
+                (url, snapshot.0, snapshot.1)
             };
             if let Some(url) = target_url {
-                // Stash + restore history so push_history doesn't clobber
-                // the cursor we just moved.
-                let stash = {
-                    let page = ctx
-                        .get_session_page_mut(session_id)
-                        .ok_or("No page for session")?;
-                    (page.history.clone(), page.history_index)
-                };
-                let (frame_id, page_id, network_events, page_url, reached_idle) = {
+                let nav_result = {
                     let page = ctx
                         .get_session_page_mut(session_id)
                         .ok_or("No page for session")?;
                     page.navigate_with_wait(&url, WaitUntil::DomContentLoaded)
                         .await
-                        .map_err(|e| e.to_string())?;
-                    page.history = stash.0;
-                    page.history_index = stash.1;
+                };
+                // navigate_with_wait's push_history rewrote history during the
+                // load, so restore the snapshot either way. On failure the page
+                // never moved — put the cursor back where it was (#920).
+                if let Err(e) = nav_result {
+                    if let Some(page) = ctx.get_session_page_mut(session_id) {
+                        page.history = saved_history;
+                        page.history_index = prev_index;
+                    }
+                    return Err(e.to_string());
+                }
+                let (frame_id, page_id, network_events, page_url, reached_idle) = {
+                    let page = ctx
+                        .get_session_page_mut(session_id)
+                        .ok_or("No page for session")?;
+                    page.history = saved_history;
+                    page.history_index = entry_id;
+                    // Flush script-initiated network events before draining,
+                    // matching do_navigate — otherwise fetch/XHR requests the
+                    // navigated page starts are dropped from CDP events (#920).
+                    page.sync_js_network_events();
                     (
                         page.frame_id.clone(),
                         page.id.clone(),
@@ -1746,6 +1760,76 @@ fn timestamp() -> f64 {
 mod tests {
     use super::*;
     use crate::dispatch::CdpContext;
+
+    // #920: a history navigation that fails to load must not move the recorded
+    // currentIndex — the page never actually went anywhere, so a later
+    // getNavigationHistory must still report where it really is.
+    #[tokio::test(flavor = "current_thread")]
+    async fn failed_history_navigation_leaves_current_index_unchanged() {
+        let mut ctx = CdpContext::new();
+        let page_id = ctx.create_page();
+        let session = Some(format!("{page_id}-session"));
+        ctx.sessions.insert(session.clone().unwrap(), page_id);
+
+        {
+            let page = ctx.get_session_page_mut(&session).unwrap();
+            page.history = vec![
+                "data:text/html,<p>ok</p>".to_string(),
+                "not-a-url".to_string(),
+            ];
+            page.history_index = 0;
+        }
+
+        let res = handle(
+            "navigateToHistoryEntry",
+            &json!({ "entryId": 1 }),
+            &mut ctx,
+            &session,
+        )
+        .await;
+        assert!(
+            res.is_err(),
+            "navigating to an invalid entry URL must fail, got {res:?}"
+        );
+
+        let index = ctx.get_session_page(&session).unwrap().history_index;
+        assert_eq!(
+            index, 0,
+            "a failed history navigation must leave currentIndex where the page actually is"
+        );
+    }
+
+    // Guard the success path (there was no coverage): a valid back-navigation
+    // moves currentIndex to the target entry and preserves the history list.
+    #[tokio::test(flavor = "current_thread")]
+    async fn history_navigation_moves_current_index_on_success() {
+        let mut ctx = CdpContext::new();
+        let page_id = ctx.create_page();
+        let session = Some(format!("{page_id}-session"));
+        ctx.sessions.insert(session.clone().unwrap(), page_id);
+
+        {
+            let page = ctx.get_session_page_mut(&session).unwrap();
+            page.history = vec![
+                "data:text/html,<title>a</title>".to_string(),
+                "data:text/html,<title>b</title>".to_string(),
+            ];
+            page.history_index = 1;
+        }
+
+        handle(
+            "navigateToHistoryEntry",
+            &json!({ "entryId": 0 }),
+            &mut ctx,
+            &session,
+        )
+        .await
+        .expect("navigating back to a valid entry must succeed");
+
+        let page = ctx.get_session_page(&session).unwrap();
+        assert_eq!(page.history_index, 0, "currentIndex must move to the target entry");
+        assert_eq!(page.history.len(), 2, "history must be preserved across the navigation");
+    }
 
     // #833: chromiumoxide's new_page waits for the initial target's "load"
     // lifecycle event before returning. Page.enable on a freshly created


### PR DESCRIPTION
## What & why

Two defects in the `Page.navigateToHistoryEntry` handler (`crates/obscura-cdp/src/domains/page.rs`):

### 1. History index corrupted on navigation failure
`set_history_index(entry_id)` moved the cursor *before* navigating, and the stash/restore only ran on the success path. When `navigate_with_wait` failed (invalid URL, DNS error, timeout), the `?` propagated with `history_index` left pointing at the entry that was never reached — a later `getNavigationHistory` then reported the wrong `currentIndex` while the page still showed the old content.

**Fix:** snapshot the pre-navigation history + cursor, and on failure restore them before returning the error. The page never moved, so the cursor rolls back to where it actually is.

### 2. Script-initiated network events dropped
The handler drained `page.network_events` without first calling `page.sync_js_network_events()` — unlike `do_navigate` (which syncs before draining). So fetch/XHR requests started by the navigated page were silently missing from CDP `Network` events during `goBack`/`goForward`.

**Fix:** add the `sync_js_network_events()` before the drain, matching `do_navigate`.

Closes #920.

## Tests

TDD RED→GREEN for the state-corruption bug, plus a guard for the previously-untested success path:
- `failed_history_navigation_leaves_current_index_unchanged` — a navigation to an invalid entry URL fails and leaves `currentIndex` unchanged (verified RED first: it was left on the failed target).
- `history_navigation_moves_current_index_on_success` — a valid back-navigation moves `currentIndex` and preserves the history list (no prior coverage existed).

Full `obscura-cdp` suite: **156 passed, 0 failed**.

> Note on defect 2: the `sync_js_network_events()` addition is a one-line parity fix mirroring the proven-correct `do_navigate` path. A dedicated unit test would require an integration scenario (the navigated page running `fetch`/XHR *during* a history navigation), which isn't practical to drive at the handler-test layer; it is exercised by the same mechanism `do_navigate` relies on.

https://claude.ai/code/session_01W4C7V9e3rXKRY8jn1rYCoY
