### PR TITLE
fix(obscura-cdp): deliver binary Fetch.fulfillRequest bodies intact via bodyBase64 (#912)

### DIFF
--- a/crates/obscura-cdp/src/server.rs
+++ b/crates/obscura-cdp/src/server.rs
@@ -1239,14 +1239,18 @@ fn handle_fetch_resolution(
                 "Fetch.fulfillRequest" => {
                     let status = req.params.get("responseCode").and_then(|v| v.as_u64()).unwrap_or(200) as u16;
                     let raw_body = req.params.get("body").and_then(|v| v.as_str()).unwrap_or("");
+                    // `body` is a lossy text view; `body_base64` carries the CDP
+                    // body (already base64) through unchanged so op_fetch_url can
+                    // hand JS the exact bytes for a binary fulfill (#912).
                     let body = decode_base64(raw_body);
+                    let body_base64 = raw_body.to_string();
                     let headers = req.params.get("responseHeaders")
                         .and_then(|v| v.as_array())
                         .map(|arr| arr.iter().filter_map(|h| {
                             Some((h.get("name")?.as_str()?.to_string(), h.get("value")?.as_str()?.to_string()))
                         }).collect())
                         .unwrap_or_default();
-                    obscura_js::ops::InterceptResolution::Fulfill { status, headers, body }
+                    obscura_js::ops::InterceptResolution::Fulfill { status, headers, body, body_base64 }
                 }
                 "Fetch.failRequest" => {
                     let reason = req.params.get("errorReason").and_then(|v| v.as_str()).unwrap_or("Failed").to_string();

--- a/crates/obscura-js/src/ops.rs
+++ b/crates/obscura-js/src/ops.rs
@@ -43,7 +43,14 @@ pub enum InterceptResolution {
     Fulfill {
         status: u16,
         headers: HashMap<String, String>,
+        /// Lossy UTF-8 view of the fulfilled body, for text consumers.
         body: String,
+        /// The exact fulfilled body as standard base64. CDP delivers the
+        /// fulfillRequest body base64-encoded; carrying it through unchanged
+        /// lets the bootstrap fetch layer reconstruct the exact bytes
+        /// (`_base64ToUint8Array`) instead of a `from_utf8_lossy` corruption
+        /// of any non-UTF-8 payload (image, font, protobuf). See #912.
+        body_base64: String,
     },
     Fail {
         reason: String,
@@ -2300,6 +2307,28 @@ fn cors_response_allows(
     }
 }
 
+/// Build the JS-facing result for an intercepted request a CDP client chose to
+/// fulfill (`Fetch.fulfillRequest`). Mirrors the normal fetch result contract:
+/// `body` is a lossy text view and `bodyBase64` carries the exact bytes, which
+/// the bootstrap fetch layer prefers (`_base64ToUint8Array`) so a binary
+/// fulfilled body is delivered intact rather than `from_utf8_lossy`-corrupted.
+/// See #912.
+fn intercept_fulfill_response(
+    status: u16,
+    headers: HashMap<String, String>,
+    body: &str,
+    body_base64: &str,
+    url: &str,
+) -> serde_json::Value {
+    serde_json::json!({
+        "status": status,
+        "body": body,
+        "bodyBase64": body_base64,
+        "url": url,
+        "headers": headers,
+    })
+}
+
 #[op2(async)]
 #[string]
 async fn op_fetch_url(
@@ -2425,15 +2454,9 @@ async fn op_fetch_url(
                     status,
                     headers: h,
                     body: b,
+                    body_base64: bb,
                 }) => {
-                    let resp_headers: HashMap<String, String> = h;
-                    return Ok(serde_json::json!({
-                        "status": status,
-                        "body": b,
-                        "url": url,
-                        "headers": resp_headers,
-                    })
-                    .to_string());
+                    return Ok(intercept_fulfill_response(status, h, &b, &bb, &url).to_string());
                 }
                 Ok(InterceptResolution::Fail { reason }) => {
                     return Ok(serde_json::json!({
@@ -3120,6 +3143,31 @@ mod tests {
 
     use super::read_body_capped;
     use super::{pbkdf2_derive, push_capped, PBKDF2_MAX_ITERATIONS, PBKDF2_MAX_OUTPUT_BYTES};
+    use super::intercept_fulfill_response;
+    use base64::{engine::general_purpose::STANDARD as FULFILL_BASE64, Engine as _};
+
+    // #912 — a fulfilled binary body (non-UTF-8) must survive as exact bytes via
+    // `bodyBase64`, not be silently corrupted by the lossy `body` text view.
+    #[test]
+    fn intercept_fulfill_carries_binary_body_as_base64() {
+        let raw = [0x89u8, b'P', b'N', b'G', 0x0D, 0x0A, 0x1A, 0x0A, 0xFF, 0xFE, 0x00];
+        let b64 = FULFILL_BASE64.encode(raw);
+        let lossy = String::from_utf8_lossy(&raw).to_string();
+        let result = intercept_fulfill_response(
+            200,
+            std::collections::HashMap::new(),
+            &lossy,
+            &b64,
+            "https://example.test/",
+        );
+        let out_b64 = result["bodyBase64"]
+            .as_str()
+            .expect("fulfill result must carry bodyBase64");
+        let decoded = FULFILL_BASE64
+            .decode(out_b64)
+            .expect("bodyBase64 must be valid base64");
+        assert_eq!(decoded, raw, "the exact bytes must survive via bodyBase64");
+    }
 
     // SEC-002 / #705 — fetched_urls (and the like) must not grow without bound.
     #[test]


### PR DESCRIPTION
## What & why

A CDP client that fulfills a request with a **binary body** — Playwright `route.fulfill({ body: imageBuffer })`, Puppeteer `request.respond(...)` — got a **corrupted** response. The fulfilled body crossed the Rust→JS boundary only as a `from_utf8_lossy` string, so every non-UTF-8 byte (any image, font, compressed, or protobuf payload) became U+FFFD.

The **normal** fetch path already ships both `body` (lossy text) *and* `bodyBase64` (exact bytes), and the bootstrap fetch layer prefers the latter:

```js
// bootstrap.js
const responseBody = parsed.bodyBase64 ? _base64ToUint8Array(parsed.bodyBase64) : (parsed.body || "");
```

The intercept/**fulfill** path shipped only the lossy `body`.

Closes #912.

## Fix

Carry the fulfilled body's exact bytes to JS the same way the normal path does:

- Add `body_base64` to `InterceptResolution::Fulfill`. `server.rs` passes the CDP `body` param — which is *already* base64 per the CDP spec — through unchanged (`_base64ToUint8Array` tolerates whitespace/padding).
- `op_fetch_url` emits it as `bodyBase64`, via a small `intercept_fulfill_response` helper mirroring the normal-path result contract.

The bootstrap fetch layer then reconstructs the exact bytes. The lossy `body` field is retained for text consumers, matching the normal path.

## Scope / relationship to other PRs

- Targets the **live** interception path (`InterceptResolution` → `op_fetch_url` → `fetch()`), which is what Playwright/Puppeteer actually drive.
- Independent of #924 (which addressed the separate `fetch.rs` `FetchInterceptState` path — that path currently has no production producer): different enum, different functions, no overlap.
- Text consumers that read only `.body` (e.g. document navigation / CSS import loaders) still get the lossy text view; the primary `route.fulfill` → `fetch()` binary path is fixed here.

## Tests

TDD RED→GREEN. New unit test `intercept_fulfill_carries_binary_body_as_base64` proves a non-UTF-8 payload (PNG magic + `0xFF 0xFE 0x00`) round-trips **exactly** through `bodyBase64`. Verified RED first (no `bodyBase64` in the result), then GREEN. Full suites: `obscura-js` **399**, `obscura-cdp` **154**, no regressions.

https://claude.ai/code/session_01W4C7V9e3rXKRY8jn1rYCoY
