### PR TITLE
fix(fetch): send default Referer on same-origin requests

### DIFF
--- a/crates/obscura-js/js/bootstrap.js
+++ b/crates/obscura-js/js/bootstrap.js
@@ -326,7 +326,7 @@ async function __fetchDynClassicScript(task) {
     body = _decodeDataScriptUrl(task.url);
   } else {
     const raw = await Deno.core.ops.op_fetch_url(
-      task.url, "GET", "{}", new Uint8Array(0), task.pageOrigin, "no-cors", "same-origin"
+      task.url, "GET", "{}", new Uint8Array(0), task.pageOrigin, "no-cors", "same-origin", ""
     );
     const parsed = JSON.parse(raw);
     // The HTML script-fetch algorithm treats an unsuccessful HTTP response
@@ -552,7 +552,7 @@ async function _fetchLinkedCss(url, pageOrigin, depth = 0, seen = new Set()) {
   if (depth > 4 || seen.has(url)) return "";
   seen.add(url);
   const raw = await Deno.core.ops.op_fetch_url(
-    url, "GET", "{}", new Uint8Array(0), pageOrigin, "no-cors", "same-origin"
+    url, "GET", "{}", new Uint8Array(0), pageOrigin, "no-cors", "same-origin", ""
   );
   const parsed = JSON.parse(raw);
   if (parsed.blocked || parsed.status >= 400 || parsed.status === 0) {
@@ -7217,8 +7217,21 @@ globalThis.fetch = async (input, init = {}) => {
   if (fetchCredentials !== "omit" && fetchCredentials !== "same-origin" && fetchCredentials !== "include") {
     throw new TypeError("Failed to execute 'fetch': '" + fetchCredentials + "' is not a valid RequestCredentials value");
   }
+  // Default Referer (issue #875): init.referrer wins, then the input
+  // Request's referrer, then about:client resolved to the document URL.
+  // An explicit empty string selects no-referrer. The op applies the
+  // same-origin policy (origin-only cross-origin, no https downgrade).
+  const rawReferrer = init.referrer !== undefined
+    ? init.referrer
+    : (request ? request.referrer : 'about:client');
+  const fetchReferrer = (function() {
+    if (rawReferrer === '' || rawReferrer === 'no-referrer') return '';
+    const docUrl = _domParse("document_url") || "about:blank";
+    try { return new URL(rawReferrer === 'about:client' ? docUrl : String(rawReferrer), docUrl).href; }
+    catch (e) { return ''; }
+  })();
   const pageOrigin = (function() { try { const u = new URL(_domParse("document_url") || "about:blank"); return u.origin; } catch(e) { return ""; } })();
-  const raw = await Deno.core.ops.op_fetch_url(url, method, hdrs, body, pageOrigin, fetchMode, fetchCredentials);
+  const raw = await Deno.core.ops.op_fetch_url(url, method, hdrs, body, pageOrigin, fetchMode, fetchCredentials, fetchReferrer);
   const parsed = JSON.parse(raw);
   if (parsed.blocked) {
     const err = new TypeError('net::ERR_FAILED');
@@ -7634,7 +7647,9 @@ if (typeof Request === 'undefined') {
         throw new TypeError("Failed to construct 'Request': '" + this.credentials + "' is not a valid RequestCredentials value");
       }
       this.redirect = init.redirect || 'follow';
-      this.referrer = init.referrer || '';
+      // Spec default is about:client, resolved to the document URL at fetch
+      // time. An empty init.referrer selects no-referrer explicitly.
+      this.referrer = init.referrer !== undefined ? init.referrer : 'about:client';
       this.signal = init.signal || { aborted: false, addEventListener(){}, removeEventListener(){} };
       this.cache = init.cache || 'default';
     }

--- a/crates/obscura-js/src/ops.rs
+++ b/crates/obscura-js/src/ops.rs
@@ -16,7 +16,8 @@ use obscura_net::{RequestCredentials, RequestMode, ResourceRequest};
 #[cfg(feature = "stealth")]
 use obscura_net::StealthHttpClient;
 use obscura_net::{
-    CallbackRegistry, CookieJar, ObscuraHttpClient, RequestInfo, ResourceType, Response,
+    request_referrer, CallbackRegistry, CookieJar, ObscuraHttpClient, RequestInfo, ResourceType,
+    Response,
 };
 use tokio::sync::Mutex;
 
@@ -2300,6 +2301,18 @@ fn cors_response_allows(
     }
 }
 
+/// Default Referer for scripted fetch()/XHR (issue #875). The JS layer
+/// resolves about:client to the document URL and forwards explicit
+/// init.referrer, so `referrer` here is an absolute URL or empty
+/// (no-referrer). The shared request_referrer policy decides the header
+/// value: document URL same-origin, origin-only cross-origin, none on a
+/// https-to-http downgrade.
+fn default_fetch_referer(referrer: &str, target: &url::Url) -> Option<String> {
+    let source = url::Url::parse(referrer).ok()?;
+    let request = obscura_net::ResourceRequest::subresource(obscura_net::ResourceType::Fetch, &source);
+    request_referrer(&request, target)
+}
+
 #[op2(async)]
 #[string]
 async fn op_fetch_url(
@@ -2311,6 +2324,7 @@ async fn op_fetch_url(
     #[string] origin: String,
     #[string] mode: String,
     #[string] credentials: String,
+    #[string] referrer: String,
 ) -> Result<String, deno_error::JsErrorBox> {
     let body = body.to_vec();
     tracing::debug!(
@@ -2608,6 +2622,7 @@ async fn op_fetch_url(
                 credentials,
                 callbacks.clone(),
                 allow_private_network,
+                referrer.clone(),
             )
             .await;
         }
@@ -2659,6 +2674,20 @@ async fn op_fetch_url(
                 "User-Agent",
                 "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/145.0.0.0 Safari/537.36",
             );
+        }
+        // Default Referer (issue #875): the JS layer resolves about:client to
+        // the document URL and passes explicit init.referrer through, so this
+        // only applies the same-origin policy via the shared request_referrer
+        // plumbing. An explicit Referer header always wins.
+        if !custom_headers
+            .keys()
+            .any(|k| k.eq_ignore_ascii_case("referer"))
+        {
+            if let Ok(target) = url::Url::parse(&current_url) {
+                if let Some(value) = default_fetch_referer(&referrer, &target) {
+                    req = req.header(reqwest::header::REFERER, value);
+                }
+            }
         }
 
         for (k, v) in &custom_headers {
@@ -2925,6 +2954,7 @@ async fn stealth_fetch_all(
     credentials: FetchCredentials,
     callbacks: Option<Arc<CallbackRegistry>>,
     allow_private_network: bool,
+    referrer: String,
 ) -> Result<String, deno_error::JsErrorBox> {
     let mut current_url = url.clone();
     let mut current_method = method;
@@ -2954,6 +2984,14 @@ async fn stealth_fetch_all(
         }
         for (k, v) in &custom_headers {
             req_headers.insert(k.to_lowercase(), v.clone());
+        }
+        // Default Referer (issue #875), mirroring the non-stealth loop below:
+        // an explicit Referer header wins, otherwise the shared
+        // request_referrer policy derives one from the JS-resolved referrer.
+        if !req_headers.contains_key("referer") {
+            if let Some(value) = default_fetch_referer(&referrer, &parsed_current) {
+                req_headers.insert("referer".to_string(), value);
+            }
         }
 
         let credentials_allowed = credentials.allows(&page_origin, &current_url);

--- a/crates/obscura-js/src/runtime.rs
+++ b/crates/obscura-js/src/runtime.rs
@@ -6899,6 +6899,109 @@ mod tests {
         );
     }
 
+    /// Fixture for the fetch() default-Referer tests (issue #875): a raw TCP
+    /// server that captures each request's bytes and answers 200 "ok".
+    fn fetch_referer_fixture(
+        expected_requests: usize,
+    ) -> (String, std::sync::mpsc::Receiver<String>) {
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+        let address = listener.local_addr().unwrap();
+        let (requests_tx, requests_rx) = std::sync::mpsc::channel();
+        std::thread::spawn(move || {
+            use std::io::{Read as _, Write as _};
+
+            for _ in 0..expected_requests {
+                let (mut stream, _) = listener.accept().unwrap();
+                let mut request = [0u8; 8192];
+                let length = stream.read(&mut request).unwrap();
+                requests_tx
+                    .send(String::from_utf8_lossy(&request[..length]).to_string())
+                    .unwrap();
+                let body = "ok";
+                let response = format!(
+                    "HTTP/1.1 200 OK\r\nContent-Type: text/plain\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{body}",
+                    body.len(),
+                );
+                stream.write_all(response.as_bytes()).unwrap();
+            }
+        });
+        (format!("http://{address}"), requests_rx)
+    }
+
+    fn fetch_referer_runtime(origin: &str) -> ObscuraJsRuntime {
+        let mut rt = ObscuraJsRuntime::new();
+        rt.set_dom(parse_html("<html><body></body></html>"));
+        rt.set_url(&format!("{origin}/page?q=1#frag"));
+        rt.set_http_client(std::sync::Arc::new(
+            obscura_net::ObscuraHttpClient::with_full_options(
+                std::sync::Arc::new(obscura_net::CookieJar::new()),
+                None,
+                true,
+            ),
+        ));
+        rt.run_page_init();
+        rt
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn fetch_default_referer_is_document_url() {
+        let (origin, requests) = fetch_referer_fixture(1);
+        let mut rt = fetch_referer_runtime(&origin);
+        rt.execute_script(
+            "fetch-default-referer",
+            "fetch('/echo').then(response => response.text()).then(text => {\
+                 globalThis.__echo = text;\
+             });",
+        )
+        .unwrap();
+        rt.run_event_loop_until_quiescent(3_000, 150)
+            .await
+            .unwrap();
+        assert_eq!(
+            rt.evaluate("globalThis.__echo").unwrap(),
+            serde_json::json!("ok"),
+        );
+        let request = requests
+            .recv_timeout(std::time::Duration::from_secs(1))
+            .expect("fixture fetch was not issued");
+        // Same-origin default: document URL with credentials and fragment
+        // stripped, query kept (matches Headless Chrome 152, issue #875).
+        assert!(
+            request.contains(&format!("\r\nreferer: {origin}/page?q=1\r\n")),
+            "{request}",
+        );
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn fetch_explicit_referrer_overrides_default() {
+        let (origin, requests) = fetch_referer_fixture(1);
+        let mut rt = fetch_referer_runtime(&origin);
+        rt.execute_script(
+            "fetch-explicit-referrer",
+            &format!(
+                "fetch('/echo', {{ referrer: '{origin}/custom/path' }})\
+                 .then(response => response.text()).then(text => {{\
+                     globalThis.__echo = text;\
+                 }});",
+            ),
+        )
+        .unwrap();
+        rt.run_event_loop_until_quiescent(3_000, 150)
+            .await
+            .unwrap();
+        assert_eq!(
+            rt.evaluate("globalThis.__echo").unwrap(),
+            serde_json::json!("ok"),
+        );
+        let request = requests
+            .recv_timeout(std::time::Duration::from_secs(1))
+            .expect("fixture fetch was not issued");
+        assert!(
+            request.contains(&format!("\r\nreferer: {origin}/custom/path\r\n")),
+            "{request}",
+        );
+    }
+
     #[tokio::test(flavor = "current_thread")]
     async fn quiescent_event_loop_bounds_a_hanging_page_request() {
         let (mut rt, accepted) = delayed_fetch_runtime(std::time::Duration::from_secs(3));

--- a/crates/obscura-net/src/client.rs
+++ b/crates/obscura-net/src/client.rs
@@ -427,7 +427,7 @@ pub(crate) fn request_fetch_site(request: &ResourceRequest, target: &Url) -> &'s
     }
 }
 
-pub(crate) fn request_referrer(request: &ResourceRequest, target: &Url) -> Option<String> {
+pub fn request_referrer(request: &ResourceRequest, target: &Url) -> Option<String> {
     let source = request
         .referrer
         .as_ref()

--- a/crates/obscura-net/src/lib.rs
+++ b/crates/obscura-net/src/lib.rs
@@ -8,9 +8,9 @@ pub mod blocklist;
 pub mod wreq_client;
 
 pub use client::{
-    env_allows_private_network, is_forbidden_ip, CallbackRegistry, ObscuraHttpClient,
-    ObscuraNetError, RequestCallback, RequestCredentials, RequestInfo, RequestMode,
-    ResourceRequest, ResourceType, Response, ResponseCallback, SsrfGuardResolver,
+    env_allows_private_network, is_forbidden_ip, request_referrer, CallbackRegistry,
+    ObscuraHttpClient, ObscuraNetError, RequestCallback, RequestCredentials, RequestInfo,
+    RequestMode, ResourceRequest, ResourceType, Response, ResponseCallback, SsrfGuardResolver,
 };
 pub use cookies::{canonical_domain, default_cookie_path, CookieInfo, CookieJar};
 pub use encoding::{


### PR DESCRIPTION
I hit missing Referer headers on same-origin fetch() calls where Chrome (152 behavior) sends the document URL by default, so same-origin observability and referrer-dependent flows break under obscura.

What this does: the `Request` referrer now defaults to `about:client`, resolved in the fetch shim to the document URL and forwarded through the existing `request_referrer` plumbing in obscura-net; an explicit `init.referrer` or `Referer` header still wins, and empty string still means no referrer.

Repro and result: added two runtime tests with a raw-TCP fixture asserting raw wire bytes — `fetch_default_referer_is_document_url` (fragment stripped, query kept) and `fetch_explicit_referrer_overrides_default`. Focused run: 2 passed. Neighboring regression run (credentials forwarding, op-boundary bytes, base-href fetch targets, module referer/cookies, document.referrer): 5 passed. obscura-net shared-policy unit test: 1 passed.

Link: https://github.com/h4ckf0r0day/obscura/issues/875

Fixes #875
