### PR TITLE
fix(cdp): preserve undefined in by-value results

### DIFF
--- a/crates/obscura-cdp/tests/runtime_by_value_undefined.rs
+++ b/crates/obscura-cdp/tests/runtime_by_value_undefined.rs
@@ -1,0 +1,81 @@
+use obscura_cdp::dispatch::{dispatch, CdpContext};
+use obscura_cdp::types::CdpRequest;
+use serde_json::{json, Value};
+
+async fn check_by_value(method: &str, await_promise: bool) {
+    let mut ctx = CdpContext::new();
+    let page_id = ctx.create_page();
+    let session_id = "by-value".to_string();
+    ctx.sessions.insert(session_id.clone(), page_id);
+
+    for (expression, expected_type, expected_value) in [
+        ("undefined", "undefined", None),
+        ("null", "object", Some(Value::Null)),
+        ("0", "number", Some(json!(0.0))),
+        ("false", "boolean", Some(json!(false))),
+        ("''", "string", Some(json!(""))),
+        ("({answer: 42})", "object", Some(json!({"answer": 42}))),
+        ("[null, 1]", "object", Some(json!([null, 1]))),
+    ] {
+        let expression = if await_promise {
+            format!("Promise.resolve({expression})")
+        } else {
+            expression.to_string()
+        };
+        let mut params = json!({"returnByValue": true, "awaitPromise": await_promise});
+        if method == "Runtime.evaluate" {
+            params["expression"] = json!(expression);
+        } else {
+            params["functionDeclaration"] = json!(format!("function() {{ return {expression}; }}"));
+        }
+        let response = dispatch(
+            &CdpRequest {
+                id: 1,
+                method: method.to_string(),
+                params,
+                session_id: Some(session_id.clone()),
+            },
+            &mut ctx,
+        )
+        .await;
+        assert!(response.error.is_none(), "{method}: {:?}", response.error);
+        let reply = response.result.unwrap();
+        assert!(reply.get("exceptionDetails").is_none(), "{reply}");
+        let result = &reply["result"];
+        assert_eq!(
+            result["type"], expected_type,
+            "{method}, {expression}: {reply}"
+        );
+        assert_eq!(
+            result.get("value"),
+            expected_value.as_ref(),
+            "{method}, {expression}: {reply}"
+        );
+        assert!(result.get("objectId").is_none(), "{reply}");
+        if expected_type == "undefined" {
+            assert!(result.get("subtype").is_none(), "{reply}");
+        } else if expected_value == Some(Value::Null) {
+            assert_eq!(result["subtype"], "null", "{reply}");
+        }
+    }
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn evaluate_by_value_preserves_undefined() {
+    check_by_value("Runtime.evaluate", false).await;
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn call_function_on_by_value_preserves_undefined() {
+    check_by_value("Runtime.callFunctionOn", false).await;
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn evaluate_awaited_by_value_preserves_undefined() {
+    check_by_value("Runtime.evaluate", true).await;
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn call_function_on_awaited_by_value_preserves_undefined() {
+    check_by_value("Runtime.callFunctionOn", true).await;
+}

--- a/crates/obscura-js/src/runtime.rs
+++ b/crates/obscura-js/src/runtime.rs
@@ -1998,8 +1998,7 @@ impl ObscuraJsRuntime {
                     format!("globalThis.__obscura_objects['{}']", oid),
                 )
                 .map_err(|e| format!("JS error: {}", e))?;
-            let json_val = self.v8_to_json(read)?;
-            return Ok(Self::info_from_json(&json_val));
+            return self.v8_to_cdp_value(read);
         }
 
         Ok(Self::info_from_meta(&meta_json, Some(oid)))
@@ -2132,8 +2131,7 @@ impl ObscuraJsRuntime {
                         format!("globalThis.__obscura_objects['{}']", oid),
                     )
                     .map_err(|e| format!("JS error: {}", e))?;
-                let json_val = self.v8_to_json(read)?;
-                return Ok(Self::info_from_json(&json_val));
+                return self.v8_to_cdp_value(read);
             }
 
             let meta_result = self
@@ -2168,8 +2166,7 @@ impl ObscuraJsRuntime {
             let result = self
                 .execute_runtime_script("<callFnByValue>", code)
                 .map_err(|e| format!("JS error: {}", e))?;
-            let json_val = self.v8_to_json(result)?;
-            return Ok(Self::info_from_json(&json_val));
+            return self.v8_to_cdp_value(result);
         }
 
         let code = format!(
@@ -3526,6 +3523,31 @@ impl ObscuraJsRuntime {
 
         let s = local.to_rust_string_lossy(scope);
         Ok(serde_json::Value::String(s))
+    }
+
+    fn v8_to_cdp_value(
+        &mut self,
+        result: deno_core::v8::Global<deno_core::v8::Value>,
+    ) -> Result<RemoteObjectInfo, String> {
+        // JSON collapses undefined into null. Classify it before serialization.
+        let is_undefined = {
+            let mut entered = self.runtime();
+            let scope = &mut entered.handle_scope();
+            deno_core::v8::Local::new(scope, &result).is_undefined()
+        };
+        if is_undefined {
+            return Ok(RemoteObjectInfo {
+                thrown: false,
+                js_type: "undefined".into(),
+                subtype: None,
+                class_name: String::new(),
+                description: String::new(),
+                object_id: None,
+                value: None,
+            });
+        }
+        let value = self.v8_to_json(result)?;
+        Ok(Self::info_from_json(&value))
     }
 
     fn info_from_json(value: &serde_json::Value) -> RemoteObjectInfo {


### PR DESCRIPTION
## Change

Preserve JavaScript `undefined` before the by-value CDP result passes through JSON. `Runtime.evaluate` and both `Runtime.callFunctionOn` by-value paths now report `{"type":"undefined"}` instead of `{"type":"object","subtype":"null","value":null}`. Other values use the existing serializer.

Refs #779. This covers the by-value case explicitly left out of #780. It does not change the handle/metadata path, primitive object IDs, numeric descriptions, or unserializable values.

## Reproduction

On the v0.2.2 macOS render+stealth release, both methods collapse synchronous `undefined` and awaited `Promise.resolve(undefined)` into null. Awaited examples:

```js
await cdp.send('Runtime.evaluate', {
  expression: 'undefined', returnByValue: true, awaitPromise: true
});
await cdp.send('Runtime.callFunctionOn', {
  objectId: windowObjectId,
  functionDeclaration: 'function() { return Promise.resolve(undefined); }',
  returnByValue: true, awaitPromise: true
});
```

A local Playwright fixture also reproduces `locator('.missing').count()` throwing `value: expected integer, got object`. Playwright uses `undefined` as its no-match sentinel. Chromium reports zero for that locator and preserves the undefined CDP type.

## Validation

Four CDP regression tests cover synchronous and awaited results from both methods. Each also checks null, zero, false, empty string, object and array controls.

- [Paired fork validation](https://github.com/lkraider/obscura/actions/runs/34359497259) completed and its uploaded logs were reviewed. The four new tests fail on untouched v0.2.2 and pass on this patch in both release/render and release/no-render.
- Existing Linux render suite: 1,632 passed, 4 skipped on both baseline and candidate. Affected no-render suite (`obscura-cdp`, `obscura-js`): 540 passed, 3 skipped on both. New regression tests are run separately from these counts.
- Linux render and no-render CLI builds pass. macOS render+stealth build and focused CDP tests pass.
- Pinned obstacle course (`6ebac8293d7477f59e837768bfd4e74173f04f1c`): baseline and candidate both pass 32/33. Both fail only `observer-intersection` (`expected 'io:50', got ''`). This is a baseline failure, not a full obstacle-course pass. One run without warmup does not establish a performance result.


No network, input, navigation, feature-gate or rendering changes are included. The patch adds one V8 undefined check to the by-value result conversion.
