### PR TITLE
fix(js): enforce CORS preflight permissions

### DIFF
--- a/crates/obscura-js/src/ops.rs
+++ b/crates/obscura-js/src/ops.rs
@@ -2321,6 +2321,162 @@ fn cors_response_allows(
     }
 }
 
+fn is_cors_safelisted_method(method: &reqwest::Method) -> bool {
+    matches!(method.as_str(), "GET" | "HEAD" | "POST")
+}
+
+fn is_cors_unsafe_request_header_byte(byte: u8) -> bool {
+    (byte < 0x20 && byte != b'\t')
+        || matches!(
+            byte,
+            b'"' | b'(' | b')' | b':' | b'<' | b'>' | b'?' | b'@' | b'[' | b'\\'
+                | b']' | b'{' | b'}' | 0x7f
+        )
+}
+
+fn is_http_token_byte(byte: u8) -> bool {
+    byte.is_ascii_alphanumeric()
+        || matches!(
+            byte,
+            b'!' | b'#' | b'$' | b'%' | b'&' | b'\'' | b'*' | b'+' | b'-' | b'.'
+                | b'^' | b'_' | b'`' | b'|' | b'~'
+        )
+}
+
+fn is_cors_safelisted_content_type(value: &str) -> bool {
+    if value.bytes().any(is_cors_unsafe_request_header_byte) {
+        return false;
+    }
+
+    // A MIME type must have a valid type/subtype before its parameters. This
+    // is deliberately narrower than merely splitting at ';': malformed values
+    // must not turn an application/json request into a simple request.
+    let essence = value
+        .split_once(';')
+        .map_or(value, |(essence, _)| essence)
+        .trim_matches([' ', '\t']);
+    let Some((type_, subtype)) = essence.split_once('/') else {
+        return false;
+    };
+    if type_.is_empty()
+        || subtype.is_empty()
+        || !type_.bytes().all(is_http_token_byte)
+        || !subtype.bytes().all(is_http_token_byte)
+    {
+        return false;
+    }
+
+    essence.eq_ignore_ascii_case("application/x-www-form-urlencoded")
+        || essence.eq_ignore_ascii_case("multipart/form-data")
+        || essence.eq_ignore_ascii_case("text/plain")
+}
+
+fn decimal_is_at_most(left: &str, right: &str) -> bool {
+    let left = left.trim_start_matches('0');
+    let right = right.trim_start_matches('0');
+    left.len() < right.len() || (left.len() == right.len() && left <= right)
+}
+
+fn is_cors_safelisted_range(value: &str) -> bool {
+    let Some(range) = value.strip_prefix("bytes=") else {
+        return false;
+    };
+    let Some((start, end)) = range.split_once('-') else {
+        return false;
+    };
+    if start.is_empty()
+        || !start.bytes().all(|byte| byte.is_ascii_digit())
+        || !end.bytes().all(|byte| byte.is_ascii_digit())
+    {
+        return false;
+    }
+    end.is_empty() || decimal_is_at_most(start, end)
+}
+
+fn is_cors_safelisted_request_header(name: &str, value: &str) -> bool {
+    if value.len() > 128 {
+        return false;
+    }
+    if name.eq_ignore_ascii_case("accept") {
+        return !value.bytes().any(is_cors_unsafe_request_header_byte);
+    }
+    if name.eq_ignore_ascii_case("accept-language")
+        || name.eq_ignore_ascii_case("content-language")
+    {
+        return value.bytes().all(|byte| {
+            byte.is_ascii_alphanumeric() || matches!(byte, b' ' | b'*' | b',' | b'-' | b'.' | b';' | b'=')
+        });
+    }
+    if name.eq_ignore_ascii_case("content-type") {
+        return is_cors_safelisted_content_type(value);
+    }
+    if name.eq_ignore_ascii_case("range") {
+        return is_cors_safelisted_range(value);
+    }
+    false
+}
+
+/// Return the sorted, lowercase header names that must be authorized by a
+/// CORS preflight. The aggregate safelist cap is observable only on unusual
+/// requests and does not add work to same-origin requests.
+fn cors_unsafe_request_header_names(headers: &HashMap<String, String>) -> Vec<String> {
+    let mut unsafe_names = Vec::new();
+    let mut safelist_value_size = 0usize;
+
+    for (name, value) in headers {
+        if is_cors_safelisted_request_header(name, value) {
+            safelist_value_size = safelist_value_size.saturating_add(value.len());
+        } else {
+            unsafe_names.push(name.to_ascii_lowercase());
+        }
+    }
+    if safelist_value_size > 1024 {
+        unsafe_names.extend(
+            headers
+                .iter()
+                .filter(|(name, value)| is_cors_safelisted_request_header(name, value))
+                .map(|(name, _)| name.to_ascii_lowercase()),
+        );
+    }
+    unsafe_names.sort_unstable();
+    unsafe_names.dedup();
+    unsafe_names
+}
+
+fn parse_cors_header_list<'a>(
+    headers: &'a reqwest::header::HeaderMap,
+    name: &'static str,
+) -> Option<Vec<&'a str>> {
+    let mut items = Vec::new();
+    for value in headers.get_all(name).iter() {
+        let value = value.to_str().ok()?;
+        for item in value.split(',') {
+            let item = item.trim_matches([' ', '\t']);
+            if item.is_empty() || !item.bytes().all(is_http_token_byte) {
+                return None;
+            }
+            items.push(item);
+        }
+    }
+    Some(items)
+}
+
+fn preflight_allows_method(method: &reqwest::Method, allowed: &[&str], credentialed: bool) -> bool {
+    is_cors_safelisted_method(method)
+        || allowed.iter().any(|allowed| {
+            *allowed == method.as_str() || (*allowed == "*" && !credentialed)
+        })
+}
+
+fn preflight_allows_header(name: &str, allowed: &[&str], credentialed: bool) -> bool {
+    allowed
+        .iter()
+        .any(|allowed| allowed.eq_ignore_ascii_case(name))
+        || (!name.eq_ignore_ascii_case("authorization")
+            && !credentialed
+            && allowed.contains(&"*"))
+}
+
 /// Build the JS-facing result for an intercepted request a CDP client chose to
 /// fulfill (`Fetch.fulfillRequest`). Mirrors the normal fetch result contract:
 /// `body` is a lossy text view and `bodyBase64` carries the exact bytes, which
@@ -2570,33 +2726,28 @@ async fn op_fetch_url(
         }
     }
 
+    let unsafe_header_names = if is_cross_origin && mode == "cors" {
+        cors_unsafe_request_header_names(&custom_headers)
+    } else {
+        Vec::new()
+    };
     let needs_preflight = is_cross_origin
         && mode == "cors"
-        && (req_method != reqwest::Method::GET
-            && req_method != reqwest::Method::HEAD
-            && req_method != reqwest::Method::POST
-            || custom_headers.keys().any(|k| {
-                let kl = k.to_lowercase();
-                kl != "accept"
-                    && kl != "accept-language"
-                    && kl != "content-language"
-                    && kl != "content-type"
-            }));
+        && (!is_cors_safelisted_method(&req_method) || !unsafe_header_names.is_empty());
 
     if needs_preflight {
-        let preflight = client
+        let mut preflight_request = client
             .request(reqwest::Method::OPTIONS, &url)
             .timeout(fetch_timeout())
             .header("Origin", &page_origin)
-            .header("Access-Control-Request-Method", method.as_str())
-            .header(
+            .header("Access-Control-Request-Method", method.as_str());
+        if !unsafe_header_names.is_empty() {
+            preflight_request = preflight_request.header(
                 "Access-Control-Request-Headers",
-                custom_headers
-                    .keys()
-                    .cloned()
-                    .collect::<Vec<_>>()
-                    .join(", "),
-            )
+                unsafe_header_names.join(","),
+            );
+        }
+        let preflight = preflight_request
             .send()
             .await
             .map_err(|e| {
@@ -2618,6 +2769,47 @@ async fn op_fetch_url(
             return Err(deno_error::JsErrorBox::generic(format!(
                 "CORS preflight: Origin '{}' not allowed by Access-Control-Allow-Origin '{}'",
                 page_origin, allowed_origin
+            )));
+        }
+        if !preflight.status().is_success() {
+            return Err(deno_error::JsErrorBox::generic(format!(
+                "CORS preflight returned HTTP {}",
+                preflight.status()
+            )));
+        }
+
+        let allowed_methods = parse_cors_header_list(
+            preflight.headers(),
+            "access-control-allow-methods",
+        )
+        .ok_or_else(|| {
+            deno_error::JsErrorBox::generic(
+                "CORS preflight returned an invalid Access-Control-Allow-Methods value",
+            )
+        })?;
+        let allowed_headers = parse_cors_header_list(
+            preflight.headers(),
+            "access-control-allow-headers",
+        )
+        .ok_or_else(|| {
+            deno_error::JsErrorBox::generic(
+                "CORS preflight returned an invalid Access-Control-Allow-Headers value",
+            )
+        })?;
+        let credentialed = credentials == FetchCredentials::Include;
+        if !preflight_allows_method(&req_method, &allowed_methods, credentialed) {
+            return Err(deno_error::JsErrorBox::generic(format!(
+                "CORS preflight did not allow method '{}'",
+                req_method
+            )));
+        }
+        if let Some(name) = unsafe_header_names
+            .iter()
+            .find(|name| !preflight_allows_header(name, &allowed_headers, credentialed))
+        {
+            return Err(deno_error::JsErrorBox::generic(format!(
+                "CORS preflight did not allow request header '{}'",
+                name
             )));
         }
     }
@@ -3139,11 +3331,15 @@ fn glob_match(pattern: &str, url: &str) -> bool {
 #[cfg(test)]
 mod tests {
     use super::{
-        cors_response_allows, glob_match, validate_fetch_url, FetchCredentials, ObscuraState,
+        cors_response_allows, cors_unsafe_request_header_names, glob_match,
+        is_cors_safelisted_content_type, is_cors_safelisted_request_header,
+        parse_cors_header_list, preflight_allows_header, preflight_allows_method,
+        validate_fetch_url, FetchCredentials, ObscuraState,
     };
     use crate::runtime::ObscuraJsRuntime;
     use obscura_dom::parse_html;
     use std::cell::RefCell;
+    use std::collections::HashMap;
     use std::rc::Rc;
 
     #[cfg(feature = "render")]
@@ -3159,6 +3355,139 @@ mod tests {
     use super::{pbkdf2_derive, push_capped, PBKDF2_MAX_ITERATIONS, PBKDF2_MAX_OUTPUT_BYTES};
     use super::intercept_fulfill_response;
     use base64::{engine::general_purpose::STANDARD as FULFILL_BASE64, Engine as _};
+
+    #[test]
+    fn cors_request_header_safelist_checks_values() {
+        assert!(is_cors_safelisted_content_type(
+            "application/x-www-form-urlencoded;charset=UTF-8"
+        ));
+        assert!(is_cors_safelisted_content_type(
+            "multipart/form-data; boundary=test"
+        ));
+        assert!(is_cors_safelisted_content_type("text/plain"));
+        assert!(!is_cors_safelisted_content_type("application/json"));
+        assert!(!is_cors_safelisted_content_type("text /plain"));
+
+        assert!(is_cors_safelisted_request_header(
+            "Accept-Language",
+            "en-US, en;q=0.9"
+        ));
+        assert!(!is_cors_safelisted_request_header(
+            "Accept-Language",
+            "en_US"
+        ));
+        assert!(!is_cors_safelisted_request_header(
+            "Accept",
+            &"a".repeat(129)
+        ));
+        assert!(is_cors_safelisted_request_header("Range", "bytes=0-499"));
+        assert!(is_cors_safelisted_request_header("Range", "bytes=500-"));
+        assert!(!is_cors_safelisted_request_header("Range", "bytes=-500"));
+        assert!(!is_cors_safelisted_request_header("Range", "bytes=500-499"));
+        assert!(!is_cors_safelisted_request_header(
+            "Range",
+            "bytes=0-1,4-5"
+        ));
+    }
+
+    #[test]
+    fn cors_unsafe_header_names_are_lowercase_sorted_and_only_include_unsafe_headers() {
+        let headers = HashMap::from([
+            ("Content-Type".to_string(), "application/json".to_string()),
+            ("X-Trace".to_string(), "1".to_string()),
+            ("Accept".to_string(), "text/html".to_string()),
+            ("Range".to_string(), "bytes=0-99".to_string()),
+        ]);
+        assert_eq!(
+            cors_unsafe_request_header_names(&headers),
+            vec!["content-type", "x-trace"]
+        );
+    }
+
+    #[test]
+    fn cors_safelist_aggregate_cap_forces_preflight() {
+        let mut headers = HashMap::new();
+        for bits in 0..9u8 {
+            let name = "accept"
+                .bytes()
+                .enumerate()
+                .map(|(index, byte)| {
+                    if bits & (1 << index) == 0 {
+                        byte as char
+                    } else {
+                        (byte as char).to_ascii_uppercase()
+                    }
+                })
+                .collect::<String>();
+            headers.insert(name, "a".repeat(128));
+        }
+        assert_eq!(cors_unsafe_request_header_names(&headers), vec!["accept"]);
+    }
+
+    #[test]
+    fn cors_preflight_permissions_follow_credentials_and_authorization_rules() {
+        assert!(preflight_allows_method(
+            &reqwest::Method::POST,
+            &[],
+            true
+        ));
+        assert!(preflight_allows_method(
+            &reqwest::Method::DELETE,
+            &["DELETE"],
+            true
+        ));
+        assert!(!preflight_allows_method(
+            &reqwest::Method::DELETE,
+            &["delete"],
+            false
+        ));
+        assert!(preflight_allows_method(
+            &reqwest::Method::DELETE,
+            &["*"],
+            false
+        ));
+        assert!(!preflight_allows_method(
+            &reqwest::Method::DELETE,
+            &["*"],
+            true
+        ));
+
+        assert!(preflight_allows_header(
+            "Authorization",
+            &["authorization"],
+            true
+        ));
+        assert!(!preflight_allows_header(
+            "Authorization",
+            &["*"],
+            false
+        ));
+        assert!(preflight_allows_header("X-Trace", &["*"], false));
+        assert!(!preflight_allows_header("X-Trace", &["*"], true));
+    }
+
+    #[test]
+    fn cors_preflight_rejects_malformed_permission_lists() {
+        let mut headers = reqwest::header::HeaderMap::new();
+        headers.append(
+            "access-control-allow-methods",
+            "GET, DELETE".parse().unwrap(),
+        );
+        headers.append(
+            "access-control-allow-methods",
+            "PATCH".parse().unwrap(),
+        );
+        assert_eq!(
+            parse_cors_header_list(&headers, "access-control-allow-methods"),
+            Some(vec!["GET", "DELETE", "PATCH"])
+        );
+
+        headers.append(
+            "access-control-allow-methods",
+            "@invalid".parse().unwrap(),
+        );
+        assert!(parse_cors_header_list(&headers, "access-control-allow-methods").is_none());
+    }
 
     // #912 — a fulfilled binary body (non-UTF-8) must survive as exact bytes via
     // `bodyBase64`, not be silently corrupted by the lossy `body` text view.

--- a/crates/obscura-js/src/runtime.rs
+++ b/crates/obscura-js/src/runtime.rs
@@ -16266,6 +16266,85 @@ mod tests {
         );
     }
 
+    fn cors_preflight_runtime() -> (
+        ObscuraJsRuntime,
+        String,
+        std::sync::mpsc::Receiver<String>,
+    ) {
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+        let address = listener.local_addr().unwrap();
+        let target = format!("http://{address}/resource");
+        let (requests_tx, requests_rx) = std::sync::mpsc::channel();
+        std::thread::spawn(move || {
+            use std::io::{Read as _, Write as _};
+
+            for _ in 0..2 {
+                let Ok((mut stream, _)) = listener.accept() else {
+                    return;
+                };
+                let mut request = [0u8; 4096];
+                let length = stream.read(&mut request).unwrap_or(0);
+                let request = String::from_utf8_lossy(&request[..length]).to_string();
+                requests_tx.send(request.clone()).unwrap();
+                let response = if request.starts_with("OPTIONS ") {
+                    "HTTP/1.1 204 No Content\r\n\
+                     Access-Control-Allow-Origin: *\r\n\
+                     Access-Control-Allow-Headers: content-type\r\n\
+                     Content-Length: 0\r\nConnection: close\r\n\r\n"
+                        .to_string()
+                } else {
+                    "HTTP/1.1 200 OK\r\n\
+                     Access-Control-Allow-Origin: *\r\n\
+                     Content-Length: 2\r\nConnection: close\r\n\r\nok"
+                        .to_string()
+                };
+                stream.write_all(response.as_bytes()).unwrap();
+            }
+        });
+
+        let rt = setup_runtime("<html><body></body></html>");
+        rt.set_http_client(std::sync::Arc::new(
+            obscura_net::ObscuraHttpClient::with_full_options(
+                std::sync::Arc::new(obscura_net::CookieJar::new()),
+                None,
+                true,
+            ),
+        ));
+        (rt, target, requests_rx)
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn denied_preflight_never_sends_the_unsafe_request() {
+        let (mut rt, target, requests) = cors_preflight_runtime();
+        let result = rt
+            .call_function_on_for_cdp(
+                &format!(
+                    r#"async () => await fetch({target:?}, {{
+                        method: "DELETE",
+                        headers: {{ "Authorization": "Bearer test" }},
+                    }}).then(() => "resolved", () => "rejected")"#
+                ),
+                None,
+                &[],
+                true,
+                true,
+            )
+            .await
+            .unwrap();
+        assert_eq!(result.value, Some(serde_json::json!("rejected")));
+
+        let preflight = requests
+            .recv_timeout(std::time::Duration::from_secs(1))
+            .expect("preflight request");
+        assert!(preflight.starts_with("OPTIONS /resource "), "{preflight}");
+        assert!(
+            requests
+                .recv_timeout(std::time::Duration::from_millis(100))
+                .is_err(),
+            "the denied DELETE request reached the server"
+        );
+    }
+
     #[tokio::test(flavor = "current_thread")]
     async fn fetch_preserves_binary_body_sources_at_the_op_boundary() {
         let mut rt = setup_runtime("<html><body></body></html>");


### PR DESCRIPTION
## What changed

Fixes #942.

Cross-origin `fetch()` and XHR requests now perform and validate CORS preflights when the method or request headers are not safelisted.

The implementation validates:

* safelisted header values and size limits
* requested methods and headers
* malformed preflight response lists
* credentialed wildcard responses
* explicit authorization-header permission
* unsuccessful preflight HTTP responses

A rejected preflight stops the actual request from being sent. Same-origin requests and ordinary safelisted requests keep their existing fast path.

## Validation

Ran the six focused CORS tests with and without rendering:

```bash
cargo nextest run --release --features render -p obscura-js
cargo nextest run --release -p obscura-js
```

This includes an end-to-end regression test confirming that a denied preflight never sends the unsafe request.

Also validated the combined merge candidate:

```bash
cargo nextest run --release --features render --no-fail-fast
CARGO_INCREMENTAL=0 CARGO_BUILD_JOBS=2 cargo build --release -p obscura-cli --bins --features render
OBSCURA_BIN=./target/release/obscura python3 obstacle-course/run.py --runs 1 --warmup 0
```

The full parallel suite ran 1,695 tests. Four timing-sensitive tests failed under suite-wide load and all four passed when rerun serially. The obstacle course passed 33/33.

## Rendering

Not applicable.

## Performance

Preflight classification runs only for cross-origin requests using CORS mode. Same-origin requests do not scan or parse headers.

Obstacle-course median latency:

* main: 3046.2 ms
* candidate: 3045.3 ms

No measurable regression.

## Checklist

* [x] The change is focused and does not remove existing behavior without justification.
* [x] Tests cover the failure or feature.
* [x] Existing tests pass, including render and no-render configurations when affected.
* [x] I checked for CPU, latency, and memory regressions.
* [x] Public API or user-facing behavior changes are documented.
