### PR TITLE
fix(mcp): include script requests in network history

### DIFF
--- a/crates/obscura-mcp/src/lib.rs
+++ b/crates/obscura-mcp/src/lib.rs
@@ -1164,6 +1164,7 @@ async fn tool_wait_for(args: &Value, state: &mut BrowserState) -> Result<String,
 
 fn tool_network_requests(state: &mut BrowserState) -> Result<String, String> {
     let page = state.page_mut();
+    page.sync_js_network_events();
     let events = &page.network_events;
 
     if events.is_empty() {
@@ -2249,6 +2250,43 @@ mod tests {
         assert!(
             submitted.contains("q=hello"),
             "the submitted body must carry the filled field, got {submitted}"
+        );
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn network_tool_includes_completed_script_fetches() {
+        std::env::set_var("OBSCURA_ALLOW_PRIVATE_NETWORK", "1");
+        let (base, requests) = spawn_form_recording_server();
+        let mut state = BrowserState::new(None, None, false);
+        state
+            .page_mut()
+            .navigate(&base)
+            .await
+            .expect("test page should navigate");
+        requests
+            .recv_timeout(std::time::Duration::from_secs(2))
+            .expect("the test page itself must be fetched");
+
+        let fetch_url = serde_json::to_string(&format!("{base}/script-request"))
+            .expect("fetch URL should serialize");
+        state.page_mut().evaluate(&format!(
+            "fetch({fetch_url}).then(() => document.body.id = 'fetch-complete')"
+        ));
+        tool_wait_for(
+            &json!({ "selector": "#fetch-complete", "timeout": 2 }),
+            &mut state,
+        )
+        .await
+        .expect("script fetch should complete");
+        let request = requests
+            .recv_timeout(std::time::Duration::from_secs(2))
+            .expect("the script fetch must reach the server");
+        assert!(request.starts_with("GET /script-request"), "got {request}");
+
+        let output = tool_network_requests(&mut state).expect("network tool should succeed");
+        assert!(
+            output.contains("/script-request"),
+            "completed script fetch missing from network history: {output}"
         );
     }
 


### PR DESCRIPTION
<html><head></head><body><h2>What changed</h2><p>Synchronize pending JavaScript network events before returning <code>browser_network_requests</code>.</p><p>Fetch and XHR requests were already recorded by the runtime, but the MCP tool read the page history without draining those events first. As a result, completed script requests were missing from its output.</p><p>Adds a regression test that performs a real script fetch and verifies that it appears in MCP network history.</p><p>Fixes #950.</p><h2>Validation</h2><ul><li><p><code>cargo nextest run --release --features render -p obscura-mcp -E 'test(network_tool_includes_completed_script_fetches)' --test-threads=1</code></p><ul><li><p>1 passed</p></li></ul></li><li><p><code>cargo nextest run --release --features render -p obscura-mcp --no-fail-fast --test-threads=1</code></p><ul><li><p>16 passed</p></li></ul></li><li><p><code>cargo nextest run --release -p obscura-mcp --no-fail-fast --test-threads=1</code></p><ul><li><p>15 passed</p></li></ul></li><li><p><code>cargo build --release -p obscura-cli --bins --features render</code></p><ul><li><p>Passed</p></li></ul></li><li><p><code>python3 scripts/ci/perf_smoke.py --base &lt;base-binary&gt; --candidate &lt;candidate-binary&gt; --output /tmp/obscura-p1-950-perf.json</code></p><ul><li><p>Passed</p></li></ul></li></ul><h2>Rendering</h2><p>Not applicable.</p><h2>Performance</h2><p>The synchronization occurs only when <code>browser_network_requests</code> is explicitly called. It drains events already recorded by the runtime and adds no polling or background work.</p><p>Interleaved five-round latency/RSS comparison:</p>
Scenario | Base latency | Candidate latency | Base RSS | Candidate RSS
-- | -- | -- | -- | --
DOM build | 467.4 ms | 368.0 ms | 51.1 MiB | 51.0 MiB
Storage | 65.9 ms | 65.7 ms | 36.9 MiB | 37.6 MiB

<p>The performance gate passed with no regression.</p><h2>Checklist</h2><ul class="contains-task-list"><li class="task-list-item"><p><input type="checkbox" checked="checked" disabled="disabled"> The change is focused and does not remove existing behavior without justification.</p></li><li class="task-list-item"><p><input type="checkbox" checked="checked" disabled="disabled"> Tests cover the failure or feature.</p></li><li class="task-list-item"><p><input type="checkbox" checked="checked" disabled="disabled"> Existing tests pass, including render and no-render configurations when affected.</p></li><li class="task-list-item"><p><input type="checkbox" checked="checked" disabled="disabled"> I checked for CPU, latency, and memory regressions.</p></li><li class="task-list-item"><p><input type="checkbox" checked="checked" disabled="disabled"> Public API or user-facing behavior changes are documented.</p></li></ul></body></html>