### PR TITLE
fix(mcp): collect page console messages

### DIFF
--- a/crates/obscura-browser/src/page.rs
+++ b/crates/obscura-browser/src/page.rs
@@ -316,6 +316,7 @@ pub struct Page {
     /// Page-owned so the subscription survives replacement of the JS runtime
     /// during navigation.
     runtime_events_enabled: std::cell::Cell<bool>,
+    console_messages_enabled: std::cell::Cell<bool>,
     pending_frame_work: std::collections::VecDeque<PendingFrameWork>,
     /// Document-owned HTML script preparation flags saved while the V8 realm
     /// is suspended for CDP/MCP tab switching.  These are restored only when
@@ -1162,6 +1163,7 @@ impl Page {
             intercept_tx: None,
             preload_scripts: Vec::new(),
             runtime_events_enabled: std::cell::Cell::new(false),
+            console_messages_enabled: std::cell::Cell::new(false),
             pending_frame_work: std::collections::VecDeque::new(),
             suspended_started_script_ids: Vec::new(),
             suspended_cdp_object_state: obscura_js::runtime::CdpObjectState::default(),
@@ -1863,6 +1865,7 @@ impl Page {
         #[cfg(feature = "render")]
         rt.set_intercept_block_patterns(self.intercept_block_patterns.clone());
         rt.set_runtime_events_enabled(self.runtime_events_enabled.get());
+        rt.set_console_messages_enabled(self.console_messages_enabled.get());
 
         if let Some(dom) = self.dom.take() {
             rt.set_dom(dom);
@@ -4571,10 +4574,24 @@ impl Page {
         }
     }
 
+    pub fn take_pending_console_messages(&mut self) -> Vec<String> {
+        self.js
+            .as_ref()
+            .map(ObscuraJsRuntime::take_pending_console_messages)
+            .unwrap_or_default()
+    }
+
     pub fn set_runtime_events_enabled(&self, enabled: bool) {
         self.runtime_events_enabled.set(enabled);
         if let Some(js) = &self.js {
             js.set_runtime_events_enabled(enabled);
+        }
+    }
+
+    pub fn set_console_messages_enabled(&self, enabled: bool) {
+        self.console_messages_enabled.set(enabled);
+        if let Some(js) = &self.js {
+            js.set_console_messages_enabled(enabled);
         }
     }
 

--- a/crates/obscura-js/src/ops.rs
+++ b/crates/obscura-js/src/ops.rs
@@ -140,6 +140,8 @@ pub struct ObscuraState {
     // The CDP layer drains this after commands and autonomous event-loop turns.
     pub pending_runtime_events: VecDeque<RuntimeEvent>,
     pub runtime_events_enabled: bool,
+    pub pending_console_messages: VecDeque<String>,
+    pub console_messages_enabled: bool,
     pub runtime_exception_counter: u64,
     pub network_response_bodies: HashMap<String, StoredNetworkResponseBody>,
     pub network_response_body_order: VecDeque<String>,
@@ -356,6 +358,8 @@ impl ObscuraState {
             pending_binding_calls: Vec::new(),
             pending_runtime_events: VecDeque::new(),
             runtime_events_enabled: false,
+            pending_console_messages: VecDeque::new(),
+            console_messages_enabled: false,
             runtime_exception_counter: 0,
             network_response_bodies: HashMap::new(),
             network_response_body_order: VecDeque::new(),
@@ -2291,6 +2295,13 @@ fn op_console_msg(
 
     let page = state.borrow::<SharedState>().clone();
     let mut page = page.borrow_mut();
+    if page.console_messages_enabled {
+        if page.pending_console_messages.len() >= 1_024 {
+            page.pending_console_messages.pop_front();
+        }
+        page.pending_console_messages
+            .push_back(format!("[{level}] {msg}"));
+    }
     if !page.runtime_events_enabled {
         return;
     }

--- a/crates/obscura-js/src/runtime.rs
+++ b/crates/obscura-js/src/runtime.rs
@@ -1245,6 +1245,18 @@ impl ObscuraJsRuntime {
         self.state.borrow_mut().runtime_events_enabled = enabled;
     }
 
+    pub fn set_console_messages_enabled(&self, enabled: bool) {
+        self.state.borrow_mut().console_messages_enabled = enabled;
+    }
+
+    pub fn take_pending_console_messages(&self) -> Vec<String> {
+        self.state
+            .borrow_mut()
+            .pending_console_messages
+            .drain(..)
+            .collect()
+    }
+
     fn record_uncaught_exception(&self, error: &deno_core::error::JsError, fallback_url: &str) {
         let mut state = self.state.borrow_mut();
         if !state.runtime_events_enabled {

--- a/crates/obscura-mcp/src/lib.rs
+++ b/crates/obscura-mcp/src/lib.rs
@@ -100,7 +100,9 @@ impl BrowserState {
         if self.active_tab.is_none() {
             self.tab_counter += 1;
             let id = format!("tab-{}", self.tab_counter);
-            self.tabs.insert(id.clone(), Page::new("mcp-page".to_string(), self.context.clone()));
+            let page = Page::new("mcp-page".to_string(), self.context.clone());
+            page.set_console_messages_enabled(true);
+            self.tabs.insert(id.clone(), page);
             self.active_tab = Some(id);
         }
         let id = self.active_tab.as_ref().unwrap().clone();
@@ -111,7 +113,9 @@ impl BrowserState {
     fn new_tab(&mut self) -> String {
         self.tab_counter += 1;
         let id = format!("tab-{}", self.tab_counter);
-        self.tabs.insert(id.clone(), Page::new(format!("mcp-{id}"), self.context.clone()));
+        let page = Page::new(format!("mcp-{id}"), self.context.clone());
+        page.set_console_messages_enabled(true);
+        self.tabs.insert(id.clone(), page);
         self.active_tab = Some(id.clone());
         self.interactive_refs.clear();
         id
@@ -1177,7 +1181,13 @@ fn tool_network_requests(state: &mut BrowserState) -> Result<String, String> {
     Ok(lines.join("\n"))
 }
 
-fn tool_console_messages(state: &BrowserState) -> Result<String, String> {
+fn tool_console_messages(state: &mut BrowserState) -> Result<String, String> {
+    let messages = state.page_mut().take_pending_console_messages();
+    state.console_messages.extend(messages);
+    if state.console_messages.len() > 1_024 {
+        let overflow = state.console_messages.len() - 1_024;
+        state.console_messages.drain(..overflow);
+    }
     if state.console_messages.is_empty() {
         Ok("No console messages.".to_string())
     } else {
@@ -2165,6 +2175,38 @@ mod tests {
             &mut state,
         ).await.result.expect("invalid PDF response");
         assert_eq!(invalid_pdf["isError"], true);
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn console_tool_returns_page_messages() {
+        const PAGE: &str = "data:text/html,<button id=log>Log</button><script>\
+            console.error('mcp-console-inline');\
+            document.getElementById('log').onclick=()=>{\
+                console.error('mcp-console-click');\
+                setTimeout(()=>{console.error('mcp-console-async');document.body.id='done'},25)\
+            }</script>";
+        let mut state = BrowserState::new(None, None, false);
+        state
+            .page_mut()
+            .navigate(PAGE)
+            .await
+            .expect("console test page should navigate");
+
+        let inline = tool_console_messages(&mut state).expect("console tool should succeed");
+        assert!(
+            inline.contains("mcp-console-inline"),
+            "inline console message missing from MCP output: {inline}"
+        );
+
+        tool_click(&json!({ "selector": "#log" }), &mut state)
+            .await
+            .expect("console test button should be clickable");
+        tool_wait_for(&json!({ "selector": "#done", "timeout": 2 }), &mut state)
+            .await
+            .expect("asynchronous console callback should complete");
+        let later = tool_console_messages(&mut state).expect("console tool should succeed");
+        assert!(later.contains("mcp-console-click"), "{later}");
+        assert!(later.contains("mcp-console-async"), "{later}");
     }
 
     /// Records the method, path and body of every request it serves, so a test


### PR DESCRIPTION
<html><head></head><body><h2>What changed</h2><p>Connect page console output to the existing <code>browser_console_messages</code> MCP tool.</p><p>MCP pages now enable a lightweight console capture path that records formatted messages in a bounded 1,024-entry queue. The tool drains that queue into its existing history before returning results.</p><p>The capture path is enabled only for MCP pages. It does not enable CDP runtime events, serialize remote objects, or retain JavaScript argument handles.</p><p>Adds regression coverage for console messages produced by inline scripts, click handlers, and asynchronous timer callbacks.</p><p>Fixes #951.</p><h2>Validation</h2><ul><li><p><code>cargo nextest run --release --features render -p obscura-mcp -E 'test(console_tool_returns_page_messages)' --test-threads=1</code></p><ul><li><p>1 passed</p></li></ul></li><li><p><code>cargo nextest run --release --features render -p obscura-mcp --no-fail-fast --test-threads=1</code></p><ul><li><p>16 passed</p></li></ul></li><li><p><code>cargo nextest run --release -p obscura-mcp --no-fail-fast --test-threads=1</code></p><ul><li><p>15 passed</p></li></ul></li><li><p><code>cargo nextest run --release --features render --no-fail-fast</code></p><ul><li><p>1,696 passed, 4 skipped</p></li></ul></li><li><p><code>cargo build --release -p obscura-cli --bins --features render</code></p><ul><li><p>Passed</p></li></ul></li><li><p><code>OBSCURA_BIN=/root/obscura2/repo/target/release/obscura python3 obstacle-course/run.py --runs 1 --warmup 0</code></p><ul><li><p>33/33 stages passed</p></li></ul></li><li><p><code>python3 scripts/ci/perf_smoke.py --base &lt;base-binary&gt; --candidate &lt;candidate-binary&gt; --output /tmp/obscura-p1-951-perf.json</code></p><ul><li><p>Passed</p></li></ul></li></ul><h2>Rendering</h2><p>Not applicable.</p><h2>Performance</h2><p>Console capture remains disabled outside MCP. For MCP pages, each console call adds one bounded string entry and removes the oldest entry once the 1,024-message limit is reached.</p><p>Interleaved five-round latency/RSS comparison:</p>
Scenario | Base latency | Candidate latency | Change | Base RSS | Candidate RSS | Change
-- | -- | -- | -- | -- | -- | --
DOM build | 367.0 ms | 367.0 ms | -0.0% | 51.4 MiB | 51.0 MiB | -0.6%
Storage | 66.1 ms | 66.1 ms | -0.1% | 37.4 MiB | 38.0 MiB | +1.5%

<p>The performance gate passed with no meaningful latency or memory regression.</p><h2>Checklist</h2><ul class="contains-task-list"><li class="task-list-item"><p><input type="checkbox" checked="checked" disabled="disabled"> The change is focused and does not remove existing behavior without justification.</p></li><li class="task-list-item"><p><input type="checkbox" checked="checked" disabled="disabled"> Tests cover the failure or feature.</p></li><li class="task-list-item"><p><input type="checkbox" checked="checked" disabled="disabled"> Existing tests pass, including render and no-render configurations when affected.</p></li><li class="task-list-item"><p><input type="checkbox" checked="checked" disabled="disabled"> I checked for CPU, latency, and memory regressions.</p></li><li class="task-list-item"><p><input type="checkbox" checked="checked" disabled="disabled"> Public API or user-facing behavior changes are documented.</p></li></ul></body></html>