### PR TITLE
fix(cdp): preserve canonical node wrappers when resolving handles

### DIFF
--- a/crates/obscura-cdp/src/domains/dom.rs
+++ b/crates/obscura-cdp/src/domains/dom.rs
@@ -187,17 +187,8 @@ pub async fn handle(
             let js_code = format!(
                 "(function() {{\
                     var nid = {};\
-                    var node = null;\
-                    if (globalThis._cache && globalThis._cache.has(nid)) {{\
-                        node = globalThis._cache.get(nid);\
-                    }} else {{\
-                        var t = +Deno.core.ops.op_dom('node_type', String(nid), '', globalThis.__obscura_frameId >>> 0);\
-                        if (t === 1) node = new Element(nid);\
-                        else if (t === 9) node = globalThis.document;\
-                        else node = new Node(nid);\
-                        if (globalThis._cache) globalThis._cache.set(nid, node);\
-                    }}\
-                    return node;\
+                    var t = +Deno.core.ops.op_dom('node_type', String(nid), '', globalThis.__obscura_frameId >>> 0);\
+                    return t === 9 ? globalThis.document : globalThis._wrap(nid);\
                 }})()",
                 node_id,
             );
@@ -645,6 +636,28 @@ mod tests {
             json!("INPUT"),
             "DOM.focus must set document.activeElement to the focused input"
         );
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn resolve_node_preserves_identity_and_specialized_wrappers() {
+        let mut ctx = CdpContext::new();
+        let page_id = ctx.create_page();
+        let session = Some(format!("{page_id}-session"));
+        ctx.sessions.insert(session.clone().unwrap(), page_id);
+        crate::domains::page::handle("navigate", &json!({
+            "url": "data:text/html,<html><body><textarea id=field></textarea><a id=link href=https://example.com>Next</a></body></html>"
+        }), &mut ctx, &session).await.unwrap();
+        for id in ["field", "link"] {
+            let selector = format!("#{id}");
+            let query = handle("querySelector", &json!({"selector": selector}), &mut ctx, &session).await.unwrap();
+            let resolved = handle("resolveNode", &json!({"backendNodeId": query["nodeId"]}), &mut ctx, &session).await.unwrap();
+            let object_id = resolved["object"]["objectId"].as_str().unwrap();
+            let expression = format!(
+                "globalThis.__obscura_objects[{}] === document.getElementById({})",
+                serde_json::to_string(object_id).unwrap(), serde_json::to_string(id).unwrap()
+            );
+            assert_eq!(ctx.get_session_page_mut(&session).unwrap().evaluate(&expression), json!(true));
+        }
     }
 
     #[tokio::test(flavor = "current_thread")]


### PR DESCRIPTION
## What changed

Fixes #956.

Playwright MCP can return a valid snapshot reference and then reject it during click or fill normalization because a CDP-resolved node is not strictly identical to the same node returned by DOM queries.

Resolve valid node handles through the bootstrap's existing `_wrap(nid)` helper. Looking up `globalThis._cache` misses the lexical cache and falls back to a fresh generic `Element`, losing canonical identity and specialized wrappers. The regression test covers a textarea and an anchor. Invalid-object-ID handling remains covered by the existing tests.

## Validation

Standalone candidate `94e857b`, based on upstream main `eec047a`, built with Rust 1.94.1, two build jobs, and incremental compilation disabled:

- `cargo build --release -p obscura-cli --bins --features render`: passed.
- `cargo nextest run --release --features render --no-fail-fast`: **1,698 passed, 4 skipped**, including `resolve_node_preserves_identity_and_specialized_wrappers`.
- No-render release build: passed. Supported no-render API and workspace suites: **30 + 921 passed, 3 skipped**. The minimal render-library check also passed.
- Raw CDP reproduction from #956: baseline fails strict identity for both controls and the specialized textarea check; this candidate and Chrome 151.0.7922.169 pass all checks.
- Trusted PR policy: zero errors. It reports its integration-file warning because the focused regression is a module test in `dom.rs`.
- Original pinned obstacle course (`6ebac8293d7477f59e837768bfd4e74173f04f1c`): **32/33**, with the same `observer-intersection` failure as unmodified main. Chrome also stops at 10 items in that fixture. With the separately diagnosed fixture-progression correction, this exact candidate passes **33/33**. The benchmark correction is not part of this PR, and the original 33/33 gate is not claimed to pass.

## Rendering

Not applicable. This change affects CDP node resolution and contains no layout or paint changes.

## Performance

The trusted `scripts/ci/perf_smoke.py` comparison passed with five interleaved rounds against the same main binary and runtime conditions:

| Scenario | Main latency | Candidate latency | Main peak RSS | Candidate peak RSS |
| --- | ---: | ---: | ---: | ---: |
| Build 5,000 DOM elements | 63.9 ms | 63.9 ms | 50.3 MiB | 51.0 MiB |
| 2,000 storage round trips | 15.6 ms | 15.8 ms | 36.3 MiB | 36.7 MiB |

These are CLI smoke scenarios, not a direct CDP-resolution microbenchmark or a claim about broader workloads. The fix reuses the existing wrapper cache instead of allocating another wrapper for a cached node.

## Checklist

- [x] The change is focused and does not remove existing behavior without justification.
- [x] Tests cover the failure or feature.
- [x] Existing render and supported no-render tests pass; the unchanged benchmark exception is reported above.
- [x] I checked for CPU, latency, and memory regressions.
- [x] The user-facing failure, reproduction, and resulting behavior are documented in #956 and this PR.
