### PR TITLE
fix(cdp): preserve canonical node wrappers when resolving handles

### DIFF
--- a/crates/obscura-cdp/src/domains/dom.rs
+++ b/crates/obscura-cdp/src/domains/dom.rs
@@ -187,17 +187,8 @@ pub async fn handle(
             let js_code = format!(
                 "(function() {{\
                     var nid = {};\
-                    var node = null;\
-                    if (globalThis._cache && globalThis._cache.has(nid)) {{\
-                        node = globalThis._cache.get(nid);\
-                    }} else {{\
-                        var t = +Deno.core.ops.op_dom('node_type', String(nid), '', globalThis.__obscura_frameId >>> 0);\
-                        if (t === 1) node = new Element(nid);\
-                        else if (t === 9) node = globalThis.document;\
-                        else node = new Node(nid);\
-                        if (globalThis._cache) globalThis._cache.set(nid, node);\
-                    }}\
-                    return node;\
+                    var t = +Deno.core.ops.op_dom('node_type', String(nid), '', globalThis.__obscura_frameId >>> 0);\
+                    return t === 9 ? globalThis.document : globalThis._wrap(nid);\
                 }})()",
                 node_id,
             );
@@ -645,6 +636,28 @@ mod tests {
             json!("INPUT"),
             "DOM.focus must set document.activeElement to the focused input"
         );
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn resolve_node_preserves_identity_and_specialized_wrappers() {
+        let mut ctx = CdpContext::new();
+        let page_id = ctx.create_page();
+        let session = Some(format!("{page_id}-session"));
+        ctx.sessions.insert(session.clone().unwrap(), page_id);
+        crate::domains::page::handle("navigate", &json!({
+            "url": "data:text/html,<html><body><textarea id=field></textarea><a id=link href=https://example.com>Next</a></body></html>"
+        }), &mut ctx, &session).await.unwrap();
+        for id in ["field", "link"] {
+            let selector = format!("#{id}");
+            let query = handle("querySelector", &json!({"selector": selector}), &mut ctx, &session).await.unwrap();
+            let resolved = handle("resolveNode", &json!({"backendNodeId": query["nodeId"]}), &mut ctx, &session).await.unwrap();
+            let object_id = resolved["object"]["objectId"].as_str().unwrap();
+            let expression = format!(
+                "globalThis.__obscura_objects[{}] === document.getElementById({})",
+                serde_json::to_string(object_id).unwrap(), serde_json::to_string(id).unwrap()
+            );
+            assert_eq!(ctx.get_session_page_mut(&session).unwrap().evaluate(&expression), json!(true));
+        }
     }
 
     #[tokio::test(flavor = "current_thread")]

--- a/crates/obscura-cdp/src/domains/dom.rs
+++ b/crates/obscura-cdp/src/domains/dom.rs
@@ -184,14 +184,7 @@ pub async fn handle(
                 return Err("nodeId or objectId required".to_string());
             };
 
-            let js_code = format!(
-                "(function() {{\
-                    var nid = {};\
-                    var t = +Deno.core.ops.op_dom('node_type', String(nid), '', globalThis.__obscura_frameId >>> 0);\
-                    return t === 9 ? globalThis.document : globalThis._wrap(nid);\
-                }})()",
-                node_id,
-            );
+            let js_code = format!("globalThis._wrap({node_id})");
 
             let info = if let Some(js) = &mut page.js {
                 match js.store_object_with_meta(&js_code) {
@@ -647,17 +640,64 @@ mod tests {
         crate::domains::page::handle("navigate", &json!({
             "url": "data:text/html,<html><body><textarea id=field></textarea><a id=link href=https://example.com>Next</a></body></html>"
         }), &mut ctx, &session).await.unwrap();
-        for id in ["field", "link"] {
+        for (id, constructor) in [
+            ("field", "HTMLTextAreaElement"),
+            ("link", "HTMLAnchorElement"),
+        ] {
             let selector = format!("#{id}");
-            let query = handle("querySelector", &json!({"selector": selector}), &mut ctx, &session).await.unwrap();
-            let resolved = handle("resolveNode", &json!({"backendNodeId": query["nodeId"]}), &mut ctx, &session).await.unwrap();
+            let query = handle(
+                "querySelector",
+                &json!({"selector": selector}),
+                &mut ctx,
+                &session,
+            )
+            .await
+            .unwrap();
+            let resolved = handle(
+                "resolveNode",
+                &json!({"backendNodeId": query["nodeId"]}),
+                &mut ctx,
+                &session,
+            )
+            .await
+            .unwrap();
             let object_id = resolved["object"]["objectId"].as_str().unwrap();
             let expression = format!(
-                "globalThis.__obscura_objects[{}] === document.getElementById({})",
-                serde_json::to_string(object_id).unwrap(), serde_json::to_string(id).unwrap()
+                "(() => {{ const node = globalThis.__obscura_objects[{}]; return node === document.getElementById({}) && node instanceof {}; }})()",
+                serde_json::to_string(object_id).unwrap(),
+                serde_json::to_string(id).unwrap(),
+                constructor
             );
-            assert_eq!(ctx.get_session_page_mut(&session).unwrap().evaluate(&expression), json!(true));
+            assert_eq!(
+                ctx.get_session_page_mut(&session)
+                    .unwrap()
+                    .evaluate(&expression),
+                json!(true)
+            );
         }
+
+        let document = handle("getDocument", &json!({}), &mut ctx, &session)
+            .await
+            .unwrap();
+        let resolved = handle(
+            "resolveNode",
+            &json!({"nodeId": document["root"]["nodeId"]}),
+            &mut ctx,
+            &session,
+        )
+        .await
+        .unwrap();
+        let object_id = resolved["object"]["objectId"].as_str().unwrap();
+        let expression = format!(
+            "globalThis.__obscura_objects[{}] === document",
+            serde_json::to_string(object_id).unwrap()
+        );
+        assert_eq!(
+            ctx.get_session_page_mut(&session)
+                .unwrap()
+                .evaluate(&expression),
+            json!(true)
+        );
     }
 
     #[tokio::test(flavor = "current_thread")]


### PR DESCRIPTION
<html><head></head><body><h2>What changed</h2><p>Connect page console output to the existing <code>browser_console_messages</code> MCP tool.</p><p>MCP pages now enable a lightweight console capture path that records formatted messages in a bounded 1,024-entry queue. The tool drains that queue into its existing history before returning results.</p><p>The capture path is enabled only for MCP pages. It does not enable CDP runtime events, serialize remote objects, or retain JavaScript argument handles.</p><p>Adds regression coverage for console messages produced by inline scripts, click handlers, and asynchronous timer callbacks.</p><p>Fixes #951.</p><h2>Validation</h2><ul><li><p><code>cargo nextest run --release --features render -p obscura-mcp -E 'test(console_tool_returns_page_messages)' --test-threads=1</code></p><ul><li><p>1 passed</p></li></ul></li><li><p><code>cargo nextest run --release --features render -p obscura-mcp --no-fail-fast --test-threads=1</code></p><ul><li><p>16 passed</p></li></ul></li><li><p><code>cargo nextest run --release -p obscura-mcp --no-fail-fast --test-threads=1</code></p><ul><li><p>15 passed</p></li></ul></li><li><p><code>cargo nextest run --release --features render --no-fail-fast</code></p><ul><li><p>1,696 passed, 4 skipped</p></li></ul></li><li><p><code>cargo build --release -p obscura-cli --bins --features render</code></p><ul><li><p>Passed</p></li></ul></li><li><p><code>OBSCURA_BIN=/root/obscura2/repo/target/release/obscura python3 obstacle-course/run.py --runs 1 --warmup 0</code></p><ul><li><p>33/33 stages passed</p></li></ul></li><li><p><code>python3 scripts/ci/perf_smoke.py --base &lt;base-binary&gt; --candidate &lt;candidate-binary&gt; --output /tmp/obscura-p1-951-perf.json</code></p><ul><li><p>Passed</p></li></ul></li></ul><h2>Rendering</h2><p>Not applicable.</p><h2>Performance</h2><p>Console capture remains disabled outside MCP. For MCP pages, each console call adds one bounded string entry and removes the oldest entry once the 1,024-message limit is reached.</p><p>Interleaved five-round latency/RSS comparison:</p>
Scenario | Base latency | Candidate latency | Change | Base RSS | Candidate RSS | Change
-- | -- | -- | -- | -- | -- | --
DOM build | 367.0 ms | 367.0 ms | -0.0% | 51.4 MiB | 51.0 MiB | -0.6%
Storage | 66.1 ms | 66.1 ms | -0.1% | 37.4 MiB | 38.0 MiB | +1.5%

<p>The performance gate passed with no meaningful latency or memory regression.</p><h2>Checklist</h2><ul class="contains-task-list"><li class="task-list-item"><p><input type="checkbox" checked="checked" disabled="disabled"> The change is focused and does not remove existing behavior without justification.</p></li><li class="task-list-item"><p><input type="checkbox" checked="checked" disabled="disabled"> Tests cover the failure or feature.</p></li><li class="task-list-item"><p><input type="checkbox" checked="checked" disabled="disabled"> Existing tests pass, including render and no-render configurations when affected.</p></li><li class="task-list-item"><p><input type="checkbox" checked="checked" disabled="disabled"> I checked for CPU, latency, and memory regressions.</p></li><li class="task-list-item"><p><input type="checkbox" checked="checked" disabled="disabled"> Public API or user-facing behavior changes are documented.</p></li></ul></body></html>