### PR TITLE
fix(render): paint live input values and selection state

### DIFF
--- a/crates/obscura-dom/src/selector.rs
+++ b/crates/obscura-dom/src/selector.rs
@@ -500,7 +500,9 @@ impl<'a> Element for DomElement<'a> {
             PseudoClass::Enabled => self.is_form_control() && !self.has_boolean_attr("disabled"),
             PseudoClass::Disabled => self.is_form_control() && self.has_boolean_attr("disabled"),
             PseudoClass::Checked => {
-                self.has_boolean_attr("checked") || self.has_boolean_attr("selected")
+                self.tree.form_control_state(self.node_id)
+                    .and_then(|control| control.checked)
+                    .unwrap_or_else(|| self.has_boolean_attr("checked") || self.has_boolean_attr("selected"))
             }
             // Dynamic user-interaction pseudo-classes have no meaning against
             // a static DOM snapshot with no live user input.

--- a/crates/obscura-dom/src/selector.rs
+++ b/crates/obscura-dom/src/selector.rs
@@ -500,8 +500,8 @@ impl<'a> Element for DomElement<'a> {
             PseudoClass::Enabled => self.is_form_control() && !self.has_boolean_attr("disabled"),
             PseudoClass::Disabled => self.is_form_control() && self.has_boolean_attr("disabled"),
             PseudoClass::Checked => {
-                self.tree.form_control_state(self.node_id)
-                    .and_then(|control| control.checked)
+                self.tree
+                    .form_control_checked(self.node_id)
                     .unwrap_or_else(|| self.has_boolean_attr("checked") || self.has_boolean_attr("selected"))
             }
             // Dynamic user-interaction pseudo-classes have no meaning against

--- a/crates/obscura-dom/src/tree.rs
+++ b/crates/obscura-dom/src/tree.rs
@@ -248,11 +248,20 @@ pub struct DomTree {
     inner: RefCell<DomTreeInner>,
 }
 
+/// Live control state is separate from content attributes and serialization.
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct FormControlState {
+    pub value: Option<String>,
+    pub checked: Option<bool>,
+    pub indeterminate: bool,
+}
+
 pub(crate) struct DomTreeInner {
     pub(crate) nodes: Vec<Option<Node>>,
     pub(crate) free_list: Vec<u32>,
     pub(crate) document: NodeId,
     pub(crate) id_index: HashMap<String, NodeId>,
+    form_controls: HashMap<NodeId, FormControlState>,
     /// Shadow roots are arena nodes with their own child list. They are kept
     /// outside the ordinary parent links so light-tree traversal never crosses
     /// into a shadow tree by accident.
@@ -284,6 +293,7 @@ impl DomTree {
                 free_list: Vec::new(),
                 document: NodeId(0),
                 id_index: HashMap::new(),
+                form_controls: HashMap::new(),
                 shadow_roots: HashMap::new(),
                 shadow_roots_by_host: HashMap::new(),
                 allow_declarative_shadow_roots: false,
@@ -294,6 +304,17 @@ impl DomTree {
 
     pub fn document(&self) -> NodeId {
         self.inner.borrow().document
+    }
+
+    pub fn form_control_state(&self, node: NodeId) -> Option<FormControlState> {
+        self.inner.borrow().form_controls.get(&node).cloned()
+    }
+
+    pub fn update_form_control_state(&self, node: NodeId, update: impl FnOnce(&mut FormControlState)) {
+        let mut inner = self.inner.borrow_mut();
+        if inner.nodes.get(node.index()).is_some_and(|entry| entry.as_ref().is_some_and(Node::is_element)) {
+            update(inner.form_controls.entry(node).or_default());
+        }
     }
 
     /// Record whether the document was parsed in (full) quirks mode.
@@ -912,6 +933,7 @@ impl DomTree {
         // same NodeId to two live nodes (aliasing).
         for id in nodes_to_remove {
             if matches!(inner.nodes.get(id.index()), Some(Some(_))) {
+                inner.form_controls.remove(&id);
                 inner.nodes[id.index()] = None;
                 inner.free_list.push(id.0);
             }
@@ -1431,6 +1453,10 @@ impl DomTree {
         }
         let source_data = self.get_node(source_node_id)?.data;
         let cloned_root = self.new_node(source_data);
+        if let Some(mut state) = self.form_control_state(source_node_id) {
+            state.indeterminate = false;
+            self.update_form_control_state(cloned_root, |control| *control = state);
+        }
         let mut stack = Vec::new();
         self.prepare_cloned_children(source_node_id, cloned_root, deep, &mut stack);
 
@@ -1440,6 +1466,10 @@ impl DomTree {
                 None => continue,
             };
             let cloned_node = self.new_node(source_data);
+            if let Some(mut state) = self.form_control_state(source_node) {
+                state.indeterminate = false;
+                self.update_form_control_state(cloned_node, |control| *control = state);
+            }
             self.append_child(dest_parent, cloned_node);
             self.prepare_cloned_children(source_node, cloned_node, true, &mut stack);
         }

--- a/crates/obscura-dom/src/tree.rs
+++ b/crates/obscura-dom/src/tree.rs
@@ -310,6 +310,31 @@ impl DomTree {
         self.inner.borrow().form_controls.get(&node).cloned()
     }
 
+    pub fn form_control_value_matches(&self, node: NodeId, value: &str) -> bool {
+        self.inner
+            .borrow()
+            .form_controls
+            .get(&node)
+            .and_then(|control| control.value.as_deref())
+            == Some(value)
+    }
+
+    pub fn form_control_checked(&self, node: NodeId) -> Option<bool> {
+        self.inner
+            .borrow()
+            .form_controls
+            .get(&node)
+            .and_then(|control| control.checked)
+    }
+
+    pub fn form_control_indeterminate(&self, node: NodeId) -> bool {
+        self.inner
+            .borrow()
+            .form_controls
+            .get(&node)
+            .is_some_and(|control| control.indeterminate)
+    }
+
     pub fn update_form_control_state(&self, node: NodeId, update: impl FnOnce(&mut FormControlState)) {
         let mut inner = self.inner.borrow_mut();
         if inner.nodes.get(node.index()).is_some_and(|entry| entry.as_ref().is_some_and(Node::is_element)) {

--- a/crates/obscura-js/js/bootstrap.js
+++ b/crates/obscura-js/js/bootstrap.js
@@ -697,13 +697,7 @@ function _getFp() {
 }
 function _fp(key) { return _getFp()[key]; }
 globalThis._eventRegistry = globalThis._eventRegistry || {};
-globalThis._formValues = globalThis._formValues || {};
-globalThis._formChecked = globalThis._formChecked || {};
-globalThis._formIndeterminate = globalThis._formIndeterminate || {};
 const _eventRegistry = globalThis._eventRegistry;
-const _formValues = globalThis._formValues;
-const _formChecked = globalThis._formChecked;
-const _formIndeterminate = globalThis._formIndeterminate;
 const _domParse = (cmd, a1, a2) => { try { return JSON.parse(_dom(cmd, a1, a2)); } catch { return null; } };
 
 // HTML "ASCII whitespace": U+0009 TAB, U+000A LF, U+000C FF, U+000D CR, U+0020 SPACE.
@@ -3972,7 +3966,8 @@ class Element extends Node {
       if (opts.length) return opts[0].getAttribute('value') !== null ? opts[0].getAttribute('value') : opts[0].textContent;
       return '';
     }
-    if (_formValues[this._nid] !== undefined) return _formValues[this._nid];
+    const currentValue = _domParse("get_form_value", this._nid);
+    if (currentValue !== null) return currentValue;
     if (tag === 'textarea') return this.textContent;
     if (tag === 'option') {
       const attr = this.getAttribute('value');
@@ -4023,7 +4018,7 @@ class Element extends Node {
       }
       return;
     }
-    _formValues[this._nid] = String(v);
+    _dom("set_form_value", this._nid, String(v));
     if (tag === 'textarea') {
       this.textContent = String(v);
     }
@@ -4101,17 +4096,17 @@ class Element extends Node {
     this.value = _inputFormatNumber(t, value);
   }
   get checked() {
-    if (_formChecked[this._nid] !== undefined) return _formChecked[this._nid];
+    const currentChecked = _domParse("get_form_checked", this._nid);
+    if (currentChecked !== null) return currentChecked;
     return this.hasAttribute("checked");
   }
-  set checked(v) { _formChecked[this._nid] = !!v; }
+  set checked(v) { _dom("set_form_checked", this._nid, String(!!v)); }
   // `indeterminate` is IDL-only: it has no content attribute to reflect, so
   // the property itself must exist on the prototype for `'indeterminate' in
-  // el` to be true on a freshly created element. It is node-keyed like
-  // `checked` because element wrappers are rebuilt on each lookup, so a
-  // per-instance field would not survive getElementById returning a new one.
-  get indeterminate() { return _formIndeterminate[this._nid] === true; }
-  set indeterminate(v) { _formIndeterminate[this._nid] = !!v; }
+  // el` to be true on a freshly created element. Native node-keyed state
+  // keeps IDL access and rendering consistent without changing attributes.
+  get indeterminate() { return _domParse("get_form_indeterminate", this._nid) === true; }
+  set indeterminate(v) { _dom("set_form_indeterminate", this._nid, String(!!v)); }
   get selected() {
     if (this._selected !== undefined) return this._selected;
     return this.hasAttribute("selected");

--- a/crates/obscura-js/js/bootstrap.js
+++ b/crates/obscura-js/js/bootstrap.js
@@ -697,8 +697,25 @@ function _getFp() {
 }
 function _fp(key) { return _getFp()[key]; }
 globalThis._eventRegistry = globalThis._eventRegistry || {};
+globalThis._formValues = globalThis._formValues || {};
+globalThis._formChecked = globalThis._formChecked || {};
+globalThis._formIndeterminate = globalThis._formIndeterminate || {};
 const _eventRegistry = globalThis._eventRegistry;
+const _formValues = globalThis._formValues;
+const _formChecked = globalThis._formChecked;
+const _formIndeterminate = globalThis._formIndeterminate;
 const _domParse = (cmd, a1, a2) => { try { return JSON.parse(_dom(cmd, a1, a2)); } catch { return null; } };
+const _formStateLoaded = new Set();
+function _loadFormState(nid) {
+  if (_formStateLoaded.has(nid)) return;
+  const state = _domParse("get_form_state", nid);
+  if (state) {
+    if (state.value !== null) _formValues[nid] = state.value;
+    if (state.checked !== null) _formChecked[nid] = state.checked;
+    if (state.indeterminate) _formIndeterminate[nid] = true;
+  }
+  _formStateLoaded.add(nid);
+}
 
 // HTML "ASCII whitespace": U+0009 TAB, U+000A LF, U+000C FF, U+000D CR, U+0020 SPACE.
 // Class token splitting (classList, getElementsByClassName) uses exactly this set.
@@ -3966,8 +3983,8 @@ class Element extends Node {
       if (opts.length) return opts[0].getAttribute('value') !== null ? opts[0].getAttribute('value') : opts[0].textContent;
       return '';
     }
-    const currentValue = _domParse("get_form_value", this._nid);
-    if (currentValue !== null) return currentValue;
+    if (_formValues[this._nid] === undefined) _loadFormState(this._nid);
+    if (_formValues[this._nid] !== undefined) return _formValues[this._nid];
     if (tag === 'textarea') return this.textContent;
     if (tag === 'option') {
       const attr = this.getAttribute('value');
@@ -4018,9 +4035,11 @@ class Element extends Node {
       }
       return;
     }
-    _dom("set_form_value", this._nid, String(v));
+    const value = String(v);
+    _formValues[this._nid] = value;
+    _dom("set_form_value", this._nid, value);
     if (tag === 'textarea') {
-      this.textContent = String(v);
+      this.textContent = value;
     }
   }
   get min() { return this.getAttribute('min') || ''; }
@@ -4096,17 +4115,28 @@ class Element extends Node {
     this.value = _inputFormatNumber(t, value);
   }
   get checked() {
-    const currentChecked = _domParse("get_form_checked", this._nid);
-    if (currentChecked !== null) return currentChecked;
+    if (_formChecked[this._nid] === undefined) _loadFormState(this._nid);
+    if (_formChecked[this._nid] !== undefined) return _formChecked[this._nid];
     return this.hasAttribute("checked");
   }
-  set checked(v) { _dom("set_form_checked", this._nid, String(!!v)); }
+  set checked(v) {
+    const checked = !!v;
+    _formChecked[this._nid] = checked;
+    _dom("set_form_checked", this._nid, String(checked));
+  }
   // `indeterminate` is IDL-only: it has no content attribute to reflect, so
   // the property itself must exist on the prototype for `'indeterminate' in
   // el` to be true on a freshly created element. Native node-keyed state
   // keeps IDL access and rendering consistent without changing attributes.
-  get indeterminate() { return _domParse("get_form_indeterminate", this._nid) === true; }
-  set indeterminate(v) { _dom("set_form_indeterminate", this._nid, String(!!v)); }
+  get indeterminate() {
+    if (_formIndeterminate[this._nid] === undefined) _loadFormState(this._nid);
+    return _formIndeterminate[this._nid] === true;
+  }
+  set indeterminate(v) {
+    const indeterminate = !!v;
+    _formIndeterminate[this._nid] = indeterminate;
+    _dom("set_form_indeterminate", this._nid, String(indeterminate));
+  }
   get selected() {
     if (this._selected !== undefined) return this._selected;
     return this.hasAttribute("selected");
@@ -11628,7 +11658,22 @@ globalThis.HTMLFormElement = class HTMLFormElement extends Element {
   get length() { return this.elements.length; }
   // Inherit submit() from Element.prototype: it dispatches the cancelable
   // 'submit' event and (if not prevented) builds form data and navigates.
-  reset() { for (const f of this.elements) { if ('value' in f) f.value = ''; } }
+  reset() {
+    if (!this.dispatchEvent(new Event('reset', { bubbles: true, cancelable: true }))) return;
+    for (const f of this.elements) {
+      if (f.localName === 'input') {
+        const type = (f.getAttribute('type') || 'text').toLowerCase();
+        if (type === 'checkbox' || type === 'radio') {
+          f.checked = f.hasAttribute('checked');
+          f.indeterminate = false;
+        } else {
+          f.value = f.getAttribute('value') || '';
+        }
+      } else if ('value' in f) {
+        f.value = '';
+      }
+    }
+  }
 };
 globalThis.HTMLSelectElement = Element;
 globalThis.HTMLTextAreaElement = class HTMLTextAreaElement extends Element {

--- a/crates/obscura-js/src/ops.rs
+++ b/crates/obscura-js/src/ops.rs
@@ -749,6 +749,18 @@ fn render_mutation_impact(
 ) -> RenderMutationImpact {
     let node = |value: &str| value.parse::<u32>().ok().map(NodeId::new);
     match cmd {
+        "set_form_value" | "set_form_checked" | "set_form_indeterminate" => {
+            let Some(target) = node(arg1) else {
+                return RenderMutationImpact::default();
+            };
+            let control = dom.form_control_state(target).unwrap_or_default();
+            let actual_change = match cmd {
+                "set_form_value" => control.value.as_deref() != Some(arg2),
+                "set_form_checked" => control.checked != Some(arg2 == "true"),
+                _ => control.indeterminate != (arg2 == "true"),
+            };
+            RenderMutationImpact { connected: node_is_connected(dom, target), actual_change }
+        }
         "set_attribute" => {
             let Some(target) = node(arg1) else {
                 return RenderMutationImpact::default();
@@ -1192,6 +1204,9 @@ fn is_render_mutation_command(cmd: &str) -> bool {
     matches!(
         cmd,
         "set_attribute"
+            | "set_form_value"
+            | "set_form_checked"
+            | "set_form_indeterminate"
             | "remove_attribute"
             | "set_attribute_ns"
             | "remove_attribute_ns"
@@ -1514,6 +1529,24 @@ fn op_dom_inner(shared: SharedState, cmd: String, arg1: String, arg2: String) ->
     };
 
     match cmd.as_str() {
+        "get_form_value" | "get_form_checked" | "get_form_indeterminate" => {
+            let nid = NodeId::new(arg1.parse().unwrap_or(u32::MAX));
+            let control = dom.form_control_state(nid).unwrap_or_default();
+            match cmd.as_str() {
+                "get_form_value" => serde_json::to_string(&control.value).unwrap_or("null".into()),
+                "get_form_checked" => serde_json::to_string(&control.checked).unwrap_or("null".into()),
+                _ => control.indeterminate.to_string(),
+            }
+        }
+        "set_form_value" | "set_form_checked" | "set_form_indeterminate" => {
+            let nid = NodeId::new(arg1.parse().unwrap_or(u32::MAX));
+            dom.update_form_control_state(nid, |control| match cmd.as_str() {
+                "set_form_value" => control.value = Some(arg2.clone()),
+                "set_form_checked" => control.checked = Some(arg2 == "true"),
+                _ => control.indeterminate = arg2 == "true",
+            });
+            "null".to_string()
+        }
         "document_node_id" => dom.document().index().to_string(),
         "document_title" => {
             // The DOM is authoritative after parsing. In particular, script

--- a/crates/obscura-js/src/ops.rs
+++ b/crates/obscura-js/src/ops.rs
@@ -753,11 +753,12 @@ fn render_mutation_impact(
             let Some(target) = node(arg1) else {
                 return RenderMutationImpact::default();
             };
-            let control = dom.form_control_state(target).unwrap_or_default();
             let actual_change = match cmd {
-                "set_form_value" => control.value.as_deref() != Some(arg2),
-                "set_form_checked" => control.checked != Some(arg2 == "true"),
-                _ => control.indeterminate != (arg2 == "true"),
+                "set_form_value" => !dom.form_control_value_matches(target, arg2),
+                "set_form_checked" => {
+                    dom.form_control_checked(target) != Some(arg2 == "true")
+                }
+                _ => dom.form_control_indeterminate(target) != (arg2 == "true"),
             };
             RenderMutationImpact { connected: node_is_connected(dom, target), actual_change }
         }
@@ -1529,14 +1530,18 @@ fn op_dom_inner(shared: SharedState, cmd: String, arg1: String, arg2: String) ->
     };
 
     match cmd.as_str() {
-        "get_form_value" | "get_form_checked" | "get_form_indeterminate" => {
+        "get_form_state" => {
             let nid = NodeId::new(arg1.parse().unwrap_or(u32::MAX));
-            let control = dom.form_control_state(nid).unwrap_or_default();
-            match cmd.as_str() {
-                "get_form_value" => serde_json::to_string(&control.value).unwrap_or("null".into()),
-                "get_form_checked" => serde_json::to_string(&control.checked).unwrap_or("null".into()),
-                _ => control.indeterminate.to_string(),
-            }
+            dom.form_control_state(nid)
+                .map(|control| {
+                    serde_json::json!({
+                        "value": control.value,
+                        "checked": control.checked,
+                        "indeterminate": control.indeterminate,
+                    })
+                    .to_string()
+                })
+                .unwrap_or_else(|| "null".to_string())
         }
         "set_form_value" | "set_form_checked" | "set_form_indeterminate" => {
             let nid = NodeId::new(arg1.parse().unwrap_or(u32::MAX));

--- a/crates/obscura-js/src/runtime.rs
+++ b/crates/obscura-js/src/runtime.rs
@@ -4401,14 +4401,19 @@ mod tests {
 
     #[cfg(feature = "render")]
     #[test]
-    fn resetting_an_empty_default_input_clears_live_paint_state() {
-        let mut rt = setup_runtime("<html><body><form id=form><input id=field></form></body></html>");
+    fn form_reset_restores_default_input_state_and_pixels() {
+        let mut rt = setup_runtime(
+            "<html><body><form id=form><input id=field value=default><input id=box type=checkbox checked></form></body></html>",
+        );
         rt.set_viewport(320.0, 120.0);
         let before = rt.screenshot_prepared((320.0, 120.0), Some("http://example.com/test")).unwrap();
-        rt.evaluate("document.getElementById('field').value = 'typed'").unwrap();
+        rt.evaluate("const field=document.getElementById('field'),box=document.getElementById('box');field.value='typed';box.checked=false;box.indeterminate=true").unwrap();
         assert_ne!(before, rt.screenshot_prepared((320.0, 120.0), Some("http://example.com/test")).unwrap());
         rt.evaluate("document.getElementById('form').reset()").unwrap();
-        assert_eq!(rt.evaluate("document.getElementById('field').value").unwrap(), serde_json::json!(""));
+        assert_eq!(
+            rt.evaluate("[field.value,field.getAttribute('value'),box.checked,box.indeterminate,box.hasAttribute('checked')]").unwrap(),
+            serde_json::json!(["default", "default", true, false, true])
+        );
         assert_eq!(before, rt.screenshot_prepared((320.0, 120.0), Some("http://example.com/test")).unwrap());
     }
 

--- a/crates/obscura-js/src/runtime.rs
+++ b/crates/obscura-js/src/runtime.rs
@@ -4372,6 +4372,46 @@ mod tests {
         assert!(rt.render_resource_is_known(&url));
     }
 
+    #[cfg(feature = "render")]
+    #[test]
+    fn live_form_values_paint_without_mutating_content_attributes() {
+        let mut rt = setup_runtime("<!doctype html><html><body><input id=field value=initial><input id=box type=checkbox></body></html>");
+        rt.set_viewport(320.0, 120.0);
+        let before = rt.screenshot_prepared((320.0, 120.0), Some("http://example.com/test")).unwrap();
+        rt.evaluate("document.getElementById('field').value = 'changed'").unwrap();
+        let changed_value = rt.screenshot_prepared((320.0, 120.0), Some("http://example.com/test")).unwrap();
+        assert_ne!(before, changed_value, "live text value must affect pixels");
+        rt.evaluate("document.getElementById('box').checked = true").unwrap();
+        let after = rt.screenshot_prepared((320.0, 120.0), Some("http://example.com/test")).unwrap();
+        assert_ne!(changed_value, after, "checked state must affect pixels");
+        assert_eq!(rt.evaluate("[document.getElementById('field').value, document.getElementById('field').getAttribute('value'), document.getElementById('box').getAttribute('checked'), document.querySelectorAll(':checked').length]").unwrap(), serde_json::json!(["changed", "initial", null, 1]));
+        rt.evaluate("(document.getElementById('field').value = 'initial', document.getElementById('box').checked = false)").unwrap();
+        assert_eq!(before, rt.screenshot_prepared((320.0, 120.0), Some("http://example.com/test")).unwrap());
+        rt.evaluate("document.getElementById('field').value = ''").unwrap();
+        assert_eq!(rt.evaluate("document.getElementById('field').value").unwrap(), serde_json::json!(""));
+        assert_ne!(before, rt.screenshot_prepared((320.0, 120.0), Some("http://example.com/test")).unwrap(), "empty current value must override a nonempty default");
+    }
+
+    #[test]
+    fn cloned_controls_keep_current_value_and_checked_state() {
+        let mut rt = setup_runtime("<html><body><div id=group><input id=field value=default><input id=box type=checkbox></div></body></html>");
+        let result = rt.evaluate("(() => {const field=document.getElementById('field'), box=document.getElementById('box');field.value='current';box.checked=true;box.indeterminate=true;const clone=document.getElementById('group').cloneNode(true);return [clone.children[0].value,clone.children[0].getAttribute('value'),clone.children[1].checked,clone.children[1].indeterminate];})()").unwrap();
+        assert_eq!(result, serde_json::json!(["current", "default", true, false]));
+    }
+
+    #[cfg(feature = "render")]
+    #[test]
+    fn resetting_an_empty_default_input_clears_live_paint_state() {
+        let mut rt = setup_runtime("<html><body><form id=form><input id=field></form></body></html>");
+        rt.set_viewport(320.0, 120.0);
+        let before = rt.screenshot_prepared((320.0, 120.0), Some("http://example.com/test")).unwrap();
+        rt.evaluate("document.getElementById('field').value = 'typed'").unwrap();
+        assert_ne!(before, rt.screenshot_prepared((320.0, 120.0), Some("http://example.com/test")).unwrap());
+        rt.evaluate("document.getElementById('form').reset()").unwrap();
+        assert_eq!(rt.evaluate("document.getElementById('field').value").unwrap(), serde_json::json!(""));
+        assert_eq!(before, rt.screenshot_prepared((320.0, 120.0), Some("http://example.com/test")).unwrap());
+    }
+
     // SEC-503 / #820 — createObjectURL must reject non-Blob input (an object
     // that merely has a .text() method, e.g. Response) with a TypeError, as
     // Chrome does; a real Blob is still accepted.

--- a/crates/obscura-render/src/paint.rs
+++ b/crates/obscura-render/src/paint.rs
@@ -4715,17 +4715,22 @@ fn paint_laid_dom_scrolled(
             }
         }
 
-        let input_type = node.get_attribute("type").unwrap_or("text").to_ascii_lowercase();
-        let checkable = name.local.as_ref() == "input" && matches!(input_type.as_str(), "checkbox" | "radio");
+        let input_type = (name.local.as_ref() == "input")
+            .then(|| node.get_attribute("type").unwrap_or("text"));
+        let checkable = input_type.is_some_and(|kind| {
+            kind.eq_ignore_ascii_case("checkbox") || kind.eq_ignore_ascii_case("radio")
+        });
         if checkable && rect.width > 0.0 && rect.height > 0.0 {
-            let control = tree.form_control_state(nid).unwrap_or_default();
-            let checked = control.checked.unwrap_or_else(|| node.get_attribute("checked").is_some());
-            let indeterminate = input_type == "checkbox" && control.indeterminate;
+            let checked = tree
+                .form_control_checked(nid)
+                .unwrap_or_else(|| node.get_attribute("checked").is_some());
+            let is_radio = input_type.is_some_and(|kind| kind.eq_ignore_ascii_case("radio"));
+            let indeterminate = !is_radio && tree.form_control_indeterminate(nid);
             let disabled = node.get_attribute("disabled").is_some();
             let size = rect.width.min(rect.height);
             let x = rect.x + (rect.width - size) / 2.0;
             let y = rect.y + (rect.height - size) / 2.0;
-            let shape = if input_type == "radio" {
+            let shape = if is_radio {
                 PathBuilder::from_circle(x + size / 2.0, y + size / 2.0, (size - 1.0).max(0.0) / 2.0)
             } else {
                 tiny_skia::Rect::from_xywh(x + 0.5, y + 0.5, (size - 1.0).max(0.0), (size - 1.0).max(0.0))
@@ -4738,13 +4743,13 @@ fn paint_laid_dom_scrolled(
                 control_paint.set_color(Color::from_rgba8(color[0], color[1], color[2], color[3]));
                 control_paint.anti_alias = true;
                 let stroke = tiny_skia::Stroke { width: 1.0, ..Default::default() };
-                if input_type == "checkbox" && selected {
+                if !is_radio && selected {
                     pixmap.fill_path(&shape, &control_paint, FillRule::Winding, raster_transform(raster_scale), element_clip_mask);
                 } else {
                     pixmap.stroke_path(&shape, &control_paint, &stroke, raster_transform(raster_scale), element_clip_mask);
                 }
                 if selected {
-                    if input_type == "radio" {
+                    if is_radio {
                         if let Some(dot) = PathBuilder::from_circle(x + size / 2.0, y + size / 2.0, size * 0.25) {
                             pixmap.fill_path(&dot, &control_paint, FillRule::Winding, raster_transform(raster_scale), element_clip_mask);
                         }
@@ -4792,10 +4797,8 @@ fn paint_laid_dom_scrolled(
                         let text_y = rect.y + style.padding.top + style.border.top;
                         let color = style.color.unwrap_or([0, 0, 0, 255]);
                         let masked;
-                        let shown = if node
-                            .get_attribute("type")
-                            .is_some_and(|kind| kind.eq_ignore_ascii_case("password"))
-                        {
+                        let shown = if input_type
+                            .is_some_and(|kind| kind.eq_ignore_ascii_case("password")) {
                             masked = "\u{2022}".repeat(value.chars().count());
                             masked.as_str()
                         } else {

--- a/crates/obscura-render/src/paint.rs
+++ b/crates/obscura-render/src/paint.rs
@@ -4715,25 +4715,77 @@ fn paint_laid_dom_scrolled(
             }
         }
 
+        let input_type = node.get_attribute("type").unwrap_or("text").to_ascii_lowercase();
+        let checkable = name.local.as_ref() == "input" && matches!(input_type.as_str(), "checkbox" | "radio");
+        if checkable && rect.width > 0.0 && rect.height > 0.0 {
+            let control = tree.form_control_state(nid).unwrap_or_default();
+            let checked = control.checked.unwrap_or_else(|| node.get_attribute("checked").is_some());
+            let indeterminate = input_type == "checkbox" && control.indeterminate;
+            let disabled = node.get_attribute("disabled").is_some();
+            let size = rect.width.min(rect.height);
+            let x = rect.x + (rect.width - size) / 2.0;
+            let y = rect.y + (rect.height - size) / 2.0;
+            let shape = if input_type == "radio" {
+                PathBuilder::from_circle(x + size / 2.0, y + size / 2.0, (size - 1.0).max(0.0) / 2.0)
+            } else {
+                tiny_skia::Rect::from_xywh(x + 0.5, y + 0.5, (size - 1.0).max(0.0), (size - 1.0).max(0.0))
+                    .map(PathBuilder::from_rect)
+            };
+            if let Some(shape) = shape {
+                let mut control_paint = Paint::default();
+                let selected = checked || indeterminate;
+                let color = if disabled { [160, 160, 160, 255] } else if selected { [0, 117, 255, 255] } else { [118, 118, 118, 255] };
+                control_paint.set_color(Color::from_rgba8(color[0], color[1], color[2], color[3]));
+                control_paint.anti_alias = true;
+                let stroke = tiny_skia::Stroke { width: 1.0, ..Default::default() };
+                if input_type == "checkbox" && selected {
+                    pixmap.fill_path(&shape, &control_paint, FillRule::Winding, raster_transform(raster_scale), element_clip_mask);
+                } else {
+                    pixmap.stroke_path(&shape, &control_paint, &stroke, raster_transform(raster_scale), element_clip_mask);
+                }
+                if selected {
+                    if input_type == "radio" {
+                        if let Some(dot) = PathBuilder::from_circle(x + size / 2.0, y + size / 2.0, size * 0.25) {
+                            pixmap.fill_path(&dot, &control_paint, FillRule::Winding, raster_transform(raster_scale), element_clip_mask);
+                        }
+                    } else {
+                        let mut mark = PathBuilder::new();
+                        mark.move_to(x + size * 0.2, y + size * 0.5);
+                        if indeterminate {
+                            mark.line_to(x + size * 0.8, y + size * 0.5);
+                        } else {
+                            mark.line_to(x + size * 0.43, y + size * 0.73);
+                            mark.line_to(x + size * 0.82, y + size * 0.25);
+                        }
+                        if let Some(mark) = mark.finish() {
+                            control_paint.set_color(Color::WHITE);
+                            let stroke = tiny_skia::Stroke { width: (size * 0.14).max(1.0), ..Default::default() };
+                            pixmap.stroke_path(&mark, &control_paint, &stroke, raster_transform(raster_scale), element_clip_mask);
+                        }
+                    }
+                }
+            }
+        }
+
         // An empty text `<input>`/`<textarea>` shows its `placeholder`
         // attribute as muted text; there is no DOM text node for it (it is
         // not real content), so paint it directly from the attribute instead
         // of going through `paint_text_node`.
-        if name.local.as_ref() == "input" || name.local.as_ref() == "textarea" {
-            let has_value = node
-                .get_attribute("value")
-                .map(|v| !v.is_empty())
-                .unwrap_or(false)
+        if !checkable && (name.local.as_ref() == "input" || name.local.as_ref() == "textarea") {
+            let live_value = tree.form_control_state(nid).and_then(|control| control.value);
+            let value = live_value.as_deref().or_else(|| node.get_attribute("value"));
+            let has_value = value.is_some_and(|v| !v.is_empty())
                 || (name.local.as_ref() == "textarea"
                     && !tree.text_content(nid).is_empty());
             // A text `<input>`'s value is not a DOM text node either, so it
-            // needs painting from the attribute the same way. Without this the
+            // needs painting from its live state, falling back to the attribute.
+            // Without this the
             // control renders empty however it was filled in — from markup,
             // from script, or by typing — while its `value` reads back
             // correctly, so only a screenshot or PDF shows anything wrong.
             // `<textarea>` is unaffected: its value *is* a text node.
             if has_value && name.local.as_ref() == "input" {
-                if let Some(value) = node.get_attribute("value") {
+                if let Some(value) = value {
                     if !value.is_empty() {
                         let fsize = style.font_size.unwrap_or(16.0);
                         let text_x = rect.x + style.padding.left + style.border.left;

--- a/render-repros/live-form-state.html
+++ b/render-repros/live-form-state.html
@@ -1,0 +1,31 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>Live form values and checked state</title>
+  <style>
+    body { font: 18px Arial, sans-serif; padding: 24px; }
+    label { display: block; margin: 20px 0; }
+    input[type="text"], input[type="password"] { width: 240px; height: 30px; }
+  </style>
+</head>
+<body>
+  <h1>Live control state</h1>
+  <label>Typed value <input id="live" type="text" value="Default value"></label>
+  <label>Cleared value <input id="empty" type="text" value="Default value" placeholder="Empty now"></label>
+  <label>Masked value <input id="secret" type="password"></label>
+  <label>Checked <input id="checked" type="checkbox" value="Do not paint this value"></label>
+  <label>Unchecked <input id="unchecked" type="checkbox" checked></label>
+  <label>Mixed <input id="mixed" type="checkbox"></label>
+  <label>Selected <input id="radio" type="radio" name="choice" value="Do not paint this value"></label>
+  <script>
+    document.getElementById('live').value = 'Current value';
+    document.getElementById('empty').value = '';
+    document.getElementById('secret').value = 'secret';
+    document.getElementById('checked').checked = true;
+    document.getElementById('unchecked').checked = false;
+    document.getElementById('mixed').indeterminate = true;
+    document.getElementById('radio').checked = true;
+  </script>
+</body>
+</html>


### PR DESCRIPTION
<html><head></head><body><h2>What changed</h2><p>Fixes #957.<br>Supersedes #959.</p><p>Based on the original fix and regression coverage from @AntonioRossi.</p><p>Live form-control state is now stored separately from content attributes and shared with the renderer. Screenshots and PDFs therefore reflect current JavaScript state for:</p><ul><li><p>text and password input values</p></li><li><p>explicitly cleared values and placeholders</p></li><li><p>checked and unchecked checkboxes</p></li><li><p>indeterminate checkboxes</p></li><li><p>selected radio buttons</p></li><li><p>the <code>:checked</code> pseudo-class</p></li></ul><p>Changing live state invalidates retained rendering. Cloning preserves value and checked state while resetting indeterminate state, form reset restores defaults, and deleting a node removes its stored state.</p><p>The final version keeps the common getter path allocation-free, avoids lowercasing input types into new strings during paint, and avoids cloning complete form-state records when only one field is needed.</p><h2>Validation</h2><ul><li><p>Focused live form-state regression tests: 3 passed.</p></li><li><p>Affected render-enabled release suites: 1,176 passed, 1 skipped.</p></li><li><p>Affected no-render suites: 495 passed.</p></li><li><p>Obstacle course: 33/33.</p></li><li><p>Regression coverage verifies live value painting, cleared values, password masking, checked and indeterminate state, cloning, reset behavior, unchanged content attributes, and restoration of original pixels.</p></li></ul><h2>Rendering</h2><p>Validated using <code>render-repros/live-form-state.html</code>.</p><ul><li><p>Viewport: 900 × 1000 CSS pixels</p></li><li><p>Device scale factor: 1</p></li><li><p>Output: PNG</p></li><li><p>Settle time: 2 seconds</p></li></ul>
Before | After
-- | --
Stale input values and missing selection indicators | Live values and current selection indicators

<p>The repository performance smoke gate passed. Latency and RSS differences remained within its accepted range.</p><h2>Checklist</h2><ul class="contains-task-list"><li class="task-list-item"><p><input type="checkbox" checked="checked" disabled="disabled"> The change is focused and does not remove existing behavior without justification.</p></li><li class="task-list-item"><p><input type="checkbox" checked="checked" disabled="disabled"> Tests cover the failure or feature.</p></li><li class="task-list-item"><p><input type="checkbox" checked="checked" disabled="disabled"> Existing tests pass, including render and no-render configurations when affected.</p></li><li class="task-list-item"><p><input type="checkbox" checked="checked" disabled="disabled"> I checked for CPU, latency, and memory regressions.</p></li><li class="task-list-item"><p><input type="checkbox" checked="checked" disabled="disabled"> Public API or user-facing behavior changes are documented.</p></li></ul></body></html>