### PR TITLE
fix(render): avoid rounded float boundary abort

### DIFF
--- a/crates/obscura-render/tests/layout_test.rs
+++ b/crates/obscura-render/tests/layout_test.rs
@@ -4496,3 +4496,29 @@ fn deeply_nested_wrappers_cascade_without_stack_overflow() {
         "the descendant rule must match at depth 400, got {rect:?}"
     );
 }
+
+#[test]
+fn float_ending_at_rounded_segment_boundary_does_not_panic() {
+    use taffy::{compute::FloatContext, Clear, FloatDirection, Size};
+
+    fn place(
+        context: &mut FloatContext,
+        height: f32,
+        direction: FloatDirection,
+    ) -> taffy::Point<f32> {
+        context.place_floated_box(
+            Size { width: 100.0, height },
+            1859.0,
+            [0.0, 0.0],
+            direction,
+            Clear::None,
+        )
+    }
+
+    let mut context = FloatContext::new();
+    context.set_width(1000.0);
+    place(&mut context, 421.3333, FloatDirection::Left);
+    place(&mut context, 400.3333, FloatDirection::Right);
+
+    assert_eq!(place(&mut context, 400.3333, FloatDirection::Left).y, 1859.0);
+}

--- a/vendor/taffy/src/compute/float.rs
+++ b/vendor/taffy/src/compute/float.rs
@@ -93,16 +93,14 @@ impl Segment {
 struct FloatFitter {
     /// The overall width of the Block Formatting Context
     bfc_width: f32,
-    /// The total height of the set of segments currently being considered
-    slot_height: f64,
     /// The union of the insets of the set of segments currently being considered
     insets: [f32; 2],
 }
 
 impl FloatFitter {
     /// Create a new `FloatFitter`
-    fn new(bfc_width: f32, slot_height: f32, insets: [f32; 2]) -> Self {
-        Self { bfc_width, slot_height: slot_height as f64, insets }
+    fn new(bfc_width: f32, insets: [f32; 2]) -> Self {
+        Self { bfc_width, insets }
     }
 
     // Horizontal fitting
@@ -119,17 +117,6 @@ impl FloatFitter {
         self.insets == [0.0, 0.0] || self.bfc_width - self.insets[0] - self.insets[1] - width >= 0.0
     }
 
-    // Vertical fitting
-
-    /// Add the height of another segment.
-    fn add_height(&mut self, height: f32) {
-        self.slot_height += height as f64;
-    }
-
-    /// Given the currently accounted for height, check whether the box fits vertically
-    fn fits_vertically(&mut self, height: f32) -> bool {
-        self.slot_height >= height as f64
-    }
 }
 
 /// A context for placing floated boxes
@@ -307,8 +294,8 @@ impl FloatContext {
             }
 
             start_y = start_y.max(start_segment.y.start);
-            let available_height = start_segment.y.end - start_y;
-            let mut fitter = FloatFitter::new(self.available_width, available_height, containing_block_insets);
+            let float_end = start_y + floated_box.height;
+            let mut fitter = FloatFitter::new(self.available_width, containing_block_insets);
             fitter.union_insets(start_segment.insets);
 
             // Pinning the start segment, loop over segments starting with the start segment
@@ -341,10 +328,8 @@ impl FloatContext {
                 //
                 // If it does not (yet) fit vertically then continue the inner loop to add another
                 // segment to the range of segments we are placing the float in
-                if end_idx != start_idx {
-                    fitter.add_height(end_segment.y.end - end_segment.y.start);
-                }
-                if !fitter.fits_vertically(floated_box.height) {
+                // Compare endpoints directly: summing rounded segment heights can miss an exact boundary.
+                if float_end > end_segment.y.end {
                     end_idx += 1;
                     continue;
                 }


### PR DESCRIPTION
<html><head></head><body><h2>What changed</h2><p>Fix float placement when a float ends exactly at a segment boundary.</p><p>The previous code summed rounded segment heights and could conclude that an exactly fitting float was slightly too tall. It then attempted to split the next segment at its starting coordinate, triggering a Taffy assertion and aborting the process.</p><p>The new calculation compares absolute endpoints directly and removes the accumulated-height bookkeeping.</p><p>Fixes #884.</p><h2>Validation</h2><p>Ran:</p><pre><code class="language-bash">cargo nextest run --release -p obscura-render --features paint float_ending_at_rounded_segment_boundary_does_not_panic --no-capture
cargo nextest run --release -p obscura-render --features paint --no-fail-fast
OPENSSL_NO_VENDOR=1 CARGO_INCREMENTAL=0 CARGO_BUILD_JOBS=2 cargo nextest run --release --features render --no-fail-fast
OPENSSL_NO_VENDOR=1 CARGO_INCREMENTAL=0 CARGO_BUILD_JOBS=2 cargo build --release -p obscura-cli --bins --features render
OPENSSL_NO_VENDOR=1 CARGO_INCREMENTAL=0 CARGO_BUILD_JOBS=2 cargo build --release -p obscura-cli --bins --no-default-features
</code></pre><p>Results:</p><ul><li><p>Regression test passes.</p></li><li><p>Renderer suite: 589 passed, 1 skipped.</p></li><li><p>Full render-enabled workspace: 1,702 passed, 4 skipped.</p></li><li><p>Obstacle course: 33/33 passed.</p></li><li><p>The reported URL no longer aborts and completes with a 60-second navigation timeout.</p></li><li><p>The no-render build and live-page path still work.</p></li></ul><h2>Rendering</h2><p>The regression test uses a 1000px block formatting context with fractional float heights that reproduce the failed boundary calculation.</p><p>Before: the process aborted before producing output.</p><p>After: the float is placed at <code>y = 1859</code> without splitting the following segment.</p><p>Device scale factor and raster output options are not applicable because this is a layout-unit regression and does not change screenshot or PDF configuration.</p><p>Representative render comparisons found no structural differences. Float-focused fixtures continued to match their reference geometry.</p><h2>Performance</h2><p>A five-run interleaved microbenchmark covering 1,000,000 float placements measured:</p>
Metric | Before | After
-- | -- | --
Median time | 0.235578 s | 0.240549 s
Difference | — | ~+2.1%
RSS | ~2.0–2.1 MB | ~2.0–2.1 MB

<p>The timing difference is within run-to-run noise.</p><p>The new path removes height accumulation and numeric conversions. No meaningful CPU, latency, or memory regression was found.</p><h2>Checklist</h2><ul class="contains-task-list"><li class="task-list-item"><p><input type="checkbox" checked="checked" disabled="disabled"> The change is focused and does not remove existing behavior without justification.</p></li><li class="task-list-item"><p><input type="checkbox" checked="checked" disabled="disabled"> Tests cover the failure or feature.</p></li><li class="task-list-item"><p><input type="checkbox" checked="checked" disabled="disabled"> Existing tests pass, including render and no-render configurations when affected.</p></li><li class="task-list-item"><p><input type="checkbox" checked="checked" disabled="disabled"> I checked for CPU, latency, and memory regressions.</p></li><li class="task-list-item"><p><input type="checkbox" checked="checked" disabled="disabled"> Public API or user-facing behavior changes are documented.</p></li></ul></body></html>