### PR TITLE
test(browser): inspect attached frame during cancellation

### DIFF
--- a/crates/obscura-browser/src/page.rs
+++ b/crates/obscura-browser/src/page.rs
@@ -5909,10 +5909,11 @@ mod tests {
             page_with_fetched_slow_frames("cancel-frame-scripts", 2).await;
         page.add_preload_script("globalThis.__order = ['preload'];");
         assert!(page.queue_pending_frames());
-        let expected_viewport = match &page.pending_frame_work[0] {
-            PendingFrameWork::Unattached(frame) => {
-                (frame.viewport_width, frame.viewport_height)
-            }
+        let (attached_frame_id, expected_viewport) = match &page.pending_frame_work[0] {
+            PendingFrameWork::Unattached(frame) => (
+                frame.frame_id,
+                (frame.viewport_width, frame.viewport_height),
+            ),
             PendingFrameWork::Attached { .. } => panic!("frame work started before advancement"),
         };
         let slow_request = slow_seen.notified();
@@ -5930,10 +5931,14 @@ mod tests {
             .js
             .as_mut()
             .unwrap()
-            .evaluate(
-                "(function(){ const w = document.querySelector('iframe').contentWindow; \
-                 return { order: w.__order, width: w.innerWidth, height: w.innerHeight }; })()",
-            )
+            .evaluate(&format!(
+                "(function(){{ \
+                       const frame = Array.from(document.querySelectorAll('iframe')) \
+                         .find(frame => frame._frameId === {attached_frame_id}); \
+                       const w = frame.contentWindow; \
+                       return {{ order: w.__order, width: w.innerWidth, height: w.innerHeight }}; \
+                     }})()"
+            ))
             .unwrap();
         assert_eq!(
             observable,
@@ -5942,7 +5947,7 @@ mod tests {
                 "width": expected_viewport.0,
                 "height": expected_viewport.1,
             }),
-            "a published loading frame was observable before new-document initialization",
+            "the attached loading frame was observable before new-document initialization",
         );
         assert_eq!(page.pending_frame_work.len(), 2);
         assert!(matches!(


### PR DESCRIPTION
## What changed

Fix the flaky frame cancellation regression test.

Sibling iframe documents are fetched independently, so the first completed document is not guaranteed to belong to the first iframe in DOM order. The test previously inspected `document.querySelector('iframe')`, even when a different sibling was the frame attached by the interrupted operation.

The test now records the attached frame ID and inspects that iframe. It continues to verify that viewport setup and preload scripts are complete before the attached frame becomes observable.

No production frame lifecycle behavior was changed.

Fixes #944.

## Validation

Ran the focused test 50 consecutive times:

```bash
cargo nextest run --release --features render -p obscura-browser \
  -E 'test(cancelling_frame_script_fetch_keeps_all_siblings_resumable)'
```

Result: 50/50 passed.

Ran the full relevant package suite:

```bash
cargo nextest run --release --features render -p obscura-browser --no-fail-fast
```

Result: 102/102 passed.

Also ran:

```bash
git diff --check
```

## Rendering

Not applicable.

## Performance

No expected impact. The change only affects test code and is not compiled into runtime binaries.

## Checklist

* [x] The change is focused and does not remove existing behavior without justification.
* [x] Tests cover the failure or feature.
* [x] Existing tests pass, including render and no-render configurations when affected.
* [x] I checked for CPU, latency, and memory regressions.
* [x] Public API or user-facing behavior changes are documented.
